### PR TITLE
style(my-copilot): bruk 7-dagers rullerende snitt for alle adopsjonstrender

### DIFF
--- a/apps/my-copilot/src/app/statistikk/page.tsx
+++ b/apps/my-copilot/src/app/statistikk/page.tsx
@@ -167,12 +167,12 @@ async function UsageContent({ usage }: { usage: EnterpriseMetrics[] }) {
               Adopsjon
             </Heading>
             <HelpText title="Adopsjon" placement="top">
-              Chat- og agent-brukere er basert på GitHubs rullende 30-dagersvindu. Dropp ved månedsskifter skyldes at
-              brukere fra 30+ dager siden faller ut av vinduet.
+              Alle serier viser 7-dagers rullerende snitt for enkel sammenligning. Chat og agent er basert på GitHubs
+              rullende 30-dagersvindu, CLI på daglige tall.
             </HelpText>
           </div>
           <BodyShort className="text-gray-600">
-            Bruk av Copilots funksjoner. Chat og agent viser aktive brukere siste 30 dager, CLI viser daglig aktive.
+            Bruk av Copilots funksjoner. Alle grafer viser 7-dagers rullerende snitt.
           </BodyShort>
           <HGrid columns={{ xs: 1, sm: 3 }} gap="space-16">
             <Box background="info-soft" padding="space-16" borderRadius="8">
@@ -209,9 +209,10 @@ async function UsageContent({ usage }: { usage: EnterpriseMetrics[] }) {
                   {formatNumber(aggregatedMetrics.dailyActiveCLIUsers)}
                 </Heading>
                 <div className="flex items-center justify-center gap-1">
-                  <BodyShort className="text-gray-600">CLI-brukere (daglig)</BodyShort>
+                  <BodyShort className="text-gray-600">CLI-brukere</BodyShort>
                   <HelpText title="CLI-brukere" placement="top">
-                    Brukere som brukte Copilot CLI i terminalen siste dag.
+                    Brukere som brukte Copilot CLI i terminalen. Kortet viser siste dags tall, grafen viser 7-dagers
+                    snitt.
                   </HelpText>
                 </div>
               </div>

--- a/apps/my-copilot/src/components/charts/AdoptionTrendChart.tsx
+++ b/apps/my-copilot/src/components/charts/AdoptionTrendChart.tsx
@@ -28,26 +28,25 @@ const AdoptionTrendChart: React.FC<AdoptionTrendChartProps> = ({ data }) => {
     labels: data.days,
     datasets: [
       {
-        label: "Chat-brukere (30d snitt)",
+        label: "Chat-brukere (7d snitt)",
         data: data.chatUsers,
         borderColor: chartColors[0],
         backgroundColor: getBackgroundColor(chartColors[0]),
         tension: 0.4,
       },
       {
-        label: "Agent-brukere (30d snitt)",
+        label: "Agent-brukere (7d snitt)",
         data: data.agentUsers,
         borderColor: chartColors[2],
         backgroundColor: getBackgroundColor(chartColors[2]),
         tension: 0.4,
       },
       {
-        label: "CLI-brukere (daglig)",
+        label: "CLI-brukere (7d snitt)",
         data: data.cliUsers,
         borderColor: chartColors[3],
         backgroundColor: getBackgroundColor(chartColors[3]),
         tension: 0.4,
-        borderDash: [5, 5],
       },
     ],
   };

--- a/apps/my-copilot/src/lib/data-utils.test.ts
+++ b/apps/my-copilot/src/lib/data-utils.test.ts
@@ -525,8 +525,40 @@ describe("buildTrendData", () => {
 // --- buildAdoptionTrendData ---
 
 describe("buildAdoptionTrendData", () => {
-  it("computes rolling averages for chat and agent users", () => {
-    const days = Array.from({ length: 5 }, (_, i) =>
+  it("applies 7-day rolling average to all three series", () => {
+    const days = Array.from({ length: 10 }, (_, i) =>
+      makeDay({
+        day: `2026-04-${String(i + 1).padStart(2, "0")}`,
+        monthly_active_chat_users: (i + 1) * 10, // 10, 20, 30, ..., 100
+        monthly_active_agent_users: (i + 1) * 5, // 5, 10, 15, ..., 50
+        daily_active_cli_users: (i + 1) * 2, // 2, 4, 6, ..., 20
+      })
+    );
+    const result = buildAdoptionTrendData(days);
+    expect(result.days).toHaveLength(10);
+
+    // Day 0 (index 0): window=[10], avg=10
+    expect(result.chatUsers[0]).toBe(10);
+    // Day 6 (index 6): first full 7-day window [10,20,30,40,50,60,70], avg=40
+    expect(result.chatUsers[6]).toBe(40);
+    // Day 9 (index 9): window=[40,50,60,70,80,90,100], avg=70
+    expect(result.chatUsers[9]).toBe(70);
+
+    // CLI also gets rolling average (not raw)
+    // Day 0: window=[2], avg=2
+    expect(result.cliUsers[0]).toBe(2);
+    // Day 6: window=[2,4,6,8,10,12,14], avg=8
+    expect(result.cliUsers[6]).toBe(8);
+    // Day 9: window=[8,10,12,14,16,18,20], avg=14
+    expect(result.cliUsers[9]).toBe(14);
+
+    // Agent follows same pattern
+    expect(result.agentUsers[0]).toBe(5);
+    expect(result.agentUsers[6]).toBe(20);
+  });
+
+  it("handles fewer days than window size", () => {
+    const days = Array.from({ length: 3 }, (_, i) =>
       makeDay({
         day: `2026-04-0${i + 1}`,
         monthly_active_chat_users: 100,
@@ -535,11 +567,25 @@ describe("buildAdoptionTrendData", () => {
       })
     );
     const result = buildAdoptionTrendData(days);
-    expect(result.days).toHaveLength(5);
-    // CLI is raw (no rolling average)
-    expect(result.cliUsers).toEqual([10, 10, 10, 10, 10]);
-    // Chat rolling average of constant 100 is 100
-    expect(result.chatUsers[4]).toBe(100);
+    // With constant values, rolling average equals the constant
+    expect(result.chatUsers).toEqual([100, 100, 100]);
+    expect(result.agentUsers).toEqual([50, 50, 50]);
+    expect(result.cliUsers).toEqual([10, 10, 10]);
+  });
+
+  it("handles single day", () => {
+    const days = [
+      makeDay({
+        day: "2026-04-01",
+        monthly_active_chat_users: 200,
+        monthly_active_agent_users: 100,
+        daily_active_cli_users: 30,
+      }),
+    ];
+    const result = buildAdoptionTrendData(days);
+    expect(result.chatUsers).toEqual([200]);
+    expect(result.agentUsers).toEqual([100]);
+    expect(result.cliUsers).toEqual([30]);
   });
 });
 

--- a/apps/my-copilot/src/lib/data-utils.ts
+++ b/apps/my-copilot/src/lib/data-utils.ts
@@ -309,9 +309,9 @@ export const buildTrendData = (usage: EnterpriseMetrics[]): DailyTrend[] => {
 };
 
 export const buildAdoptionTrendData = (usage: EnterpriseMetrics[]): AdoptionTrendData => {
-  // GitHub's monthly_active_*_users reset at billing period boundaries.
-  // We calculate a rolling 30-day average to smooth the reset transition.
-  // Note: CLI is already a daily metric, so we keep it raw (no rolling average).
+  // All three series use a 7-day rolling average for consistent comparison.
+  // Chat/agent come from GitHub's monthly_active_*_users (30-day window),
+  // CLI comes from daily_active_cli_users. The 7-day average smooths all series.
   const chatRaw = usage.map((d) => d.monthly_active_chat_users || 0);
   const agentRaw = usage.map((d) => d.monthly_active_agent_users || 0);
   const cliRaw = usage.map((d) => d.daily_active_cli_users || 0);
@@ -327,9 +327,9 @@ export const buildAdoptionTrendData = (usage: EnterpriseMetrics[]): AdoptionTren
 
   return {
     days: usage.map((d) => d.day),
-    chatUsers: rollingAverage(chatRaw, 30),
-    agentUsers: rollingAverage(agentRaw, 30),
-    cliUsers: cliRaw, // Daily metric, no rolling average needed
+    chatUsers: rollingAverage(chatRaw, 7),
+    agentUsers: rollingAverage(agentRaw, 7),
+    cliUsers: rollingAverage(cliRaw, 7),
   };
 };
 


### PR DESCRIPTION
## Summary
- Alle tre adopsjonsserier (Chat, Agent, CLI) bruker nå konsekvent 7-dagers rullerende snitt i stedet for å blande 30-dagers snitt med rå daglige verdier
- Gjør trendene direkte sammenlignbare i grafen
- Oppdatert labels, hjelpetekster og beskrivelser til å reflektere endringen

## Endrede filer
- `data-utils.ts` — endret rolling average vindu fra 30→7 for chat/agent, og lagt til rolling average for CLI
- `AdoptionTrendChart.tsx` — oppdatert labels til "7d snitt", fjernet stiplet linje for CLI
- `statistikk/page.tsx` — oppdatert beskrivelser og hjelpetekster
- `data-utils.test.ts` — erstattet svak test med 3 nye tester som verifiserer rolling average med varierende data, kort serie, og enkelt datapunkt