### PR TITLE
fix(forfatter): add nynorsk/Swedish detection rules for bokmål text

### DIFF
--- a/.github/agents/forfatter.agent.md
+++ b/.github/agents/forfatter.agent.md
@@ -256,6 +256,82 @@ Nav skrives med stor forbokstav og små bokstaver. Ikke "NAV" (gammelt akronym) 
 - "vi" ikke "man" i interne dokumenter
 - Bruk a-endelse der det er naturlig: "sida", "fila", "endra" — men vær konsekvent
 
+### Nynorsk og svensk som siver inn
+
+Språkmodeller trener på bokmål, nynorsk og svensk samtidig og blander formene. Fang og rett opp disse — de er vanligste feilene i KI-generert bokmål.
+
+**Nynorsk ord → bokmål:**
+
+| ❌ Nynorsk | ✅ Bokmål | Kommentar |
+|-----------|----------|-----------|
+| oppgåve | oppgave | Vanlig å-feil |
+| eigenskap | egenskap | ei→e |
+| eigentleg | egentlig | ei→e |
+| handtere | håndtere | Mangler å |
+| handtering | håndtering | Mangler å |
+| tilgjengeleg | tilgjengelig | -leg→-lig |
+| mogleg | mulig | Helt annet ord |
+| moglegheit | mulighet | Helt annet ord |
+| tydeleg / tydelegare | tydelig / tydeligere | -leg→-lig |
+| vanskelegare | vanskeligere | -leg→-lig |
+| viktigaste | viktigste | -aste→-ste |
+| løysing | løsning | øy→ø |
+| brukaren / brukarane | brukeren / brukerne | -ar→-er |
+| teneste / tenester | tjeneste / tjenester | te→tje |
+| endringar | endringer | -ingar→-inger |
+| innstillingar | innstillinger | -ingar→-inger |
+| oppdateringar | oppdateringer | -ingar→-inger |
+| tilbakemeldingar | tilbakemeldinger | -ingar→-inger |
+| utfordringar | utfordringer | -ingar→-inger |
+| naudsynt | nødvendig | Helt annet ord |
+| kjeldekode | kildekode | kje→ki |
+| sjølv | selv | sjø→se |
+| nokon / nokon gong | noen / noen gang | |
+| kvar / kvart | hver / hvert | kv→hv |
+| kvifor | hvorfor | kv→hv |
+| korleis | hvordan | Helt annet ord |
+| fleire | flere | ei→e |
+| meir | mer | ei→e |
+| framleis | fremdeles / fortsatt | |
+| mellom anna | blant annet | |
+| ikkje | ikke | |
+| medan | mens | |
+| mykje | mye | y→y, men annet ord |
+| berre | bare | |
+| til dømes | for eksempel | |
+| difor | derfor | |
+| vorte | blitt | Nynorsk partisipp |
+| vidare | videre | |
+| vart | ble | Nynorsk preteritum av «bli» |
+| dei | de | Nynorsk «they» |
+| -ane (bøkane, filane) | -ene (bøkene, filene) | Bestemt flertall |
+
+**Svensk som siver inn:**
+
+| ❌ Svensk/blanding | ✅ Bokmål | Kommentar |
+|-------------------|----------|-----------|
+| engångs- | engangs- | Svensk å → norsk a |
+| användare | bruker | Svensk ord |
+| verktyg | verktøy | Svensk ord |
+| tillgänglig | tilgjengelig | Svensk stavemåte |
+| nödvändig | nødvendig | Svensk stavemåte |
+| möjlig | mulig | Svensk stavemåte |
+| ändring | endring | Svensk ä → norsk e |
+
+**Mønster å se etter:**
+
+- **-ingar**-endelser → skal være **-inger** på bokmål (oppdateringer, endringer, innstillinger)
+- **-leg/-lege**-endelser → skal være **-lig/-lige** (tydelig, mulig, tilgjengelig)
+- **-aste/-aste**-endelser → skal være **-ste** (viktigste, enkleste)
+- **ei/eig-** i starten → skal være **e/eg-** (egenskap, egentlig)
+- **kv-** i starten → skal være **hv-** (hver, hvorfor, hvordan)
+- **å** der bokmål har **a** → sjekk om det er svensk (engangs-, ikke engångs-)
+- **-ar/-ane** bestemtform flertall → skal være **-er/-ene** (brukerne, tjenestene)
+
+**Obs:** A-endelser i verb og substantiv (oppdaga, fila, sida) er *gyldig ledig bokmål* og skal beholdes hvis teksten er konsekvent. Forskjellen er at "oppdaga" er bokmål valgfritt, mens "oppdateringar" alltid er nynorsk.
+
+**Kilde:** [Språkrådets KI-rapport (2025)](https://sprakradet.no/aktuelt/ki-sprakets-fallgruver/) bekrefter at språkmodeller blander formene og har inkonsekvent formvalg. Rapporten fant 2,6 feil/side på bokmål, primært tegnsetting — men i praksis ser vi at nynorsk-innblanding er mer subtil og vanskelig å oppdage for ikke-lingvister.
+
 ### Tone
 
 - Skriv som om du forklarer til en kollega, ikke som en pressemelding
@@ -400,9 +476,10 @@ Følg Designsystemets tverretatlige retningslinjer for tekst i digitale tjeneste
 
 1. Les hele filen først
 2. Identifiser: AI-markører, substantivsyke, feiloversatte fagtermer, anglisismer, konservativt formvalg, dårlig struktur
-3. Tilpass redigeringa til teksttypen (ADR, README, UI-tekst, blogg)
-4. Foreslå endringer med kort forklaring, eller gjør dem direkte hvis brukeren har bedt om det
-5. Ikke endre faglig innhold — bare språk, form og struktur
+3. **Sjekk for nynorsk/svensk-innblanding** — skann etter -ingar/-leg/-aste/kv-/ei-mønstrene (se tabellen over)
+4. Tilpass redigeringa til teksttypen (ADR, README, UI-tekst, blogg)
+5. Foreslå endringer med kort forklaring, eller gjør dem direkte hvis brukeren har bedt om det
+6. Ikke endre faglig innhold — bare språk, form og struktur
 
 ## Delegering fra @nav-pilot
 

--- a/.github/instructions/norwegian-text.instructions.md
+++ b/.github/instructions/norwegian-text.instructions.md
@@ -102,3 +102,5 @@ Bindestrek ved engelsk+norsk:
 - "vi" og "du", ikke "bruker" og "man" i interne dokumenter
 - Unngå superlativer og amerikansk stil
 - Konsekvent bokmål, ikke bland inn nynorsk
+- Vanlige nynorsk-feil fra KI: -ingar (skal være -inger), -leg (skal være -lig), kv- (skal være hv-), ei-/eig- (skal være e-/eg-), medan→mens, vorte→blitt, vart→ble, berre→bare, mykje→mye, difor→derfor
+- Svensk som siver inn: engångs-→engangs-, ändring→endring (å/ä der bokmål har a/e)

--- a/apps/my-copilot/src/lib/copilot-manifest.json
+++ b/apps/my-copilot/src/lib/copilot-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-05-22T08:37:23.796Z",
+  "generatedAt": "2026-05-27T08:30:22.228Z",
   "items": [
     {
       "id": "accessibility-agent",
@@ -204,7 +204,7 @@
       "domain": "general",
       "filePath": ".github/agents/forfatter.agent.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/agents/forfatter.agent.md",
-      "contentHash": "6cc31221eab50d30ed73a404027cfb6fa5dd36375ed58afc6681e1c45880a199",
+      "contentHash": "3dd47103e9bf04a8f92223e817d25077ba9e329de10389fc5f0bfb7f18e1cd99",
       "installUrl": "/install/agent?url=vscode%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fagents%2Fforfatter.agent.md",
       "insidersInstallUrl": "/install/agent?url=vscode-insiders%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fagents%2Fforfatter.agent.md",
       "tools": [
@@ -736,7 +736,7 @@
       "domain": "general",
       "filePath": ".github/instructions/norwegian-text.instructions.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/instructions/norwegian-text.instructions.md",
-      "contentHash": "910d811f828ba0073d7039f7ddedb77bb7ee48c3ab4299896d80e74c39e5e39a",
+      "contentHash": "890c8475efa051a50c510c2b6f0e219a2acbf603ecbb178e2a32abc3857afe9c",
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fnorwegian-text.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fnorwegian-text.instructions.md",
       "applyTo": "**/*.md",

--- a/docs/news/articles/agenter-skills-instruksjoner.md
+++ b/docs/news/articles/agenter-skills-instruksjoner.md
@@ -125,7 +125,7 @@ Trenger du verktøybegrensning, modellvalg eller MCP?
 Er det domenekunnskap, workflow eller prosedyre?
   → Ja → Skill (SKILL.md)
 
-Er det en enkel engångsoppgave med forhåndsdefinert kontekst?
+Er det en enkel engangsoppgave med forhåndsdefinert kontekst?
   → Ja → Prompt (.prompt.md)
 ```
 

--- a/docs/news/articles/april-2026.md
+++ b/docs/news/articles/april-2026.md
@@ -16,7 +16,7 @@ tags:
   - dependabot
 ---
 
-April 2026 var måneden GitHub la om kostnadsmodellen for Copilot, åpnet EU-dataopphold med Norge dekket via EFTA, og ga utviklere et helt nytt sett verktøy: Autopilot i VS Code, `gh skill` i terminalen, og to nye toppmodeller. Her er det viktigste for Nav-utviklere.
+April 2026 var måneden GitHub la om kostnadsmodellen for Copilot, åpnet EU-dataopphold med Norge dekket via EFTA, og ga utviklere nye verktøy: Autopilot i VS Code, `gh skill` i terminalen og to nye toppmodeller. Her er det viktigste for Nav-utviklere.
 
 ---
 
@@ -93,7 +93,7 @@ Noen avhengighetssårbarheter krever mer enn en versjonsbump — de trenger kode
 
 Du kan tildele flere agenter til samme varsel — hver jobber uavhengig og åpner sin egen PR, så du kan sammenligne tilnærminger. Spesielt nyttig for major version-oppgraderinger med breaking changes, nedgradering av kompromitterte pakker, og komplekse scenarier som faller utenfor Dependabots regelmotor.
 
-For Navs ~500 repoer kan dette akselerere sikkerhetsoppdateringer betraktelig. Krever GitHub Code Security og Copilot-abonnement med tilgang til coding agent.
+For Navs ~500 repoer kan dette gi raskere sikkerhetsoppdateringer. Krever GitHub Code Security og Copilot-abonnement med tilgang til coding agent.
 
 **Kilde:** [Dependabot alerts are now assignable to AI agents for remediation](https://github.blog/changelog/2026-04-07-dependabot-alerts-are-now-assignable-to-ai-agents-for-remediation) (GitHub Changelog, 7. april 2026)
 
@@ -119,7 +119,7 @@ Den høye prisen gjør at de bør spares til oppgaver der billigere modeller fak
 
 ## 7. Agentsesjoner synlige i Issues og Projects
 
-Cloud agent-sesjoner er nå synlige direkte i GitHub Issues og Projects. En «session pill» på issues viser aktive og fullførte agentsesjoner, og du kan åpne en sesjon i sidepanelet for å se fremdrift, gjennomgå logger eller gi agenten retning — uten å forlate issue-visningen.
+Cloud agent-sesjoner er nå synlige direkte i GitHub Issues og Projects. En «session pill» på issues viser aktive og fullførte agentsesjoner, og du kan åpne en sesjon i sidepanelet for å se fremdrift, gjennomgå logger eller gi agenten retning — uten å gå ut av issue-visningen.
 
 I Projects er «Show agent sessions» aktivert som standard for både nye og eksisterende visninger. Klikk på en agentsesjon i prosjekttavlen for å åpne den i sidepanelet.
 
@@ -129,7 +129,7 @@ Dette gjør det lettere å holde oversikt over agentaktivitet i planleggingskont
 
 ---
 
-## Også verdt å vite
+## Flere korte oppdateringer
 
 Korte oppdateringer som er nyttige å kjenne til, men som ikke krever handling fra de fleste:
 

--- a/docs/news/articles/bevisst-ai-bruk-rammeverk.md
+++ b/docs/news/articles/bevisst-ai-bruk-rammeverk.md
@@ -46,7 +46,7 @@ Vi har bygget disse prinsippene direkte inn i Copilot-oppsettet:
 - **Nav-pilot** varsler om kompetansebevaring i blindsone-sjekken
 - **Kodegjennomgang** sjekker at utvikleren forstår AI-genererte designvalg
 
-Verktøyene *oppfordrer* til refleksjon, men de kan ikke tvinge det. Rammeverket er til syvende og sist en personlig praksis — et sett med vaner som beskytter den dype forståelsen mens du bruker AI der det gir faktisk verdi.
+Verktøyene *oppfordrer* til refleksjon, men de kan ikke tvinge det. Rammeverket er til syvende og sist en personlig praksis — vaner som beskytter den dype forståelsen mens du bruker AI der det faktisk gir verdi.
 
 ## Les mer
 

--- a/docs/news/articles/mai-2026.md
+++ b/docs/news/articles/mai-2026.md
@@ -61,7 +61,7 @@ Sjekk VS Code-innstillinger etter oppgradering. Team med strenge regler for comm
 
 ## 4. Rubber Duck i Copilot CLI støtter flere modeller
 
-Rubber Duck-agenten i Copilot CLI bruker nå Claude som kritiker i GPT-sesjoner og GPT-5.5 som kritiker i Claude-sesjoner. Det gir second opinion på tvers av modellfamilier — nyttig for code review der du vil ha et motvekt-perspektiv.
+Rubber Duck-agenten i Copilot CLI bruker nå Claude som kritiker i GPT-sesjoner og GPT-5.5 som kritiker i Claude-sesjoner. Det gir second opinion på tvers av modellfamilier — nyttig for code review der du vil ha et motperspektiv.
 
 **Kilde:** [Rubber Duck in GitHub Copilot CLI now supports more models](https://github.blog/changelog/2026-05-07-rubber-duck-in-github-copilot-cli-now-supports-more-models/) (GitHub Changelog, 7. mai 2026)
 
@@ -101,7 +101,7 @@ Nytt: `cplt init` skanner prosjektet for byggsystemer og rammeverk, og genererer
 
 ## 8. GitHub Copilot-appen i technical preview
 
-GitHub lanserer en dedikert desktopapp for Copilot. Appen er en GitHub-native opplevelse for agentisk utvikling — du starter oppgaver direkte fra issues, PR-er eller kode, holder dem isolert i egne miljøer, og styrer dem fra ett samlet grensesnitt.
+GitHub lanserer en dedikert desktopapp for Copilot. Appen er GitHub-native og laget for agentisk utvikling — du starter oppgaver direkte fra issues, PR-er eller kode, holder dem isolert i egne miljøer og styrer dem fra ett samlet grensesnitt.
 
 Dette er første gang Copilot lever utenfor en IDE som en frittstående app. Målet er å gjøre det enklere å starte og overvåke agentiske oppgaver uten å forstyrre det du allerede jobber med i editoren.
 
@@ -119,7 +119,7 @@ Copilot usage metrics API har fått et nytt user-teams-endepunkt som mapper hver
 
 ## 10. Cloud agent støtter automatisk modellvalg
 
-Copilot cloud agent støtter nå «Auto» i modellvelgeren. Når du velger Auto, velger Copilot intelligent den beste tilgjengelige modellen basert på systemhelse og modellkapasitet. Dette gir bedre tilgjengelighet og potensielt lavere kostnad uten at du trenger å velge modell manuelt.
+Copilot cloud agent støtter nå «Auto» i modellvelgeren. Når du velger Auto, velger Copilot automatisk den best tilgjengelige modellen basert på systemhelse og modellkapasitet. Dette gir bedre tilgjengelighet og potensielt lavere kostnad uten at du trenger å velge modell manuelt.
 
 **Kilde:** [Copilot cloud agent supports auto model selection](https://github.blog/changelog/2026-05-14-copilot-cloud-agent-supports-auto-model-selection) (GitHub Changelog, 14. mai 2026)
 
@@ -246,7 +246,7 @@ Googles nyeste Flash-modell ruller ut i GitHub Copilot. Gemini 3.5 Flash gir næ
 | Copilot Memory-preferanser | Foreløpig kun Pro/Pro+, men signaliserer retningen. Når det kommer til Business/Enterprise kan det forenkle onboarding og personalisering. |
 | Ett-klikks Actions-fiks | Reduserer tid på CI-feil — cloud agent fikser enkle testfeil og linter-brudd uten at utvikleren trenger å bytte kontekst. |
 | Raske modeller i cloud agent | Nav kan spare AI Credits ved å bruke Flash-modeller for enkle oppgaver. Relevant med bruksbasert fakturering fra 1. juni. |
-| Spaces API GA | Muliggjør automatisert Space-administrasjon — relevant for Nav-team som onboarder mange repoer med felles kontekst. |
+| Spaces API GA | Gjør automatisert Space-administrasjon mulig — relevant for Nav-team som onboarder mange repoer med felles kontekst. |
 | Remote control GA | Utviklere kan styre CLI-sesjoner fra mobil eller nett — nyttig for langvarige agent-oppgaver. Støtter nå ikke-GitHub-repoer. |
 | Audit-API for cloud agent | Nav kan programmatisk verifisere at MCP-servere, verktøy og brannmur er konfigurert korrekt på tvers av repoer. Viktig for governance. |
 | Gemini 3.5 Flash | Ny modell med god agentstøtte og lav kostnad. Admin må aktivere i modellpolicyen. 14× multiplikator kan gjøre den dyrere enn forventet. |

--- a/docs/news/articles/model-pinning-kostnadsoptimalisering.md
+++ b/docs/news/articles/model-pinning-kostnadsoptimalisering.md
@@ -154,13 +154,13 @@ Model-pinning er første steg. Framover ser vi på:
 - **Forbruksoversikt:** Dashbord på min-copilot.ansatt.nav.no som viser hvem som bruker mest. Ikke for å henge ut noen, men for å lære av hverandre.
 - **Erfaringsdeling fra storforbrukere:** De som bruker mest AI Credits, blir invitert til å dele hva de jobber med og hvordan de bruker agenter. Målet er å spre gode arbeidsmønstre.
 
-Vi tror de mest aktive brukerne har verdifull innsikt i hva som fungerer — og hva som ikke gjør det. Den innsikten vil vi gjøre tilgjengelig for alle.
+Vi tror de mest aktive brukerne har verdifull innsikt i hva som fungerer — og hva som ikke gjør det. Den innsikten vil vi dele bredt.
 
 ## Hva du merker
 
 Ingenting — `model:` setter default, men du kan fortsatt velge modell manuelt i model picker. I juni oppgraderer vi til Opus 4.7 — da koster alle Opus-modeller det samme per token.
 
-**Bruk [`@nav-pilot`](/nav-pilot) for tunge oppgaver.** Nav-pilot er vår primæragent for arkitektur, planlegging og implementering. Den bruker model-pinning med Opus 4.6 og GPT-5.3-Codex som fallback — du får altså den kraftigste modellen automatisk når du trenger den, uten å velge Opus manuelt for alt annet. For vanlig chat og kodearbeid: bruk Auto.
+**Bruk [`@nav-pilot`](/nav-pilot) for tunge oppgaver.** Nav-pilot er vår primæragent for arkitektur, planlegging og implementering. Den bruker model-pinning med Opus 4.6 og GPT-5.3-Codex som fallback — du får automatisk den kraftigste modellen når du trenger den, uten å velge Opus manuelt for alt annet. For vanlig chat og kodearbeid: bruk Auto.
 
 **Oppgrader nav-pilot for å få siste versjon.** Kjør `nav-pilot sync` i terminalen for å hente oppdaterte agenter, skills og modellinnstillinger. Da får du automatisk de nye kostnadsoptimaliserte modellvalgene.
 


### PR DESCRIPTION
## Hva

Forfatter-agenten fanger nå opp nynorske og svenske ord som KI-modeller blander inn i bokmålstekst.

**Bakgrunn:** Brukertilbakemelding om at AI skriver "engångsoppgave" og lignende — svensk/nynorsk-former som siver inn i bokmål.

## Endringer

### `.github/agents/forfatter.agent.md`
- Ny seksjon **"Nynorsk og svensk som siver inn"** med:
  - 30+ vanlige nynorsk→bokmål-korreksjoner (eigenskap→egenskap, endringar→endringer, medan→mens, vorte→blitt, etc.)
  - 7 svenske ord/former (engångs-→engangs-, ändring→endring)
  - Mønstergjenkjenning: `-ingar`, `-leg`, `-aste`, `ei/eig-`, `kv-`, `å↔a`, `-ar/-ane`
  - Avgrensning mot gyldige a-endelser (oppdaga, fila er OK bokmål)
- Oppdatert arbeidsflyt med eksplisitt steg 3: sjekk for nynorsk/svensk-innblanding
- Kilde: [Språkrådets KI-rapport (2025)](https://sprakradet.no/aktuelt/ki-sprakets-fallgruver/)

### `.github/instructions/norwegian-text.instructions.md`
- Kompakt oppsummering av nynorsk/svensk-mønstrene (gjelder automatisk for all markdown)

### Manifest
- Regenerert `copilot-manifest.json` med oppdatert forfatter-innhold

## Verifisering

- Skannet alle ~90 nyhetsartikler — ingen nynorsk-innblanding funnet
- TypeScript kompilerer uten feil
- Prettier/ESLint passerer

Closes #252 (delvis — nynorsk-deteksjon var en del av kvalitetsarbeidet)