### PR TITLE
Implement VS Code installation redirect handling and validation

### DIFF
--- a/apps/my-copilot/src/app/install/[type]/route.ts
+++ b/apps/my-copilot/src/app/install/[type]/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest } from "next/server";
+
+import { handleInstallRedirect, INSTALL_TYPES, InstallType } from "@/lib/install-redirect";
+
+/**
+ * Redirect handler for VS Code installations (agents, instructions, prompts).
+ *
+ * GitHub's image caching via camo.githubusercontent.com breaks direct vscode: protocol links
+ * in markdown badges. This route acts as an HTTPS intermediary that redirects to the
+ * vscode: protocol URL.
+ *
+ * Security: Only allows redirects to vscode: URLs that install from navikt GitHub repos.
+ *
+ * Usage:
+ *   https://min-copilot.ansatt.nav.no/install/agent?url=vscode:chat-agent/install?url=...
+ *   https://min-copilot.ansatt.nav.no/install/instructions?url=vscode:chat-instructions/install?url=...
+ *   https://min-copilot.ansatt.nav.no/install/prompt?url=vscode:chat-prompt/install?url=...
+ *
+ * The `url` parameter should be the complete vscode: protocol URL (URL-encoded).
+ *
+ * @see https://github.com/navikt/copilot/issues/67
+ */
+export async function GET(request: NextRequest, { params }: { params: Promise<{ type: string }> }) {
+  const { type } = await params;
+
+  // Validate the type parameter
+  if (!Object.hasOwn(INSTALL_TYPES, type)) {
+    const validTypes = Object.keys(INSTALL_TYPES).join(", ");
+    return new Response(`Invalid install type '${type}'. Valid types: ${validTypes}`, { status: 400 });
+  }
+
+  const url = request.nextUrl.searchParams.get("url");
+  return handleInstallRedirect(url, type as InstallType);
+}

--- a/apps/my-copilot/src/app/install/agent/route.ts
+++ b/apps/my-copilot/src/app/install/agent/route.ts
@@ -4,9 +4,10 @@ import { NextRequest } from "next/server";
 // Allowed VS Code agent installation URL patterns
 // Only allows vscode: or vscode-insiders: scheme with chat-agent/install path
 // and a url parameter pointing to raw.githubusercontent.com/navikt/
+// Note: Next.js automatically URL-decodes query params, so we match decoded URLs
 const ALLOWED_PATTERNS = [
-  /^vscode:chat-agent\/install\?url=https%3A%2F%2Fraw\.githubusercontent\.com%2Fnavikt%2F/,
-  /^vscode-insiders:chat-agent\/install\?url=https%3A%2F%2Fraw\.githubusercontent\.com%2Fnavikt%2F/,
+  /^vscode:chat-agent\/install\?url=https:\/\/raw\.githubusercontent\.com\/navikt\//,
+  /^vscode-insiders:chat-agent\/install\?url=https:\/\/raw\.githubusercontent\.com\/navikt\//,
 ];
 
 /**

--- a/apps/my-copilot/src/app/install/instructions/route.ts
+++ b/apps/my-copilot/src/app/install/instructions/route.ts
@@ -4,9 +4,10 @@ import { NextRequest } from "next/server";
 // Allowed VS Code instructions installation URL patterns
 // Only allows vscode: or vscode-insiders: scheme with chat-instructions/install path
 // and a url parameter pointing to raw.githubusercontent.com/navikt/
+// Note: Next.js automatically URL-decodes query params, so we match decoded URLs
 const ALLOWED_PATTERNS = [
-  /^vscode:chat-instructions\/install\?url=https%3A%2F%2Fraw\.githubusercontent\.com%2Fnavikt%2F/,
-  /^vscode-insiders:chat-instructions\/install\?url=https%3A%2F%2Fraw\.githubusercontent\.com%2Fnavikt%2F/,
+  /^vscode:chat-instructions\/install\?url=https:\/\/raw\.githubusercontent\.com\/navikt\//,
+  /^vscode-insiders:chat-instructions\/install\?url=https:\/\/raw\.githubusercontent\.com\/navikt\//,
 ];
 
 /**

--- a/apps/my-copilot/src/app/install/prompt/route.ts
+++ b/apps/my-copilot/src/app/install/prompt/route.ts
@@ -4,9 +4,10 @@ import { NextRequest } from "next/server";
 // Allowed VS Code prompt installation URL patterns
 // Only allows vscode: or vscode-insiders: scheme with chat-prompt/install path
 // and a url parameter pointing to raw.githubusercontent.com/navikt/
+// Note: Next.js automatically URL-decodes query params, so we match decoded URLs
 const ALLOWED_PATTERNS = [
-  /^vscode:chat-prompt\/install\?url=https%3A%2F%2Fraw\.githubusercontent\.com%2Fnavikt%2F/,
-  /^vscode-insiders:chat-prompt\/install\?url=https%3A%2F%2Fraw\.githubusercontent\.com%2Fnavikt%2F/,
+  /^vscode:chat-prompt\/install\?url=https:\/\/raw\.githubusercontent\.com\/navikt\//,
+  /^vscode-insiders:chat-prompt\/install\?url=https:\/\/raw\.githubusercontent\.com\/navikt\//,
 ];
 
 /**

--- a/apps/my-copilot/src/lib/install-redirect.test.ts
+++ b/apps/my-copilot/src/lib/install-redirect.test.ts
@@ -1,0 +1,81 @@
+import { isAllowedInstallUrl, INSTALL_TYPES, InstallType } from "./install-redirect";
+
+describe("isAllowedInstallUrl", () => {
+  const types: InstallType[] = ["agent", "instructions", "prompt"];
+
+  describe.each(types)("for type '%s'", (type) => {
+    const chatPath = INSTALL_TYPES[type];
+
+    it("should allow valid vscode: URL with navikt repo", () => {
+      const url = `vscode:${chatPath}/install?url=https://raw.githubusercontent.com/navikt/copilot/main/.github/agents/nais.agent.md`;
+      expect(isAllowedInstallUrl(url, type)).toBe(true);
+    });
+
+    it("should allow valid vscode-insiders: URL with navikt repo", () => {
+      const url = `vscode-insiders:${chatPath}/install?url=https://raw.githubusercontent.com/navikt/copilot/main/.github/agents/nais.agent.md`;
+      expect(isAllowedInstallUrl(url, type)).toBe(true);
+    });
+
+    it("should allow URLs with different branches", () => {
+      const url = `vscode:${chatPath}/install?url=https://raw.githubusercontent.com/navikt/my-repo/feature-branch/.github/agents/custom.agent.md`;
+      expect(isAllowedInstallUrl(url, type)).toBe(true);
+    });
+
+    it("should reject URLs from non-navikt orgs", () => {
+      const url = `vscode:${chatPath}/install?url=https://raw.githubusercontent.com/evil-org/copilot/main/.github/agents/malicious.agent.md`;
+      expect(isAllowedInstallUrl(url, type)).toBe(false);
+    });
+
+    it("should reject URLs with wrong scheme", () => {
+      const url = `http:${chatPath}/install?url=https://raw.githubusercontent.com/navikt/copilot/main/.github/agents/nais.agent.md`;
+      expect(isAllowedInstallUrl(url, type)).toBe(false);
+    });
+
+    it("should reject URLs with http:// instead of vscode:", () => {
+      const url = `https://example.com/malicious?redirect=https://raw.githubusercontent.com/navikt/copilot/main/.github/agents/nais.agent.md`;
+      expect(isAllowedInstallUrl(url, type)).toBe(false);
+    });
+
+    it("should reject URLs with wrong chat path", () => {
+      // Using agent path for instructions type, etc.
+      const wrongPath = type === "agent" ? "chat-prompt" : "chat-agent";
+      const url = `vscode:${wrongPath}/install?url=https://raw.githubusercontent.com/navikt/copilot/main/.github/agents/nais.agent.md`;
+      expect(isAllowedInstallUrl(url, type)).toBe(false);
+    });
+
+    it("should reject empty URLs", () => {
+      expect(isAllowedInstallUrl("", type)).toBe(false);
+    });
+
+    it("should reject URLs trying to escape with encoded characters", () => {
+      // Attempt to use URL encoding to bypass validation
+      const url = `vscode:${chatPath}/install?url=https://raw.githubusercontent.com/navikt/../evil-org/copilot/main/malicious.md`;
+      expect(isAllowedInstallUrl(url, type)).toBe(false);
+    });
+
+    it("should reject URLs with navikt in subdirectory but not org", () => {
+      const url = `vscode:${chatPath}/install?url=https://raw.githubusercontent.com/evil/navikt/main/file.md`;
+      expect(isAllowedInstallUrl(url, type)).toBe(false);
+    });
+  });
+
+  describe("cross-type validation", () => {
+    it("should not allow agent URL for instructions type", () => {
+      const url =
+        "vscode:chat-agent/install?url=https://raw.githubusercontent.com/navikt/copilot/main/.github/agents/nais.agent.md";
+      expect(isAllowedInstallUrl(url, "instructions")).toBe(false);
+    });
+
+    it("should not allow instructions URL for prompt type", () => {
+      const url =
+        "vscode:chat-instructions/install?url=https://raw.githubusercontent.com/navikt/copilot/main/.github/instructions/test.instructions.md";
+      expect(isAllowedInstallUrl(url, "prompt")).toBe(false);
+    });
+
+    it("should not allow prompt URL for agent type", () => {
+      const url =
+        "vscode:chat-prompt/install?url=https://raw.githubusercontent.com/navikt/copilot/main/.github/prompts/test.prompt.md";
+      expect(isAllowedInstallUrl(url, "agent")).toBe(false);
+    });
+  });
+});

--- a/apps/my-copilot/src/lib/install-redirect.ts
+++ b/apps/my-copilot/src/lib/install-redirect.ts
@@ -1,0 +1,64 @@
+import { redirect } from "next/navigation";
+
+/**
+ * Supported VS Code installation types and their corresponding paths.
+ */
+export const INSTALL_TYPES = {
+  agent: "chat-agent",
+  instructions: "chat-instructions",
+  prompt: "chat-prompt",
+} as const;
+
+export type InstallType = keyof typeof INSTALL_TYPES;
+
+/**
+ * Validates if the URL is an allowed VS Code installation URL.
+ *
+ * Security: Only allows redirects to vscode: URLs that:
+ * 1. Use vscode: or vscode-insiders: scheme
+ * 2. Have the correct installation path for the type
+ * 3. Install from raw.githubusercontent.com/navikt/ (our GitHub org)
+ * 4. Do not contain path traversal sequences
+ *
+ * @param url - The URL to validate (already URL-decoded by Next.js)
+ * @param type - The installation type (agent, instructions, prompt)
+ * @returns true if the URL is allowed, false otherwise
+ */
+export function isAllowedInstallUrl(url: string, type: InstallType): boolean {
+  // Reject path traversal attempts
+  if (url.includes("..")) {
+    return false;
+  }
+
+  const chatPath = INSTALL_TYPES[type];
+
+  // Build patterns for this specific type
+  // Note: Next.js automatically URL-decodes query params, so we match decoded URLs
+  const patterns = [
+    new RegExp(`^vscode:${chatPath}/install\\?url=https://raw\\.githubusercontent\\.com/navikt/`),
+    new RegExp(`^vscode-insiders:${chatPath}/install\\?url=https://raw\\.githubusercontent\\.com/navikt/`),
+  ];
+
+  return patterns.some((pattern) => pattern.test(url));
+}
+
+/**
+ * Handles the redirect for VS Code installation URLs.
+ *
+ * @param url - The URL parameter from the request (may be null)
+ * @param type - The installation type
+ * @returns Response with error, or redirects (never returns normally)
+ */
+export function handleInstallRedirect(url: string | null, type: InstallType): Response {
+  if (!url) {
+    return new Response("Missing 'url' parameter", { status: 400 });
+  }
+
+  if (!isAllowedInstallUrl(url, type)) {
+    return new Response(`Invalid URL. Only navikt GitHub ${type} installations are allowed.`, { status: 400 });
+  }
+
+  // Redirect to the vscode: protocol URL
+  // This will throw NEXT_REDIRECT, so it never returns
+  redirect(url);
+}


### PR DESCRIPTION
Introduce a redirect handler for VS Code installations, validating URLs to ensure they originate from the navikt GitHub organization. This update enhances security by allowing only specific installation types and patterns. Additionally, it includes tests to verify the URL validation logic.