### PR TITLE
docs(news): rewrite token article for terminal-first Nav developers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,9 @@ All apps deployed on NAIS (Kubernetes on GCP).
 
 ## Target Users
 
-Our primary users are ~600 developers at Nav who use GitHub Copilot daily. Most write **Kotlin** (backend, Ktor/Spring) and **TypeScript/React** (frontend, Next.js) and are comfortable in both IntelliJ and VS Code.
+Our primary users are ~600 developers at Nav who use GitHub Copilot daily. The vast majority are developers in product teams with end-to-end responsibility for their applications — they build, deploy, operate, and monitor their own services. Most write **Kotlin** (backend, Ktor/Spring) and **TypeScript/React** (frontend, Next.js) and are comfortable in both IntelliJ and VS Code.
+
+A smaller group of non-developers also use the tools: operators, designers, and architects. Our tooling is optimized for developers, but should remain accessible to anyone working in a repo.
 
 We are pushing developers towards **autonomous AI agent work in the terminal** — primarily Copilot CLI, but our most advanced users also use tools like opencode and Pi (all backed by their corporate GitHub Copilot subscription). Demand is high, which makes cost optimization a priority: keep token costs down without sacrificing quality.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,25 @@ Monorepo containing Nav's GitHub Copilot ecosystem tools:
 
 All apps deployed on NAIS (Kubernetes on GCP).
 
+## Target Users
+
+Our primary users are ~600 developers at Nav who use GitHub Copilot daily. They interact primarily through **Copilot CLI** (terminal) and **VS Code Copilot Chat**.
+
+### User profiles
+
+| Profile | Description | Primary interface | Interaction style |
+|---------|-------------|-------------------|-------------------|
+| **Terminal-first developer** | Uses Copilot CLI for code generation, refactoring, debugging. Prefers keyboard and command line. | `copilot` CLI | Writes task descriptions, expects code output. Invokes skills by name in messages. |
+| **VS Code chat user** | Uses Copilot Chat panel alongside editor. Selects files, asks questions about code. | VS Code Chat | `@nav-pilot` + natural language. Uses `$skill-name` or just skill names inline. |
+| **Team lead / platform** | Manages collections, instructions, and customizations for their team. | `.github/` config files | Edits YAML/markdown, runs `mise` commands. |
+
+### How users interact with nav-pilot and skills
+
+1. **Default experience**: User writes `@nav-pilot` (VS Code) or just starts a session in a repo with our collections installed (CLI). Nav-pilot applies conventions silently, interviews when needed, delivers code.
+2. **Skills are invoked by name** in the chat message — either with `$` prefix (`$terse-mode`) or without (`bruk terse-mode`). The `$` is our visual convention, not required syntax. Skills work in VS Code, Copilot CLI, and cloud agent.
+3. **Most users never invoke skills manually.** Nav-pilot auto-routes relevant knowledge based on file types and request context. Skills exist for power users who want explicit control.
+4. **Instructions load automatically** based on `applyTo` glob patterns — users don't need to know they exist.
+
 ## Build & Test Commands
 
 From repo root:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,11 +27,12 @@ We are pushing developers towards **autonomous AI agent work in the terminal** �
 
 ### How users interact with nav-pilot and skills
 
-1. **Default experience**: User writes `@nav-pilot` (VS Code) or starts a session in a repo with our collections installed (CLI). Nav-pilot applies conventions silently, interviews when needed, delivers code.
-2. **Skills are invoked by name** in the chat message — either with `$` prefix (`$terse-mode`) or without (`bruk terse-mode`). The `$` is our visual convention, not required syntax. Skills work across VS Code, Copilot CLI, opencode, and cloud agent.
-3. **Most users never invoke skills manually.** Nav-pilot auto-routes relevant knowledge based on file types and request context. Skills exist for power users who want explicit control.
-4. **Instructions load automatically** based on `applyTo` glob patterns — users don't need to know they exist.
-5. **Cost awareness**: With usage-based billing, every token counts. Our tooling defaults to concise output, on-demand skill loading, and focused sessions to keep costs down without user effort.
+1. **Primary entry point**: `nav-pilot --sync` syncs configs and launches Copilot CLI with the `@nav-pilot` agent. This is the recommended way to start AI coding sessions — it ensures collections, instructions, and skills are up to date.
+2. **In VS Code**: User writes `@nav-pilot` in Chat. Same agent, same conventions, just a different interface.
+3. **Skills are invoked by name** in the chat message — either with `$` prefix (`$terse-mode`) or without (`bruk terse-mode`). The `$` is our visual convention, not required syntax. Skills work across VS Code, Copilot CLI, opencode, and cloud agent.
+4. **Most users never invoke skills manually.** Nav-pilot auto-routes relevant knowledge based on file types and request context. Skills exist for power users who want explicit control.
+5. **Instructions load automatically** based on `applyTo` glob patterns — users don't need to know they exist.
+6. **Cost awareness**: With usage-based billing, every token counts. Our tooling defaults to concise output, on-demand skill loading, and focused sessions to keep costs down without user effort.
 
 ## Build & Test Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,22 +11,25 @@ All apps deployed on NAIS (Kubernetes on GCP).
 
 ## Target Users
 
-Our primary users are ~600 developers at Nav who use GitHub Copilot daily. They interact primarily through **Copilot CLI** (terminal) and **VS Code Copilot Chat**.
+Our primary users are ~600 developers at Nav who use GitHub Copilot daily. Most write **Kotlin** (backend, Ktor/Spring) and **TypeScript/React** (frontend, Next.js) and are comfortable in both IntelliJ and VS Code.
+
+We are pushing developers towards **autonomous AI agent work in the terminal** — primarily Copilot CLI, but our most advanced users also use tools like opencode and Pi (all backed by their corporate GitHub Copilot subscription). Demand is high, which makes cost optimization a priority: keep token costs down without sacrificing quality.
 
 ### User profiles
 
-| Profile | Description | Primary interface | Interaction style |
-|---------|-------------|-------------------|-------------------|
-| **Terminal-first developer** | Uses Copilot CLI for code generation, refactoring, debugging. Prefers keyboard and command line. | `copilot` CLI | Writes task descriptions, expects code output. Invokes skills by name in messages. |
-| **VS Code chat user** | Uses Copilot Chat panel alongside editor. Selects files, asks questions about code. | VS Code Chat | `@nav-pilot` + natural language. Uses `$skill-name` or just skill names inline. |
-| **Team lead / platform** | Manages collections, instructions, and customizations for their team. | `.github/` config files | Edits YAML/markdown, runs `mise` commands. |
+| Profile | Description | Primary interface |
+|---------|-------------|-------------------|
+| **IDE developer** | Majority of users. Codes in IntelliJ or VS Code, uses Copilot Chat for quick questions and inline completions. | VS Code Chat / IntelliJ |
+| **Terminal agent user** | Growing segment. Runs multi-step agentic sessions for scaffolding, refactoring, debugging. Prefers keyboard-driven workflow. | Copilot CLI, opencode, Pi |
+| **Team lead / platform** | Manages collections, instructions, and customizations for their team. Configures what developers get out of the box. | `.github/` config files, `mise` tasks |
 
 ### How users interact with nav-pilot and skills
 
-1. **Default experience**: User writes `@nav-pilot` (VS Code) or just starts a session in a repo with our collections installed (CLI). Nav-pilot applies conventions silently, interviews when needed, delivers code.
-2. **Skills are invoked by name** in the chat message — either with `$` prefix (`$terse-mode`) or without (`bruk terse-mode`). The `$` is our visual convention, not required syntax. Skills work in VS Code, Copilot CLI, and cloud agent.
+1. **Default experience**: User writes `@nav-pilot` (VS Code) or starts a session in a repo with our collections installed (CLI). Nav-pilot applies conventions silently, interviews when needed, delivers code.
+2. **Skills are invoked by name** in the chat message — either with `$` prefix (`$terse-mode`) or without (`bruk terse-mode`). The `$` is our visual convention, not required syntax. Skills work across VS Code, Copilot CLI, opencode, and cloud agent.
 3. **Most users never invoke skills manually.** Nav-pilot auto-routes relevant knowledge based on file types and request context. Skills exist for power users who want explicit control.
 4. **Instructions load automatically** based on `applyTo` glob patterns — users don't need to know they exist.
+5. **Cost awareness**: With usage-based billing, every token counts. Our tooling defaults to concise output, on-demand skill loading, and focused sessions to keep costs down without user effort.
 
 ## Build & Test Commands
 

--- a/docs/news/articles/token-forbruk-verktoy-teknikker.md
+++ b/docs/news/articles/token-forbruk-verktoy-teknikker.md
@@ -42,9 +42,11 @@ Når du starter Copilot via `nav-pilot`, får du automatisk:
 
 I VS Code Chat kan du skrive `@nav-pilot` for å få det samme.
 
-## Vil du ha enda kortere svar? Bruk `$terse-mode`
+## Vil du ha enda kortere svar? Bruk `terse-mode`
 
-`$`-prefikset er vår konvensjon for å markere skill-navn — det gjør det tydelig for både deg og agenten at du ber om en spesifikk [skill](https://code.visualstudio.com/docs/copilot/customization/agent-skills). Du kan også bare skrive navnet uten `$` (f.eks. «terse-mode» eller «bruk terse-mode»). Agenten gjenkjenner det uansett. Skriv `$terse-mode` for å skru på ekstra kompakt stil. Tre nivåer:
+Skills er tilleggskunnskap nav-pilot kan bruke. Du aktiverer dem ved å skrive navnet i meldingen — enten med `$`-prefiks (`$terse-mode`) eller uten (`bruk terse-mode`). `$` er vår visuelle konvensjon, ikke påkrevd syntax. Les mer om [skills i VS Code-dokumentasjonen](https://code.visualstudio.com/docs/copilot/customization/agent-skills).
+
+Skriv `terse-mode` for å skru på ekstra kompakt stil. Tre nivåer:
 
 | Nivå | Hva den gjør | Eksempel |
 | ---- | ------------ | -------- |
@@ -55,9 +57,9 @@ I VS Code Chat kan du skrive `@nav-pilot` for å få det samme.
 Slik bruker du det:
 
 ```text
-@nav-pilot $terse-mode          ← slår på normal-nivå
-@nav-pilot $terse-mode ultra    ← for raske iterasjoner
-Stopp terse                     ← tilbake til vanlig stil
+terse-mode                ← slår på normal-nivå
+terse-mode ultra          ← for raske iterasjoner
+Stopp terse               ← tilbake til vanlig stil
 ```
 
 Stilen vedvarer hele sesjonen. Ved sikkerhetsvarsler eller destruktive handlinger bytter den automatisk tilbake til full prosa — du mister aldri viktig informasjon.

--- a/docs/news/articles/token-forbruk-verktoy-teknikker.md
+++ b/docs/news/articles/token-forbruk-verktoy-teknikker.md
@@ -29,7 +29,7 @@ Du trenger ikke gjøre noe spesielt. Bare bruk `@nav-pilot` i stedet for standar
 
 ## Vil du ha enda kortere svar? Bruk `$terse-mode`
 
-Skriv `$terse-mode` i en Copilot-sesjon for å skru på ekstra kompakt stil. Tre nivåer:
+`$`-prefikset er Copilot sin måte å aktivere en [skill](https://code.visualstudio.com/docs/copilot/customization/agent-skills) — tenk på det som en kommando du skriver i chatten. Skriv `$terse-mode` for å skru på ekstra kompakt stil. Tre nivåer:
 
 | Nivå | Hva den gjør | Eksempel |
 | ---- | ------------ | -------- |
@@ -61,19 +61,21 @@ Den dyreste token-sløsingen er misforståelser. Fem runder med «mente du A ell
 
 Jo mer kontekst du gir i første melding, jo færre runder bruker du.
 
-### 2. Bruk `$nav-deep-interview` for store oppgaver
+### 2. For store oppgaver: la intervjuet gjøre jobben
 
-Før en større endring (ny tjeneste, stor refaktor): start med [`$nav-deep-interview`](https://github.com/navikt/copilot/blob/main/.github/skills/nav-deep-interview/SKILL.md). Den stiller presise spørsmål om personvern, auth og avhengigheter *før* koden skrives.
+`@nav-pilot` starter alltid med en intervjufase der den kartlegger blindsoner — personvern, auth, avhengigheter. For små oppgaver går dette raskt. For store oppgaver (ny tjeneste, stor refaktor) bruker den mer tid på å stille presise spørsmål.
+
+Hvis du vil ha et enda grundigere intervju, kan du be om det eksplisitt med `$nav-deep-interview`. Den kjører en strukturert gjennomgang med impactanalyse og dekker flere områder enn standardintervjuet.
 
 Fem minutter med avklaring slår en bortkastet sesjon.
 
 ### 3. Hold sesjoner fokuserte
 
-Copilot sender hele samtalehistorikken med hver melding. Jo lengre samtale, jo mer betaler du per svar. Én oppgave per sesjon holder kostnadene nede og gir bedre svar.
+Copilot bruker [prompt caching](/nyheter/model-pinning-kostnadsoptimalisering) — kontekst fra tidligere i sesjonen koster opptil 90 % mindre enn ny kontekst. Det betyr at du *ikke* trenger å starte ny sesjon bare for å spare penger. Men en fokusert sesjon gir bedre svar fordi modellen slipper å filtrere bort irrelevant historikk.
 
-- Start ny sesjon når du bytter oppgave
-- Skriv tydelig hva du vil ha i første melding
-- Unngå «kan du også...» etter at oppgaven er ferdig
+- Én oppgave per sesjon gir mer presise svar
+- Unngå «kan du også...» som tar sesjonen i helt ny retning
+- Lang, ufokusert historikk forvirrer — ikke bare koster
 
 ### 4. La `@nav-pilot` finne verktøyene
 
@@ -92,8 +94,8 @@ Du kan be om en spesifikk skill med `$skill-navn`, men for de fleste oppgaver kl
 | Bruk `@nav-pilot` | Alle | Skriv `@nav-pilot` foran spørsmålet — kompakte svar er standard |
 | `$terse-mode` | Deg som vil ha kortere svar | Skriv `$terse-mode` i starten av sesjonen |
 | Vær presis | Alle | Nevn språk, rammeverk og integrasjoner i første melding |
-| `$nav-deep-interview` | Nye tjenester, stor refaktor | Skriv `$nav-deep-interview` før du starter |
-| Ny sesjon per oppgave | Alle | Lukk gammel sesjon, start ny når du bytter fokus |
+| `$nav-deep-interview` | Nye tjenester, stor refaktor | Skriv `$nav-deep-interview` for grundigere avklaring |
+| Fokuserte sesjoner | Alle | Hold deg til én oppgave per sesjon — bedre svar |
 
 ---
 

--- a/docs/news/articles/token-forbruk-verktoy-teknikker.md
+++ b/docs/news/articles/token-forbruk-verktoy-teknikker.md
@@ -62,7 +62,7 @@ Stopp terse                     ← tilbake til vanlig stil
 
 Stilen vedvarer hele sesjonen. Ved sikkerhetsvarsler eller destruktive handlinger bytter den automatisk tilbake til full prosa — du mister aldri viktig informasjon.
 
-## Fire vaner som kutter kostnader
+## Fem vaner som kutter kostnader
 
 ### 1. Vær presis i spørsmålet
 
@@ -78,9 +78,9 @@ Jo mer kontekst du gir i første melding, jo færre runder bruker du.
 
 ### 2. For store oppgaver: la intervjuet gjøre jobben
 
-`@nav-pilot` starter alltid med en intervjufase der den kartlegger blindsoner — personvern, auth, avhengigheter. For små oppgaver går dette raskt. For store oppgaver (ny tjeneste, stor refaktor) bruker den mer tid på å stille presise spørsmål.
+For små oppgaver gjør nav-pilot jobben direkte — ingen spørsmål. For medium/store oppgaver går den gjennom en kort intervjufase der den sjekker blindsoner som personvern, auth og avhengigheter.
 
-Hvis du vil ha et enda grundigere intervju, kan du be om det eksplisitt med `$nav-deep-interview`. Den kjører en strukturert gjennomgang med impactanalyse og dekker flere områder enn standardintervjuet.
+Hvis du vil ha et enda grundigere intervju, be om det med `nav-deep-interview`. Den kjører en strukturert gjennomgang med impactanalyse.
 
 Fem minutter med avklaring slår en bortkastet sesjon.
 
@@ -92,25 +92,54 @@ Copilot bruker [prompt caching](/nyheter/model-pinning-kostnadsoptimalisering) �
 - Unngå «kan du også...» som tar sesjonen i helt ny retning
 - Lang, ufokusert historikk forvirrer — ikke bare koster
 
-### 4. La `@nav-pilot` finne verktøyene
+### 4. La nav-pilot finne verktøyene
 
-Du trenger ikke huske alle skills. `@nav-pilot` bruker riktig kunnskap basert på konteksten:
+Du trenger ikke huske alle skills. Nav-pilot bruker riktig kunnskap basert på konteksten:
 
-- Skriver du Go eller Kotlin? → Sikkerhetsregler (OWASP) er allerede aktive
+- Skriver du Kotlin eller TypeScript? → Sikkerhetsregler (OWASP) er allerede aktive
 - Jobber du med Nais-manifest? → Nais-kunnskap aktiveres
 - Trenger du auth? → TokenX/Azure AD-kunnskap brukes
 
-Du kan be om en spesifikk skill med `$skill-navn`, men for de fleste oppgaver klarer nav-pilot seg selv.
+Du kan be om en spesifikk skill med navn (f.eks. `bruk terse-mode`), men for de fleste oppgaver klarer nav-pilot seg selv.
+
+### 5. Hjelp agenten med å lese mindre
+
+I terminalen er den største token-lekkasjen ofte verktøyoutput — testlogger, stacktraces, store diffs. Noen vaner som hjelper:
+
+- La agenten lese filer selv i stedet for å lime inn hele filer
+- Ved testfeil: gi den relevante feilmeldingen, ikke hele build-loggen
+- Be agenten kjøre målrettede tester (`./gradlew test --tests *MinTest`) før full pipeline
+- Pek på branch eller fil for diff i stedet for å lime inn manuelt
+
+## Gode første meldinger
+
+Eksempler som gir presise svar uten mange oppfølgingsrunder:
+
+```text
+Legg til et nytt REST-endepunkt /vedtak/{id} i Ktor-appen.
+Valider tilgang med TokenX. Hent vedtak fra Postgres via kotliquery.
+Les eksisterende endepunkter i src/main/kotlin/routes/ for stil.
+
+Finn ut hvorfor /soknader-siden i Next.js-appen re-rendrer mye.
+Sjekk komponenten i src/app/soknader/page.tsx. Foreslå minimal fix.
+
+Podden dp-soknad krasjer i dev med OOMKilled. Se på .nais/dev.yaml
+og foreslå justeringer. Ikke endre prod-konfig.
+
+Migrer denne Java-klassen til idiomatic Kotlin. Behold samme
+offentlige API. Bruk sealed class for feilhåndtering.
+```
 
 ## Oppsummert
 
 | Tips | For hvem | Hva du gjør |
 | ---- | -------- | ----------- |
 | Start via `nav-pilot` | Alle | `nav-pilot --sync` synkroniserer og starter Copilot med riktig oppsett |
-| `$terse-mode` | Deg som vil ha kortere svar | Skriv `terse-mode` eller `$terse-mode` i starten av sesjonen |
 | Vær presis | Alle | Nevn språk, rammeverk og integrasjoner i første melding |
-| `$nav-deep-interview` | Nye tjenester, stor refaktor | Skriv `$nav-deep-interview` for grundigere avklaring |
-| Fokuserte sesjoner | Alle | Hold deg til én oppgave per sesjon — bedre svar |
+| Fokuserte sesjoner | Alle | Én oppgave per sesjon — start ny når du bytter problem |
+| La agenten lese | Alle i terminalen | Ikke lim inn store filer/logger — la agenten lese selv |
+| `terse-mode` | Deg som vil ha kortere svar | Skriv `terse-mode` i starten av sesjonen |
+| `nav-deep-interview` | Nye tjenester, stor refaktor | Skriv `nav-deep-interview` for grundigere avklaring |
 
 ---
 
@@ -160,7 +189,9 @@ brew install rtk
 rtk init -g --copilot
 ```
 
-RTK rapporterer 60–90 % reduksjon på verktøydata. RTK og `$terse-mode` utfyller hverandre: RTK kutter det agenten *leser*, terse-mode kutter det agenten *skriver*.
+RTK rapporterer 60–90 % reduksjon på verktøydata. RTK og terse-mode utfyller hverandre: RTK kutter det agenten *leser*, terse-mode kutter det agenten *skriver*.
+
+**Merk:** RTK prosesserer terminaloutput lokalt. Sjekk at verktøyet er godkjent for ditt team før du bruker det med output som kan inneholde sensitive data.
 
 ### TOON og dynamiske verktøysett
 

--- a/docs/news/articles/token-forbruk-verktoy-teknikker.md
+++ b/docs/news/articles/token-forbruk-verktoy-teknikker.md
@@ -21,7 +21,7 @@ En [2026-studie](https://arxiv.org/abs/2604.00025) fant at modeller ble mer tref
 `nav-pilot` er kommandolinjeverktøyet som holder Copilot-oppsettet ditt oppdatert og starter Copilot med riktig konfigurasjon. Den enkleste måten å starte en AI-sesjon:
 
 ```bash
-nav-pilot --sync    # synkroniserer, deretter starter Copilot med @nav-pilot-agenten
+nav-pilot --sync    # synkroniserer, deretter starter Copilot med @nav-pilot
 ```
 
 Eventuelt steg for steg:

--- a/docs/news/articles/token-forbruk-verktoy-teknikker.md
+++ b/docs/news/articles/token-forbruk-verktoy-teknikker.md
@@ -3,187 +3,158 @@ title: "Slik holder du token-forbruket nede"
 date: 2026-05-28
 author: starefossen
 category: praksis
-excerpt: "Praktiske verktøy og teknikker for å redusere token-forbruk i agentiske arbeidsflyter — fra native $terse-mode og RTK til kontekstkomprimering og smartere instruksjonsarkitektur."
+excerpt: "Praktiske tips for å få raskere og billigere Copilot-svar — fra innebygd $terse-mode til smarte vaner som sparer tokens."
 tags:
   - token-optimization
   - cost-optimization
   - tools
   - agents
-  - context-engineering
-  - instructions
-  - skills
-  - owasp
+  - nav-pilot
 ---
 
-Med [bruksbasert fakturering](/nyheter/model-pinning-kostnadsoptimalisering) blir token-forbruk direkte synlig på regningen. Den skjulte kostnadsdriveren er ofte input-tokens: hver runde i en agentisk sesjon sender hele konteksten på nytt — systemprompt, instruksjonsfiler, åpne filer og samtalehistorikk. En enkelt flerstegs-sesjon i Copilot CLI kan bruke over 1 million input-tokens. [Vantage sin analyse](https://www.vantage.sh/blog/agentic-coding-costs) viser at kostnader varierer opptil 30x mellom kjøringer på samme oppgave.
+Med [bruksbasert fakturering](/nyheter/model-pinning-kostnadsoptimalisering) betaler du per token. Lange sesjoner med mye frem og tilbake koster mer. Den gode nyheten: du kan få kortere, mer presise svar uten å miste kvalitet — og det er enklere enn du tror.
 
-Nytt funn fra forskningen gjør dette ekstra interessant: en [2026-studie på arXiv](https://arxiv.org/abs/2604.00025) fant at store modeller ble **26 prosentpoeng mer treffsikre** på enkelte resonneringsoppgaver når de ble tvunget til å svare kort. For mye forklaring gir flere feil. Terse betyr derfor ikke nødvendigvis dårligere svar.
+En [2026-studie](https://arxiv.org/abs/2604.00025) fant at modeller ble mer treffsikre når de ble tvunget til å svare kort. Kortere svar er altså ikke bare billigere — de kan også være bedre.
 
-Her er verktøy og teknikker som fungerer med GitHub Copilot-økosystemet i dag.
+## Det viktigste først: bruk `@nav-pilot`
 
-## Konkrete tall fra dette repoet
+`@nav-pilot` er allerede satt opp for å gi deg kompakte svar. Den:
 
-Vi flyttet `security-owasp.instructions.md` fra alltid-aktiv instruks til en on-demand skill. Før ble OWASP-referansen lastet ved hver Go- og Kotlin-redigering, også når oppgaven ikke handlet om sikkerhet. Nå ligger bare en kort instruksjonsstub igjen med kritiske regler og peker til skillen.
+- Starter med konklusjonen, ikke forklaringen
+- Viser kode direkte uten lang innledning
+- Tilbyr «Si 'forklar' for detaljer» når den hopper over begrunnelse
+- Spør bare når svaret faktisk endrer implementeringen
 
-| Måling | Før | Etter | Endring |
-| ------ | --- | ----- | ------- |
-| `security-owasp` per redigering | 21 KB | ~1 KB stub | −95 % |
-| Go-kontekst | 42 KB | 22 KB | −20 KB |
-| Kotlin-kontekst | 54 KB | 34 KB | −20 KB |
+Du trenger ikke gjøre noe spesielt. Bare bruk `@nav-pilot` i stedet for standard Copilot Chat, så får du dette automatisk.
 
-Dette er fortsatt det mest lønnsomme grepet vi har gjort: flytt referansemateriale ut av hot path. Instruksjonsfiler er i hovedsak maskinlest innmat. Det betyr at vi trygt kan komprimere dem hardere enn vi ville gjort med menneskevennlig dokumentasjon, så lenge reglene fortsatt er presise.
+## Vil du ha enda kortere svar? Bruk `$terse-mode`
 
-## Verktøy
+Skriv `$terse-mode` i en Copilot-sesjon for å skru på ekstra kompakt stil. Tre nivåer:
 
-### `$terse-mode` — native tershet i nav-pilot
+| Nivå | Hva den gjør | Eksempel |
+| ---- | ------------ | -------- |
+| **lett** | Fjerner fyllord, beholder fulle setninger | «Komponenten re-rendrer fordi du lager ny objektreferanse. Bruk `useMemo`.» |
+| **normal** | Fragmenter og korte synonymer | «Ny objekt-ref hver render → re-render. `useMemo`.» |
+| **ultra** | Telegrafisk, forkortelser | «Inline obj-prop → ny ref → re-render. `useMemo`.» |
 
-Den viktigste nyheten er at nav-pilot nå har en innebygd [`$terse-mode`](https://github.com/navikt/copilot/blob/main/.github/skills/terse-mode/SKILL.md)-skill. Du trenger ikke installere noe. Skriv bare `$terse-mode` i en Copilot-sesjon.
-
-Den bygger på de samme idéene som Caveman, men er skrevet for norsk arbeidsflyt og følger nav-pilot-konvensjonene våre:
-
-- **lett** — korte, profesjonelle svar med hele setninger
-- **normal** — fragmenter og mindre fyllord. God standard for hverdagsarbeid
-- **ultra** — telegrafisk stil for raske iterasjoner
-
-Det viktigste er ikke bare at svarene blir kortere. Skilen har en eksplisitt vedvaringsregel som hindrer modellen i å falle tilbake til lange svar etter noen runder. Den har også **auto-klarhet**: ved sikkerhetsvarsler, destruktive operasjoner eller tvetydige steg bytter den automatisk tilbake til full prosa.
-
-Praktisk bruk:
+Slik bruker du det:
 
 ```text
-$terse-mode
-Aktiver terse-mode ultra
-Stopp terse
+@nav-pilot $terse-mode          ← slår på normal-nivå
+@nav-pilot $terse-mode ultra    ← for raske iterasjoner
+Stopp terse                     ← tilbake til vanlig stil
 ```
 
-Dette er førstevalget vårt for output-komprimering i Nav-miljøet: native, norsk, ingen tredjepartsavhengighet.
+Stilen vedvarer hele sesjonen. Ved sikkerhetsvarsler eller destruktive handlinger bytter den automatisk tilbake til full prosa — du mister aldri viktig informasjon.
 
-### RTK — komprimerer verktøyutdata
+## Fire vaner som kutter kostnader
 
-[RTK](https://github.com/rtk-ai/rtk) (55k+ stjerner) er et praktisk verktøy for team som bruker agenter i terminalen. Det komprimerer kommandoutput før den når LLM-konteksten. Det treffer et annet problem enn `$terse-mode`: ikke agentens prosa, men verktøyutdata.
+### 1. Vær presis i forespørselen
 
-**Typisk besparelse (illustrativt eksempel):**
+Den dyreste token-sløsingen er misforståelser. Fem runder med «mente du A eller B?» koster mer enn ett godt spørsmål.
 
-| Operasjon | Uten RTK | Med RTK | Besparelse |
-| --------- | -------- | ------- | ---------- |
-| `cat` / `read` (20x) | ~40 000 | ~12 000 | ~70 % |
-| `cargo test` / `npm test` (5x) | ~25 000 | ~2 500 | ~90 % |
-| `git diff` (5x) | ~10 000 | ~2 500 | ~75 % |
+**Dyrt** (vagt → mange oppfølgingsspørsmål):
+> «Lag en tjeneste for søknader»
 
-RTK rapporterer selv 60–90 % reduksjon avhengig av verktøytype.
+**Billig** (presist → agenten kan starte med én gang):
+> «Lag et Ktor REST-endepunkt som tar imot dagpengesøknader over Kafka fra dp-soknad. Kotlin, Nais, Postgres.»
 
-Installer med én kommando: `brew install rtk`. For Copilot CLI bruker du `rtk init -g --copilot`, som setter opp en `PreToolUse`-hook. Det fungerer godt med `kubectl`, `git`, `go test` og `cargo test`, altså kommandoer mange av oss bruker i Nais-arbeidsflyter.
+Jo mer kontekst du gir opp front, jo færre runder bruker du. Nevn språk, rammeverk, og hva tjenesten skal snakke med.
 
-RTK og `$terse-mode` er komplementære: RTK kutter verktøyutdata, `$terse-mode` kutter agentprosa.
+### 2. Bruk `$nav-deep-interview` for store oppgaver
 
-### Caveman — ekstern output-komprimering
+Før en større endring (ny tjeneste, stor refaktor): start med [`$nav-deep-interview`](https://github.com/navikt/copilot/blob/main/.github/skills/nav-deep-interview/SKILL.md). Den stiller presise spørsmål om personvern, auth og avhengigheter *før* koden skrives.
 
-[Caveman](https://github.com/JuliusBrussee/caveman) (66k+ stjerner) er fortsatt relevant. Det er et populært oppsett for output-komprimering og fungerer også med Copilot. Forskjellen nå er at du ikke trenger Caveman for å få samme stilgrep i nav-pilot.
+Det er billigere å bruke 5 minutter på avklaring enn å kaste bort en hel sesjon fordi agenten antok feil datamodell.
 
-**Når Caveman fortsatt er nyttig:**
+### 3. Hold sesjoner fokuserte
 
-- du vil ha samme terse-stil på tvers av flere assistenter utenfor nav-pilot
-- du vil eksperimentere med `caveman-compress` for å korte ned instruksjonsfiler
-- du eier repoets `copilot-instructions.md` og vil la et eksternt verktøy skrive dit
+Copilot sender hele samtalehistorikken med hver melding. Jo lengre samtale, jo mer betaler du per svar. Én oppgave per sesjon holder kostnadene nede og gir bedre svar.
 
-For Nav-team er anbefalingen enklere enn før: start med `$terse-mode`. Vurder Caveman hvis du trenger et agent-uavhengig oppsett.
+- Start ny sesjon når du bytter oppgave
+- Skriv tydelig hva du vil ha i første melding
+- Unngå «kan du også...» etter at oppgaven er ferdig
 
-### TOON — mindre tokens for strukturerte data
+### 4. La `@nav-pilot` finne verktøyene
 
-[TOON](https://toonformat.dev/) ([spec](https://github.com/toon-format/spec)) er et serialiseringsformat designet for LLM-kontekster. Det koder JSON-lignende data med 30–60 % færre tokens, uten tap av informasjon.
+Du trenger ikke huske alle skills. `@nav-pilot` bruker riktig kunnskap basert på konteksten:
 
-**Eksempel:**
+- Skriver du Go eller Kotlin? → Sikkerhetsregler (OWASP) er allerede aktive
+- Jobber du med Nais-manifest? → Nais-kunnskap aktiveres
+- Trenger du auth? → TokenX/Azure AD-kunnskap brukes
 
-```json
-{ "users": [{ "id": 1, "name": "Ada" }, { "id": 2, "name": "Linus" }] }
+Du kan be om en spesifikk skill med `$skill-navn`, men for de fleste oppgaver klarer nav-pilot seg selv.
+
+## Oppsummert
+
+| Tips | For hvem | Hva du gjør |
+| ---- | -------- | ----------- |
+| Bruk `@nav-pilot` | Alle | Skriv `@nav-pilot` foran spørsmålet — kompakte svar er standard |
+| `$terse-mode` | Deg som vil ha kortere svar | Skriv `$terse-mode` i starten av sesjonen |
+| Vær presis | Alle | Nevn språk, rammeverk og integrasjoner i første melding |
+| `$nav-deep-interview` | Nye tjenester, stor refaktor | Skriv `$nav-deep-interview` før du starter |
+| Ny sesjon per oppgave | Alle | Lukk gammel sesjon, start ny når du bytter fokus |
+
+---
+
+## For viderekomne: hva skjer under panseret
+
+Resten er for deg som vedlikeholder instruksjoner, bygger MCP-servere, eller vil forstå *hvorfor* tipsene over fungerer.
+
+### Hvorfor kortere kontekst gir bedre svar
+
+Hver gang du sender en melding, pakker Copilot med alt: systemprompt, instruksjonsfiler, åpne filer, verktøydefinisjoner og hele samtalehistorikken. En flerstegs-sesjon i Copilot CLI kan bruke over 1 million input-tokens. [Vantage sin analyse](https://www.vantage.sh/blog/agentic-coding-costs) viser at kostnader varierer opptil 30x mellom kjøringer på samme oppgave.
+
+Det betyr at de to største besparelsene er:
+1. **Kortere sesjoner** (færre runder = mindre historikk å sende)
+2. **Mindre instruksjonslast** (smalere `applyTo`-mønstre = færre filer i konteksten)
+
+### Hva vi gjorde i dette repoet
+
+Vi hadde en OWASP-sikkerhetsinstruks på 21 KB som ble lastet ved *hver eneste* Go- og Kotlin-redigering — også når oppgaven ikke handlet om sikkerhet. Vi flyttet innholdet til en on-demand skill og beholdt bare en kort stub (1 KB) med de mest kritiske reglene.
+
+| Måling | Før | Etter |
+| ------ | --- | ----- |
+| OWASP per redigering | 21 KB | ~1 KB |
+| Go-kontekst totalt | 42 KB | 22 KB |
+| Kotlin-kontekst totalt | 54 KB | 34 KB |
+
+**Tommelfingerregel:** Hvis en instruks bare er relevant for 10 % av oppgavene, hør den hjemme i en skill — ikke i en alltid-aktiv fil.
+
+### Instruksjonsarkitektur
+
+Det viktigste feltet i en Copilot-instruksjon er `applyTo`-globen:
+
+- `applyTo: "**"` → lastes alltid (bruk sparsomt)
+- `applyTo: "**/*.go"` → lastes bare for Go-filer
+- `applyTo: "**/db/migration/**/*.sql"` → lastes bare ved databasemigrering
+
+Andre tips for vedlikeholdere:
+- Komprimer innhold — instruksjoner leses av modellen, ikke mennesker
+- Hold filer stabile — prompt caching fungerer best når innholdet sjelden endres
+- Bruk konkrete dropp-lister («dropp artikler og høflighetsfraser») fremfor vagt «vær kort»
+
+### RTK — komprimerer terminaloutput
+
+[RTK](https://github.com/rtk-ai/rtk) komprimerer kommandoutput (testresultater, diff, kubectl) før den når kontekstvinduet. Nyttig hvis du bruker Copilot CLI mye.
+
+```bash
+brew install rtk
+rtk init -g --copilot
 ```
 
-```text
-users[2]{id,name}:
-  1,Ada
-  2,Linus
-```
+RTK rapporterer 60–90 % reduksjon på verktøydata. Det er komplementært med `$terse-mode`: RTK kutter det agenten *leser*, terse-mode kutter det agenten *skriver*.
 
-Dette er mest relevant for MCP-servere og verktøy som sender mye strukturert data. Hvis du eier formatet selv, er TOON ofte et bedre grep enn å be modellen være «kort».
+### TOON og dynamiske verktøysett
 
-### Copilot Memory — innebygd kontekstbevaring
+To teknikker for deg som bygger MCP-servere:
 
-GitHub Copilot har [innebygd memory](/nyheter/copilot-memory) som lagrer fakta og preferanser på tvers av sesjoner. For lengre økter bruker Copilot CLI også checkpointing, som komprimerer eldre kontekst når vinduet fylles opp.
-
-Det løser ikke alt, men det reduserer behovet for å gjenta samme bakgrunnsinformasjon i hver nye sesjon.
-
-## Teknikker
-
-### 1. Avklaring før implementering
-
-En stor del av token-sløsing kommer ikke fra lange svar, men fra lange misforståelser. Matt Pocock sitt [skills-repo](https://github.com/mattpocock/skills) har passert 109k stjerner og populariserte **grill**-mønsteret: la agenten kjøre et sokratisk, nesten adversarialt intervju før implementering starter.
-
-Poenget er enkelt: bruk noen få presise spørsmål først, så slipper du ti runder med «mente du A eller B?». I vårt økosystem dekker [`$nav-deep-interview`](https://github.com/navikt/copilot/blob/main/.github/skills/nav-deep-interview/SKILL.md) mye av det samme behovet. Den avdekker blindsoner rundt personvern, auth, avhengigheter og observerbarhet før koden skrives.
-
-Hvis oppgaven er uklar, er dette ofte den billigste token-optimaliseringen du kan gjøre.
-
-### 2. Kontekstkomprimering i Copilot CLI
-
-Copilot CLI har innebygd kontekstkomprimering som trigges automatisk når kontekstvinduet fylles opp. Den oppsummerer eldre kontekst via checkpointing. Besparelsen er stor, men du får best effekt hvis samtalen er strukturert.
-
-Tips: bruk tydelige overskrifter, eksplisitte tilstandsrapporter og korte beslutningsnotater underveis. Slike signaler overlever komprimering bedre enn løs prat.
-
-### 3. Instruksjonsarkitektur
-
-Her ligger de største input-gevinstene i repo vi kontrollerer selv.
-
-Det viktigste feltet i en Copilot-instruksjon er ofte ikke teksten, men `applyTo`-globen. Den er Copilot sitt sterkeste lazy-loading-grep. En fil med `applyTo: "**"` er alltid på. En fil med et smalt mønster lastes bare når den faktisk trengs.
-
-Det vi ser nå, er et tydelig mønster:
-
-- **Komprimer maskininnhold hardt.** Instruksjonsfiler leses primært av modellen, ikke av mennesker
-- **Hold stabile filer stabile.** Prompt caching treffer best når de sjelden endres og starter med det samme innholdet hver gang
-- **Bruk konkrete dropp-lister.** Ord som «dropp artikler, høflighetsfraser og hedging» virker bedre enn vage instrukser som «vær kort»
-- **Flytt oppslagsverk til skills.** Det ga oss 42 KB → 22 KB i Go-kontekst og 54 KB → 34 KB i Kotlin-kontekst
-
-Faustregel: Hvis en instruks bare er relevant for 10 % av oppgavene, hører den hjemme i en skill.
-
-### 4. Dynamiske verktøysett i MCP
-
-[Speakeasy rapporterer 100x reduksjon](https://www.speakeasy.com/blog/how-we-reduced-token-usage-by-100x-dynamic-toolsets-v2) ved å gå fra å laste alle verktøyskjemaer på forhånd til et søk → beskriv → utfør-mønster. 400 verktøy gikk fra 410 000 tokens til 8 000–31 000.
-
-Relevant for team som bruker mange MCP-servere: bruk [Atlassian mcp-compressor](https://github.com/atlassian/mcp-compressor) for skjemakomprimering eller implementer progressiv avsløring i egne servere.
-
-### 5. Output-kontroll med eksplisitte regler
-
-Ikke skriv bare «be concise». Det er for vagt. Gi modellen konkrete stilregler eller bruk en skill som allerede gjør det.
-
-Tre nivåer som fungerer i praksis:
-
-- **lett** for vanlig samarbeid og PR-gjennomgang
-- **normal** for daglig terminalarbeid
-- **ultra** for raske iterasjoner når du kjenner domenet godt
-
-Det er akkurat derfor `$terse-mode` fungerer bedre enn en løs énlinjer i prompten: den spesifiserer hva som skal bort, når full prosa må tilbake og at stilen skal vedvare.
-
-### 6. Modell-routing
-
-Bruk billige og raske modeller for enkle oppgaver som klassifisering, filsøk og formatering. Reserver frontier-modeller for kompleks resonnering. Copilot CLI gjør dette allerede med explore-agenter på Haiku.
-
-### 7. Filtrer verktøyresponsene
-
-Returner bare feltene du trenger fra MCP-verktøy. Ikke dump hele objekter hvis brukeren bare trenger `name`, `id` og `status`.
-
-Hvis du kontrollerer output-formatet, har du ofte mer å hente på responsfiltrering eller TOON enn på å be modellen oppsummere dataene etterpå.
-
-## Hva du kan gjøre i dag
-
-1. **Slå på `$terse-mode`** i neste Copilot-sesjon. Start med `lett`, bytt til `ultra` når du vil ha høy fart
-2. **Installer RTK** med `brew install rtk && rtk init -g --copilot`
-3. **Bruk `$nav-deep-interview`** før større endringer. Færre misforståelser gir kortere sesjoner
-4. **Se på `applyTo`-mønstrene dine** og finn instruksjoner som lastes oftere enn de burde
-5. **Flytt referansestoff til skills** og behold bare kritiske regler i instruksjonsfila
-6. **Gjør instruksjoner mer konkrete** med dropp-lister og korte, stabile regler i toppen av filen
-7. **Komprimer strukturerte data** med TOON eller smalere responser fra MCP-verktøy
+- [TOON](https://toonformat.dev/) koder strukturert data med 30–60 % færre tokens. Relevant når serveren returnerer store JSON-objekter.
+- **Dynamiske verktøysett** — ikke last alle verktøyskjemaer på forhånd. Bruk et søk → beskriv → utfør-mønster. [Speakeasy rapporterer 100x reduksjon](https://www.speakeasy.com/blog/how-we-reduced-token-usage-by-100x-dynamic-toolsets-v2) med denne tilnærmingen.
 
 ## Videre lesing
 
-- [GitHub: Improving Token Efficiency in Agentic Workflows](https://github.blog/ai-and-ml/github-copilot/improving-token-efficiency-in-github-agentic-workflows/) — GitHub sin egen tilnærming
-- [arXiv: Brief is better?](https://arxiv.org/abs/2604.00025) — studie om hvorfor korte svar kan gi bedre nøyaktighet
-- [Matt Pocock: skills](https://github.com/mattpocock/skills) — grill-mønster, TDD og andre agent-skills
-- [awesome-llm-token-optimization](https://github.com/pleasedodisturb/awesome-llm-token-optimization) — kuratert samling
-- [Vantage: Hidden Cost Driver in Agentic Coding](https://www.vantage.sh/blog/agentic-coding-costs) — kostnadsanalyse
+- [GitHub: Improving Token Efficiency in Agentic Workflows](https://github.blog/ai-and-ml/github-copilot/improving-token-efficiency-in-github-agentic-workflows/)
+- [arXiv: Brief is better?](https://arxiv.org/abs/2604.00025) — korte svar kan gi bedre nøyaktighet
+- [Matt Pocock: skills](https://github.com/mattpocock/skills) — grill-mønster og andre agent-skills
+- [Vantage: Hidden Cost Driver in Agentic Coding](https://www.vantage.sh/blog/agentic-coding-costs) — kostnadsanalyse av agentiske arbeidsflyter

--- a/docs/news/articles/token-forbruk-verktoy-teknikker.md
+++ b/docs/news/articles/token-forbruk-verktoy-teknikker.md
@@ -14,7 +14,7 @@ tags:
 
 Med [bruksbasert fakturering](/nyheter/model-pinning-kostnadsoptimalisering) betaler du per token. Lange sesjoner med mye frem og tilbake koster mer. Den gode nyheten: du kan få kortere, mer presise svar uten å miste kvalitet.
 
-En [2026-studie](https://arxiv.org/abs/2604.00025) fant at modeller ble mer treffsikre når de ble tvunget til å svare kort. Kortere svar er altså ikke bare billigere — de kan også være bedre.
+En [2026-studie](https://arxiv.org/abs/2604.00025) fant at modeller ble mer treffsikre når de ble tvunget til å svare kort. Kortere svar kan derfor koste mindre og gi bedre resultat.
 
 ## Det viktigste først: bruk `nav-pilot` CLI
 
@@ -184,7 +184,7 @@ Andre tips for vedlikeholdere:
 
 ### RTK — komprimerer terminaloutput
 
-[RTK](https://github.com/rtk-ai/rtk) komprimerer kommandoutput (testresultater, diff, kubectl) før den når kontekstvinduet. Nyttig hvis du bruker Copilot CLI mye.
+[RTK](https://github.com/rtk-ai/rtk) komprimerer kommando-output (testresultater, diff, kubectl) før den når kontekstvinduet. Nyttig hvis du bruker Copilot CLI mye.
 
 ```bash
 brew install rtk

--- a/docs/news/articles/token-forbruk-verktoy-teknikker.md
+++ b/docs/news/articles/token-forbruk-verktoy-teknikker.md
@@ -12,7 +12,7 @@ tags:
   - nav-pilot
 ---
 
-Med [bruksbasert fakturering](/nyheter/model-pinning-kostnadsoptimalisering) betaler du per token. Lange sesjoner med mye frem og tilbake koster mer. Den gode nyheten: du kan få kortere, mer presise svar uten å miste kvalitet — og det er enklere enn du tror.
+Med [bruksbasert fakturering](/nyheter/model-pinning-kostnadsoptimalisering) betaler du per token. Lange sesjoner med mye frem og tilbake koster mer. Den gode nyheten: du kan få kortere, mer presise svar uten å miste kvalitet.
 
 En [2026-studie](https://arxiv.org/abs/2604.00025) fant at modeller ble mer treffsikre når de ble tvunget til å svare kort. Kortere svar er altså ikke bare billigere — de kan også være bedre.
 
@@ -49,7 +49,7 @@ Stilen vedvarer hele sesjonen. Ved sikkerhetsvarsler eller destruktive handlinge
 
 ## Fire vaner som kutter kostnader
 
-### 1. Vær presis i forespørselen
+### 1. Vær presis i spørsmålet
 
 Den dyreste token-sløsingen er misforståelser. Fem runder med «mente du A eller B?» koster mer enn ett godt spørsmål.
 
@@ -59,13 +59,13 @@ Den dyreste token-sløsingen er misforståelser. Fem runder med «mente du A ell
 **Billig** (presist → agenten kan starte med én gang):
 > «Lag et Ktor REST-endepunkt som tar imot dagpengesøknader over Kafka fra dp-soknad. Kotlin, Nais, Postgres.»
 
-Jo mer kontekst du gir opp front, jo færre runder bruker du. Nevn språk, rammeverk, og hva tjenesten skal snakke med.
+Jo mer kontekst du gir i første melding, jo færre runder bruker du.
 
 ### 2. Bruk `$nav-deep-interview` for store oppgaver
 
 Før en større endring (ny tjeneste, stor refaktor): start med [`$nav-deep-interview`](https://github.com/navikt/copilot/blob/main/.github/skills/nav-deep-interview/SKILL.md). Den stiller presise spørsmål om personvern, auth og avhengigheter *før* koden skrives.
 
-Det er billigere å bruke 5 minutter på avklaring enn å kaste bort en hel sesjon fordi agenten antok feil datamodell.
+Fem minutter med avklaring slår en bortkastet sesjon.
 
 ### 3. Hold sesjoner fokuserte
 
@@ -97,15 +97,15 @@ Du kan be om en spesifikk skill med `$skill-navn`, men for de fleste oppgaver kl
 
 ---
 
-## For viderekomne: hva skjer under panseret
+## Under panseret
 
 Resten er for deg som vedlikeholder instruksjoner, bygger MCP-servere, eller vil forstå *hvorfor* tipsene over fungerer.
 
 ### Hvorfor kortere kontekst gir bedre svar
 
-Hver gang du sender en melding, pakker Copilot med alt: systemprompt, instruksjonsfiler, åpne filer, verktøydefinisjoner og hele samtalehistorikken. En flerstegs-sesjon i Copilot CLI kan bruke over 1 million input-tokens. [Vantage sin analyse](https://www.vantage.sh/blog/agentic-coding-costs) viser at kostnader varierer opptil 30x mellom kjøringer på samme oppgave.
+Hver gang du sender en melding, pakker Copilot med alt: systemprompt, instruksjonsfiler, åpne filer, verktøydefinisjoner og hele samtalehistorikken. En flerstegssesjon i Copilot CLI kan bruke over 1 million input-tokens. [Vantage sin analyse](https://www.vantage.sh/blog/agentic-coding-costs) viser at kostnader varierer opptil 30x mellom kjøringer på samme oppgave.
 
-Det betyr at de to største besparelsene er:
+De to største besparelsene:
 1. **Kortere sesjoner** (færre runder = mindre historikk å sende)
 2. **Mindre instruksjonslast** (smalere `applyTo`-mønstre = færre filer i konteksten)
 
@@ -119,7 +119,7 @@ Vi hadde en OWASP-sikkerhetsinstruks på 21 KB som ble lastet ved *hver eneste* 
 | Go-kontekst totalt | 42 KB | 22 KB |
 | Kotlin-kontekst totalt | 54 KB | 34 KB |
 
-**Tommelfingerregel:** Hvis en instruks bare er relevant for 10 % av oppgavene, hør den hjemme i en skill — ikke i en alltid-aktiv fil.
+**Tommelfingerregel:** Hvis en instruks bare er relevant for 10 % av oppgavene, hører den hjemme i en skill — ikke i en alltid-aktiv fil.
 
 ### Instruksjonsarkitektur
 
@@ -143,7 +143,7 @@ brew install rtk
 rtk init -g --copilot
 ```
 
-RTK rapporterer 60–90 % reduksjon på verktøydata. Det er komplementært med `$terse-mode`: RTK kutter det agenten *leser*, terse-mode kutter det agenten *skriver*.
+RTK rapporterer 60–90 % reduksjon på verktøydata. RTK og `$terse-mode` utfyller hverandre: RTK kutter det agenten *leser*, terse-mode kutter det agenten *skriver*.
 
 ### TOON og dynamiske verktøysett
 

--- a/docs/news/articles/token-forbruk-verktoy-teknikker.md
+++ b/docs/news/articles/token-forbruk-verktoy-teknikker.md
@@ -29,7 +29,7 @@ Du trenger ikke gjøre noe spesielt. Bare bruk `@nav-pilot` i stedet for standar
 
 ## Vil du ha enda kortere svar? Bruk `$terse-mode`
 
-`$`-prefikset er Copilot sin måte å aktivere en [skill](https://code.visualstudio.com/docs/copilot/customization/agent-skills) — tenk på det som en kommando du skriver i chatten. Skriv `$terse-mode` for å skru på ekstra kompakt stil. Tre nivåer:
+`$`-prefikset er vår konvensjon for å markere skill-navn — det gjør det tydelig for både deg og agenten at du ber om en spesifikk [skill](https://code.visualstudio.com/docs/copilot/customization/agent-skills). Du kan også bare skrive navnet uten `$` (f.eks. «terse-mode» eller «bruk terse-mode»). Agenten gjenkjenner det uansett. Skriv `$terse-mode` for å skru på ekstra kompakt stil. Tre nivåer:
 
 | Nivå | Hva den gjør | Eksempel |
 | ---- | ------------ | -------- |

--- a/docs/news/articles/token-forbruk-verktoy-teknikker.md
+++ b/docs/news/articles/token-forbruk-verktoy-teknikker.md
@@ -16,16 +16,31 @@ Med [bruksbasert fakturering](/nyheter/model-pinning-kostnadsoptimalisering) bet
 
 En [2026-studie](https://arxiv.org/abs/2604.00025) fant at modeller ble mer treffsikre når de ble tvunget til å svare kort. Kortere svar er altså ikke bare billigere — de kan også være bedre.
 
-## Det viktigste først: bruk `@nav-pilot`
+## Det viktigste først: bruk `nav-pilot` CLI
 
-`@nav-pilot` er allerede satt opp for å gi deg kompakte svar. Den:
+`nav-pilot` er kommandolinjeverktøyet som holder Copilot-oppsettet ditt oppdatert og starter Copilot med riktig konfigurasjon. Den enkleste måten å starte en AI-sesjon:
 
-- Starter med konklusjonen, ikke forklaringen
-- Viser kode direkte uten lang innledning
-- Tilbyr «Si 'forklar' for detaljer» når den hopper over begrunnelse
-- Spør bare når svaret faktisk endrer implementeringen
+```bash
+nav-pilot --sync    # synkroniserer, deretter starter Copilot med @nav-pilot-agenten
+```
 
-Du trenger ikke gjøre noe spesielt. Bare bruk `@nav-pilot` i stedet for standard Copilot Chat, så får du dette automatisk.
+Eventuelt steg for steg:
+
+```bash
+nav-pilot install kotlin-backend   # installer collection for teamet ditt
+nav-pilot sync                     # sjekk for oppdateringer
+nav-pilot                          # interaktiv meny — install, sync, eller start Copilot
+```
+
+Når du starter Copilot via `nav-pilot`, får du automatisk:
+
+- Konklusjonen først, ikke forklaringen
+- Kode direkte uten lang innledning
+- «Si 'forklar' for detaljer» når begrunnelse hoppes over
+- Spørsmål bare når svaret faktisk endrer implementeringen
+- Nav-konvensjoner (Aksel, Nais, auth) uten at du trenger å be om det
+
+I VS Code Chat kan du skrive `@nav-pilot` for å få det samme.
 
 ## Vil du ha enda kortere svar? Bruk `$terse-mode`
 
@@ -91,8 +106,8 @@ Du kan be om en spesifikk skill med `$skill-navn`, men for de fleste oppgaver kl
 
 | Tips | For hvem | Hva du gjør |
 | ---- | -------- | ----------- |
-| Bruk `@nav-pilot` | Alle | Skriv `@nav-pilot` foran spørsmålet — kompakte svar er standard |
-| `$terse-mode` | Deg som vil ha kortere svar | Skriv `$terse-mode` i starten av sesjonen |
+| Start via `nav-pilot` | Alle | `nav-pilot --sync` synkroniserer og starter Copilot med riktig oppsett |
+| `$terse-mode` | Deg som vil ha kortere svar | Skriv `terse-mode` eller `$terse-mode` i starten av sesjonen |
 | Vær presis | Alle | Nevn språk, rammeverk og integrasjoner i første melding |
 | `$nav-deep-interview` | Nye tjenester, stor refaktor | Skriv `$nav-deep-interview` for grundigere avklaring |
 | Fokuserte sesjoner | Alle | Hold deg til én oppgave per sesjon — bedre svar |


### PR DESCRIPTION
## Hva

Omskriving av token-optimaliserings-artikkelen for å treffe målgruppen bedre: Nav-utviklere i produktteam som bruker Copilot CLI.

## Hvorfor

Artikkelen var for VS Code-orientert, brukte mye intern jargon (skills, `$`-prefiks), og manglet konkrete eksempler for Kotlin/Next.js-utviklere i terminalen.

## Endringer

### Artikkel (`docs/news/articles/token-forbruk-verktoy-teknikker.md`)
- **nav-pilot CLI som primær inngang** — `nav-pilot --sync` er det første brukeren ser
- **Fem vaner** i stedet for fire — lagt til "hjelp agenten med å lese mindre" (terminalspesifikt)
- **"Gode første meldinger"** — copy/paste-eksempler for Ktor, Next.js, Nais og Java→Kotlin
- **Riktig intervjubeskrivelse** — små oppgaver får ingen spørsmål
- **Prompt caching** — korrigert fra "lange sesjoner koster mer" til riktig nyansering
- **Skills-forklaring** — `$` er valgfritt, bare skriv navnet
- **RTK sikkerhetsnotat** — sjekk teamgodkjenning før bruk med sensitive data
- **Språkvask** via @forfatter — fjernet AI-markører og anglismer

### AGENTS.md
- Lagt til "Target Users" med brukerprofiler og interaksjonsmodell
- nav-pilot CLI som primær entry point
- Kontekst: end-to-end produktteam, Kotlin+TS, kostnadsoptimalisering

## Squash-tittel
```
docs(news): rewrite token article for terminal-first Nav developers
```