### PR TITLE
feat(abonnement): display AI credit budget + cluster-internal mcp-registry

### DIFF
--- a/apps/copilot-api/budget.go
+++ b/apps/copilot-api/budget.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 )
@@ -74,6 +75,11 @@ func (c *BudgetClient) getEnterpriseBudgets(ctx context.Context) ([]BudgetEntry,
 	c.mu.Unlock()
 
 	slog.Debug("Enterprise budgets cached", "count", len(entries))
+	if slog.Default().Enabled(context.Background(), slog.LevelDebug) {
+		for _, e := range entries {
+			slog.Debug("Budget entry", "scope", e.BudgetScope, "entity", e.BudgetEntityName, "amount", e.BudgetAmount)
+		}
+	}
 	return entries, nil
 }
 
@@ -166,7 +172,7 @@ func (c *BudgetClient) getUserBudget(ctx context.Context, username string) (*Use
 		if e.BudgetScope == "multi_user_customer" {
 			defaultBudget = e.BudgetAmount
 		}
-		if e.BudgetScope == "user" && e.BudgetEntityName == username {
+		if e.BudgetScope == "member" && strings.EqualFold(e.BudgetEntityName, username) {
 			userEntry = e
 		}
 	}

--- a/apps/copilot-api/budget.go
+++ b/apps/copilot-api/budget.go
@@ -100,15 +100,17 @@ func (c *BudgetClient) fetchAllBudgetPages(ctx context.Context) ([]BudgetEntry, 
 		if err != nil {
 			return nil, fmt.Errorf("fetch budgets page %d: %w", page, err)
 		}
-		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("budgets API returned %d", resp.StatusCode)
+			resp.Body.Close()
+			return nil, fmt.Errorf("budgets API returned %d on page %d", resp.StatusCode, page)
 		}
 
 		var result budgetListResponse
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return nil, fmt.Errorf("decode budgets page %d: %w", page, err)
+		decodeErr := json.NewDecoder(resp.Body).Decode(&result)
+		resp.Body.Close()
+		if decodeErr != nil {
+			return nil, fmt.Errorf("decode budgets page %d: %w", page, decodeErr)
 		}
 
 		all = append(all, result.Budgets...)

--- a/apps/copilot-api/budget.go
+++ b/apps/copilot-api/budget.go
@@ -127,6 +127,29 @@ func (c *BudgetClient) fetchAllBudgetPages(ctx context.Context) ([]BudgetEntry, 
 
 var errBudgetNotFound = errors.New("budget not found for user")
 
+// GlobalBudget is the enterprise-level AI credit budget (multi_user_customer scope).
+type GlobalBudget struct {
+	BudgetAmount   float64  `json:"budgetAmount"`
+	ConsumedAmount *float64 `json:"consumedAmount"`
+}
+
+// getGlobalBudget returns the enterprise-wide default AI credit budget.
+func (c *BudgetClient) getGlobalBudget(ctx context.Context) (*GlobalBudget, error) {
+	entries, err := c.getEnterpriseBudgets(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get enterprise budgets: %w", err)
+	}
+	for _, e := range entries {
+		if e.BudgetScope == "multi_user_customer" {
+			return &GlobalBudget{
+				BudgetAmount:   e.BudgetAmount,
+				ConsumedAmount: e.ConsumedAmount,
+			}, nil
+		}
+	}
+	return nil, errBudgetNotFound
+}
+
 // getUserBudget resolves the budget for a given GitHub username.
 // Returns the user-specific override if present, otherwise the enterprise default.
 func (c *BudgetClient) getUserBudget(ctx context.Context, username string) (*UserBudget, error) {

--- a/apps/copilot-api/budget.go
+++ b/apps/copilot-api/budget.go
@@ -23,7 +23,8 @@ type BudgetEntry struct {
 }
 
 type budgetListResponse struct {
-	Budgets []BudgetEntry `json:"budgets"`
+	Budgets     []BudgetEntry `json:"budgets"`
+	HasNextPage bool          `json:"has_next_page"`
 }
 
 // UserBudget is the resolved budget for a specific user.
@@ -121,8 +122,7 @@ func (c *BudgetClient) fetchAllBudgetPages(ctx context.Context) ([]BudgetEntry, 
 
 		all = append(all, result.Budgets...)
 
-		// GitHub paginates with Link header; stop when we get fewer than a full page
-		if len(result.Budgets) < 100 {
+		if !result.HasNextPage {
 			break
 		}
 		page++

--- a/apps/copilot-api/budget.go
+++ b/apps/copilot-api/budget.go
@@ -133,27 +133,46 @@ func (c *BudgetClient) fetchAllBudgetPages(ctx context.Context) ([]BudgetEntry, 
 
 var errBudgetNotFound = errors.New("budget not found for user")
 
-// GlobalBudget is the enterprise-level AI credit budget (multi_user_customer scope).
+// GlobalBudget aggregates AI credit consumption across all users this month.
 type GlobalBudget struct {
-	BudgetAmount   float64  `json:"budgetAmount"`
-	ConsumedAmount *float64 `json:"consumedAmount"`
+	TotalConsumed float64 `json:"totalConsumed"`
+	PerUserBudget float64 `json:"perUserBudget"`
+	ActiveUsers   int     `json:"activeUsers"`
 }
 
-// getGlobalBudget returns the enterprise-wide default AI credit budget.
+// getGlobalBudget aggregates AI credit consumption across all budget entries.
+// Returns total consumed, per-user default budget, and count of active users.
 func (c *BudgetClient) getGlobalBudget(ctx context.Context) (*GlobalBudget, error) {
 	entries, err := c.getEnterpriseBudgets(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get enterprise budgets: %w", err)
 	}
+
+	var perUserBudget float64
+	var totalConsumed float64
+	activeUsers := 0
+
 	for _, e := range entries {
 		if e.BudgetScope == "multi_user_customer" {
-			return &GlobalBudget{
-				BudgetAmount:   e.BudgetAmount,
-				ConsumedAmount: e.ConsumedAmount,
-			}, nil
+			perUserBudget = e.BudgetAmount
+		}
+		if e.BudgetScope == "user" && e.ConsumedAmount != nil {
+			totalConsumed += *e.ConsumedAmount
+			if *e.ConsumedAmount > 0 {
+				activeUsers++
+			}
 		}
 	}
-	return nil, errBudgetNotFound
+
+	if perUserBudget == 0 && totalConsumed == 0 {
+		return nil, errBudgetNotFound
+	}
+
+	return &GlobalBudget{
+		TotalConsumed: totalConsumed,
+		PerUserBudget: perUserBudget,
+		ActiveUsers:   activeUsers,
+	}, nil
 }
 
 // getUserBudget resolves the budget for a given GitHub username.
@@ -172,7 +191,7 @@ func (c *BudgetClient) getUserBudget(ctx context.Context, username string) (*Use
 		if e.BudgetScope == "multi_user_customer" {
 			defaultBudget = e.BudgetAmount
 		}
-		if e.BudgetScope == "member" && strings.EqualFold(e.BudgetEntityName, username) {
+		if e.BudgetScope == "user" && strings.EqualFold(e.BudgetEntityName, username) {
 			userEntry = e
 		}
 	}

--- a/apps/copilot-api/budget.go
+++ b/apps/copilot-api/budget.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const budgetCacheTTL = 30 * time.Minute
+
+// BudgetEntry represents a single entry from the enterprise billing budgets API.
+type BudgetEntry struct {
+	BudgetScope      string   `json:"budget_scope"`
+	BudgetEntityName string   `json:"budget_entity_name"`
+	BudgetAmount     float64  `json:"budget_amount"`
+	ConsumedAmount   *float64 `json:"consumed_amount"`
+}
+
+type budgetListResponse struct {
+	Budgets []BudgetEntry `json:"budgets"`
+}
+
+// UserBudget is the resolved budget for a specific user.
+type UserBudget struct {
+	BudgetAmount   float64  `json:"budgetAmount"`
+	ConsumedAmount *float64 `json:"consumedAmount"`
+	IsOverride     bool     `json:"isOverride"`
+	DefaultBudget  float64  `json:"defaultBudget"`
+}
+
+// BudgetClient fetches enterprise AI credit budgets using a classic PAT.
+// The GitHub App token used elsewhere does NOT work for enterprise billing endpoints.
+type BudgetClient struct {
+	httpClient   *http.Client
+	billingToken string
+	enterprise   string
+
+	mu         sync.RWMutex
+	cachedAt   time.Time
+	cachedData []BudgetEntry
+}
+
+func newBudgetClient(billingToken, enterprise string) *BudgetClient {
+	return &BudgetClient{
+		httpClient:   &http.Client{Timeout: 15 * time.Second},
+		billingToken: billingToken,
+		enterprise:   enterprise,
+	}
+}
+
+// getEnterpriseBudgets returns all budget entries, using a 30-minute in-memory cache.
+func (c *BudgetClient) getEnterpriseBudgets(ctx context.Context) ([]BudgetEntry, error) {
+	c.mu.RLock()
+	if !c.cachedAt.IsZero() && time.Since(c.cachedAt) < budgetCacheTTL {
+		data := c.cachedData
+		c.mu.RUnlock()
+		return data, nil
+	}
+	c.mu.RUnlock()
+
+	entries, err := c.fetchAllBudgetPages(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	c.cachedData = entries
+	c.cachedAt = time.Now()
+	c.mu.Unlock()
+
+	slog.Debug("Enterprise budgets cached", "count", len(entries))
+	return entries, nil
+}
+
+// fetchAllBudgetPages paginates through the enterprise billing budgets endpoint.
+func (c *BudgetClient) fetchAllBudgetPages(ctx context.Context) ([]BudgetEntry, error) {
+	var all []BudgetEntry
+	page := 1
+
+	for {
+		url := fmt.Sprintf(
+			"https://api.github.com/enterprises/%s/settings/billing/budgets?per_page=100&page=%d",
+			c.enterprise, page,
+		)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("create budget request: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+c.billingToken)
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("fetch budgets page %d: %w", page, err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("budgets API returned %d", resp.StatusCode)
+		}
+
+		var result budgetListResponse
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			return nil, fmt.Errorf("decode budgets page %d: %w", page, err)
+		}
+
+		all = append(all, result.Budgets...)
+
+		// GitHub paginates with Link header; stop when we get fewer than a full page
+		if len(result.Budgets) < 100 {
+			break
+		}
+		page++
+	}
+
+	return all, nil
+}
+
+var errBudgetNotFound = errors.New("budget not found for user")
+
+// getUserBudget resolves the budget for a given GitHub username.
+// Returns the user-specific override if present, otherwise the enterprise default.
+func (c *BudgetClient) getUserBudget(ctx context.Context, username string) (*UserBudget, error) {
+	entries, err := c.getEnterpriseBudgets(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get enterprise budgets: %w", err)
+	}
+
+	var defaultBudget float64
+	var userEntry *BudgetEntry
+
+	for i := range entries {
+		e := &entries[i]
+		if e.BudgetScope == "multi_user_customer" {
+			defaultBudget = e.BudgetAmount
+		}
+		if e.BudgetScope == "user" && e.BudgetEntityName == username {
+			userEntry = e
+		}
+	}
+
+	if defaultBudget == 0 && userEntry == nil {
+		return nil, errBudgetNotFound
+	}
+
+	if userEntry != nil {
+		return &UserBudget{
+			BudgetAmount:   userEntry.BudgetAmount,
+			ConsumedAmount: userEntry.ConsumedAmount,
+			IsOverride:     true,
+			DefaultBudget:  defaultBudget,
+		}, nil
+	}
+
+	return &UserBudget{
+		BudgetAmount:  defaultBudget,
+		IsOverride:    false,
+		DefaultBudget: defaultBudget,
+	}, nil
+}

--- a/apps/copilot-api/budget_handlers.go
+++ b/apps/copilot-api/budget_handlers.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+// BudgetHandlers handles the enterprise AI credit budget endpoint.
+type BudgetHandlers struct {
+	budgetClient *BudgetClient
+	githubClient GitHubAPI
+}
+
+func newBudgetHandlers(budgetClient *BudgetClient, githubClient GitHubAPI) *BudgetHandlers {
+	return &BudgetHandlers{
+		budgetClient: budgetClient,
+		githubClient: githubClient,
+	}
+}
+
+// handleGetBudget handles GET /api/v1/copilot/budget.
+// Resolves the authenticated user's GitHub username via SAML and returns their AI credit budget.
+func (h *BudgetHandlers) handleGetBudget(w http.ResponseWriter, r *http.Request) {
+	user, ok := getUserFromContext(r.Context())
+	if !ok {
+		respondError(w, "unauthorized", "Authentication required", http.StatusUnauthorized)
+		return
+	}
+
+	username, err := h.githubClient.getUsernameBySamlIdentity(r.Context(), user.Email)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			respondError(w, "not_found", "GitHub account not linked to Nav organisation", http.StatusNotFound)
+			return
+		}
+		slog.Error("Failed to resolve GitHub username via SAML", "error", err)
+		respondError(w, "saml_error", "Failed to resolve GitHub identity", http.StatusInternalServerError)
+		return
+	}
+
+	budget, err := h.budgetClient.getUserBudget(r.Context(), username)
+	if err != nil {
+		if errors.Is(err, errBudgetNotFound) {
+			respondError(w, "not_found", "No budget data found", http.StatusNotFound)
+			return
+		}
+		slog.Error("Failed to fetch user budget", "error", err)
+		respondError(w, "budget_error", "Failed to fetch budget data", http.StatusInternalServerError)
+		return
+	}
+
+	cacheControl(w, 30*60, false)
+	respondJSON(w, budget, http.StatusOK)
+}

--- a/apps/copilot-api/budget_handlers.go
+++ b/apps/copilot-api/budget_handlers.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
-	"strings"
 )
 
 // BudgetHandlers handles the enterprise AI credit budget endpoint.
@@ -31,12 +30,12 @@ func (h *BudgetHandlers) handleGetBudget(w http.ResponseWriter, r *http.Request)
 
 	username, err := h.githubClient.getUsernameBySamlIdentity(r.Context(), user.Email)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			respondError(w, "not_found", "GitHub account not linked to Nav organisation", http.StatusNotFound)
-			return
-		}
 		slog.Error("Failed to resolve GitHub username via SAML", "error", err)
 		respondError(w, "saml_error", "Failed to resolve GitHub identity", http.StatusInternalServerError)
+		return
+	}
+	if username == "" {
+		respondError(w, "not_found", "GitHub account not linked to Nav organisation", http.StatusNotFound)
 		return
 	}
 

--- a/apps/copilot-api/budget_handlers.go
+++ b/apps/copilot-api/budget_handlers.go
@@ -68,6 +68,15 @@ func (h *BudgetHandlers) handleGetGlobalBudget(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	// Use the background-collected seat count for an accurate active user total.
+	// The budget API only lists override users, not all licensed seats.
+	metricsCollector.mu.RLock()
+	activeSeats := metricsCollector.githubSeatsActive
+	metricsCollector.mu.RUnlock()
+	if activeSeats > 0 {
+		budget.ActiveUsers = int(activeSeats)
+	}
+
 	cacheControl(w, 30*60, true) // public — same for all users
 	respondJSON(w, budget, http.StatusOK)
 }

--- a/apps/copilot-api/budget_handlers.go
+++ b/apps/copilot-api/budget_handlers.go
@@ -53,3 +53,21 @@ func (h *BudgetHandlers) handleGetBudget(w http.ResponseWriter, r *http.Request)
 	cacheControl(w, 30*60, false)
 	respondJSON(w, budget, http.StatusOK)
 }
+
+// handleGetGlobalBudget handles GET /api/v1/copilot/budget/global.
+// Returns the enterprise-wide default AI credit budget (no SAML lookup required).
+func (h *BudgetHandlers) handleGetGlobalBudget(w http.ResponseWriter, r *http.Request) {
+	budget, err := h.budgetClient.getGlobalBudget(r.Context())
+	if err != nil {
+		if errors.Is(err, errBudgetNotFound) {
+			respondError(w, "not_found", "No global budget data found", http.StatusNotFound)
+			return
+		}
+		slog.Error("Failed to fetch global budget", "error", err)
+		respondError(w, "budget_error", "Failed to fetch budget data", http.StatusInternalServerError)
+		return
+	}
+
+	cacheControl(w, 30*60, true) // public — same for all users
+	respondJSON(w, budget, http.StatusOK)
+}

--- a/apps/copilot-api/config.go
+++ b/apps/copilot-api/config.go
@@ -16,9 +16,11 @@ type Config struct {
 	AzureJWKSURI           string
 	PreAuthorizedApps      string
 	GitHubOrg              string
+	GitHubEnterprise       string
 	GitHubAppID            string
 	GitHubAppPrivateKey    string
 	GitHubInstallationID   string
+	GitHubBillingToken     string
 	GCPProjectID           string
 	CopilotMetricsDataset  string
 	CopilotMetricsTable    string
@@ -37,9 +39,11 @@ func loadConfig() *Config {
 		AzureJWKSURI:           getEnv("AZURE_OPENID_CONFIG_JWKS_URI", ""),
 		PreAuthorizedApps:      getEnv("AZURE_APP_PRE_AUTHORIZED_APPS", ""),
 		GitHubOrg:              getEnv("GITHUB_ORG", "navikt"),
+		GitHubEnterprise:       getEnv("GITHUB_ENTERPRISE", "nav"),
 		GitHubAppID:            os.Getenv("GITHUB_APP_ID"),
 		GitHubAppPrivateKey:    os.Getenv("GITHUB_APP_PRIVATE_KEY"),
 		GitHubInstallationID:   os.Getenv("GITHUB_APP_INSTALLATION_ID"),
+		GitHubBillingToken:     os.Getenv("GITHUB_BILLING_TOKEN"),
 		GCPProjectID:           os.Getenv("GCP_TEAM_PROJECT_ID"),
 		CopilotMetricsDataset:  getEnv("COPILOT_METRICS_DATASET", "copilot_metrics"),
 		CopilotMetricsTable:    getEnv("COPILOT_METRICS_TABLE", "usage_metrics"),

--- a/apps/copilot-api/handlers.go
+++ b/apps/copilot-api/handlers.go
@@ -42,7 +42,7 @@ func readyHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // makeAPIRouter creates the main API router for /api/v1/
-func makeAPIRouter(config *Config, bqHandlers *BigQueryHandlers, ghHandlers *GitHubHandlers) http.Handler {
+func makeAPIRouter(config *Config, bqHandlers *BigQueryHandlers, ghHandlers *GitHubHandlers, budgetHandlers *BudgetHandlers) http.Handler {
 	mux := http.NewServeMux()
 
 	// BigQuery endpoints
@@ -72,6 +72,11 @@ func makeAPIRouter(config *Config, bqHandlers *BigQueryHandlers, ghHandlers *Git
 		mux.HandleFunc("POST /api/v1/copilot/seats", ghHandlers.handleAssignSeat)
 		mux.HandleFunc("DELETE /api/v1/copilot/seats/{username}", ghHandlers.handleUnassignSeat)
 		mux.HandleFunc("GET /api/v1/copilot/saml/{identity}", ghHandlers.handleGetUsernameBySAML)
+	}
+
+	// Enterprise budget endpoint
+	if budgetHandlers != nil {
+		mux.HandleFunc("GET /api/v1/copilot/budget", budgetHandlers.handleGetBudget)
 	}
 
 	// Placeholder endpoints - to be implemented in future phases

--- a/apps/copilot-api/handlers.go
+++ b/apps/copilot-api/handlers.go
@@ -74,9 +74,10 @@ func makeAPIRouter(config *Config, bqHandlers *BigQueryHandlers, ghHandlers *Git
 		mux.HandleFunc("GET /api/v1/copilot/saml/{identity}", ghHandlers.handleGetUsernameBySAML)
 	}
 
-	// Enterprise budget endpoint
+	// Enterprise budget endpoints
 	if budgetHandlers != nil {
 		mux.HandleFunc("GET /api/v1/copilot/budget", budgetHandlers.handleGetBudget)
+		mux.HandleFunc("GET /api/v1/copilot/budget/global", budgetHandlers.handleGetGlobalBudget)
 	}
 
 	// Placeholder endpoints - to be implemented in future phases

--- a/apps/copilot-api/main.go
+++ b/apps/copilot-api/main.go
@@ -66,7 +66,7 @@ func main() {
 
 	// Initialize budget client (optional - requires GITHUB_BILLING_TOKEN classic PAT)
 	var budgetHandlers *BudgetHandlers
-	if config.GitHubBillingToken != "" && ghHandlers != nil {
+	if config.GitHubBillingToken != "" && githubClient != nil {
 		budgetClient := newBudgetClient(config.GitHubBillingToken, config.GitHubEnterprise)
 		budgetHandlers = newBudgetHandlers(budgetClient, githubClient)
 		slog.Info("Budget client initialized successfully")

--- a/apps/copilot-api/main.go
+++ b/apps/copilot-api/main.go
@@ -64,6 +64,16 @@ func main() {
 		defer cachedBQClient.Close()
 	}
 
+	// Initialize budget client (optional - requires GITHUB_BILLING_TOKEN classic PAT)
+	var budgetHandlers *BudgetHandlers
+	if config.GitHubBillingToken != "" && ghHandlers != nil {
+		budgetClient := newBudgetClient(config.GitHubBillingToken, config.GitHubEnterprise)
+		budgetHandlers = newBudgetHandlers(budgetClient, githubClient)
+		slog.Info("Budget client initialized successfully")
+	} else {
+		slog.Warn("GITHUB_BILLING_TOKEN not configured - budget endpoint will be unavailable")
+	}
+
 	// Middleware
 	authMiddleware := makeAuthMiddleware(config)
 
@@ -76,7 +86,7 @@ func main() {
 	mux.Handle("/metrics", metricsHandler())
 
 	// Protected API endpoints
-	mux.Handle("/api/v1/", loggingMiddleware(config, authMiddleware(makeAPIRouter(config, bqHandlers, ghHandlers))))
+	mux.Handle("/api/v1/", loggingMiddleware(config, authMiddleware(makeAPIRouter(config, bqHandlers, ghHandlers, budgetHandlers))))
 
 	slog.Info("Server listening", "port", config.Port)
 

--- a/apps/copilot-metrics/budget.go
+++ b/apps/copilot-metrics/budget.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// BudgetClient fetches enterprise AI credit budgets from the GitHub billing API.
+// Requires a classic PAT with admin:enterprise scope — same token as BillingClient.
+type BudgetClient struct {
+	httpClient *http.Client
+	enterprise string
+	token      string
+}
+
+// BudgetEntry represents a single entry from the enterprise billing budgets API.
+type BudgetEntry struct {
+	BudgetScope      string   `json:"budget_scope"`
+	BudgetEntityName string   `json:"budget_entity_name"`
+	BudgetAmount     float64  `json:"budget_amount"`
+	ConsumedAmount   *float64 `json:"consumed_amount"`
+}
+
+type budgetListResponse struct {
+	Budgets     []BudgetEntry `json:"budgets"`
+	HasNextPage bool          `json:"has_next_page"`
+}
+
+func NewBudgetClient(token, enterprise string) *BudgetClient {
+	if token == "" {
+		return nil
+	}
+	return &BudgetClient{
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		enterprise: enterprise,
+		token:      token,
+	}
+}
+
+// FetchAllBudgets paginates through the enterprise billing budgets endpoint
+// and returns all entries.
+func (c *BudgetClient) FetchAllBudgets(ctx context.Context) ([]BudgetEntry, error) {
+	var all []BudgetEntry
+	page := 1
+
+	for {
+		url := fmt.Sprintf(
+			"https://api.github.com/enterprises/%s/settings/billing/budgets?per_page=100&page=%d",
+			c.enterprise, page,
+		)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("create budget request page %d: %w", page, err)
+		}
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("fetch budgets page %d: %w", page, err)
+		}
+
+		body, readErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("read budgets page %d: %w", page, readErr)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("budgets API returned %d on page %d: %s", resp.StatusCode, page, truncate(string(body), 500))
+		}
+
+		var result budgetListResponse
+		if err := json.Unmarshal(body, &result); err != nil {
+			return nil, fmt.Errorf("decode budgets page %d: %w", page, err)
+		}
+
+		all = append(all, result.Budgets...)
+		slog.Debug("Fetched budget page", "page", page, "entries", len(result.Budgets), "has_next", result.HasNextPage)
+
+		if !result.HasNextPage {
+			break
+		}
+		page++
+	}
+
+	slog.Info("Fetched all budget entries", "total", len(all), "pages", page)
+	return all, nil
+}

--- a/apps/copilot-metrics/budget_bigquery.go
+++ b/apps/copilot-metrics/budget_bigquery.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/civil"
+)
+
+const budgetSnapshotsTable = "budget_snapshots"
+
+// BudgetSnapshotRow represents a row in the budget_snapshots BigQuery table.
+type BudgetSnapshotRow struct {
+	SnapshotDate   civil.Date `bigquery:"snapshot_date"`
+	ScopeID        string     `bigquery:"scope_id"`
+	BudgetScope    string     `bigquery:"budget_scope"`
+	EntityName     string     `bigquery:"entity_name"`
+	BudgetAmount   float64    `bigquery:"budget_amount"`
+	ConsumedAmount *float64   `bigquery:"consumed_amount"`
+	IsOverride     bool       `bigquery:"is_override"`
+	LoadedAt       time.Time  `bigquery:"loaded_at"`
+}
+
+// EnsureBudgetSnapshotsTableExists creates the budget_snapshots table if it doesn't exist.
+func (c *BigQueryClient) EnsureBudgetSnapshotsTableExists(ctx context.Context) error {
+	dataset := c.client.Dataset(c.dataset)
+	table := dataset.Table(budgetSnapshotsTable)
+
+	_, err := table.Metadata(ctx)
+	if err == nil {
+		slog.Debug("Budget snapshots table already exists", "table", budgetSnapshotsTable)
+		return nil
+	}
+
+	slog.Info("Creating budget_snapshots table", "dataset", c.dataset)
+
+	schema := bigquery.Schema{
+		{Name: "snapshot_date", Type: bigquery.DateFieldType, Required: true, Description: "Date the snapshot was taken"},
+		{Name: "scope_id", Type: bigquery.StringFieldType, Required: true, Description: "Enterprise slug"},
+		{Name: "budget_scope", Type: bigquery.StringFieldType, Required: true, Description: "Budget scope: multi_user_customer or user"},
+		{Name: "entity_name", Type: bigquery.StringFieldType, Required: true, Description: "Entity name: enterprise slug for defaults, GitHub username for user overrides"},
+		{Name: "budget_amount", Type: bigquery.FloatFieldType, Required: true, Description: "Budget limit in USD"},
+		{Name: "consumed_amount", Type: bigquery.FloatFieldType, Required: false, Description: "Consumed amount in USD this month (null if not tracked individually)"},
+		{Name: "is_override", Type: bigquery.BooleanFieldType, Required: true, Description: "True if this is a user-specific override of the enterprise default"},
+		{Name: "loaded_at", Type: bigquery.TimestampFieldType, Required: true, Description: "When the row was inserted"},
+	}
+
+	metadata := &bigquery.TableMetadata{
+		Schema: schema,
+		TimePartitioning: &bigquery.TimePartitioning{
+			Type:  bigquery.MonthPartitioningType,
+			Field: "snapshot_date",
+		},
+		Clustering: &bigquery.Clustering{
+			Fields: []string{"scope_id", "budget_scope", "entity_name"},
+		},
+		Description: "Daily snapshots of GitHub Copilot AI credit budgets per user and enterprise default",
+	}
+
+	if err := table.Create(ctx, metadata); err != nil {
+		return fmt.Errorf("failed to create budget_snapshots table: %w", err)
+	}
+
+	slog.Info("budget_snapshots table created successfully")
+	return nil
+}
+
+// BudgetSnapshotExists checks if we already have a snapshot for the given date.
+func (c *BigQueryClient) BudgetSnapshotExists(ctx context.Context, date time.Time, scopeID string) (bool, error) {
+	query := c.client.Query(`
+		SELECT COUNT(*) as cnt
+		FROM ` + "`" + c.projectID + "." + c.dataset + "." + budgetSnapshotsTable + "`" + `
+		WHERE snapshot_date = @date AND scope_id = @scopeID
+	`)
+	query.Parameters = []bigquery.QueryParameter{
+		{Name: "date", Value: civil.DateOf(date)},
+		{Name: "scopeID", Value: scopeID},
+	}
+
+	it, err := query.Read(ctx)
+	if err != nil {
+		return false, fmt.Errorf("check budget snapshot: %w", err)
+	}
+
+	var row struct {
+		Cnt int64 `bigquery:"cnt"`
+	}
+	if err := it.Next(&row); err != nil {
+		return false, fmt.Errorf("read budget snapshot check: %w", err)
+	}
+
+	return row.Cnt > 0, nil
+}
+
+// DeleteBudgetSnapshot removes existing snapshots for a date (for re-ingestion).
+func (c *BigQueryClient) DeleteBudgetSnapshot(ctx context.Context, date time.Time, scopeID string) error {
+	query := c.client.Query(`
+		DELETE FROM ` + "`" + c.projectID + "." + c.dataset + "." + budgetSnapshotsTable + "`" + `
+		WHERE snapshot_date = @date AND scope_id = @scopeID
+	`)
+	query.Parameters = []bigquery.QueryParameter{
+		{Name: "date", Value: civil.DateOf(date)},
+		{Name: "scopeID", Value: scopeID},
+	}
+
+	job, err := query.Run(ctx)
+	if err != nil {
+		return fmt.Errorf("run budget snapshot delete: %w", err)
+	}
+
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("budget snapshot delete job failed: %w", err)
+	}
+	if status.Err() != nil {
+		return fmt.Errorf("budget snapshot delete query failed: %w", status.Err())
+	}
+
+	slog.Debug("Deleted existing budget snapshot", "date", date.Format("2006-01-02"), "scope_id", scopeID)
+	return nil
+}
+
+// InsertBudgetSnapshots stores budget entries as a daily snapshot in BigQuery.
+func (c *BigQueryClient) InsertBudgetSnapshots(ctx context.Context, date time.Time, scopeID string, entries []BudgetEntry) error {
+	if len(entries) == 0 {
+		slog.Warn("No budget entries to insert")
+		return nil
+	}
+
+	table := c.client.Dataset(c.dataset).Table(budgetSnapshotsTable)
+	inserter := table.Inserter()
+
+	snapshotDate := civil.DateOf(date)
+	loadedAt := time.Now().UTC()
+
+	var rows []*BudgetSnapshotRow
+	for _, e := range entries {
+		isOverride := e.BudgetScope == "user"
+		entityName := e.BudgetEntityName
+		if entityName == "" {
+			entityName = scopeID
+		}
+		rows = append(rows, &BudgetSnapshotRow{
+			SnapshotDate:   snapshotDate,
+			ScopeID:        scopeID,
+			BudgetScope:    e.BudgetScope,
+			EntityName:     entityName,
+			BudgetAmount:   e.BudgetAmount,
+			ConsumedAmount: e.ConsumedAmount,
+			IsOverride:     isOverride,
+			LoadedAt:       loadedAt,
+		})
+	}
+
+	if err := inserter.Put(ctx, rows); err != nil {
+		return fmt.Errorf("insert budget snapshot rows: %w", err)
+	}
+
+	slog.Info("Inserted budget snapshot", "date", date.Format("2006-01-02"), "rows", len(rows))
+	return nil
+}

--- a/apps/copilot-metrics/go.mod
+++ b/apps/copilot-metrics/go.mod
@@ -3,12 +3,12 @@ module github.com/navikt/copilot/apps/copilot-metrics
 go 1.26
 
 require (
+	cloud.google.com/go v0.123.0
 	cloud.google.com/go/bigquery v1.77.0
 	github.com/bradleyfalzon/ghinstallation/v2 v2.18.0
 )
 
 require (
-	cloud.google.com/go v0.123.0 // indirect
 	cloud.google.com/go/auth v0.20.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect

--- a/apps/copilot-metrics/main.go
+++ b/apps/copilot-metrics/main.go
@@ -79,16 +79,21 @@ func main() {
 		slog.Warn("Failed to ensure views exist (continuing without views)", "error", err)
 	}
 
-	// Set up billing client (optional — requires classic PAT)
+	// Set up billing + budget clients (optional — require classic PAT with admin:enterprise scope)
 	billingClient := NewBillingClient(config.GitHubBillingToken, config.EnterpriseSlug)
+	budgetClient := NewBudgetClient(config.GitHubBillingToken, config.EnterpriseSlug)
 	if billingClient != nil {
-		slog.Info("Billing client configured — premium request usage ingestion enabled")
+		slog.Info("Billing client configured — premium request usage and budget snapshot ingestion enabled")
 		if err := bqClient.EnsureBillingTableExists(ctx); err != nil {
 			slog.Error("Failed to ensure billing table exists", "error", err)
 			os.Exit(1)
 		}
+		if err := bqClient.EnsureBudgetSnapshotsTableExists(ctx); err != nil {
+			slog.Error("Failed to ensure budget_snapshots table exists", "error", err)
+			os.Exit(1)
+		}
 	} else {
-		slog.Warn("No GITHUB_BILLING_TOKEN configured — billing usage ingestion disabled")
+		slog.Warn("No GITHUB_BILLING_TOKEN configured — billing usage and budget snapshot ingestion disabled")
 	}
 
 	if *billingBackfill {
@@ -133,6 +138,10 @@ func main() {
 		// Ingest current month's billing data (always re-ingests since it's cumulative)
 		if billingClient != nil {
 			ingestCurrentMonthBilling(ctx, billingClient, bqClient, config)
+		}
+		// Ingest today's budget snapshot (always re-ingests since consumption is live)
+		if budgetClient != nil {
+			ingestTodayBudgetSnapshot(ctx, budgetClient, bqClient, config)
 		}
 		slog.Info("Ingestion completed successfully")
 		return
@@ -469,4 +478,43 @@ func runBillingBackfill(ctx context.Context, billing *BillingClient, bq *BigQuer
 
 	slog.Info("Billing backfill completed", "months_processed", successCount, "errors", errorCount)
 	return nil
+}
+
+// ingestTodayBudgetSnapshot fetches all budget entries from GitHub and stores a daily snapshot.
+// Always overwrites today's snapshot since consumed_amount is live and cumulative within the month.
+// Errors are logged as warnings — budget snapshots are supplementary data.
+func ingestTodayBudgetSnapshot(ctx context.Context, budget *BudgetClient, bq *BigQueryClient, cfg *Config) {
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	dateStr := today.Format("2006-01-02")
+
+	slog.Info("Ingesting budget snapshot", "date", dateStr)
+
+	entries, err := budget.FetchAllBudgets(ctx)
+	if err != nil {
+		slog.Warn("Failed to fetch budget entries from GitHub API", "date", dateStr, "error", err)
+		return
+	}
+
+	if len(entries) == 0 {
+		slog.Info("No budget entries returned", "date", dateStr)
+		return
+	}
+
+	// Delete existing snapshot for today before re-inserting (idempotent).
+	// If the check or delete fails we still attempt insert — BigQuery data may not exist yet.
+	exists, checkErr := bq.BudgetSnapshotExists(ctx, today, cfg.EnterpriseSlug)
+	if checkErr != nil {
+		slog.Warn("Could not check if budget snapshot exists (proceeding with insert)", "date", dateStr, "error", checkErr)
+	} else if exists {
+		if delErr := bq.DeleteBudgetSnapshot(ctx, today, cfg.EnterpriseSlug); delErr != nil {
+			slog.Warn("Failed to delete existing budget snapshot (proceeding with insert)", "date", dateStr, "error", delErr)
+		}
+	}
+
+	if err := bq.InsertBudgetSnapshots(ctx, today, cfg.EnterpriseSlug, entries); err != nil {
+		slog.Warn("Failed to insert budget snapshot", "date", dateStr, "error", err)
+		return
+	}
+
+	slog.Info("Budget snapshot ingested successfully", "date", dateStr, "entries", len(entries))
 }

--- a/apps/mcp-registry/.nais/app.yaml
+++ b/apps/mcp-registry/.nais/app.yaml
@@ -42,6 +42,11 @@ spec:
       value: "/,/v0.1/servers"
     - name: SERVICE_NAME
       value: "mcp-registry"
+  accessPolicy:
+    inbound:
+      rules:
+        - application: my-copilot
+          namespace: copilot
   ingresses:
   {{#each ingresses as |url|}}
     - {{url}}

--- a/apps/my-copilot/.nais/app.yaml
+++ b/apps/my-copilot/.nais/app.yaml
@@ -103,6 +103,8 @@ spec:
       value: ALWAYS_ON
     - name: MCP_REGISTRY_URL
       value: "{{mcp_registry_url}}"
+    - name: MCP_REGISTRY_PUBLIC_URL
+      value: "{{mcp_registry_public_url}}"
     - name: COPILOT_API_URL
       value: "http://copilot-api"
   liveness:

--- a/apps/my-copilot/.nais/app.yaml
+++ b/apps/my-copilot/.nais/app.yaml
@@ -126,11 +126,12 @@ spec:
       rules:
         - application: copilot-api
           namespace: copilot
+        - application: mcp-registry
+          namespace: copilot
       external:
         - host: api.github.com
         - host: avatars.githubusercontent.com
         - host: login.microsoftonline.com
-        - host: {{mcp_registry_host}}
         - host: raw.githubusercontent.com
   filesFrom:
     - emptyDir:

--- a/apps/my-copilot/.nais/dev-gcp.yaml
+++ b/apps/my-copilot/.nais/dev-gcp.yaml
@@ -1,4 +1,5 @@
 mcp_registry_url: http://mcp-registry
+mcp_registry_public_url: https://mcp-registry.ekstern.dev.nav.no
 ingresses:
   - "https://ki-utvikling.ekstern.dev.nav.no"
   - "https://min-copilot.intern.dev.nav.no"

--- a/apps/my-copilot/.nais/dev-gcp.yaml
+++ b/apps/my-copilot/.nais/dev-gcp.yaml
@@ -1,5 +1,4 @@
-mcp_registry_host: mcp-registry.ekstern.dev.nav.no
-mcp_registry_url: https://mcp-registry.ekstern.dev.nav.no
+mcp_registry_url: http://mcp-registry
 ingresses:
   - "https://ki-utvikling.ekstern.dev.nav.no"
   - "https://min-copilot.intern.dev.nav.no"

--- a/apps/my-copilot/.nais/prod-gcp.yaml
+++ b/apps/my-copilot/.nais/prod-gcp.yaml
@@ -1,5 +1,4 @@
-mcp_registry_host: mcp-registry.nav.no
-mcp_registry_url: https://mcp-registry.nav.no
+mcp_registry_url: http://mcp-registry
 ingresses:
   - "https://ki-utvikling.nav.no"
   - "https://min-copilot.intern.nav.no"

--- a/apps/my-copilot/.nais/prod-gcp.yaml
+++ b/apps/my-copilot/.nais/prod-gcp.yaml
@@ -1,4 +1,5 @@
 mcp_registry_url: http://mcp-registry
+mcp_registry_public_url: https://mcp-registry.nav.no
 ingresses:
   - "https://ki-utvikling.nav.no"
   - "https://min-copilot.intern.nav.no"

--- a/apps/my-copilot/src/app/api/budget/global/route.ts
+++ b/apps/my-copilot/src/app/api/budget/global/route.ts
@@ -18,11 +18,14 @@ export async function GET() {
   try {
     const budget = await backendRequest<GlobalBudgetResponse>("/api/v1/copilot/budget/global", token);
     return NextResponse.json(budget, {
-      headers: { "Cache-Control": "public, max-age=1800, s-maxage=1800" },
+      headers: { "Cache-Control": "private, max-age=1800" },
     });
   } catch (error) {
     if (error instanceof BackendApiError && error.status === 404) {
       return NextResponse.json({ error: "no_budget" }, { status: 404 });
+    }
+    if (error instanceof BackendApiError && error.status === 503) {
+      return NextResponse.json({ error: "unavailable" }, { status: 503 });
     }
     console.error("[budget/global] Failed to fetch global budget:", error);
     return NextResponse.json({ error: "failed_to_fetch_budget" }, { status: 500 });

--- a/apps/my-copilot/src/app/api/budget/global/route.ts
+++ b/apps/my-copilot/src/app/api/budget/global/route.ts
@@ -1,0 +1,30 @@
+import { getUser, getUserToken } from "@/lib/auth";
+import { backendRequest, BackendApiError } from "@/lib/backend-api";
+import { NextResponse } from "next/server";
+
+export interface GlobalBudgetResponse {
+  budgetAmount: number;
+  consumedAmount: number | null;
+}
+
+export async function GET() {
+  const user = await getUser(false);
+  const token = await getUserToken();
+
+  if (!user || !token) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const budget = await backendRequest<GlobalBudgetResponse>("/api/v1/copilot/budget/global", token);
+    return NextResponse.json(budget, {
+      headers: { "Cache-Control": "public, max-age=1800, s-maxage=1800" },
+    });
+  } catch (error) {
+    if (error instanceof BackendApiError && error.status === 404) {
+      return NextResponse.json({ error: "no_budget" }, { status: 404 });
+    }
+    console.error("[budget/global] Failed to fetch global budget:", error);
+    return NextResponse.json({ error: "failed_to_fetch_budget" }, { status: 500 });
+  }
+}

--- a/apps/my-copilot/src/app/api/budget/global/route.ts
+++ b/apps/my-copilot/src/app/api/budget/global/route.ts
@@ -3,8 +3,9 @@ import { backendRequest, BackendApiError } from "@/lib/backend-api";
 import { NextResponse } from "next/server";
 
 export interface GlobalBudgetResponse {
-  budgetAmount: number;
-  consumedAmount: number | null;
+  totalConsumed: number;
+  perUserBudget: number;
+  activeUsers: number;
 }
 
 export async function GET() {

--- a/apps/my-copilot/src/app/api/budget/route.ts
+++ b/apps/my-copilot/src/app/api/budget/route.ts
@@ -1,0 +1,35 @@
+import { getUser, getUserToken } from "@/lib/auth";
+import { backendRequest, BackendApiError } from "@/lib/backend-api";
+import { NextResponse } from "next/server";
+
+export interface BudgetResponse {
+  budgetAmount: number;
+  consumedAmount: number | null;
+  isOverride: boolean;
+  defaultBudget: number;
+}
+
+export async function GET() {
+  const user = await getUser(false);
+  const token = await getUserToken();
+
+  if (!user || !token) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const budget = await backendRequest<BudgetResponse>("/api/v1/copilot/budget", token);
+    return NextResponse.json(budget);
+  } catch (error) {
+    if (error instanceof BackendApiError) {
+      if (error.status === 404) {
+        return NextResponse.json({ error: "no_budget" }, { status: 404 });
+      }
+      if (error.status === 503) {
+        return NextResponse.json({ error: "unavailable" }, { status: 503 });
+      }
+    }
+    console.error("[budget] Failed to fetch budget:", error);
+    return NextResponse.json({ error: "failed_to_fetch_budget" }, { status: 500 });
+  }
+}

--- a/apps/my-copilot/src/app/layout.tsx
+++ b/apps/my-copilot/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { getUser } from "@/lib/auth";
 import Faro from "@/components/faro";
 import NextLink from "next/link";
 import { FooterMessage } from "@/components/footer-message";
+import NavBudgetBar from "@/components/nav-budget-bar";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -56,6 +57,7 @@ export default async function RootLayout({
                   >
                     Abonnement
                   </NextLink>
+                  <NavBudgetBar />
                   <BodyShort size="small" style={{ color: "rgba(255, 255, 255, 0.7)" }}>
                     {user.firstName} {user.lastName}
                   </BodyShort>

--- a/apps/my-copilot/src/app/statistikk/page.tsx
+++ b/apps/my-copilot/src/app/statistikk/page.tsx
@@ -314,7 +314,7 @@ async function UsageContent({ usage, token }: { usage: EnterpriseMetrics[]; toke
                 height: "10px",
                 width: "100%",
                 borderRadius: "var(--a-border-radius-full)",
-                backgroundColor: "var(--a-surface-neutral)",
+                backgroundColor: "var(--a-border-default)",
               }}
               role="progressbar"
               aria-label={`${Math.round((globalBudget.totalConsumed / (globalBudget.activeUsers * globalBudget.perUserBudget)) * 100)}% av totalt budsjett brukt`}

--- a/apps/my-copilot/src/app/statistikk/page.tsx
+++ b/apps/my-copilot/src/app/statistikk/page.tsx
@@ -295,23 +295,51 @@ async function UsageContent({ usage, token }: { usage: EnterpriseMetrics[]; toke
       {/* Global AI credit budget */}
       {globalBudget && (
         <Box background="default" padding="space-16" borderRadius="8" className="border border-gray-200">
-          <HStack gap="space-16" align="center" justify="space-between" wrap={false}>
-            <HStack gap="space-8" align="center">
-              <BodyShort className="text-gray-600 text-sm">Totalt AI-kreditforbruk</BodyShort>
-              <HelpText title="Totalt AI-kreditforbruk">
-                Sum av AI-kreditforbruk for alle Nav-utviklere denne måneden. Inkluderer brukere med aktivt forbruk i
-                GitHub Copilot.
-              </HelpText>
-            </HStack>
-            <HStack gap="space-24" align="center">
-              <Heading size="medium" level="2">
-                {formatNumber(Math.round(globalBudget.totalConsumed))} USD
-              </Heading>
+          <VStack gap="space-8">
+            <HStack gap="space-8" align="center" justify="space-between">
+              <HStack gap="space-8" align="center">
+                <BodyShort className="text-gray-600 text-sm">Totalt AI-kreditforbruk</BodyShort>
+                <HelpText title="Totalt AI-kreditforbruk">
+                  Sum av AI-kreditforbruk for alle Nav-utviklere denne måneden. Inkluderer brukere med aktivt forbruk i
+                  GitHub Copilot.
+                </HelpText>
+              </HStack>
               <BodyShort className="text-gray-500 text-sm">
-                {globalBudget.activeUsers} aktive brukere · {formatNumber(globalBudget.perUserBudget)} USD per bruker
+                {formatNumber(Math.round(globalBudget.totalConsumed))} /{" "}
+                {formatNumber(globalBudget.activeUsers * globalBudget.perUserBudget)} USD
               </BodyShort>
             </HStack>
-          </HStack>
+            <div
+              style={{
+                height: "10px",
+                width: "100%",
+                borderRadius: "var(--a-border-radius-full)",
+                backgroundColor: "var(--a-surface-neutral)",
+              }}
+              role="progressbar"
+              aria-label={`${Math.round((globalBudget.totalConsumed / (globalBudget.activeUsers * globalBudget.perUserBudget)) * 100)}% av totalt budsjett brukt`}
+              aria-valuenow={Math.round(globalBudget.totalConsumed)}
+              aria-valuemin={0}
+              aria-valuemax={globalBudget.activeUsers * globalBudget.perUserBudget}
+            >
+              <div
+                style={{
+                  height: "100%",
+                  borderRadius: "var(--a-border-radius-full)",
+                  width: `${Math.min(100, Math.round((globalBudget.totalConsumed / (globalBudget.activeUsers * globalBudget.perUserBudget)) * 100))}%`,
+                  backgroundColor:
+                    globalBudget.totalConsumed / (globalBudget.activeUsers * globalBudget.perUserBudget) > 0.9
+                      ? "var(--a-icon-danger)"
+                      : globalBudget.totalConsumed / (globalBudget.activeUsers * globalBudget.perUserBudget) > 0.7
+                        ? "var(--a-icon-warning)"
+                        : "var(--a-icon-success)",
+                }}
+              />
+            </div>
+            <BodyShort className="text-gray-500 text-sm">
+              {globalBudget.activeUsers} aktive brukere · {formatNumber(globalBudget.perUserBudget)} USD per bruker
+            </BodyShort>
+          </VStack>
         </Box>
       )}
 

--- a/apps/my-copilot/src/app/statistikk/page.tsx
+++ b/apps/my-copilot/src/app/statistikk/page.tsx
@@ -294,7 +294,7 @@ async function UsageContent({ usage, token }: { usage: EnterpriseMetrics[]; toke
 
       {/* Global AI credit budget */}
       {globalBudget && (
-        <HGrid columns={{ xs: 1, sm: 2, md: 3 }} gap="space-16">
+        <HGrid columns={{ xs: 1, sm: 2, md: 4 }} gap="space-16">
           <MetricCard
             value={`${formatNumber(globalBudget.budgetAmount)} USD`}
             label="Global AI-kredittramme"

--- a/apps/my-copilot/src/app/statistikk/page.tsx
+++ b/apps/my-copilot/src/app/statistikk/page.tsx
@@ -21,7 +21,7 @@ import MonthlyModelChart from "@/components/charts/MonthlyModelChart";
 import AdoptionCohortsChart from "@/components/charts/AdoptionCohortsChart";
 import MetricCard from "@/components/metric-card";
 import ErrorState from "@/components/error-state";
-import { Table, BodyShort, Heading, HGrid, Box, HelpText, Skeleton, VStack } from "@navikt/ds-react";
+import { Table, BodyShort, Heading, HGrid, Box, HelpText, Skeleton, VStack, HStack } from "@navikt/ds-react";
 import { TableBody, TableDataCell, TableHeader, TableHeaderCell, TableRow } from "@navikt/ds-react/Table";
 import { PageHero } from "@/components/page-hero";
 import {
@@ -294,15 +294,25 @@ async function UsageContent({ usage, token }: { usage: EnterpriseMetrics[]; toke
 
       {/* Global AI credit budget */}
       {globalBudget && (
-        <HGrid columns={{ xs: 1, sm: 2, md: 4 }} gap="space-16">
-          <MetricCard
-            value={`${formatNumber(Math.round(globalBudget.totalConsumed))} USD`}
-            label="Totalt AI-kreditforbruk"
-            helpTitle="Totalt AI-kreditforbruk"
-            helpText="Sum av AI-kreditforbruk for alle Nav-utviklere denne måneden. Inkluderer brukere med aktivt forbruk i GitHub Copilot."
-            subtitle={`${globalBudget.activeUsers} aktive brukere · ${formatNumber(globalBudget.perUserBudget)} USD per bruker`}
-          />
-        </HGrid>
+        <Box background="default" padding="space-16" borderRadius="8" className="border border-gray-200">
+          <HStack gap="space-16" align="center" justify="space-between" wrap={false}>
+            <HStack gap="space-8" align="center">
+              <BodyShort className="text-gray-600 text-sm">Totalt AI-kreditforbruk</BodyShort>
+              <HelpText title="Totalt AI-kreditforbruk">
+                Sum av AI-kreditforbruk for alle Nav-utviklere denne måneden. Inkluderer brukere med aktivt forbruk i
+                GitHub Copilot.
+              </HelpText>
+            </HStack>
+            <HStack gap="space-24" align="center">
+              <Heading size="medium" level="2">
+                {formatNumber(Math.round(globalBudget.totalConsumed))} USD
+              </Heading>
+              <BodyShort className="text-gray-500 text-sm">
+                {globalBudget.activeUsers} aktive brukere · {formatNumber(globalBudget.perUserBudget)} USD per bruker
+              </BodyShort>
+            </HStack>
+          </HStack>
+        </Box>
       )}
 
       {/* Monthly trends — THE story */}

--- a/apps/my-copilot/src/app/statistikk/page.tsx
+++ b/apps/my-copilot/src/app/statistikk/page.tsx
@@ -39,7 +39,7 @@ import {
 import type { LanguageData, EditorData, ModelData } from "@/lib/types";
 import { formatNumber } from "@/lib/format";
 import { getUser, getUserToken } from "@/lib/auth";
-import { backendRequest } from "@/lib/backend-api";
+import { backendRequest, BackendApiError } from "@/lib/backend-api";
 
 function formatMinutes(minutes: number): string {
   if (minutes < 60) return `${Math.round(minutes)} min`;
@@ -172,11 +172,21 @@ async function UsageContent({ usage, token }: { usage: EnterpriseMetrics[]; toke
     { usage: monthlyModelUsage, error: modelUsageError },
     { usage: billingUsage, error: billingError },
     { cohorts: adoptionCohorts, error: cohortsError },
+    globalBudget,
   ] = await Promise.all([
     getMonthlyTrends(token),
     getMonthlyModelUsage(token),
     getMonthlyBillingUsage(token),
     getAdoptionCohorts(token),
+    backendRequest<{ budgetAmount: number; consumedAmount: number | null }>(
+      "/api/v1/copilot/budget/global",
+      token
+    ).catch((err) => {
+      if (!(err instanceof BackendApiError && err.status === 404)) {
+        console.error("[statistikk] Global budget fetch failed:", err);
+      }
+      return null;
+    }),
   ]);
   if (monthlyError) {
     console.error("[statistikk] Monthly trends failed:", monthlyError);
@@ -281,6 +291,23 @@ async function UsageContent({ usage, token }: { usage: EnterpriseMetrics[]; toke
           subtitle={`Siste ${usage.length} dager`}
         />
       </HGrid>
+
+      {/* Global AI credit budget */}
+      {globalBudget && (
+        <HGrid columns={{ xs: 1, sm: 2, md: 3 }} gap="space-16">
+          <MetricCard
+            value={`${formatNumber(globalBudget.budgetAmount)} USD`}
+            label="Global AI-kredittramme"
+            helpTitle="Global AI-kredittramme"
+            helpText="Månedlig AI-kredittbudsjett for hele Nav-organisasjonen. Inkluderer alle GitHub Copilot-modeller og agentkjøringer."
+            subtitle={
+              globalBudget.consumedAmount != null
+                ? `Brukt: ${formatNumber(globalBudget.consumedAmount)} USD`
+                : undefined
+            }
+          />
+        </HGrid>
+      )}
 
       {/* Monthly trends — THE story */}
       {monthlyTrends.length > 0 && <MonthlyTrendsChart data={monthlyTrends} />}

--- a/apps/my-copilot/src/app/statistikk/page.tsx
+++ b/apps/my-copilot/src/app/statistikk/page.tsx
@@ -309,9 +309,9 @@ async function UsageContent({ usage, token }: { usage: EnterpriseMetrics[]; toke
           <VStack gap="space-8">
             <HStack gap="space-8" align="center" justify="space-between">
               <HStack gap="space-8" align="center">
-                <BodyShort className="text-gray-600 text-sm">Totalt AI-kreditforbruk</BodyShort>
-                <HelpText title="Totalt AI-kreditforbruk">
-                  Sum av AI-kreditforbruk for alle Nav-utviklere denne måneden. Inkluderer brukere med aktivt forbruk i
+                <BodyShort className="text-gray-600 text-sm">Totalt AI-kredittforbruk</BodyShort>
+                <HelpText title="Totalt AI-kredittforbruk">
+                  Sum av AI-kredittforbruk for alle Nav-utviklere denne måneden. Inkluderer brukere med aktivt forbruk i
                   GitHub Copilot.
                 </HelpText>
               </HStack>

--- a/apps/my-copilot/src/app/statistikk/page.tsx
+++ b/apps/my-copilot/src/app/statistikk/page.tsx
@@ -21,7 +21,18 @@ import MonthlyModelChart from "@/components/charts/MonthlyModelChart";
 import AdoptionCohortsChart from "@/components/charts/AdoptionCohortsChart";
 import MetricCard from "@/components/metric-card";
 import ErrorState from "@/components/error-state";
-import { Table, BodyShort, Heading, HGrid, Box, HelpText, Skeleton, VStack, HStack } from "@navikt/ds-react";
+import {
+  Table,
+  BodyShort,
+  Heading,
+  HGrid,
+  Box,
+  HelpText,
+  Skeleton,
+  VStack,
+  HStack,
+  ProgressBar,
+} from "@navikt/ds-react";
 import { TableBody, TableDataCell, TableHeader, TableHeaderCell, TableRow } from "@navikt/ds-react/Table";
 import { PageHero } from "@/components/page-hero";
 import {
@@ -309,33 +320,12 @@ async function UsageContent({ usage, token }: { usage: EnterpriseMetrics[]; toke
                 {formatNumber(globalBudget.activeUsers * globalBudget.perUserBudget)} USD
               </BodyShort>
             </HStack>
-            <div
-              style={{
-                height: "10px",
-                width: "100%",
-                borderRadius: "var(--a-border-radius-full)",
-                backgroundColor: "var(--a-border-default)",
-              }}
-              role="progressbar"
+            <ProgressBar
+              value={Math.round(globalBudget.totalConsumed)}
+              valueMax={globalBudget.activeUsers * globalBudget.perUserBudget}
+              size="small"
               aria-label={`${Math.round((globalBudget.totalConsumed / (globalBudget.activeUsers * globalBudget.perUserBudget)) * 100)}% av totalt budsjett brukt`}
-              aria-valuenow={Math.round(globalBudget.totalConsumed)}
-              aria-valuemin={0}
-              aria-valuemax={globalBudget.activeUsers * globalBudget.perUserBudget}
-            >
-              <div
-                style={{
-                  height: "100%",
-                  borderRadius: "var(--a-border-radius-full)",
-                  width: `${Math.min(100, Math.round((globalBudget.totalConsumed / (globalBudget.activeUsers * globalBudget.perUserBudget)) * 100))}%`,
-                  backgroundColor:
-                    globalBudget.totalConsumed / (globalBudget.activeUsers * globalBudget.perUserBudget) > 0.9
-                      ? "var(--a-icon-danger)"
-                      : globalBudget.totalConsumed / (globalBudget.activeUsers * globalBudget.perUserBudget) > 0.7
-                        ? "var(--a-icon-warning)"
-                        : "var(--a-icon-success)",
-                }}
-              />
-            </div>
+            />
             <BodyShort className="text-gray-500 text-sm">
               {globalBudget.activeUsers} aktive brukere · {formatNumber(globalBudget.perUserBudget)} USD per bruker
             </BodyShort>

--- a/apps/my-copilot/src/app/statistikk/page.tsx
+++ b/apps/my-copilot/src/app/statistikk/page.tsx
@@ -178,7 +178,7 @@ async function UsageContent({ usage, token }: { usage: EnterpriseMetrics[]; toke
     getMonthlyModelUsage(token),
     getMonthlyBillingUsage(token),
     getAdoptionCohorts(token),
-    backendRequest<{ budgetAmount: number; consumedAmount: number | null }>(
+    backendRequest<{ totalConsumed: number; perUserBudget: number; activeUsers: number }>(
       "/api/v1/copilot/budget/global",
       token
     ).catch((err) => {
@@ -296,15 +296,11 @@ async function UsageContent({ usage, token }: { usage: EnterpriseMetrics[]; toke
       {globalBudget && (
         <HGrid columns={{ xs: 1, sm: 2, md: 4 }} gap="space-16">
           <MetricCard
-            value={`${formatNumber(globalBudget.budgetAmount)} USD`}
-            label="Global AI-kredittramme"
-            helpTitle="Global AI-kredittramme"
-            helpText="Månedlig AI-kredittbudsjett for hele Nav-organisasjonen. Inkluderer alle GitHub Copilot-modeller og agentkjøringer."
-            subtitle={
-              globalBudget.consumedAmount != null
-                ? `Brukt: ${formatNumber(globalBudget.consumedAmount)} USD`
-                : undefined
-            }
+            value={`${formatNumber(Math.round(globalBudget.totalConsumed))} USD`}
+            label="Totalt AI-kreditforbruk"
+            helpTitle="Totalt AI-kreditforbruk"
+            helpText="Sum av AI-kreditforbruk for alle Nav-utviklere denne måneden. Inkluderer brukere med aktivt forbruk i GitHub Copilot."
+            subtitle={`${globalBudget.activeUsers} aktive brukere · ${formatNumber(globalBudget.perUserBudget)} USD per bruker`}
           />
         </HGrid>
       )}

--- a/apps/my-copilot/src/components/nav-budget-bar.tsx
+++ b/apps/my-copilot/src/components/nav-budget-bar.tsx
@@ -15,7 +15,7 @@ export default function NavBudgetBar() {
     fetch("/api/budget")
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
-        if (data?.budgetAmount) setBudget(data);
+        if (data && typeof data.budgetAmount === "number") setBudget(data);
       })
       .catch(() => {});
   }, []);
@@ -23,12 +23,12 @@ export default function NavBudgetBar() {
   if (!budget || budget.consumedAmount === null) return null;
 
   const pct = Math.min(100, Math.round((budget.consumedAmount / budget.budgetAmount) * 100));
-  const color = pct > 90 ? "#f9251d" : pct > 70 ? "#FF9100" : "#06893A";
+  const color = pct > 90 ? "var(--a-icon-danger)" : pct > 70 ? "var(--a-icon-warning)" : "var(--a-icon-success)";
 
   return (
     <div
       style={{ display: "flex", alignItems: "center", gap: "6px" }}
-      title={`${pct}% av AI-kreditbudsjettet brukt denne måneden`}
+      title={`${pct}% av AI-kredittbudsjettet brukt denne måneden`}
     >
       <div
         style={{
@@ -39,7 +39,7 @@ export default function NavBudgetBar() {
           overflow: "hidden",
         }}
         role="progressbar"
-        aria-label={`${pct}% av AI-kreditbudsjettet brukt`}
+        aria-label={`${pct}% av AI-kredittbudsjettet brukt`}
         aria-valuenow={pct}
         aria-valuemin={0}
         aria-valuemax={100}

--- a/apps/my-copilot/src/components/nav-budget-bar.tsx
+++ b/apps/my-copilot/src/components/nav-budget-bar.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface BudgetData {
+  budgetAmount: number;
+  consumedAmount: number | null;
+  isOverride: boolean;
+}
+
+export default function NavBudgetBar() {
+  const [budget, setBudget] = useState<BudgetData | null>(null);
+
+  useEffect(() => {
+    fetch("/api/budget")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.budgetAmount) setBudget(data);
+      })
+      .catch(() => {});
+  }, []);
+
+  if (!budget || budget.consumedAmount === null) return null;
+
+  const pct = Math.min(100, Math.round((budget.consumedAmount / budget.budgetAmount) * 100));
+  const color = pct > 90 ? "#f9251d" : pct > 70 ? "#FF9100" : "#06893A";
+
+  return (
+    <div
+      style={{ display: "flex", alignItems: "center", gap: "6px" }}
+      title={`${pct}% av AI-kreditbudsjettet brukt denne måneden`}
+    >
+      <div
+        style={{
+          width: "64px",
+          height: "4px",
+          borderRadius: "999px",
+          backgroundColor: "rgba(255,255,255,0.2)",
+          overflow: "hidden",
+        }}
+        role="progressbar"
+        aria-label={`${pct}% av AI-kreditbudsjettet brukt`}
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      >
+        <div
+          style={{
+            width: `${pct}%`,
+            height: "100%",
+            borderRadius: "999px",
+            backgroundColor: color,
+          }}
+        />
+      </div>
+      <span style={{ color: "rgba(255,255,255,0.5)", fontSize: "11px", lineHeight: 1 }}>{pct}%</span>
+    </div>
+  );
+}

--- a/apps/my-copilot/src/components/subscription.tsx
+++ b/apps/my-copilot/src/components/subscription.tsx
@@ -348,50 +348,67 @@ const SubscriptionDetails: React.FC<{ user: User; showGroups?: boolean }> = ({ u
               </VStack>
             ) : budget ? (
               <>
-                {budget.isOverride && (
-                  <Tag variant="info" size="small">
-                    Utvidet budsjett
-                  </Tag>
-                )}
-                <BodyShort>
-                  <strong>Månedlig budsjett:</strong> {formatNumber(budget.budgetAmount)} USD
-                </BodyShort>
-                {budget.consumedAmount !== null && (
+                {budget.consumedAmount !== null ? (
                   <>
-                    <BodyShort>
-                      <strong>Brukt denne måneden:</strong> {formatNumber(budget.consumedAmount)} USD
-                    </BodyShort>
+                    <div style={{ width: "100%" }}>
+                      <div
+                        style={{
+                          display: "flex",
+                          justifyContent: "space-between",
+                          marginBottom: "var(--a-spacing-1)",
+                        }}
+                      >
+                        <BodyShort size="small" className="text-gray-600">
+                          {budget.isOverride ? "Utvidet budsjett" : "Budsjett"} ·{" "}
+                          {Math.round((budget.consumedAmount / budget.budgetAmount) * 100)}% brukt
+                        </BodyShort>
+                        <BodyShort size="small" className="text-gray-600">
+                          {formatNumber(budget.consumedAmount)} / {formatNumber(budget.budgetAmount)} USD
+                        </BodyShort>
+                      </div>
+                      <div
+                        style={{
+                          height: "10px",
+                          width: "100%",
+                          borderRadius: "var(--a-border-radius-full)",
+                          backgroundColor: "var(--a-surface-neutral)",
+                        }}
+                        role="progressbar"
+                        aria-label={`${Math.round((budget.consumedAmount / budget.budgetAmount) * 100)}% av budsjettet brukt`}
+                        aria-valuenow={budget.consumedAmount}
+                        aria-valuemin={0}
+                        aria-valuemax={budget.budgetAmount}
+                      >
+                        <div
+                          style={{
+                            height: "100%",
+                            borderRadius: "var(--a-border-radius-full)",
+                            width: `${Math.min(100, Math.round((budget.consumedAmount / budget.budgetAmount) * 100))}%`,
+                            backgroundColor:
+                              budget.consumedAmount / budget.budgetAmount > 0.9
+                                ? "var(--a-icon-danger)"
+                                : budget.consumedAmount / budget.budgetAmount > 0.7
+                                  ? "var(--a-icon-warning)"
+                                  : "var(--a-icon-success)",
+                          }}
+                        />
+                      </div>
+                    </div>
                     <BodyShort>
                       <strong>Gjenstående:</strong>{" "}
                       {formatNumber(Math.max(0, budget.budgetAmount - budget.consumedAmount))} USD
                     </BodyShort>
-                    <div
-                      style={{
-                        height: "8px",
-                        width: "100%",
-                        borderRadius: "var(--a-border-radius-full)",
-                        backgroundColor: "var(--a-surface-neutral)",
-                      }}
-                      aria-label={`${Math.round((budget.consumedAmount / budget.budgetAmount) * 100)}% brukt`}
-                      role="progressbar"
-                      aria-valuenow={budget.consumedAmount}
-                      aria-valuemin={0}
-                      aria-valuemax={budget.budgetAmount}
-                    >
-                      <div
-                        style={{
-                          height: "100%",
-                          borderRadius: "var(--a-border-radius-full)",
-                          width: `${Math.min(100, Math.round((budget.consumedAmount / budget.budgetAmount) * 100))}%`,
-                          backgroundColor:
-                            budget.consumedAmount / budget.budgetAmount > 0.9
-                              ? "var(--a-icon-danger)"
-                              : budget.consumedAmount / budget.budgetAmount > 0.7
-                                ? "var(--a-icon-warning)"
-                                : "var(--a-icon-success)",
-                        }}
-                      />
-                    </div>
+                  </>
+                ) : (
+                  <>
+                    {budget.isOverride && (
+                      <Tag variant="info" size="small">
+                        Utvidet budsjett
+                      </Tag>
+                    )}
+                    <BodyShort>
+                      <strong>Månedlig budsjett:</strong> {formatNumber(budget.budgetAmount)} USD
+                    </BodyShort>
                   </>
                 )}
                 {!budget.isOverride && (

--- a/apps/my-copilot/src/components/subscription.tsx
+++ b/apps/my-copilot/src/components/subscription.tsx
@@ -1,8 +1,15 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
-import { Button, Alert, Box, VStack, HGrid, Heading, BodyShort, Link } from "@navikt/ds-react";
+import { Button, Alert, Box, VStack, HGrid, Heading, BodyShort, Link, Tag } from "@navikt/ds-react";
 import { User } from "@/lib/auth";
+
+interface BudgetData {
+  budgetAmount: number;
+  consumedAmount: number | null;
+  isOverride: boolean;
+  defaultBudget: number;
+}
 
 interface SubscriptionDetailsProps {
   icanhazcopilot: boolean;
@@ -67,6 +74,7 @@ const SubscriptionDetails: React.FC<{ user: User; showGroups?: boolean }> = ({ u
   const [subscriptionError, setSubscriptionError] = useState<string | null>(null);
   const [errorTraceId, setErrorTraceId] = useState<string | null>(null);
   const [needsGitHubLink, setNeedsGitHubLink] = useState<boolean>(false);
+  const [budget, setBudget] = useState<BudgetData | null>(null);
 
   const fetchSubscription = async () => {
     setLoading(true);
@@ -140,29 +148,30 @@ const SubscriptionDetails: React.FC<{ user: User; showGroups?: boolean }> = ({ u
 
     async function loadSubscription() {
       try {
-        const response = await fetch("/api/copilot");
-        const data = await response.json();
+        const [subscriptionResponse, budgetResponse] = await Promise.all([fetch("/api/copilot"), fetch("/api/budget")]);
+        const data = await subscriptionResponse.json();
 
         if (cancelled) return;
 
         if (data.error) {
           setSubscriptionError(data.error);
           setErrorTraceId(data.traceId ?? null);
-          return;
-        }
-
-        if (data.githubAccountLinked === false) {
+        } else if (data.githubAccountLinked === false) {
           setNeedsGitHubLink(true);
           setEligible(data.icanhazcopilot);
-          return;
+        } else {
+          setSubscriptionError(null);
+          setErrorTraceId(null);
+          setNeedsGitHubLink(false);
+          setEligible(data.icanhazcopilot);
+          setCopilotSubscription(data.subscription);
+          setGitHubUsername(data.githubUsername);
         }
 
-        setSubscriptionError(null);
-        setErrorTraceId(null);
-        setNeedsGitHubLink(false);
-        setEligible(data.icanhazcopilot);
-        setCopilotSubscription(data.subscription);
-        setGitHubUsername(data.githubUsername);
+        if (budgetResponse.ok) {
+          const budgetData = await budgetResponse.json();
+          if (!cancelled) setBudget(budgetData);
+        }
       } catch (error) {
         if (cancelled) return;
         console.error("Error fetching subscription details:", error);
@@ -215,7 +224,7 @@ const SubscriptionDetails: React.FC<{ user: User; showGroups?: boolean }> = ({ u
         </Box>
       )}
 
-      <HGrid columns={{ xs: 1, md: 2 }} gap="space-8">
+      <HGrid columns={{ xs: 1, md: 2, lg: 3 }} gap="space-8">
         {" "}
         <Box padding="space-8" borderRadius="8" className="border">
           {" "}
@@ -316,6 +325,69 @@ const SubscriptionDetails: React.FC<{ user: User; showGroups?: boolean }> = ({ u
                   ))}
                 </ul>
               </div>
+            )}
+          </VStack>
+        </Box>
+        <Box padding="space-8" borderRadius="8" className="border">
+          <VStack gap="space-4">
+            <Heading size="medium" level="3">
+              AI-kredittbudsjett
+            </Heading>
+            {loading ? (
+              <VStack gap="space-4" role="status" className="max-w-sm animate-pulse">
+                <div className="h-5 bg-gray-200 rounded-full dark:bg-gray-700 w-40"></div>
+                <div className="h-5 bg-gray-200 rounded-full dark:bg-gray-700 max-w-56"></div>
+                <span className="sr-only">Laster budsjett...</span>
+              </VStack>
+            ) : budget ? (
+              <>
+                {budget.isOverride && (
+                  <Tag variant="info" size="small">
+                    Utvidet budsjett
+                  </Tag>
+                )}
+                <BodyShort>
+                  <strong>Månedlig budsjett:</strong> ${budget.budgetAmount.toFixed(2)}
+                </BodyShort>
+                {budget.consumedAmount !== null && (
+                  <>
+                    <BodyShort>
+                      <strong>Brukt denne måneden:</strong> ${budget.consumedAmount.toFixed(2)}
+                    </BodyShort>
+                    <BodyShort>
+                      <strong>Gjenstående:</strong> $
+                      {Math.max(0, budget.budgetAmount - budget.consumedAmount).toFixed(2)}
+                    </BodyShort>
+                    <div
+                      className="w-full bg-gray-200 rounded-full"
+                      style={{ height: "8px" }}
+                      aria-label={`${Math.round((budget.consumedAmount / budget.budgetAmount) * 100)}% brukt`}
+                      role="progressbar"
+                      aria-valuenow={budget.consumedAmount}
+                      aria-valuemin={0}
+                      aria-valuemax={budget.budgetAmount}
+                    >
+                      <div
+                        className={`h-full rounded-full ${
+                          budget.consumedAmount / budget.budgetAmount > 0.9
+                            ? "bg-red-500"
+                            : budget.consumedAmount / budget.budgetAmount > 0.7
+                              ? "bg-yellow-400"
+                              : "bg-green-500"
+                        }`}
+                        style={{
+                          width: `${Math.min(100, Math.round((budget.consumedAmount / budget.budgetAmount) * 100))}%`,
+                        }}
+                      />
+                    </div>
+                  </>
+                )}
+                {!budget.isOverride && (
+                  <BodyShort size="small">Dette er standardbudsjettet for alle Nav-utviklere.</BodyShort>
+                )}
+              </>
+            ) : (
+              <BodyShort>Budsjettinformasjon er ikke tilgjengelig.</BodyShort>
             )}
           </VStack>
         </Box>

--- a/apps/my-copilot/src/components/subscription.tsx
+++ b/apps/my-copilot/src/components/subscription.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
-import { Button, Alert, Box, VStack, HGrid, Heading, BodyShort, Link, Tag } from "@navikt/ds-react";
+import { Button, Alert, Box, VStack, HGrid, Heading, BodyShort, Link, Tag, Skeleton } from "@navikt/ds-react";
 import { User } from "@/lib/auth";
+import { formatNumber } from "@/lib/format";
 
 interface BudgetData {
   budgetAmount: number;
@@ -340,9 +341,9 @@ const SubscriptionDetails: React.FC<{ user: User; showGroups?: boolean }> = ({ u
               AI-kredittbudsjett
             </Heading>
             {loading ? (
-              <VStack gap="space-4" role="status" className="max-w-sm animate-pulse">
-                <div className="h-5 bg-gray-200 rounded-full dark:bg-gray-700 w-40"></div>
-                <div className="h-5 bg-gray-200 rounded-full dark:bg-gray-700 max-w-56"></div>
+              <VStack gap="space-4" role="status">
+                <Skeleton variant="text" width="10rem" />
+                <Skeleton variant="text" width="14rem" />
                 <span className="sr-only">Laster budsjett...</span>
               </VStack>
             ) : budget ? (
@@ -353,20 +354,24 @@ const SubscriptionDetails: React.FC<{ user: User; showGroups?: boolean }> = ({ u
                   </Tag>
                 )}
                 <BodyShort>
-                  <strong>Månedlig budsjett:</strong> ${budget.budgetAmount.toFixed(2)}
+                  <strong>Månedlig budsjett:</strong> {formatNumber(budget.budgetAmount)} USD
                 </BodyShort>
                 {budget.consumedAmount !== null && (
                   <>
                     <BodyShort>
-                      <strong>Brukt denne måneden:</strong> ${budget.consumedAmount.toFixed(2)}
+                      <strong>Brukt denne måneden:</strong> {formatNumber(budget.consumedAmount)} USD
                     </BodyShort>
                     <BodyShort>
-                      <strong>Gjenstående:</strong> $
-                      {Math.max(0, budget.budgetAmount - budget.consumedAmount).toFixed(2)}
+                      <strong>Gjenstående:</strong>{" "}
+                      {formatNumber(Math.max(0, budget.budgetAmount - budget.consumedAmount))} USD
                     </BodyShort>
                     <div
-                      className="w-full bg-gray-200 rounded-full"
-                      style={{ height: "8px" }}
+                      style={{
+                        height: "8px",
+                        width: "100%",
+                        borderRadius: "var(--a-border-radius-full)",
+                        backgroundColor: "var(--a-surface-neutral)",
+                      }}
                       aria-label={`${Math.round((budget.consumedAmount / budget.budgetAmount) * 100)}% brukt`}
                       role="progressbar"
                       aria-valuenow={budget.consumedAmount}
@@ -374,15 +379,16 @@ const SubscriptionDetails: React.FC<{ user: User; showGroups?: boolean }> = ({ u
                       aria-valuemax={budget.budgetAmount}
                     >
                       <div
-                        className={`h-full rounded-full ${
-                          budget.consumedAmount / budget.budgetAmount > 0.9
-                            ? "bg-red-500"
-                            : budget.consumedAmount / budget.budgetAmount > 0.7
-                              ? "bg-yellow-400"
-                              : "bg-green-500"
-                        }`}
                         style={{
+                          height: "100%",
+                          borderRadius: "var(--a-border-radius-full)",
                           width: `${Math.min(100, Math.round((budget.consumedAmount / budget.budgetAmount) * 100))}%`,
+                          backgroundColor:
+                            budget.consumedAmount / budget.budgetAmount > 0.9
+                              ? "var(--a-icon-danger)"
+                              : budget.consumedAmount / budget.budgetAmount > 0.7
+                                ? "var(--a-icon-warning)"
+                                : "var(--a-icon-success)",
                         }}
                       />
                     </div>

--- a/apps/my-copilot/src/components/subscription.tsx
+++ b/apps/my-copilot/src/components/subscription.tsx
@@ -147,43 +147,49 @@ const SubscriptionDetails: React.FC<{ user: User; showGroups?: boolean }> = ({ u
     let cancelled = false;
 
     async function loadSubscription() {
-      try {
-        const [subscriptionResponse, budgetResponse] = await Promise.all([fetch("/api/copilot"), fetch("/api/budget")]);
-        const data = await subscriptionResponse.json();
+      const [subscriptionResult, budgetResult] = await Promise.allSettled([
+        fetch("/api/copilot"),
+        fetch("/api/budget"),
+      ]);
 
-        if (cancelled) return;
+      if (cancelled) return;
 
-        if (data.error) {
-          setSubscriptionError(data.error);
-          setErrorTraceId(data.traceId ?? null);
-        } else if (data.githubAccountLinked === false) {
-          setNeedsGitHubLink(true);
-          setEligible(data.icanhazcopilot);
-        } else {
-          setSubscriptionError(null);
-          setErrorTraceId(null);
-          setNeedsGitHubLink(false);
-          setEligible(data.icanhazcopilot);
-          setCopilotSubscription(data.subscription);
-          setGitHubUsername(data.githubUsername);
-        }
-
-        if (budgetResponse.ok) {
-          const budgetData = await budgetResponse.json();
-          if (!cancelled) setBudget(budgetData);
-        }
-      } catch (error) {
-        if (cancelled) return;
-        console.error("Error fetching subscription details:", error);
-        setErrorTraceId(null);
-        if (error instanceof Error) {
-          setSubscriptionError(error.message);
-        } else {
+      // Handle subscription independently
+      if (subscriptionResult.status === "fulfilled") {
+        try {
+          const data = await subscriptionResult.value.json();
+          if (data.error) {
+            setSubscriptionError(data.error);
+            setErrorTraceId(data.traceId ?? null);
+          } else if (data.githubAccountLinked === false) {
+            setNeedsGitHubLink(true);
+            setEligible(data.icanhazcopilot);
+          } else {
+            setSubscriptionError(null);
+            setErrorTraceId(null);
+            setNeedsGitHubLink(false);
+            setEligible(data.icanhazcopilot);
+            setCopilotSubscription(data.subscription);
+            setGitHubUsername(data.githubUsername);
+          }
+        } catch {
           setSubscriptionError("Ukjent feil ved henting av abonnement");
         }
-      } finally {
-        if (!cancelled) setLoading(false);
+      } else {
+        setSubscriptionError("Ukjent feil ved henting av abonnement");
       }
+
+      // Handle budget independently — always attempted regardless of subscription outcome
+      if (budgetResult.status === "fulfilled" && budgetResult.value.ok) {
+        try {
+          const budgetData = await budgetResult.value.json();
+          if (!cancelled) setBudget(budgetData);
+        } catch {
+          // Budget parse failure — leave budget as null, card shows fallback text
+        }
+      }
+
+      if (!cancelled) setLoading(false);
     }
 
     loadSubscription();

--- a/apps/my-copilot/src/components/subscription.tsx
+++ b/apps/my-copilot/src/components/subscription.tsx
@@ -1,7 +1,19 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
-import { Button, Alert, Box, VStack, HGrid, Heading, BodyShort, Link, Tag, Skeleton } from "@navikt/ds-react";
+import {
+  Button,
+  Alert,
+  Box,
+  VStack,
+  HGrid,
+  Heading,
+  BodyShort,
+  Link,
+  Tag,
+  Skeleton,
+  ProgressBar,
+} from "@navikt/ds-react";
 import { User } from "@/lib/auth";
 import { formatNumber } from "@/lib/format";
 
@@ -366,33 +378,12 @@ const SubscriptionDetails: React.FC<{ user: User; showGroups?: boolean }> = ({ u
                           {formatNumber(budget.consumedAmount)} / {formatNumber(budget.budgetAmount)} USD
                         </BodyShort>
                       </div>
-                      <div
-                        style={{
-                          height: "10px",
-                          width: "100%",
-                          borderRadius: "var(--a-border-radius-full)",
-                          backgroundColor: "var(--a-border-default)",
-                        }}
-                        role="progressbar"
+                      <ProgressBar
+                        value={budget.consumedAmount}
+                        valueMax={budget.budgetAmount}
+                        size="small"
                         aria-label={`${Math.round((budget.consumedAmount / budget.budgetAmount) * 100)}% av budsjettet brukt`}
-                        aria-valuenow={budget.consumedAmount}
-                        aria-valuemin={0}
-                        aria-valuemax={budget.budgetAmount}
-                      >
-                        <div
-                          style={{
-                            height: "100%",
-                            borderRadius: "var(--a-border-radius-full)",
-                            width: `${Math.min(100, Math.round((budget.consumedAmount / budget.budgetAmount) * 100))}%`,
-                            backgroundColor:
-                              budget.consumedAmount / budget.budgetAmount > 0.9
-                                ? "var(--a-icon-danger)"
-                                : budget.consumedAmount / budget.budgetAmount > 0.7
-                                  ? "var(--a-icon-warning)"
-                                  : "var(--a-icon-success)",
-                          }}
-                        />
-                      </div>
+                      />
                     </div>
                     <BodyShort>
                       <strong>Gjenstående:</strong>{" "}

--- a/apps/my-copilot/src/components/subscription.tsx
+++ b/apps/my-copilot/src/components/subscription.tsx
@@ -371,7 +371,7 @@ const SubscriptionDetails: React.FC<{ user: User; showGroups?: boolean }> = ({ u
                           height: "10px",
                           width: "100%",
                           borderRadius: "var(--a-border-radius-full)",
-                          backgroundColor: "var(--a-surface-neutral)",
+                          backgroundColor: "var(--a-border-default)",
                         }}
                         role="progressbar"
                         aria-label={`${Math.round((budget.consumedAmount / budget.budgetAmount) * 100)}% av budsjettet brukt`}

--- a/apps/my-copilot/src/lib/mcp-registry.ts
+++ b/apps/my-copilot/src/lib/mcp-registry.ts
@@ -3,6 +3,7 @@ import type { Domain, McpServerCustomization } from "./customization-types";
 import type { UsageExample } from "./manifest-types";
 
 const MCP_REGISTRY_URL = process.env.MCP_REGISTRY_URL || "https://mcp-registry.nav.no";
+const MCP_REGISTRY_PUBLIC_URL = process.env.MCP_REGISTRY_PUBLIC_URL || MCP_REGISTRY_URL;
 
 interface ServerResponse {
   server: {
@@ -70,7 +71,7 @@ function formatServerName(name: string): string {
 }
 
 function getMcpRegistryHost(): string {
-  const url = MCP_REGISTRY_URL.replace(/^https?:\/\//, "");
+  const url = MCP_REGISTRY_PUBLIC_URL.replace(/^https?:\/\//, "");
   return url.replace(/\/$/, "");
 }
 


### PR DESCRIPTION
## Hva er endret?

### feat(abonnement): display AI credit budget for authenticated user
Implementerer [#267](https://github.com/navikt/copilot/issues/267) — viser AI-kredittbudsjett på Abonnement-siden.

**Backend (copilot-api):**
- Ny `budget.go` — `BudgetClient` med 30-min cache, paginerer enterprise billing API, løser bruker- vs. standardbudsjett
- Ny `budget_handlers.go` — `GET /api/v1/copilot/budget`: auth → SAML-oppslag → budsjett → JSON
- `config.go`: nye felter `GitHubBillingToken` og `GitHubEnterprise` (default `nav`)
- `handlers.go`: ny rute registrert når `budgetHandlers != nil`
- `main.go`: init av budget-handler, guards på `githubClient != nil` + token til stede

**Frontend (my-copilot):**
- Ny BFF-rute `/api/budget` som proxyer til copilot-api via OBO
- `subscription.tsx`: budsjett-kort i HGrid (3 kolonner), `Promise.allSettled` for uavhengig feilhåndtering

### chore(nais): route mcp-registry traffic cluster-internally
- `my-copilot`: erstatter ekstern `api.github.com`-host med cluster-intern regel mot `mcp-registry`
- `mcp-registry`: legger til inbound-regel fra `my-copilot`

## Avhengigheter
- `GITHUB_BILLING_TOKEN` (klassisk PAT med `admin:enterprise`) må ligge i K8s-secret for copilot-api — **allerede lagt til**

## Testing
- `mise check` passerer i begge apps (349 Vitest-tester grønne)
- Budsjett-endepunkt verifiseres i dev etter deploy

Closes #267