### PR TITLE
Restrict PR deployment to the same repository in dev environment

### DIFF
--- a/.github/workflows/mise-build-deploy-nais.yaml
+++ b/.github/workflows/mise-build-deploy-nais.yaml
@@ -371,7 +371,7 @@ jobs:
 
   deploy-pr:
     name: Deploy PR to dev
-    if: ${{ inputs.deploy-pr-to-dev && github.event_name == 'pull_request' }}
+    if: ${{ inputs.deploy-pr-to-dev && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
Limit the deployment of pull requests to the development environment only for the same repository. This change enhances security and ensures that deployments occur only within the intended context.