### PR TITLE
feat(nav-pilot): add shorthands for (i)nstall, list (ls), (s)ync, (up)grade, uninstall (rm)

### DIFF
--- a/cli/nav-pilot/main.go
+++ b/cli/nav-pilot/main.go
@@ -32,6 +32,15 @@ var timeNow = time.Now
 
 // ─── CLI ────────────────────────────────────────────────────────────────────
 
+// commandAliases maps short aliases to their canonical command names.
+var commandAliases = map[string]string{
+	"i":  "install",
+	"ls": "list",
+	"s":  "sync",
+	"up": "upgrade",
+	"rm": "uninstall",
+}
+
 func usage() {
 	fmt.Fprintf(os.Stderr, `nav-pilot — Nav's Copilot toolkit for developers
 
@@ -42,14 +51,14 @@ Usage:
   nav-pilot <command> [flags]
 
 Commands:
-  install <name>          Install a collection or individual agent/skill/instruction/prompt
+  install (i) <name>      Install a collection or individual agent/skill/instruction/prompt
   install --user --all    Install all agents, skills & instructions to ~/.copilot (user-wide)
   init                    Scaffold repo-local Copilot config files (AGENTS.md, instructions)
-  sync                    Check for updates and optionally apply them
-  list                    List available collections and items
+  sync (s)                Check for updates and optionally apply them
+  list (ls)               List available collections and items
   list --installed        Show what's currently installed
-  upgrade                 Update nav-pilot CLI to the latest version
-  uninstall               Remove installed collection files
+  upgrade (up)            Update nav-pilot CLI to the latest version
+  uninstall (rm)          Remove installed collection files
   export <format>         Export Nav customizations to another tool's format
   env                     Print shell exports for Copilot CLI integration
   ignore <type> <name>    Suppress new-item reminders for a specific item (--user)
@@ -103,6 +112,11 @@ func run(args []string) error {
 
 	command := args[0]
 	rest := args[1:]
+
+	// Resolve short aliases to canonical command names.
+	if canonical, ok := commandAliases[command]; ok {
+		command = canonical
+	}
 
 	var dryRun, force, apply, jsonOutput, listItems, featureRequest, userScope, targetProvided, installAll, listInstalled bool
 	var targetDir, ref, sourceRepo, installType string

--- a/cli/nav-pilot/main_test.go
+++ b/cli/nav-pilot/main_test.go
@@ -80,6 +80,63 @@ func TestRun_RefMissingValue(t *testing.T) {
 	}
 }
 
+// ─── Command alias tests ────────────────────────────────────────────────────
+
+func TestRun_AliasInstall(t *testing.T) {
+	// "i" should behave identically to "install" — error when no name given
+	err := run([]string{"i"})
+	if err == nil {
+		t.Fatal("expected error when no name given via alias")
+	}
+	if !strings.Contains(err.Error(), "install requires a name") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_AliasList(t *testing.T) {
+	// "ls" should behave identically to "list"
+	err := run([]string{"ls", "--json"})
+	if err != nil {
+		t.Fatalf("list alias failed: %v", err)
+	}
+}
+
+func TestRun_AliasSync(t *testing.T) {
+	// "s" should behave identically to "sync"
+	err := run([]string{"s", "--json"})
+	if err != nil && err != errUpdatesAvailable && err != errSyncFailed {
+		t.Fatalf("sync alias failed unexpectedly: %v", err)
+	}
+}
+
+func TestRun_AliasUpgrade(t *testing.T) {
+	// "up" should behave identically to "upgrade" — non-nil error is acceptable
+	// (upgrade fetches from the network), but must not be "unknown command"
+	err := run([]string{"up"})
+	if err != nil && strings.Contains(err.Error(), "unknown command") {
+		t.Errorf("alias 'up' was not resolved: %v", err)
+	}
+}
+
+func TestRun_AliasUninstall(t *testing.T) {
+	// "rm" should behave identically to "uninstall"
+	err := run([]string{"rm", "--dry-run"})
+	if err != nil {
+		t.Fatalf("uninstall alias failed: %v", err)
+	}
+}
+
+func TestRun_AliasDoesNotAffectUnknownCommands(t *testing.T) {
+	// Aliases must not accidentally suppress the unknown-command error
+	err := run([]string{"xyz"})
+	if err == nil {
+		t.Fatal("expected error for unknown command")
+	}
+	if !strings.Contains(err.Error(), "unknown command") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestIsGitRepo(t *testing.T) {
 	// Temp dir with .git
 	dir := t.TempDir()


### PR DESCRIPTION
Small QOL DX addition of shorthands for common commands, to allow for e.g. `nav-pilot s` or `na<TAB> ls` 😄 