### PR TITLE
fix: nav-pilot launch/sync fixes + my-copilot anchor/pricing updates

### DIFF
--- a/apps/my-copilot/src/app/layout.tsx
+++ b/apps/my-copilot/src/app/layout.tsx
@@ -7,6 +7,7 @@ import Faro from "@/components/faro";
 import NextLink from "next/link";
 import { FooterMessage } from "@/components/footer-message";
 import NavBudgetBar from "@/components/nav-budget-bar";
+import { HashAnchorScroll } from "@/components/hash-anchor-scroll";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -36,6 +37,7 @@ export default async function RootLayout({
   return (
     <html lang="nb">
       <body className={`${inter.className} bg-gray-800`}>
+        <HashAnchorScroll />
         <header style={{ background: "#0f1825" }}>
           <Box
             paddingBlock="space-8"

--- a/apps/my-copilot/src/components/hash-anchor-scroll.tsx
+++ b/apps/my-copilot/src/components/hash-anchor-scroll.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+function scrollToHash(): boolean {
+  const hash = window.location.hash.slice(1);
+  if (!hash) return true;
+
+  const id = decodeURIComponent(hash);
+  const target = document.getElementById(id);
+  if (!target) return false;
+
+  target.scrollIntoView({ block: "start" });
+  return true;
+}
+
+export function HashAnchorScroll() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    let cancelled = false;
+    let attempts = 0;
+    const maxAttempts = 30;
+
+    const tryScroll = () => {
+      if (cancelled) return;
+      if (scrollToHash() || attempts >= maxAttempts) return;
+      attempts += 1;
+      window.setTimeout(tryScroll, 50);
+    };
+
+    tryScroll();
+
+    const onHashChange = () => {
+      scrollToHash();
+    };
+
+    window.addEventListener("hashchange", onHashChange);
+    return () => {
+      cancelled = true;
+      window.removeEventListener("hashchange", onHashChange);
+    };
+  }, [pathname]);
+
+  return null;
+}

--- a/apps/my-copilot/src/components/hash-anchor-scroll.tsx
+++ b/apps/my-copilot/src/components/hash-anchor-scroll.tsx
@@ -7,7 +7,12 @@ function scrollToHash(): boolean {
   const hash = window.location.hash.slice(1);
   if (!hash) return true;
 
-  const id = decodeURIComponent(hash);
+  let id = hash;
+  try {
+    id = decodeURIComponent(hash);
+  } catch {
+    // Keep raw hash if fragment is malformed.
+  }
   const target = document.getElementById(id);
   if (!target) return false;
 

--- a/apps/my-copilot/src/lib/model-pricing.ts
+++ b/apps/my-copilot/src/lib/model-pricing.ts
@@ -1,7 +1,7 @@
 /**
  * GitHub Copilot model pricing data.
  * Source: https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
- * Last updated: 2026-05-29
+ * Last updated: 2026-06-05
  *
  * All prices are per 1 million tokens in USD.
  * 1 AI credit = $0.01 USD.
@@ -23,16 +23,6 @@ export interface ModelPrice {
 
 export const MODEL_PRICING: ModelPrice[] = [
   // OpenAI
-  {
-    model: "GPT-4.1",
-    provider: "OpenAI",
-    category: "Versatile",
-    status: "GA",
-    input: 2,
-    cachedInput: 0.5,
-    output: 8,
-    note: "Included model",
-  },
   {
     model: "GPT-5 mini",
     provider: "OpenAI",
@@ -236,4 +226,4 @@ export const MODEL_PRICING: ModelPrice[] = [
 ];
 
 export const PRICING_SOURCE_URL = "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing";
-export const PRICING_LAST_UPDATED = "2026-05-29";
+export const PRICING_LAST_UPDATED = "2026-06-05";

--- a/cli/nav-pilot/add_test.go
+++ b/cli/nav-pilot/add_test.go
@@ -809,7 +809,7 @@ func TestCmdAdd_ClearsIgnoredStatus(t *testing.T) {
 	}
 
 	// Verify resolveSyncFiles includes the file again
-	files, _, err := resolveSyncFiles(scope, "")
+	files, _, err := resolveSyncFiles(scope, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/nav-pilot/interactive.go
+++ b/cli/nav-pilot/interactive.go
@@ -652,12 +652,10 @@ func cliDisplayName(name string) string {
 }
 
 // copilotAgentArgs returns extra CLI flags for a given agent.
-// For nav-pilot we pin model selection to auto to avoid unexpected jumps
-// to a specific model when launching via --agent.
+// Keep this empty by default so model/effort selection follows agent defaults
+// (or explicit user overrides in the CLI), not hardcoded launch arguments.
 func copilotAgentArgs(agent string) []string {
-	if agent == "nav-pilot" {
-		return []string{"--model", "auto"}
-	}
+	_ = agent
 	return nil
 }
 

--- a/cli/nav-pilot/interactive.go
+++ b/cli/nav-pilot/interactive.go
@@ -652,10 +652,11 @@ func cliDisplayName(name string) string {
 }
 
 // copilotAgentArgs returns extra CLI flags for a given agent.
-// nav-pilot benefits from plan mode and high reasoning effort.
+// For nav-pilot we pin model selection to auto to avoid unexpected jumps
+// to a specific model when launching via --agent.
 func copilotAgentArgs(agent string) []string {
 	if agent == "nav-pilot" {
-		return []string{"--mode", "plan", "--effort", "high"}
+		return []string{"--model", "auto"}
 	}
 	return nil
 }

--- a/cli/nav-pilot/interactive_test.go
+++ b/cli/nav-pilot/interactive_test.go
@@ -475,7 +475,7 @@ func TestCopilotAgentArgs(t *testing.T) {
 		agent string
 		want  []string
 	}{
-		{"nav-pilot", []string{"--mode", "plan", "--effort", "high"}},
+		{"nav-pilot", []string{"--model", "auto"}},
 		{"auth", nil},
 		{"", nil},
 	}
@@ -523,13 +523,13 @@ func TestBuildCopilotArgs(t *testing.T) {
 			name:    "cplt with agent",
 			cliName: "cplt",
 			agent:   "nav-pilot",
-			want:    []string{"--", "--agent", "nav-pilot", "--mode", "plan", "--effort", "high"},
+			want:    []string{"--", "--agent", "nav-pilot", "--model", "auto"},
 		},
 		{
 			name:    "copilot with agent",
 			cliName: "copilot",
 			agent:   "nav-pilot",
-			want:    []string{"--agent", "nav-pilot", "--mode", "plan", "--effort", "high"},
+			want:    []string{"--agent", "nav-pilot", "--model", "auto"},
 		},
 		{
 			name:    "cplt without agent",

--- a/cli/nav-pilot/interactive_test.go
+++ b/cli/nav-pilot/interactive_test.go
@@ -475,7 +475,7 @@ func TestCopilotAgentArgs(t *testing.T) {
 		agent string
 		want  []string
 	}{
-		{"nav-pilot", []string{"--model", "auto"}},
+		{"nav-pilot", nil},
 		{"auth", nil},
 		{"", nil},
 	}
@@ -523,13 +523,13 @@ func TestBuildCopilotArgs(t *testing.T) {
 			name:    "cplt with agent",
 			cliName: "cplt",
 			agent:   "nav-pilot",
-			want:    []string{"--", "--agent", "nav-pilot", "--model", "auto"},
+			want:    []string{"--", "--agent", "nav-pilot"},
 		},
 		{
 			name:    "copilot with agent",
 			cliName: "copilot",
 			agent:   "nav-pilot",
-			want:    []string{"--agent", "nav-pilot", "--model", "auto"},
+			want:    []string{"--agent", "nav-pilot"},
 		},
 		{
 			name:    "cplt without agent",

--- a/cli/nav-pilot/main_test.go
+++ b/cli/nav-pilot/main_test.go
@@ -2127,7 +2127,7 @@ func TestPickerInstallSyncCycle(t *testing.T) {
 	}
 
 	// Step 3: Verify resolveSyncFiles skips ignored items
-	syncFiles, _, err := resolveSyncFiles(scope, source)
+	syncFiles, _, err := resolveSyncFiles(scope, source, false)
 	if err != nil {
 		t.Fatalf("resolveSyncFiles: %v", err)
 	}

--- a/cli/nav-pilot/source.go
+++ b/cli/nav-pilot/source.go
@@ -16,6 +16,9 @@ type Source struct {
 	Version string // release version (e.g. "2026.04.14-..."), empty for local dev
 }
 
+// cloneRemoteFn is overridable in tests.
+var cloneRemoteFn = cloneRemote
+
 func (s *Source) Cleanup() {
 	if s.TempDir != "" {
 		os.RemoveAll(s.TempDir)
@@ -29,11 +32,11 @@ func (s *Source) Cleanup() {
 func resolveSource(ref, sourceRepo string) (*Source, error) {
 	// If a custom source repo is specified, always clone remote
 	if sourceRepo != "" {
-		return cloneRemote(ref, sourceRepo)
+		return cloneRemoteFn(ref, sourceRepo)
 	}
 
 	if ref != "" {
-		src, err := cloneRemote(ref, "")
+		src, err := cloneRemoteFn(ref, "")
 		if err != nil {
 			return nil, err
 		}
@@ -59,7 +62,22 @@ func resolveSource(ref, sourceRepo string) (*Source, error) {
 	}
 
 	// Always clone HEAD of main to get the latest content regardless of binary version
-	src, err := cloneRemote("", "")
+	src, err := cloneRemoteFn("", "")
+	if err != nil {
+		return nil, err
+	}
+	src.Version = version
+	return src, nil
+}
+
+// resolveSourceForSync resolves source for sync checks.
+// Unlike resolveSource, it skips local repo auto-detection when no ref/source
+// is provided, so sync compares against upstream content by default.
+func resolveSourceForSync(ref, sourceRepo string) (*Source, error) {
+	if sourceRepo != "" || ref != "" {
+		return resolveSource(ref, sourceRepo)
+	}
+	src, err := cloneRemoteFn("", "")
 	if err != nil {
 		return nil, err
 	}

--- a/cli/nav-pilot/source_resolution_test.go
+++ b/cli/nav-pilot/source_resolution_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveSource_UsesLocalRepoWhenCollectionsExist(t *testing.T) {
+	repoDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoDir, ".github", "collections"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prevWD) })
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatal(err)
+	}
+
+	src, err := resolveSource("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer src.Cleanup()
+
+	// Normalize symlinked temp paths on macOS (/var vs /private/var).
+	got, _ := filepath.EvalSymlinks(src.Dir)
+	want, _ := filepath.EvalSymlinks(repoDir)
+	if got != want {
+		t.Fatalf("resolveSource dir = %q (resolved: %q), want %q (resolved: %q)", src.Dir, got, repoDir, want)
+	}
+}
+
+func TestResolveSourceForSync_SkipsLocalRepoAutoDetection(t *testing.T) {
+	repoDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoDir, ".github", "collections"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prevWD) })
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatal(err)
+	}
+
+	origClone := cloneRemoteFn
+	t.Cleanup(func() { cloneRemoteFn = origClone })
+
+	calls := 0
+	cloneRemoteFn = func(ref, sourceRepo string) (*Source, error) {
+		calls++
+		if ref != "" || sourceRepo != "" {
+			t.Fatalf("cloneRemoteFn called with unexpected args ref=%q sourceRepo=%q", ref, sourceRepo)
+		}
+		return &Source{Dir: "/tmp/remote", SHA: "abc123"}, nil
+	}
+
+	src, err := resolveSourceForSync("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer src.Cleanup()
+
+	if calls != 1 {
+		t.Fatalf("cloneRemoteFn calls = %d, want 1", calls)
+	}
+	if src.Dir != "/tmp/remote" {
+		t.Fatalf("resolveSourceForSync dir = %q, want %q", src.Dir, "/tmp/remote")
+	}
+}

--- a/cli/nav-pilot/sync.go
+++ b/cli/nav-pilot/sync.go
@@ -16,6 +16,7 @@ type syncResult struct {
 	Errors    []string     `json:"errors,omitempty"`
 	Overrides []string     `json:"overrides,omitempty"`
 	Ignored   []string     `json:"ignored,omitempty"`
+	Conflicts []string     `json:"conflicts,omitempty"`
 }
 
 type syncUpdate struct {
@@ -33,6 +34,9 @@ var errUpdatesAvailable = fmt.Errorf("updates available")
 // main() maps this to exit code 2 to distinguish from "updates available".
 var errSyncFailed = fmt.Errorf("sync failed")
 
+// cmdSyncFn is overridable in tests.
+var cmdSyncFn = cmdSync
+
 // cmdSync checks installed files against source and optionally applies updates.
 //
 // Modes:
@@ -41,19 +45,42 @@ var errSyncFailed = fmt.Errorf("sync failed")
 //
 // Works with both state-based repos (nav-pilot install) and auto-detected repos.
 func cmdSync(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bool) error {
-	src, err := resolveSource(ref, sourceRepo)
+	src, err := resolveSourceForSync(ref, sourceRepo)
 	if err != nil {
 		return err
 	}
 	defer src.Cleanup()
 
 	// Determine which files to check
-	files, _, err := resolveSyncFiles(scope, src.Dir)
+	files, _, err := resolveSyncFiles(scope, src.Dir, apply)
 	if err != nil {
 		return err
 	}
 
+	conflictPaths := conflictStatePaths(scope)
+
 	if len(files) == 0 {
+		if len(conflictPaths) > 0 && !apply {
+			result := syncResult{
+				UpToDate:  false,
+				Source:    src.SHA,
+				Conflicts: conflictPaths,
+			}
+			if jsonOutput {
+				if err := outputJSON(result); err != nil {
+					return err
+				}
+				return errUpdatesAvailable
+			}
+			fmt.Printf("%s %d file(s) are in conflict state and were skipped (source: %s)\n\n",
+				yellow("⚠"), len(conflictPaths), src.SHA)
+			for _, p := range conflictPaths {
+				fmt.Printf("  %s %s\n", dim("⊘"), p)
+			}
+			fmt.Println()
+			fmt.Printf("Run %s to apply updates.\n", bold("nav-pilot sync --apply"))
+			return errUpdatesAvailable
+		}
 		if jsonOutput {
 			return outputJSON(syncResult{UpToDate: true, Source: src.SHA})
 		}
@@ -82,6 +109,12 @@ func cmdSync(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bool
 	if !jsonOutput && len(overriddenPaths) > 0 {
 		for _, p := range overriddenPaths {
 			fmt.Printf("  %s %s (override)\n", dim("⊘"), p)
+		}
+		fmt.Println()
+	}
+	if !jsonOutput && len(conflictPaths) > 0 && !apply {
+		for _, p := range conflictPaths {
+			fmt.Printf("  %s %s (conflict — skipped, run sync --apply to overwrite)\n", dim("⊘"), p)
 		}
 		fmt.Println()
 	}
@@ -129,12 +162,13 @@ func cmdSync(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bool
 	}
 
 	result := syncResult{
-		UpToDate:  len(updates) == 0 && len(syncErrors) == 0,
+		UpToDate:  len(updates) == 0 && len(syncErrors) == 0 && (apply || len(conflictPaths) == 0),
 		Source:    src.SHA,
 		Updates:   updates,
 		Errors:    syncErrors,
 		Overrides: overriddenPaths,
 		Ignored:   ignoredPaths,
+		Conflicts: conflictPaths,
 	}
 
 	if jsonOutput {
@@ -171,12 +205,21 @@ func cmdSync(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bool
 	}
 
 	// Report updates
-	fmt.Printf("%s %d of %d files have updates available (source: %s)\n\n",
-		yellow("⚠"), len(updates), len(files), src.SHA)
-	for _, u := range updates {
-		fmt.Printf("  %s %s\n", yellow("~"), u.Path)
+	if len(updates) > 0 {
+		fmt.Printf("%s %d of %d files have updates available (source: %s)\n\n",
+			yellow("⚠"), len(updates), len(files), src.SHA)
+		for _, u := range updates {
+			fmt.Printf("  %s %s\n", yellow("~"), u.Path)
+		}
+		fmt.Println()
+	} else if len(conflictPaths) > 0 && !apply {
+		fmt.Printf("%s %d file(s) are in conflict state and were skipped (source: %s)\n\n",
+			yellow("⚠"), len(conflictPaths), src.SHA)
+		for _, p := range conflictPaths {
+			fmt.Printf("  %s %s\n", dim("⊘"), p)
+		}
+		fmt.Println()
 	}
-	fmt.Println()
 
 	if !apply {
 		fmt.Printf("Run %s to apply updates.\n", bold("nav-pilot sync --apply"))
@@ -252,13 +295,22 @@ func cmdSyncAuto(repoDir, ref, sourceRepo string, apply, jsonOutput bool) error 
 	var firstErr error
 
 	if repoState != nil {
-		if !jsonOutput && userState != nil {
+		if !jsonOutput {
 			fmt.Printf("%s Syncing %s scope...\n", dim("→"), bold("repo"))
 		}
-		if err := cmdSync(repoScope, ref, sourceRepo, apply, jsonOutput); err != nil {
+		if err := cmdSyncFn(repoScope, ref, sourceRepo, apply, jsonOutput); err != nil {
 			if firstErr == nil {
 				firstErr = err
 			}
+			if !jsonOutput {
+				if err == errUpdatesAvailable {
+					fmt.Printf("%s Repo scope has updates available.\n", yellow("⚠"))
+				} else {
+					fmt.Printf("%s Repo scope sync failed.\n", yellow("⚠"))
+				}
+			}
+		} else if !jsonOutput {
+			fmt.Printf("%s Repo scope synced.\n", green("✓"))
 		}
 	}
 
@@ -267,14 +319,21 @@ func cmdSyncAuto(repoDir, ref, sourceRepo string, apply, jsonOutput bool) error 
 			if repoState != nil {
 				fmt.Println()
 			}
-			if repoState != nil {
-				fmt.Printf("%s Syncing %s scope...\n", dim("→"), bold("user"))
-			}
+			fmt.Printf("%s Syncing %s scope...\n", dim("→"), bold("user"))
 		}
-		if err := cmdSync(userScope, ref, sourceRepo, apply, jsonOutput); err != nil {
+		if err := cmdSyncFn(userScope, ref, sourceRepo, apply, jsonOutput); err != nil {
 			if firstErr == nil {
 				firstErr = err
 			}
+			if !jsonOutput {
+				if err == errUpdatesAvailable {
+					fmt.Printf("%s User scope has updates available.\n", yellow("⚠"))
+				} else {
+					fmt.Printf("%s User scope sync failed.\n", yellow("⚠"))
+				}
+			}
+		} else if !jsonOutput {
+			fmt.Printf("%s User scope synced.\n", green("✓"))
 		}
 	}
 
@@ -291,7 +350,7 @@ type syncFile struct {
 // resolveSyncFiles determines which files to sync.
 // If a state file exists, uses the installed file list.
 // Otherwise, auto-detects customization files in the target repo.
-func resolveSyncFiles(scope *InstallScope, sourceDir string) ([]syncFile, string, error) {
+func resolveSyncFiles(scope *InstallScope, sourceDir string, includeConflicts bool) ([]syncFile, string, error) {
 	state, err := readScopedState(scope)
 	if err != nil {
 		return nil, "", fmt.Errorf("reading state: %w", err)
@@ -302,7 +361,10 @@ func resolveSyncFiles(scope *InstallScope, sourceDir string) ([]syncFile, string
 		resolver := NewSourceResolver(sourceDir)
 		var files []syncFile
 		for _, f := range state.Files {
-			if f.Status == fileStatusIgnored || f.Status == fileStatusConflict {
+			if f.Status == fileStatusIgnored {
+				continue
+			}
+			if f.Status == fileStatusConflict && !includeConflicts {
 				continue
 			}
 			sp := resolver.MapLocalPath(f.Path, scope.IsUser())
@@ -322,6 +384,20 @@ func resolveSyncFiles(scope *InstallScope, sourceDir string) ([]syncFile, string
 
 	// Auto-detect: scan for customization files that also exist in source
 	return autoDetectSyncFiles(scope.RootDir, sourceDir)
+}
+
+func conflictStatePaths(scope *InstallScope) []string {
+	state, err := readScopedState(scope)
+	if err != nil || state == nil {
+		return nil
+	}
+	var conflicts []string
+	for _, f := range state.Files {
+		if f.Status == fileStatusConflict {
+			conflicts = append(conflicts, f.Path)
+		}
+	}
+	return conflicts
 }
 
 // detectNewItems checks if the source has agents/skills/instructions not in the state file.
@@ -475,6 +551,7 @@ func updateScopedStateHashes(scope *InstallScope, updates []syncUpdate) error {
 			continue
 		}
 		state.Files[i].Hash = hash
+		state.Files[i].Status = ""
 	}
 
 	return writeScopedState(scope, state)

--- a/cli/nav-pilot/sync.go
+++ b/cli/nav-pilot/sync.go
@@ -112,12 +112,6 @@ func cmdSync(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bool
 		}
 		fmt.Println()
 	}
-	if !jsonOutput && len(conflictPaths) > 0 && !apply {
-		for _, p := range conflictPaths {
-			fmt.Printf("  %s %s (conflict — skipped, run sync --apply to overwrite)\n", dim("⊘"), p)
-		}
-		fmt.Println()
-	}
 
 	// Compare each file against source.
 	// Files that are in state but missing on disk are treated as intentionally
@@ -245,6 +239,11 @@ func cmdSync(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bool
 	// Update state with new hashes
 	if err := updateScopedStateHashes(scope, appliedUpdates); err != nil {
 		fmt.Fprintf(os.Stderr, "%s Could not update state file: %v\n", yellow("⚠"), err)
+	}
+	if apply {
+		if err := clearResolvedConflicts(scope, src.Dir, files, conflictPaths); err != nil {
+			fmt.Fprintf(os.Stderr, "%s Could not clear resolved conflicts: %v\n", yellow("⚠"), err)
+		}
 	}
 
 	// Only bump source SHA and version if ALL updates were applied successfully
@@ -554,6 +553,57 @@ func updateScopedStateHashes(scope *InstallScope, updates []syncUpdate) error {
 		state.Files[i].Status = ""
 	}
 
+	return writeScopedState(scope, state)
+}
+
+// clearResolvedConflicts clears conflict status for files that currently match source.
+func clearResolvedConflicts(scope *InstallScope, sourceDir string, files []syncFile, conflictPaths []string) error {
+	if len(conflictPaths) == 0 {
+		return nil
+	}
+
+	state, err := readScopedState(scope)
+	if err != nil || state == nil {
+		return nil
+	}
+
+	byLocalPath := make(map[string]syncFile, len(files))
+	for _, sf := range files {
+		byLocalPath[sf.localPath] = sf
+	}
+	conflictSet := make(map[string]bool, len(conflictPaths))
+	for _, p := range conflictPaths {
+		conflictSet[p] = true
+	}
+
+	changed := false
+	for i, f := range state.Files {
+		if !conflictSet[f.Path] {
+			continue
+		}
+		sf, ok := byLocalPath[f.Path]
+		if !ok {
+			continue
+		}
+
+		localFull := filepath.Join(scope.RootDir, sf.localPath)
+		sourceFull := filepath.Join(sourceDir, sf.sourcePath)
+		isDir := strings.HasSuffix(sf.localPath, "/")
+
+		localHash, localErr := rawArtifactHash(localFull, isDir)
+		sourceHash, sourceErr := rawArtifactHash(sourceFull, isDir)
+		if localErr != nil || sourceErr != nil {
+			continue
+		}
+		if localHash == sourceHash && state.Files[i].Status != "" {
+			state.Files[i].Status = ""
+			changed = true
+		}
+	}
+
+	if !changed {
+		return nil
+	}
 	return writeScopedState(scope, state)
 }
 

--- a/cli/nav-pilot/sync_test.go
+++ b/cli/nav-pilot/sync_test.go
@@ -27,9 +27,10 @@ func TestResolveSyncFiles_WithState(t *testing.T) {
 			{Path: ".github/skills/api-design/", Hash: "def456"},
 		},
 	}
+
 	writeState(dir, state)
 
-	files, collection, err := resolveSyncFiles(ScopeRepo(dir), sourceDir)
+	files, collection, err := resolveSyncFiles(ScopeRepo(dir), sourceDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,6 +42,41 @@ func TestResolveSyncFiles_WithState(t *testing.T) {
 	}
 	if !files[1].isDir {
 		t.Error("skill path should be detected as dir")
+	}
+}
+
+func TestResolveSyncFiles_ConflictHandling(t *testing.T) {
+	dir := t.TempDir()
+	sourceDir := t.TempDir()
+
+	os.MkdirAll(filepath.Join(sourceDir, ".github", "agents"), 0o755)
+	os.WriteFile(filepath.Join(sourceDir, ".github", "agents", "nav-pilot.agent.md"), []byte("# New"), 0o644)
+
+	state := &StateFile{
+		Collection: "fullstack",
+		Version:    "2025.07",
+		Files: []InstalledFile{
+			{Path: ".github/agents/nav-pilot.agent.md", Hash: "abc123", Status: fileStatusConflict},
+		},
+	}
+	writeState(dir, state)
+
+	// Default sync check should skip conflicts
+	files, _, err := resolveSyncFiles(ScopeRepo(dir), sourceDir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("files count (exclude conflicts) = %d, want 0", len(files))
+	}
+
+	// Apply mode should include conflicts so they can be overwritten
+	files, _, err = resolveSyncFiles(ScopeRepo(dir), sourceDir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("files count (include conflicts) = %d, want 1", len(files))
 	}
 }
 
@@ -63,7 +99,7 @@ func TestResolveSyncFiles_AutoDetect(t *testing.T) {
 	os.MkdirAll(filepath.Join(sourceDir, ".github", "skills", "api-design"), 0o755)
 	os.WriteFile(filepath.Join(sourceDir, ".github", "skills", "api-design", "SKILL.md"), []byte("# API"), 0o644)
 
-	files, collection, err := resolveSyncFiles(ScopeRepo(targetDir), sourceDir)
+	files, collection, err := resolveSyncFiles(ScopeRepo(targetDir), sourceDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +144,7 @@ func TestResolveSyncFiles_AutoDetect_RootLevelSource(t *testing.T) {
 	os.MkdirAll(filepath.Join(sourceDir, "skills", "api-design"), 0o755)
 	os.WriteFile(filepath.Join(sourceDir, "skills", "api-design", "SKILL.md"), []byte("new"), 0o644)
 
-	files, _, err := resolveSyncFiles(ScopeRepo(targetDir), sourceDir)
+	files, _, err := resolveSyncFiles(ScopeRepo(targetDir), sourceDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -322,6 +358,34 @@ func TestUpdateStateHashes(t *testing.T) {
 	}
 }
 
+func TestUpdateStateHashes_ClearsConflictStatus(t *testing.T) {
+	dir := t.TempDir()
+
+	rel := filepath.Join(".github", "agents", "x.agent.md")
+	os.MkdirAll(filepath.Join(dir, ".github", "agents"), 0o755)
+	os.WriteFile(filepath.Join(dir, rel), []byte("updated content"), 0o644)
+
+	state := &StateFile{
+		Collection: "test",
+		Files: []InstalledFile{
+			{Path: rel, Hash: "oldhash", Status: fileStatusConflict},
+		},
+	}
+	writeState(dir, state)
+
+	newHash, _ := fileHash(filepath.Join(dir, rel))
+	updates := []syncUpdate{{Path: rel, CurrentHash: "oldhash", SourceHash: newHash}}
+
+	if err := updateStateHashes(dir, updates); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := readState(dir)
+	if got.Files[0].Status != "" {
+		t.Errorf("status = %q, want empty", got.Files[0].Status)
+	}
+}
+
 func TestUpdateStateHashes_NoState(t *testing.T) {
 	dir := t.TempDir()
 	// Should not error when no state file exists
@@ -437,7 +501,7 @@ func TestResolveSyncFiles_UserScope_PathRemapping(t *testing.T) {
 	}
 	writeScopedState(scope, state)
 
-	files, collection, err := resolveSyncFiles(scope, sourceDir)
+	files, collection, err := resolveSyncFiles(scope, sourceDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -497,7 +561,7 @@ func TestResolveSyncFiles_UserScope_InstructionPathNotDoubled(t *testing.T) {
 	}
 	writeScopedState(scope, state)
 
-	files, _, err := resolveSyncFiles(scope, sourceDir)
+	files, _, err := resolveSyncFiles(scope, sourceDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -613,7 +677,7 @@ func TestResolveSyncFiles_UserScope_NoState_ReturnsEmpty(t *testing.T) {
 		SupportedTypes: []string{"agent", "skill", "instruction"},
 	}
 
-	files, collection, err := resolveSyncFiles(scope, "")
+	files, collection, err := resolveSyncFiles(scope, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -805,7 +869,7 @@ func TestResolveSyncFiles_SkipsIgnoredFiles(t *testing.T) {
 	}
 	writeState(dir, state)
 
-	files, _, err := resolveSyncFiles(ScopeRepo(dir), sourceDir)
+	files, _, err := resolveSyncFiles(ScopeRepo(dir), sourceDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -839,7 +903,7 @@ func TestResolveSyncFiles_SkipsConflictedFiles(t *testing.T) {
 	}
 	writeState(dir, state)
 
-	files, _, err := resolveSyncFiles(ScopeRepo(dir), sourceDir)
+	files, _, err := resolveSyncFiles(ScopeRepo(dir), sourceDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -923,7 +987,7 @@ func TestStateFile_BackwardsCompat_NoStatusField(t *testing.T) {
 	}
 
 	// resolveSyncFiles should include all files (none ignored)
-	files, _, err := resolveSyncFiles(ScopeRepo(dir), "")
+	files, _, err := resolveSyncFiles(ScopeRepo(dir), "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -977,7 +1041,7 @@ func TestResolveSyncFiles_AutoDetect_InvalidRootFallsBack(t *testing.T) {
 	os.MkdirAll(filepath.Join(sourceDir, ".github", "skills", "my-skill"), 0o755)
 	os.WriteFile(filepath.Join(sourceDir, ".github", "skills", "my-skill", "SKILL.md"), []byte("new-legacy"), 0o644)
 
-	files, _, err := resolveSyncFiles(ScopeRepo(targetDir), sourceDir)
+	files, _, err := resolveSyncFiles(ScopeRepo(targetDir), sourceDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1009,7 +1073,7 @@ func TestResolveSyncFiles_AutoDetect_RootLevelAgents(t *testing.T) {
 	os.MkdirAll(filepath.Join(sourceDir, "agents"), 0o755)
 	os.WriteFile(filepath.Join(sourceDir, "agents", "nais.agent.md"), []byte("new"), 0o644)
 
-	files, _, err := resolveSyncFiles(ScopeRepo(targetDir), sourceDir)
+	files, _, err := resolveSyncFiles(ScopeRepo(targetDir), sourceDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1041,7 +1105,7 @@ func TestResolveSyncFiles_AutoDetect_RootLevelInstructions(t *testing.T) {
 	os.MkdirAll(filepath.Join(sourceDir, "instructions"), 0o755)
 	os.WriteFile(filepath.Join(sourceDir, "instructions", "go.instructions.md"), []byte("new"), 0o644)
 
-	files, _, err := resolveSyncFiles(ScopeRepo(targetDir), sourceDir)
+	files, _, err := resolveSyncFiles(ScopeRepo(targetDir), sourceDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1073,7 +1137,7 @@ func TestResolveSyncFiles_AutoDetect_RootLevelPromptDir(t *testing.T) {
 	os.MkdirAll(filepath.Join(sourceDir, "prompts", "review"), 0o755)
 	os.WriteFile(filepath.Join(sourceDir, "prompts", "review", "prompt.md"), []byte("new"), 0o644)
 
-	files, _, err := resolveSyncFiles(ScopeRepo(targetDir), sourceDir)
+	files, _, err := resolveSyncFiles(ScopeRepo(targetDir), sourceDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1129,5 +1193,54 @@ func TestCmdSyncAuto_NoInstall(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "No nav-pilot collection installed") {
 		t.Errorf("expected 'no collection' message, got: %s", out)
+	}
+}
+
+func TestCmdSyncAuto_BothScopes_PrintsScopeFeedback(t *testing.T) {
+	repoDir := t.TempDir()
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	// Repo scope state
+	os.MkdirAll(filepath.Join(repoDir, ".git"), 0o755)
+	repoScope := ScopeRepo(repoDir)
+	if err := writeScopedState(repoScope, &StateFile{Collection: "fullstack", Scope: "repo"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// User scope state
+	userScope, err := ScopeUser()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeScopedState(userScope, &StateFile{Collection: CollectionAll, Scope: "user"}); err != nil {
+		t.Fatal(err)
+	}
+
+	origCmdSyncFn := cmdSyncFn
+	t.Cleanup(func() { cmdSyncFn = origCmdSyncFn })
+	cmdSyncFn = func(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bool) error {
+		return nil
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err = cmdSyncAuto(repoDir, "", "", false, false)
+
+	w.Close()
+	out, _ := io.ReadAll(r)
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	output := string(out)
+	if !strings.Contains(output, "Repo scope synced") {
+		t.Errorf("expected repo synced feedback, got: %s", output)
+	}
+	if !strings.Contains(output, "User scope synced") {
+		t.Errorf("expected user synced feedback, got: %s", output)
 	}
 }

--- a/docs/nav-pilot-changelog.md
+++ b/docs/nav-pilot-changelog.md
@@ -2,16 +2,6 @@
 
 Endringslogg for nav-pilot agent harness — agenter, skills, instruksjoner, prompts og samlinger.
 
-## 2026-06-05
-
-### nav-pilot CLI — launch følger agent-default (ikke tvungen `auto`)
-
-Justerte launch-policy i `cli/nav-pilot` for bedre balanse mellom kost og kvalitet for alle brukere:
-
-- Fjerner tvungen `--model auto` ved `--agent nav-pilot`
-- Setter ikke `effort` eksplisitt i launch-argumenter
-- Lar modellvalg styres av agent-default (Sonnet i agentfilen) eller eksplisitt bruker-overstyring
-
 ---
 
 ## 2026-06-04

--- a/docs/nav-pilot-changelog.md
+++ b/docs/nav-pilot-changelog.md
@@ -58,6 +58,10 @@ La til en eksplisitt routing-policy i `nav-pilot.agent.md` for å redusere unød
 - Eskaler kun smale høyrisiko-delproblemer til `@nav-pilot-opus`
 - Deleger domenespørsmål til spesialistagenter i stedet for å laste alt i én kontekst
 
+### Dokumentasjon — tydeligere føringer for agentvalg
+
+Oppdatert `docs/README.nav-pilot.md` med kort, praktisk anbefaling om når `@research-agent` og `@nav-pilot-opus` bør brukes.
+
 ### nav-pilot — operasjonelle kostnadsvern på routing
 
 For å dekke hele research-bildet (7 tiltak) ble policyen skjerpet med håndhevbare regler:

--- a/docs/nav-pilot-changelog.md
+++ b/docs/nav-pilot-changelog.md
@@ -2,6 +2,26 @@
 
 Endringslogg for nav-pilot agent harness — agenter, skills, instruksjoner, prompts og samlinger.
 
+## 2026-06-05
+
+### PR #276 — netto endringer mot `main`
+
+Denne posten beskriver kun det som faktisk er forskjellig fra `main` i PR-en (ikke mellomsteg i branch-historikken).
+
+### nav-pilot CLI — launch og sync
+
+- Launch sender ikke lenger tvungne `--mode plan` / `--effort high`; agent-default og bruker-overstyring gjelder
+- `sync` viser konfliktfiler tydelig i output/JSON når de blir hoppet over
+- `sync --apply` rydder `conflict`-status når filer faktisk matcher source
+- Forbedret auto-sync feedback per scope (repo/user)
+- Egen source-resolve-strategi for sync + utvidet testdekning
+
+### my-copilot — navigasjon og prising
+
+- La til hash-anchor scrolling ved hard reload (`HashAnchorScroll` i root layout)
+- Robust håndtering av ugyldig URL-fragment (fallback når `decodeURIComponent` feiler)
+- Synket model-pricing-data (inkludert oppdatert dato og modelliste)
+
 ---
 
 ## 2026-06-04

--- a/docs/nav-pilot-changelog.md
+++ b/docs/nav-pilot-changelog.md
@@ -4,9 +4,7 @@ Endringslogg for nav-pilot agent harness — agenter, skills, instruksjoner, pro
 
 ## 2026-06-05
 
-### PR #276 — netto endringer mot `main`
-
-Denne posten beskriver kun det som faktisk er forskjellig fra `main` i PR-en (ikke mellomsteg i branch-historikken).
+### nav-pilot og my-copilot — sync, launch og hash-anchor
 
 ### nav-pilot CLI — launch og sync
 

--- a/docs/nav-pilot-changelog.md
+++ b/docs/nav-pilot-changelog.md
@@ -58,10 +58,6 @@ La til en eksplisitt routing-policy i `nav-pilot.agent.md` for å redusere unød
 - Eskaler kun smale høyrisiko-delproblemer til `@nav-pilot-opus`
 - Deleger domenespørsmål til spesialistagenter i stedet for å laste alt i én kontekst
 
-### Dokumentasjon — tydeligere føringer for agentvalg
-
-Oppdatert `docs/README.nav-pilot.md` med kort, praktisk anbefaling om når `@research-agent` og `@nav-pilot-opus` bør brukes.
-
 ### nav-pilot — operasjonelle kostnadsvern på routing
 
 For å dekke hele research-bildet (7 tiltak) ble policyen skjerpet med håndhevbare regler:

--- a/docs/nav-pilot-changelog.md
+++ b/docs/nav-pilot-changelog.md
@@ -2,6 +2,16 @@
 
 Endringslogg for nav-pilot agent harness — agenter, skills, instruksjoner, prompts og samlinger.
 
+## 2026-06-05
+
+### nav-pilot CLI — launch følger agent-default (ikke tvungen `auto`)
+
+Justerte launch-policy i `cli/nav-pilot` for bedre balanse mellom kost og kvalitet for alle brukere:
+
+- Fjerner tvungen `--model auto` ved `--agent nav-pilot`
+- Setter ikke `effort` eksplisitt i launch-argumenter
+- Lar modellvalg styres av agent-default (Sonnet i agentfilen) eller eksplisitt bruker-overstyring
+
 ---
 
 ## 2026-06-04


### PR DESCRIPTION
## Hva som er endret

### nav-pilot (CLI)
- Stopper å tvinge modellvalg ved launch (ingen automatisk --model auto)
- Setter ikke effort eksplisitt ved launch
- Fjerner tvungne launch-flagg for plan/effort
- Forbedrer sync av konflikter: tydeligere feedback og remediere ved --apply
- Gir tydelig scope-feedback i default sync (repo/user)
- Forbedrer source-resolve og testdekning

### my-copilot
- Sikrer at hash-ankere scroller riktig ved hard reload
- Oppdaterer modell-prising-data

## Berørte filer (hovedområder)
- cli/nav-pilot/*
- apps/my-copilot/src/components/hash-anchor-scroll.tsx
- apps/my-copilot/src/app/layout.tsx
- apps/my-copilot/src/lib/model-pricing.ts