### PR TITLE
Bruk riktig port for Intellij MCP

### DIFF
--- a/apps/mcp-registry/allowlist.json
+++ b/apps/mcp-registry/allowlist.json
@@ -242,7 +242,7 @@
       "remotes": [
         {
           "type": "sse",
-          "url": "http://127.0.0.1:63342/sse"
+          "url": "http://127.0.0.1:64342/sse"
         }
       ],
       "tools": ["get_symbol_info", "get_file_problems", "get_project_dependencies", "get_project_modules", "search_in_files_by_text", "search_in_files_by_regex", "find_files_by_glob", "find_files_by_name_keyword", "get_file_text_by_path", "list_directory_tree", "get_all_open_file_paths", "get_run_configurations", "get_repositories", "create_new_file", "replace_text_in_file", "reformat_file", "rename_refactoring", "open_file_in_editor", "execute_terminal_command", "execute_run_configuration"],


### PR DESCRIPTION
Den ble sannsynligvis byttet når MCPen gikk fra å være en plugin til en built-in.