### PR TITLE
feat(copilot-metrics): backfill and daily ingest for billing usage reports

### DIFF
--- a/apps/copilot-api/bigquery.go
+++ b/apps/copilot-api/bigquery.go
@@ -369,6 +369,8 @@ type BigQueryQuerier interface {
 	GetMonthlyTrends(ctx context.Context, months int) ([]MonthlyTrend, error)
 	GetMonthlyModelUsage(ctx context.Context, months int) ([]MonthlyModelUsage, error)
 	GetMonthlyBillingUsage(ctx context.Context, months int) ([]MonthlyBillingUsage, error)
+	GetBillingModelDailyCosts(ctx context.Context, month string) ([]BillingModelDailyCost, error)
+	GetBillingModelForecast(ctx context.Context, month string) (*BillingModelForecast, error)
 	GetUserWeeklyTrends(ctx context.Context, userLogin string, weeks int) ([]WeeklyTrend, error)
 	GetAdoptionCohorts(ctx context.Context, days int) ([]AdoptionCohortDay, error)
 }
@@ -485,6 +487,20 @@ func (c *CachedBigQueryClient) GetMonthlyBillingUsage(ctx context.Context, month
 	cacheKey := fmt.Sprintf("monthly_billing_usage_%d", months)
 	return getCachedValue(c.cache, cacheKey, func() ([]MonthlyBillingUsage, error) {
 		return c.client.GetMonthlyBillingUsage(ctx, months)
+	})
+}
+
+func (c *CachedBigQueryClient) GetBillingModelDailyCosts(ctx context.Context, month string) ([]BillingModelDailyCost, error) {
+	cacheKey := fmt.Sprintf("billing_model_daily_costs_%s", month)
+	return getCachedValue(c.cache, cacheKey, func() ([]BillingModelDailyCost, error) {
+		return c.client.GetBillingModelDailyCosts(ctx, month)
+	})
+}
+
+func (c *CachedBigQueryClient) GetBillingModelForecast(ctx context.Context, month string) (*BillingModelForecast, error) {
+	cacheKey := fmt.Sprintf("billing_model_forecast_%s", month)
+	return getCachedValue(c.cache, cacheKey, func() (*BillingModelForecast, error) {
+		return c.client.GetBillingModelForecast(ctx, month)
 	})
 }
 

--- a/apps/copilot-api/bigquery_handlers_test.go
+++ b/apps/copilot-api/bigquery_handlers_test.go
@@ -37,6 +37,10 @@ type mockBigQueryClient struct {
 	monthlyModelsErr   error
 	monthlyBilling     []MonthlyBillingUsage
 	monthlyBillingErr  error
+	billingModelDaily  []BillingModelDailyCost
+	billingModelErr    error
+	billingForecast    *BillingModelForecast
+	billingForecastErr error
 	weeklyTrends       []WeeklyTrend
 	weeklyTrendsErr    error
 	cohorts            []AdoptionCohortDay
@@ -89,6 +93,14 @@ func (m *mockBigQueryClient) GetMonthlyModelUsage(_ context.Context, _ int) ([]M
 
 func (m *mockBigQueryClient) GetMonthlyBillingUsage(_ context.Context, _ int) ([]MonthlyBillingUsage, error) {
 	return m.monthlyBilling, m.monthlyBillingErr
+}
+
+func (m *mockBigQueryClient) GetBillingModelDailyCosts(_ context.Context, _ string) ([]BillingModelDailyCost, error) {
+	return m.billingModelDaily, m.billingModelErr
+}
+
+func (m *mockBigQueryClient) GetBillingModelForecast(_ context.Context, _ string) (*BillingModelForecast, error) {
+	return m.billingForecast, m.billingForecastErr
 }
 
 func (m *mockBigQueryClient) GetUserWeeklyTrends(_ context.Context, _ string, _ int) ([]WeeklyTrend, error) {
@@ -438,6 +450,34 @@ func TestHandleNewStatsEndpoints(t *testing.T) {
 			mock:       &mockBigQueryClient{monthlyBillingErr: errors.New("bq")},
 			req:        httptest.NewRequest(http.MethodGet, "/api/v1/copilot/billing/monthly", nil),
 			handle:     (*BigQueryHandlers).handleMonthlyBillingUsage,
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:       "billing model daily success",
+			mock:       &mockBigQueryClient{billingModelDaily: []BillingModelDailyCost{{Day: "2026-06-01", Model: "gpt-5", NetAmount: 10.2}}},
+			req:        httptest.NewRequest(http.MethodGet, "/api/v1/copilot/billing/model-daily?month=2026-06", nil),
+			handle:     (*BigQueryHandlers).handleBillingModelDaily,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "billing model daily invalid month",
+			mock:       &mockBigQueryClient{},
+			req:        httptest.NewRequest(http.MethodGet, "/api/v1/copilot/billing/model-daily?month=2026/06", nil),
+			handle:     (*BigQueryHandlers).handleBillingModelDaily,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "billing model forecast success",
+			mock:       &mockBigQueryClient{billingForecast: &BillingModelForecast{Month: "2026-06", ProjectedEOMNetAmount: 120}},
+			req:        httptest.NewRequest(http.MethodGet, "/api/v1/copilot/billing/model-forecast?month=2026-06", nil),
+			handle:     (*BigQueryHandlers).handleBillingModelForecast,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "billing model forecast error",
+			mock:       &mockBigQueryClient{billingForecastErr: errors.New("bq")},
+			req:        httptest.NewRequest(http.MethodGet, "/api/v1/copilot/billing/model-forecast?month=2026-06", nil),
+			handle:     (*BigQueryHandlers).handleBillingModelForecast,
 			wantStatus: http.StatusInternalServerError,
 		},
 		{

--- a/apps/copilot-api/bigquery_handlers_test.go
+++ b/apps/copilot-api/bigquery_handlers_test.go
@@ -467,6 +467,13 @@ func TestHandleNewStatsEndpoints(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 		},
 		{
+			name:       "billing model daily invalid calendar month",
+			mock:       &mockBigQueryClient{},
+			req:        httptest.NewRequest(http.MethodGet, "/api/v1/copilot/billing/model-daily?month=2026-13", nil),
+			handle:     (*BigQueryHandlers).handleBillingModelDaily,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
 			name:       "billing model forecast success",
 			mock:       &mockBigQueryClient{billingForecast: &BillingModelForecast{Month: "2026-06", ProjectedEOMNetAmount: 120}},
 			req:        httptest.NewRequest(http.MethodGet, "/api/v1/copilot/billing/model-forecast?month=2026-06", nil),
@@ -479,6 +486,13 @@ func TestHandleNewStatsEndpoints(t *testing.T) {
 			req:        httptest.NewRequest(http.MethodGet, "/api/v1/copilot/billing/model-forecast?month=2026-06", nil),
 			handle:     (*BigQueryHandlers).handleBillingModelForecast,
 			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:       "billing model forecast invalid calendar month",
+			mock:       &mockBigQueryClient{},
+			req:        httptest.NewRequest(http.MethodGet, "/api/v1/copilot/billing/model-forecast?month=2026-13", nil),
+			handle:     (*BigQueryHandlers).handleBillingModelForecast,
+			wantStatus: http.StatusBadRequest,
 		},
 		{
 			name:       "weekly trends success",

--- a/apps/copilot-api/bigquery_stats.go
+++ b/apps/copilot-api/bigquery_stats.go
@@ -3,10 +3,16 @@ package main
 import (
 	"context"
 	"fmt"
+	"math"
+	"regexp"
+	"slices"
+	"time"
 
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
 )
+
+var yearMonthRegex = regexp.MustCompile(`^\d{4}-\d{2}$`)
 
 type ModelInteractions struct {
 	Model        string `bigquery:"model" json:"model"`
@@ -88,6 +94,35 @@ type MonthlyBillingUsage struct {
 	NetRequests   int64   `bigquery:"net_requests" json:"net_requests"`
 	GrossAmount   float64 `bigquery:"gross_amount" json:"gross_amount"`
 	NetAmount     float64 `bigquery:"net_amount" json:"net_amount"`
+}
+
+type BillingModelDailyCost struct {
+	Day           string  `bigquery:"day" json:"day"`
+	Model         string  `bigquery:"model" json:"model"`
+	GrossRequests int64   `bigquery:"gross_requests" json:"gross_requests"`
+	NetRequests   int64   `bigquery:"net_requests" json:"net_requests"`
+	GrossAmount   float64 `bigquery:"gross_amount" json:"gross_amount"`
+	NetAmount     float64 `bigquery:"net_amount" json:"net_amount"`
+}
+
+type BillingModelForecastPoint struct {
+	Day                 string   `json:"day"`
+	ActualCumulative    *float64 `json:"actual_cumulative,omitempty"`
+	ProjectedCumulative float64  `json:"projected_cumulative"`
+	IsActual            bool     `json:"is_actual"`
+}
+
+type BillingModelForecast struct {
+	Month                 string                      `json:"month"`
+	DaysInMonth           int                         `json:"days_in_month"`
+	DaysElapsed           int                         `json:"days_elapsed"`
+	LastActualDay         string                      `json:"last_actual_day,omitempty"`
+	ActualMTDNetAmount    float64                     `json:"actual_mtd_net_amount"`
+	ProjectedDailyRunRate float64                     `json:"projected_daily_run_rate"`
+	ProjectedEOMNetAmount float64                     `json:"projected_eom_net_amount"`
+	LowerEOMNetAmount     float64                     `json:"lower_eom_net_amount"`
+	UpperEOMNetAmount     float64                     `json:"upper_eom_net_amount"`
+	Points                []BillingModelForecastPoint `json:"points"`
 }
 
 type WeeklyTrend struct {
@@ -441,6 +476,212 @@ func (bq *BigQueryClient) GetMonthlyBillingUsage(ctx context.Context, months int
 		return nil, fmt.Errorf("execute query: %w", err)
 	}
 	return readAllRows[MonthlyBillingUsage](it)
+}
+
+func (bq *BigQueryClient) GetBillingModelDailyCosts(ctx context.Context, month string) ([]BillingModelDailyCost, error) {
+	if !isValidYearMonth(month) {
+		return nil, fmt.Errorf("invalid month format %q (expected YYYY-MM)", month)
+	}
+
+	billingRef := bq.tableRef(bq.metricsDataset, "billing_usage_daily_model")
+	queryStr := fmt.Sprintf(`
+      SELECT
+        FORMAT_DATE('%%Y-%%m-%%d', day) AS day,
+        model,
+        CAST(SUM(gross_quantity) AS INT64) AS gross_requests,
+        CAST(SUM(net_quantity) AS INT64) AS net_requests,
+        SUM(gross_amount) AS gross_amount,
+        SUM(net_amount) AS net_amount
+      FROM %s
+      WHERE FORMAT_DATE('%%Y-%%m', day) = @month
+        AND scope_id = 'nav'
+        AND gross_quantity > 0
+      GROUP BY day, model
+      ORDER BY day ASC, gross_amount DESC
+    `, billingRef)
+
+	query := bq.client.Query(queryStr)
+	query.Parameters = []bigquery.QueryParameter{{Name: "month", Value: month}}
+	it, err := query.Read(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("execute query: %w", err)
+	}
+	return readAllRows[BillingModelDailyCost](it)
+}
+
+func (bq *BigQueryClient) GetBillingModelForecast(ctx context.Context, month string) (*BillingModelForecast, error) {
+	if !isValidYearMonth(month) {
+		return nil, fmt.Errorf("invalid month format %q (expected YYYY-MM)", month)
+	}
+
+	monthStart, err := time.Parse("2006-01", month)
+	if err != nil {
+		return nil, fmt.Errorf("parse month: %w", err)
+	}
+	daysInMonth := time.Date(monthStart.Year(), monthStart.Month()+1, 0, 0, 0, 0, 0, time.UTC).Day()
+
+	billingRef := bq.tableRef(bq.metricsDataset, "billing_usage_daily_model")
+	queryStr := fmt.Sprintf(`
+      SELECT
+        FORMAT_DATE('%%Y-%%m-%%d', day) AS day,
+        SUM(net_amount) AS net_amount
+      FROM %s
+      WHERE FORMAT_DATE('%%Y-%%m', day) = @month
+        AND scope_id = 'nav'
+      GROUP BY day
+      ORDER BY day ASC
+    `, billingRef)
+
+	query := bq.client.Query(queryStr)
+	query.Parameters = []bigquery.QueryParameter{{Name: "month", Value: month}}
+	it, err := query.Read(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("execute query: %w", err)
+	}
+
+	type dayAmountRow struct {
+		Day       string  `bigquery:"day"`
+		NetAmount float64 `bigquery:"net_amount"`
+	}
+
+	rows, err := readAllRows[dayAmountRow](it)
+	if err != nil {
+		return nil, err
+	}
+
+	dailyAmounts := make(map[int]float64, len(rows))
+	dayIndices := make([]int, 0, len(rows))
+	for _, row := range rows {
+		dayTime, parseErr := time.Parse("2006-01-02", row.Day)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse day %q: %w", row.Day, parseErr)
+		}
+		day := dayTime.Day()
+		dailyAmounts[day] = row.NetAmount
+		dayIndices = append(dayIndices, day)
+	}
+	slices.Sort(dayIndices)
+
+	forecast := &BillingModelForecast{
+		Month:       month,
+		DaysInMonth: daysInMonth,
+	}
+	if len(dayIndices) == 0 {
+		return forecast, nil
+	}
+
+	lastActualDay := dayIndices[len(dayIndices)-1]
+	forecast.LastActualDay = fmt.Sprintf("%s-%02d", month, lastActualDay)
+	forecast.DaysElapsed = lastActualDay
+
+	actualMTD := 0.0
+	dailySeries := make([]float64, 0, lastActualDay)
+	for day := 1; day <= lastActualDay; day++ {
+		value := dailyAmounts[day]
+		dailySeries = append(dailySeries, value)
+		actualMTD += value
+	}
+	forecast.ActualMTDNetAmount = actualMTD
+
+	runRate := weightedRunRate(dailySeries, 7)
+	if runRate <= 0 && lastActualDay > 0 {
+		runRate = actualMTD / float64(lastActualDay)
+	}
+	forecast.ProjectedDailyRunRate = runRate
+
+	remainingDays := daysInMonth - lastActualDay
+	projectedEOM := actualMTD + (runRate * float64(remainingDays))
+	forecast.ProjectedEOMNetAmount = projectedEOM
+
+	volatility := sampleStdDev(tail(dailySeries, 14))
+	lower := projectedEOM - (volatility * float64(remainingDays))
+	if lower < actualMTD {
+		lower = actualMTD
+	}
+	forecast.LowerEOMNetAmount = lower
+	forecast.UpperEOMNetAmount = projectedEOM + (volatility * float64(remainingDays))
+
+	points := make([]BillingModelForecastPoint, 0, daysInMonth)
+	actualCumulative := 0.0
+	for day := 1; day <= daysInMonth; day++ {
+		date := fmt.Sprintf("%s-%02d", month, day)
+		if day <= lastActualDay {
+			actualCumulative += dailyAmounts[day]
+			actualCopy := actualCumulative
+			points = append(points, BillingModelForecastPoint{
+				Day:                 date,
+				ActualCumulative:    &actualCopy,
+				ProjectedCumulative: actualCumulative,
+				IsActual:            true,
+			})
+			continue
+		}
+
+		projected := actualCumulative + (runRate * float64(day-lastActualDay))
+		points = append(points, BillingModelForecastPoint{
+			Day:                 date,
+			ProjectedCumulative: projected,
+			IsActual:            false,
+		})
+	}
+
+	forecast.Points = points
+	return forecast, nil
+}
+
+func weightedRunRate(series []float64, window int) float64 {
+	values := tail(series, window)
+	if len(values) == 0 {
+		return 0
+	}
+	weightedSum := 0.0
+	weightTotal := 0.0
+	for i, value := range values {
+		weight := float64(i + 1)
+		weightedSum += value * weight
+		weightTotal += weight
+	}
+	if weightTotal == 0 {
+		return 0
+	}
+	return weightedSum / weightTotal
+}
+
+func sampleStdDev(values []float64) float64 {
+	if len(values) < 2 {
+		return 0
+	}
+	mean := 0.0
+	for _, value := range values {
+		mean += value
+	}
+	mean /= float64(len(values))
+
+	variance := 0.0
+	for _, value := range values {
+		diff := value - mean
+		variance += diff * diff
+	}
+	variance /= float64(len(values) - 1)
+	return math.Sqrt(variance)
+}
+
+func tail(values []float64, n int) []float64 {
+	if n <= 0 || len(values) == 0 {
+		return nil
+	}
+	if len(values) <= n {
+		out := make([]float64, len(values))
+		copy(out, values)
+		return out
+	}
+	out := make([]float64, n)
+	copy(out, values[len(values)-n:])
+	return out
+}
+
+func isValidYearMonth(v string) bool {
+	return yearMonthRegex.MatchString(v)
 }
 
 func (bq *BigQueryClient) GetUserWeeklyTrends(ctx context.Context, userLogin string, weeks int) ([]WeeklyTrend, error) {

--- a/apps/copilot-api/bigquery_stats.go
+++ b/apps/copilot-api/bigquery_stats.go
@@ -494,7 +494,7 @@ func (bq *BigQueryClient) GetBillingModelDailyCosts(ctx context.Context, month s
         SUM(net_amount) AS net_amount
       FROM %s
       WHERE FORMAT_DATE('%%Y-%%m', day) = @month
-        AND scope_id = 'nav'
+        AND LOWER(scope_id) = 'nav'
         AND gross_quantity > 0
       GROUP BY day, model
       ORDER BY day ASC, gross_amount DESC
@@ -527,7 +527,7 @@ func (bq *BigQueryClient) GetBillingModelForecast(ctx context.Context, month str
         SUM(net_amount) AS net_amount
       FROM %s
       WHERE FORMAT_DATE('%%Y-%%m', day) = @month
-        AND scope_id = 'nav'
+        AND LOWER(scope_id) = 'nav'
       GROUP BY day
       ORDER BY day ASC
     `, billingRef)

--- a/apps/copilot-api/bigquery_stats.go
+++ b/apps/copilot-api/bigquery_stats.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"regexp"
 	"slices"
 	"time"
 
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
 )
-
-var yearMonthRegex = regexp.MustCompile(`^\d{4}-\d{2}$`)
 
 type ModelInteractions struct {
 	Model        string `bigquery:"model" json:"model"`
@@ -681,7 +678,11 @@ func tail(values []float64, n int) []float64 {
 }
 
 func isValidYearMonth(v string) bool {
-	return yearMonthRegex.MatchString(v)
+	parsed, err := time.Parse("2006-01", v)
+	if err != nil {
+		return false
+	}
+	return parsed.Format("2006-01") == v
 }
 
 func (bq *BigQueryClient) GetUserWeeklyTrends(ctx context.Context, userLogin string, weeks int) ([]WeeklyTrend, error) {

--- a/apps/copilot-api/bigquery_stats_handlers.go
+++ b/apps/copilot-api/bigquery_stats_handlers.go
@@ -3,7 +3,6 @@ package main
 import (
 	"log/slog"
 	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -25,14 +24,12 @@ func isValidUsageUsername(username string) bool {
 	return username != "" && len(username) <= 39 && !strings.Contains(username, "/") && isValidGitHubUsername(username)
 }
 
-var yearMonthPattern = regexp.MustCompile(`^\d{4}-\d{2}$`)
-
 func optionalMonthParam(r *http.Request, name string) (string, bool) {
 	value := r.URL.Query().Get(name)
 	if value == "" {
 		return time.Now().UTC().Format("2006-01"), true
 	}
-	if !yearMonthPattern.MatchString(value) {
+	if !isValidYearMonth(value) {
 		return "", false
 	}
 	return value, true

--- a/apps/copilot-api/bigquery_stats_handlers.go
+++ b/apps/copilot-api/bigquery_stats_handlers.go
@@ -3,8 +3,10 @@ package main
 import (
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func optionalIntParam(r *http.Request, name string, defaultValue, minValue, maxValue int) (int, bool) {
@@ -21,6 +23,19 @@ func optionalIntParam(r *http.Request, name string, defaultValue, minValue, maxV
 
 func isValidUsageUsername(username string) bool {
 	return username != "" && len(username) <= 39 && !strings.Contains(username, "/") && isValidGitHubUsername(username)
+}
+
+var yearMonthPattern = regexp.MustCompile(`^\d{4}-\d{2}$`)
+
+func optionalMonthParam(r *http.Request, name string) (string, bool) {
+	value := r.URL.Query().Get(name)
+	if value == "" {
+		return time.Now().UTC().Format("2006-01"), true
+	}
+	if !yearMonthPattern.MatchString(value) {
+		return "", false
+	}
+	return value, true
 }
 
 func (h *BigQueryHandlers) handleTeamUsageSummary(w http.ResponseWriter, r *http.Request) {
@@ -121,6 +136,45 @@ func (h *BigQueryHandlers) handleMonthlyBillingUsage(w http.ResponseWriter, r *h
 
 	cacheControl(w, 3600, false)
 	respondJSON(w, usage, http.StatusOK)
+}
+
+func (h *BigQueryHandlers) handleBillingModelDaily(w http.ResponseWriter, r *http.Request) {
+	month, ok := optionalMonthParam(r, "month")
+	if !ok {
+		respondError(w, "invalid_parameter", "month must be in YYYY-MM format", http.StatusBadRequest)
+		return
+	}
+
+	usage, err := h.bqClient.GetBillingModelDailyCosts(r.Context(), month)
+	if err != nil {
+		slog.Error("Failed to fetch billing model daily costs", "error", err)
+		respondError(w, "internal_error", "Failed to fetch billing model daily costs", http.StatusInternalServerError)
+		return
+	}
+	if usage == nil {
+		usage = []BillingModelDailyCost{}
+	}
+
+	cacheControl(w, 900, false)
+	respondJSON(w, usage, http.StatusOK)
+}
+
+func (h *BigQueryHandlers) handleBillingModelForecast(w http.ResponseWriter, r *http.Request) {
+	month, ok := optionalMonthParam(r, "month")
+	if !ok {
+		respondError(w, "invalid_parameter", "month must be in YYYY-MM format", http.StatusBadRequest)
+		return
+	}
+
+	forecast, err := h.bqClient.GetBillingModelForecast(r.Context(), month)
+	if err != nil {
+		slog.Error("Failed to fetch billing model forecast", "error", err)
+		respondError(w, "internal_error", "Failed to fetch billing model forecast", http.StatusInternalServerError)
+		return
+	}
+
+	cacheControl(w, 900, false)
+	respondJSON(w, forecast, http.StatusOK)
 }
 
 func (h *BigQueryHandlers) handleUserWeeklyTrends(w http.ResponseWriter, r *http.Request) {

--- a/apps/copilot-api/handlers.go
+++ b/apps/copilot-api/handlers.go
@@ -84,6 +84,8 @@ func makeAPIRouter(config *Config, bqHandlers *BigQueryHandlers, ghHandlers *Git
 	mux.HandleFunc("GET /api/v1/copilot/usage/trends", bq(nilSafe(bqHandlers, func(h *BigQueryHandlers) http.HandlerFunc { return h.handleMonthlyTrends })))
 	mux.HandleFunc("GET /api/v1/copilot/usage/models", bq(nilSafe(bqHandlers, func(h *BigQueryHandlers) http.HandlerFunc { return h.handleMonthlyModelUsage })))
 	mux.HandleFunc("GET /api/v1/copilot/billing/monthly", bq(nilSafe(bqHandlers, func(h *BigQueryHandlers) http.HandlerFunc { return h.handleMonthlyBillingUsage })))
+	mux.HandleFunc("GET /api/v1/copilot/billing/model-daily", bq(nilSafe(bqHandlers, func(h *BigQueryHandlers) http.HandlerFunc { return h.handleBillingModelDaily })))
+	mux.HandleFunc("GET /api/v1/copilot/billing/model-forecast", bq(nilSafe(bqHandlers, func(h *BigQueryHandlers) http.HandlerFunc { return h.handleBillingModelForecast })))
 	mux.HandleFunc("GET /api/v1/copilot/adoption/cohorts", bq(nilSafe(bqHandlers, func(h *BigQueryHandlers) http.HandlerFunc { return h.handleAdoptionCohorts })))
 
 	// GitHub API endpoints

--- a/apps/copilot-metrics/.mise.toml
+++ b/apps/copilot-metrics/.mise.toml
@@ -94,6 +94,16 @@ description = "Backfill billing usage data from 2026-03 (prod)"
 env = { LOG_LEVEL = "INFO", GCP_TEAM_PROJECT_ID = "copilot-prod-c697" }
 run = "fnox exec -- go run . --billing-backfill --billing-from=${BILLING_FROM:-2026-03} --force"
 
+[tasks."run:billing-usage-backfill"]
+description = "Backfill daily organization billing usage report data (dev)"
+env = { LOG_LEVEL = "DEBUG", GCP_TEAM_PROJECT_ID = "copilot-dev-e17a" }
+run = "fnox exec -- go run . --billing-usage-backfill --billing-usage-from=${BILLING_USAGE_FROM:-2025-10-10} --force"
+
+[tasks."run:billing-usage-backfill:prod"]
+description = "Backfill daily organization billing usage report data (prod)"
+env = { LOG_LEVEL = "INFO", GCP_TEAM_PROJECT_ID = "copilot-prod-c697" }
+run = "fnox exec -- go run . --billing-usage-backfill --billing-usage-from=${BILLING_USAGE_FROM:-2025-10-10} --force"
+
 [tasks."run:backfill"]
 description = "Run historical backfill (dev, from 2025-10-10)"
 env = { LOG_LEVEL = "DEBUG", GCP_TEAM_PROJECT_ID = "copilot-dev-e17a" }

--- a/apps/copilot-metrics/.mise.toml
+++ b/apps/copilot-metrics/.mise.toml
@@ -84,35 +84,65 @@ description = "Run single ingestion for yesterday"
 env = { LOG_LEVEL = "DEBUG" }
 run = "fnox exec -- go run . --run-once"
 
-[tasks."run:billing-backfill"]
-description = "Backfill billing usage data from 2026-03 (dev)"
-env = { LOG_LEVEL = "DEBUG", GCP_TEAM_PROJECT_ID = "copilot-dev-e17a" }
-run = "fnox exec -- go run . --billing-backfill --billing-from=${BILLING_FROM:-2026-03} --force"
-
-[tasks."run:billing-backfill:prod"]
-description = "Backfill billing usage data from 2026-03 (prod)"
-env = { LOG_LEVEL = "INFO", GCP_TEAM_PROJECT_ID = "copilot-prod-c697" }
-run = "fnox exec -- go run . --billing-backfill --billing-from=${BILLING_FROM:-2026-03} --force"
-
-[tasks."run:billing-usage-backfill"]
-description = "Backfill daily organization billing usage report data (dev)"
-env = { LOG_LEVEL = "DEBUG", GCP_TEAM_PROJECT_ID = "copilot-dev-e17a" }
-run = "fnox exec -- go run . --billing-usage-backfill --billing-usage-from=${BILLING_USAGE_FROM:-2025-10-10} --force"
-
-[tasks."run:billing-usage-backfill:prod"]
-description = "Backfill daily organization billing usage report data (prod)"
-env = { LOG_LEVEL = "INFO", GCP_TEAM_PROJECT_ID = "copilot-prod-c697" }
-run = "fnox exec -- go run . --billing-usage-backfill --billing-usage-from=${BILLING_USAGE_FROM:-2025-10-10} --force"
-
-[tasks."run:backfill"]
-description = "Run historical backfill (dev, from 2025-10-10)"
+[tasks."backfill:usage"]
+description = "Backfill usage metrics only (dev)"
 env = { LOG_LEVEL = "DEBUG", GCP_TEAM_PROJECT_ID = "copilot-dev-e17a" }
 run = "fnox exec -- go run . --backfill --backfill-from=${BACKFILL_FROM:-2025-10-10} --force"
 
-[tasks."run:backfill:prod"]
-description = "Run historical backfill (prod, from 2025-10-10)"
+[tasks."backfill:usage:prod"]
+description = "Backfill usage metrics only (prod)"
 env = { LOG_LEVEL = "INFO", GCP_TEAM_PROJECT_ID = "copilot-prod-c697" }
 run = "fnox exec -- go run . --backfill --backfill-from=${BACKFILL_FROM:-2025-10-10} --force"
+
+[tasks."backfill:billing-monthly"]
+description = "Backfill monthly billing usage only (dev)"
+env = { LOG_LEVEL = "DEBUG", GCP_TEAM_PROJECT_ID = "copilot-dev-e17a" }
+run = "fnox exec -- go run . --billing-monthly-backfill --billing-monthly-from=${BILLING_MONTHLY_FROM:-2026-03} --force"
+
+[tasks."backfill:billing-monthly:prod"]
+description = "Backfill monthly billing usage only (prod)"
+env = { LOG_LEVEL = "INFO", GCP_TEAM_PROJECT_ID = "copilot-prod-c697" }
+run = "fnox exec -- go run . --billing-monthly-backfill --billing-monthly-from=${BILLING_MONTHLY_FROM:-2026-03} --force"
+
+[tasks."backfill:billing-daily-report"]
+description = "Backfill daily billing usage report rows only (dev)"
+env = { LOG_LEVEL = "DEBUG", GCP_TEAM_PROJECT_ID = "copilot-dev-e17a" }
+run = "fnox exec -- go run . --billing-daily-report-backfill --billing-daily-report-from=${BILLING_DAILY_REPORT_FROM:-2025-10-10} --force"
+
+[tasks."backfill:billing-daily-report:prod"]
+description = "Backfill daily billing usage report rows only (prod)"
+env = { LOG_LEVEL = "INFO", GCP_TEAM_PROJECT_ID = "copilot-prod-c697" }
+run = "fnox exec -- go run . --billing-daily-report-backfill --billing-daily-report-from=${BILLING_DAILY_REPORT_FROM:-2025-10-10} --force"
+
+[tasks."backfill:billing-model-daily"]
+description = "Backfill daily model billing usage only (dev)"
+env = { LOG_LEVEL = "DEBUG", GCP_TEAM_PROJECT_ID = "copilot-dev-e17a" }
+run = "fnox exec -- go run . --billing-model-daily-backfill --billing-model-daily-from=${BILLING_MODEL_DAILY_FROM:-2025-10-10} --force"
+
+[tasks."backfill:billing-model-daily:prod"]
+description = "Backfill daily model billing usage only (prod)"
+env = { LOG_LEVEL = "INFO", GCP_TEAM_PROJECT_ID = "copilot-prod-c697" }
+run = "fnox exec -- go run . --billing-model-daily-backfill --billing-model-daily-from=${BILLING_MODEL_DAILY_FROM:-2025-10-10} --force"
+
+[tasks."backfill:all"]
+description = "Backfill usage metrics + monthly billing + daily billing usage reports + daily model billing (dev)"
+env = { LOG_LEVEL = "DEBUG", GCP_TEAM_PROJECT_ID = "copilot-dev-e17a" }
+run = [
+  "fnox exec -- go run . --backfill --backfill-from=${BACKFILL_FROM:-2025-10-10} --force",
+  "fnox exec -- go run . --billing-monthly-backfill --billing-monthly-from=${BILLING_MONTHLY_FROM:-2026-03} --force",
+  "fnox exec -- go run . --billing-daily-report-backfill --billing-daily-report-from=${BILLING_DAILY_REPORT_FROM:-2025-10-10} --force",
+  "fnox exec -- go run . --billing-model-daily-backfill --billing-model-daily-from=${BILLING_MODEL_DAILY_FROM:-2025-10-10} --force",
+]
+
+[tasks."backfill:all:prod"]
+description = "Backfill usage metrics + monthly billing + daily billing usage reports + daily model billing (prod)"
+env = { LOG_LEVEL = "INFO", GCP_TEAM_PROJECT_ID = "copilot-prod-c697" }
+run = [
+  "fnox exec -- go run . --backfill --backfill-from=${BACKFILL_FROM:-2025-10-10} --force",
+  "fnox exec -- go run . --billing-monthly-backfill --billing-monthly-from=${BILLING_MONTHLY_FROM:-2026-03} --force",
+  "fnox exec -- go run . --billing-daily-report-backfill --billing-daily-report-from=${BILLING_DAILY_REPORT_FROM:-2025-10-10} --force",
+  "fnox exec -- go run . --billing-model-daily-backfill --billing-model-daily-from=${BILLING_MODEL_DAILY_FROM:-2025-10-10} --force",
+]
 
 [tasks."docker:build"]
 description = "Build Docker image"

--- a/apps/copilot-metrics/README.md
+++ b/apps/copilot-metrics/README.md
@@ -33,7 +33,7 @@ GitHub Usage Metrics API → copilot-metrics (Naisjob) → BigQuery
 Runs as a Kubernetes CronJob via NAIS. Automatically detects missing days in BigQuery and fills gaps:
 
 ```bash
-copilot-metrics --run-once
+rtk copilot-metrics --run-once
 ```
 
 ### Historical backfill
@@ -41,8 +41,8 @@ copilot-metrics --run-once
 One-time operation to load historical data:
 
 ```bash
-copilot-metrics --backfill
-copilot-metrics --backfill --backfill-from=2025-10-10
+rtk copilot-metrics --backfill
+rtk copilot-metrics --backfill --backfill-from=2025-10-10
 ```
 
 ### Billing usage backfill
@@ -50,9 +50,9 @@ copilot-metrics --backfill --backfill-from=2025-10-10
 One-time operation to load premium request billing data per model (requires `GITHUB_BILLING_TOKEN`):
 
 ```bash
-copilot-metrics --billing-backfill
-copilot-metrics --billing-backfill --billing-from=2025-01
-copilot-metrics --billing-backfill --billing-from=2025-01 --force
+rtk copilot-metrics --billing-backfill
+rtk copilot-metrics --billing-backfill --billing-from=2025-01
+rtk copilot-metrics --billing-backfill --billing-from=2025-01 --force
 ```
 
 ### Billing usage report backfill (daily rows)
@@ -60,9 +60,9 @@ copilot-metrics --billing-backfill --billing-from=2025-01 --force
 One-time operation to load daily organization billing usage report rows (requires `GITHUB_BILLING_TOKEN`):
 
 ```bash
-copilot-metrics --billing-usage-backfill
-copilot-metrics --billing-usage-backfill --billing-usage-from=2025-10-10
-copilot-metrics --billing-usage-backfill --billing-usage-from=2025-10-10 --force
+rtk copilot-metrics --billing-usage-backfill
+rtk copilot-metrics --billing-usage-backfill --billing-usage-from=2025-10-10
+rtk copilot-metrics --billing-usage-backfill --billing-usage-from=2025-10-10 --force
 ```
 
 ### Local development
@@ -74,7 +74,7 @@ export GITHUB_APP_INSTALLATION_ID=789
 export GCP_TEAM_PROJECT_ID=my-project
 export LOG_LEVEL=DEBUG
 
-go run . --run-once
+rtk go run . --run-once
 ```
 
 ## Configuration
@@ -175,13 +175,13 @@ Set `GITHUB_BILLING_TOKEN` in the `copilot-metrics` secret to enable billing ing
 Deployed as a NAIS Job in the `copilot` namespace:
 
 ```bash
-kubectl apply -f .nais/naisjob.yaml -f .nais/dev.yaml
+rtk kubectl apply -f .nais/naisjob.yaml -f .nais/dev.yaml
 ```
 
 Manual trigger:
 
 ```bash
-kubectl create job --from=cronjob/copilot-metrics copilot-metrics-manual -n copilot
+rtk kubectl create job --from=cronjob/copilot-metrics copilot-metrics-manual -n copilot
 ```
 
 ## Related

--- a/apps/copilot-metrics/README.md
+++ b/apps/copilot-metrics/README.md
@@ -23,6 +23,7 @@ GitHub Usage Metrics API → copilot-metrics (Naisjob) → BigQuery
 - **Historical backfill**: CLI flag to load historical data from Oct 10, 2025
 - **Idempotent**: Re-runs delete and re-insert data for the same day
 - **Raw JSON storage**: Schema changes in GitHub API don't break the pipeline
+- **Billing usage report ingestion**: Daily organization billing usage rows with one-off backfill support
 - **Slack alerts**: Notifies on ingestion failures when `SLACK_WEBHOOK_URL` is configured
 
 ## Usage
@@ -52,6 +53,16 @@ One-time operation to load premium request billing data per model (requires `GIT
 copilot-metrics --billing-backfill
 copilot-metrics --billing-backfill --billing-from=2025-01
 copilot-metrics --billing-backfill --billing-from=2025-01 --force
+```
+
+### Billing usage report backfill (daily rows)
+
+One-time operation to load daily organization billing usage report rows (requires `GITHUB_BILLING_TOKEN`):
+
+```bash
+copilot-metrics --billing-usage-backfill
+copilot-metrics --billing-usage-backfill --billing-usage-from=2025-10-10
+copilot-metrics --billing-usage-backfill --billing-usage-from=2025-10-10 --force
 ```
 
 ### Local development
@@ -120,6 +131,28 @@ Per-model premium request billing data from the Enhanced Billing API.
 | `loaded_at`    | TIMESTAMP | When the row was inserted             |
 
 Table is partitioned by month and clustered by `scope_id`, `model`.
+
+### `billing_usage_reports` table
+
+Daily organization billing usage report rows from GitHub's billing usage API.
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `report_day` | DATE | Day covered by the report row |
+| `organization` | STRING | Organization login |
+| `repository_name` | STRING | Repository when row is repository-scoped |
+| `product` | STRING | Product name |
+| `sku` | STRING | SKU name |
+| `quantity` | FLOAT | Quantity for the line item |
+| `unit_type` | STRING | Unit type |
+| `price_per_unit` | FLOAT | Price per unit in USD |
+| `gross_amount` | FLOAT | Gross amount in USD |
+| `discount_amount` | FLOAT | Discount amount in USD |
+| `net_amount` | FLOAT | Net amount in USD |
+| `raw_record` | JSON | Full API row as JSON |
+| `loaded_at` | TIMESTAMP | Insert timestamp |
+
+Table is partitioned by month (`report_day`) and clustered by `organization`, `product`, `sku`.
 
 ## GitHub App Permissions
 

--- a/apps/copilot-metrics/README.md
+++ b/apps/copilot-metrics/README.md
@@ -28,6 +28,37 @@ GitHub Usage Metrics API → copilot-metrics (Naisjob) → BigQuery
 
 ## Usage
 
+### Mise backfill tasks (recommended)
+
+Explicit tasks so "backfill" is unambiguous:
+
+```bash
+# Usage metrics only
+rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:usage'
+
+# Monthly billing only
+rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:billing-monthly'
+
+# Daily billing usage reports only
+rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:billing-daily-report'
+
+# Daily model billing usage only
+rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:billing-model-daily'
+
+# Everything
+rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:all'
+```
+
+Prod variants:
+
+```bash
+rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:usage:prod'
+rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:billing-monthly:prod'
+rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:billing-daily-report:prod'
+rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:billing-model-daily:prod'
+rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:all:prod'
+```
+
 ### Nightly job (default)
 
 Runs as a Kubernetes CronJob via NAIS. Automatically detects missing days in BigQuery and fills gaps:
@@ -50,9 +81,9 @@ rtk copilot-metrics --backfill --backfill-from=2025-10-10
 One-time operation to load premium request billing data per model (requires `GITHUB_BILLING_TOKEN`):
 
 ```bash
-rtk copilot-metrics --billing-backfill
-rtk copilot-metrics --billing-backfill --billing-from=2025-01
-rtk copilot-metrics --billing-backfill --billing-from=2025-01 --force
+rtk copilot-metrics --billing-monthly-backfill
+rtk copilot-metrics --billing-monthly-backfill --billing-monthly-from=2025-01
+rtk copilot-metrics --billing-monthly-backfill --billing-monthly-from=2025-01 --force
 ```
 
 ### Billing usage report backfill (daily rows)
@@ -60,9 +91,19 @@ rtk copilot-metrics --billing-backfill --billing-from=2025-01 --force
 One-time operation to load daily organization billing usage report rows (requires `GITHUB_BILLING_TOKEN`):
 
 ```bash
-rtk copilot-metrics --billing-usage-backfill
-rtk copilot-metrics --billing-usage-backfill --billing-usage-from=2025-10-10
-rtk copilot-metrics --billing-usage-backfill --billing-usage-from=2025-10-10 --force
+rtk copilot-metrics --billing-daily-report-backfill
+rtk copilot-metrics --billing-daily-report-backfill --billing-daily-report-from=2025-10-10
+rtk copilot-metrics --billing-daily-report-backfill --billing-daily-report-from=2025-10-10 --force
+```
+
+### Billing daily model backfill
+
+One-time operation to load daily model-level premium request billing data (requires `GITHUB_BILLING_TOKEN`):
+
+```bash
+rtk copilot-metrics --billing-model-daily-backfill
+rtk copilot-metrics --billing-model-daily-backfill --billing-model-daily-from=2025-10-10
+rtk copilot-metrics --billing-model-daily-backfill --billing-model-daily-from=2025-10-10 --force
 ```
 
 ### Local development
@@ -153,6 +194,30 @@ Daily organization billing usage report rows from GitHub's billing usage API.
 | `loaded_at` | TIMESTAMP | Insert timestamp |
 
 Table is partitioned by month (`report_day`) and clustered by `organization`, `product`, `sku`.
+
+### `billing_usage_daily_model` table
+
+Daily model-level premium request usage from the enhanced billing endpoint.
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `day` | DATE | Day for the usage line |
+| `scope_id` | STRING | Enterprise slug |
+| `product` | STRING | Product name |
+| `sku` | STRING | SKU name |
+| `model` | STRING | Model name |
+| `unit_type` | STRING | Unit type |
+| `price_per_unit` | FLOAT | Price per unit in USD |
+| `gross_quantity` | FLOAT | Quantity before discounts |
+| `discount_quantity` | FLOAT | Discounted quantity |
+| `net_quantity` | FLOAT | Billed quantity |
+| `gross_amount` | FLOAT | Gross amount in USD |
+| `discount_amount` | FLOAT | Discount amount in USD |
+| `net_amount` | FLOAT | Net amount in USD |
+| `raw_record` | JSON | Full API row as JSON |
+| `loaded_at` | TIMESTAMP | Insert timestamp |
+
+Table is partitioned by day (`day`) and clustered by `scope_id`, `model`.
 
 ## GitHub App Permissions
 

--- a/apps/copilot-metrics/billing.go
+++ b/apps/copilot-metrics/billing.go
@@ -30,6 +30,26 @@ type BillingUsageResponse struct {
 	UsageItems []BillingUsageItem `json:"usageItems"`
 }
 
+// OrganizationBillingUsageResponse is the response from the organization billing usage report endpoint.
+type OrganizationBillingUsageResponse struct {
+	UsageItems []OrganizationBillingUsageItem `json:"usageItems"`
+}
+
+// OrganizationBillingUsageItem represents a single organization billing usage line item.
+type OrganizationBillingUsageItem struct {
+	Date             string  `json:"date"`
+	Product          string  `json:"product"`
+	SKU              string  `json:"sku"`
+	Quantity         float64 `json:"quantity"`
+	UnitType         string  `json:"unitType"`
+	PricePerUnit     float64 `json:"pricePerUnit"`
+	GrossAmount      float64 `json:"grossAmount"`
+	DiscountAmount   float64 `json:"discountAmount"`
+	NetAmount        float64 `json:"netAmount"`
+	OrganizationName string  `json:"organizationName"`
+	RepositoryName   string  `json:"repositoryName,omitempty"`
+}
+
 // BillingUsageItem represents a single line item from the billing API.
 type BillingUsageItem struct {
 	Product          string  `json:"product"`
@@ -139,6 +159,47 @@ func (c *BillingClient) FetchDailyUsage(ctx context.Context, day time.Time) (*Bi
 	var result BillingUsageResponse
 	if err := json.Unmarshal(body, &result); err != nil {
 		return nil, fmt.Errorf("failed to decode billing response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// FetchOrganizationUsage fetches billing usage report data for an organization for a specific day.
+func (c *BillingClient) FetchOrganizationUsage(ctx context.Context, org string, day time.Time) (*OrganizationBillingUsageResponse, error) {
+	url := fmt.Sprintf(
+		"https://api.github.com/organizations/%s/settings/billing/usage?year=%d&month=%d&day=%d",
+		org, day.Year(), int(day.Month()), day.Day(),
+	)
+
+	slog.Debug("Fetching organization billing usage report", "org", org, "day", day.Format("2006-01-02"))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create billing usage request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("X-GitHub-Api-Version", "2026-03-10")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("billing usage request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read billing usage response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("billing usage API returned status %d: %s", resp.StatusCode, truncate(string(body), 500))
+	}
+
+	var result OrganizationBillingUsageResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to decode billing usage response: %w", err)
 	}
 
 	return &result, nil

--- a/apps/copilot-metrics/billing.go
+++ b/apps/copilot-metrics/billing.go
@@ -167,7 +167,7 @@ func (c *BillingClient) FetchDailyUsage(ctx context.Context, day time.Time) (*Bi
 // FetchOrganizationUsage fetches billing usage report data for an organization for a specific day.
 func (c *BillingClient) FetchOrganizationUsage(ctx context.Context, org string, day time.Time) (*OrganizationBillingUsageResponse, error) {
 	url := fmt.Sprintf(
-		"https://api.github.com/organizations/%s/settings/billing/usage?year=%d&month=%d&day=%d",
+		"https://api.github.com/orgs/%s/settings/billing/usage?year=%d&month=%d&day=%d",
 		org, day.Year(), int(day.Month()), day.Day(),
 	)
 

--- a/apps/copilot-metrics/billing_daily_model.go
+++ b/apps/copilot-metrics/billing_daily_model.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+const billingDailyModelRateLimitDelay = 500 * time.Millisecond
+
+func runBillingDailyModelBackfill(ctx context.Context, billingClient *BillingClient, bqClient *BigQueryClient, config *Config, startDay time.Time, force bool) error {
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	endDay := today.AddDate(0, 0, -1)
+	if endDay.Before(startDay) {
+		slog.Info("Billing daily model backfill skipped: start day is after yesterday", "start_day", startDay.Format("2006-01-02"))
+		return nil
+	}
+
+	effectiveStart := startDay
+	if !force {
+		latest, err := bqClient.GetLatestBillingUsageDailyModelDay(ctx, config.EnterpriseSlug)
+		if err != nil {
+			return fmt.Errorf("failed to get latest billing daily model day: %w", err)
+		}
+		if !latest.IsZero() && latest.After(effectiveStart) {
+			effectiveStart = latest.AddDate(0, 0, 1)
+		}
+	}
+
+	if endDay.Before(effectiveStart) {
+		slog.Info("Billing daily model backfill skipped: data already current", "latest_day", effectiveStart.AddDate(0, 0, -1).Format("2006-01-02"))
+		return nil
+	}
+
+	for day := effectiveStart; !day.After(endDay); day = day.AddDate(0, 0, 1) {
+		if err := ingestBillingModelDay(ctx, billingClient, bqClient, config, day); err != nil {
+			return fmt.Errorf("ingest billing daily model day %s: %w", day.Format("2006-01-02"), err)
+		}
+		time.Sleep(billingDailyModelRateLimitDelay)
+	}
+
+	slog.Info("Billing daily model backfill completed",
+		"start_day", effectiveStart.Format("2006-01-02"),
+		"end_day", endDay.Format("2006-01-02"),
+	)
+	return nil
+}
+
+func ingestRecentBillingModelDaily(ctx context.Context, billingClient *BillingClient, bqClient *BigQueryClient, config *Config) error {
+	now := time.Now().UTC()
+	today := now.Truncate(24 * time.Hour)
+	yesterday := today.AddDate(0, 0, -1)
+
+	currentMonthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	for day := currentMonthStart; !day.After(yesterday); day = day.AddDate(0, 0, 1) {
+		if err := ingestBillingModelDay(ctx, billingClient, bqClient, config, day); err != nil {
+			return fmt.Errorf("ingest current month billing daily model day %s: %w", day.Format("2006-01-02"), err)
+		}
+		time.Sleep(billingDailyModelRateLimitDelay)
+	}
+
+	prevMonthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).AddDate(0, -1, 0)
+	prevMonthEnd := currentMonthStart.AddDate(0, 0, -1)
+	prevLookbackStart := prevMonthEnd.AddDate(0, 0, -4)
+	if prevLookbackStart.Before(prevMonthStart) {
+		prevLookbackStart = prevMonthStart
+	}
+	lastPrevDay := prevMonthEnd
+	if yesterday.Before(prevMonthEnd) {
+		lastPrevDay = yesterday
+	}
+
+	for day := prevLookbackStart; !day.After(lastPrevDay); day = day.AddDate(0, 0, 1) {
+		if err := ingestBillingModelDay(ctx, billingClient, bqClient, config, day); err != nil {
+			return fmt.Errorf("ingest previous month billing daily model day %s: %w", day.Format("2006-01-02"), err)
+		}
+		time.Sleep(billingDailyModelRateLimitDelay)
+	}
+
+	return nil
+}
+
+func ingestBillingModelDay(ctx context.Context, billingClient *BillingClient, bqClient *BigQueryClient, config *Config, day time.Time) error {
+	resp, err := billingClient.FetchDailyUsage(ctx, day)
+	if err != nil {
+		return fmt.Errorf("fetch daily billing usage: %w", err)
+	}
+
+	if err := bqClient.DeleteBillingUsageDailyModelDay(ctx, day, config.EnterpriseSlug); err != nil {
+		return fmt.Errorf("delete existing daily model rows: %w", err)
+	}
+
+	items := make([]BillingUsageItem, 0, len(resp.UsageItems))
+	for _, item := range resp.UsageItems {
+		if item.GrossQuantity <= 0 {
+			continue
+		}
+		items = append(items, item)
+	}
+
+	if err := bqClient.InsertBillingUsageDailyModelDay(ctx, day, config.EnterpriseSlug, items); err != nil {
+		return fmt.Errorf("insert daily model rows: %w", err)
+	}
+
+	slog.Info("Ingested billing daily model usage",
+		"day", day.Format("2006-01-02"),
+		"rows", len(items),
+	)
+	return nil
+}

--- a/apps/copilot-metrics/billing_daily_model.go
+++ b/apps/copilot-metrics/billing_daily_model.go
@@ -9,7 +9,17 @@ import (
 
 const billingDailyModelRateLimitDelay = 500 * time.Millisecond
 
-func runBillingDailyModelBackfill(ctx context.Context, billingClient *BillingClient, bqClient *BigQueryClient, config *Config, startDay time.Time, force bool) error {
+type BillingDailyModelFetcher interface {
+	FetchDailyUsage(ctx context.Context, day time.Time) (*BillingUsageResponse, error)
+}
+
+type BillingDailyModelStore interface {
+	DeleteBillingUsageDailyModelDay(ctx context.Context, day time.Time, scopeID string) error
+	InsertBillingUsageDailyModelDay(ctx context.Context, day time.Time, scopeID string, items []BillingUsageItem) error
+	GetLatestBillingUsageDailyModelDay(ctx context.Context, scopeID string) (time.Time, error)
+}
+
+func runBillingDailyModelBackfill(ctx context.Context, billingClient BillingDailyModelFetcher, bqClient BillingDailyModelStore, config *Config, startDay time.Time, force bool) error {
 	today := time.Now().UTC().Truncate(24 * time.Hour)
 	endDay := today.AddDate(0, 0, -1)
 	if endDay.Before(startDay) {
@@ -47,7 +57,7 @@ func runBillingDailyModelBackfill(ctx context.Context, billingClient *BillingCli
 	return nil
 }
 
-func ingestRecentBillingModelDaily(ctx context.Context, billingClient *BillingClient, bqClient *BigQueryClient, config *Config) error {
+func ingestRecentBillingModelDaily(ctx context.Context, billingClient BillingDailyModelFetcher, bqClient BillingDailyModelStore, config *Config) error {
 	now := time.Now().UTC()
 	today := now.Truncate(24 * time.Hour)
 	yesterday := today.AddDate(0, 0, -1)
@@ -81,14 +91,10 @@ func ingestRecentBillingModelDaily(ctx context.Context, billingClient *BillingCl
 	return nil
 }
 
-func ingestBillingModelDay(ctx context.Context, billingClient *BillingClient, bqClient *BigQueryClient, config *Config, day time.Time) error {
+func ingestBillingModelDay(ctx context.Context, billingClient BillingDailyModelFetcher, bqClient BillingDailyModelStore, config *Config, day time.Time) error {
 	resp, err := billingClient.FetchDailyUsage(ctx, day)
 	if err != nil {
 		return fmt.Errorf("fetch daily billing usage: %w", err)
-	}
-
-	if err := bqClient.DeleteBillingUsageDailyModelDay(ctx, day, config.EnterpriseSlug); err != nil {
-		return fmt.Errorf("delete existing daily model rows: %w", err)
 	}
 
 	items := make([]BillingUsageItem, 0, len(resp.UsageItems))
@@ -97,6 +103,18 @@ func ingestBillingModelDay(ctx context.Context, billingClient *BillingClient, bq
 			continue
 		}
 		items = append(items, item)
+	}
+
+	if len(items) == 0 {
+		slog.Warn("Skipping billing daily model overwrite due to empty response",
+			"day", day.Format("2006-01-02"),
+			"api_rows", len(resp.UsageItems),
+		)
+		return nil
+	}
+
+	if err := bqClient.DeleteBillingUsageDailyModelDay(ctx, day, config.EnterpriseSlug); err != nil {
+		return fmt.Errorf("delete existing daily model rows: %w", err)
 	}
 
 	if err := bqClient.InsertBillingUsageDailyModelDay(ctx, day, config.EnterpriseSlug, items); err != nil {

--- a/apps/copilot-metrics/billing_daily_model_bigquery.go
+++ b/apps/copilot-metrics/billing_daily_model_bigquery.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/civil"
+)
+
+const billingUsageDailyModelTable = "billing_usage_daily_model"
+
+type BillingUsageDailyModelRow struct {
+	Day              civil.Date `bigquery:"day"`
+	ScopeID          string     `bigquery:"scope_id"`
+	Product          string     `bigquery:"product"`
+	SKU              string     `bigquery:"sku"`
+	Model            string     `bigquery:"model"`
+	UnitType         string     `bigquery:"unit_type"`
+	PricePerUnit     float64    `bigquery:"price_per_unit"`
+	GrossQuantity    float64    `bigquery:"gross_quantity"`
+	DiscountQuantity float64    `bigquery:"discount_quantity"`
+	NetQuantity      float64    `bigquery:"net_quantity"`
+	GrossAmount      float64    `bigquery:"gross_amount"`
+	DiscountAmount   float64    `bigquery:"discount_amount"`
+	NetAmount        float64    `bigquery:"net_amount"`
+	RawRecord        string     `bigquery:"raw_record"`
+	LoadedAt         time.Time  `bigquery:"loaded_at"`
+}
+
+func (c *BigQueryClient) EnsureBillingUsageDailyModelTableExists(ctx context.Context) error {
+	dataset := c.client.Dataset(c.dataset)
+	table := dataset.Table(billingUsageDailyModelTable)
+
+	_, err := table.Metadata(ctx)
+	if err == nil {
+		slog.Debug("Billing daily model table already exists", "table", billingUsageDailyModelTable)
+		return nil
+	}
+
+	slog.Info("Creating billing_usage_daily_model table", "dataset", c.dataset)
+
+	schema := bigquery.Schema{
+		{Name: "day", Type: bigquery.DateFieldType, Required: true, Description: "Calendar day of billing usage"},
+		{Name: "scope_id", Type: bigquery.StringFieldType, Required: true, Description: "Enterprise slug"},
+		{Name: "product", Type: bigquery.StringFieldType, Required: true, Description: "Product name"},
+		{Name: "sku", Type: bigquery.StringFieldType, Required: true, Description: "SKU name"},
+		{Name: "model", Type: bigquery.StringFieldType, Required: true, Description: "Model name"},
+		{Name: "unit_type", Type: bigquery.StringFieldType, Required: true, Description: "Unit type"},
+		{Name: "price_per_unit", Type: bigquery.FloatFieldType, Required: true, Description: "Price per unit in USD"},
+		{Name: "gross_quantity", Type: bigquery.FloatFieldType, Required: true, Description: "Quantity before discounts"},
+		{Name: "discount_quantity", Type: bigquery.FloatFieldType, Required: true, Description: "Discounted quantity"},
+		{Name: "net_quantity", Type: bigquery.FloatFieldType, Required: true, Description: "Billed quantity"},
+		{Name: "gross_amount", Type: bigquery.FloatFieldType, Required: true, Description: "Gross amount in USD"},
+		{Name: "discount_amount", Type: bigquery.FloatFieldType, Required: true, Description: "Discount amount in USD"},
+		{Name: "net_amount", Type: bigquery.FloatFieldType, Required: true, Description: "Net amount in USD"},
+		{Name: "raw_record", Type: bigquery.JSONFieldType, Required: true, Description: "Full API row as JSON"},
+		{Name: "loaded_at", Type: bigquery.TimestampFieldType, Required: true, Description: "Insert timestamp"},
+	}
+
+	metadata := &bigquery.TableMetadata{
+		Schema: schema,
+		TimePartitioning: &bigquery.TimePartitioning{
+			Type:  bigquery.DayPartitioningType,
+			Field: "day",
+		},
+		Clustering: &bigquery.Clustering{
+			Fields: []string{"scope_id", "model"},
+		},
+		Description: "Daily GitHub Copilot premium request usage by model",
+	}
+
+	if err := table.Create(ctx, metadata); err != nil {
+		return fmt.Errorf("failed to create billing_usage_daily_model table: %w", err)
+	}
+
+	slog.Info("billing_usage_daily_model table created successfully")
+	return nil
+}
+
+func (c *BigQueryClient) DeleteBillingUsageDailyModelDay(ctx context.Context, day time.Time, scopeID string) error {
+	query := c.client.Query(`
+		DELETE FROM ` + "`" + c.projectID + "." + c.dataset + "." + billingUsageDailyModelTable + "`" + `
+		WHERE day = @day AND scope_id = @scopeID
+	`)
+	query.Parameters = []bigquery.QueryParameter{
+		{Name: "day", Value: civil.DateOf(day)},
+		{Name: "scopeID", Value: scopeID},
+	}
+
+	job, err := query.Run(ctx)
+	if err != nil {
+		return fmt.Errorf("run billing daily model delete: %w", err)
+	}
+
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("billing daily model delete job failed: %w", err)
+	}
+	if status.Err() != nil {
+		return fmt.Errorf("billing daily model delete query failed: %w", status.Err())
+	}
+	return nil
+}
+
+func (c *BigQueryClient) InsertBillingUsageDailyModelDay(ctx context.Context, day time.Time, scopeID string, items []BillingUsageItem) error {
+	if len(items) == 0 {
+		return nil
+	}
+
+	table := c.client.Dataset(c.dataset).Table(billingUsageDailyModelTable)
+	inserter := table.Inserter()
+	loadedAt := time.Now().UTC()
+	dayCivil := civil.DateOf(day)
+
+	rows := make([]*BillingUsageDailyModelRow, 0, len(items))
+	for _, item := range items {
+		raw, _ := json.Marshal(item)
+		rows = append(rows, &BillingUsageDailyModelRow{
+			Day:              dayCivil,
+			ScopeID:          scopeID,
+			Product:          item.Product,
+			SKU:              item.SKU,
+			Model:            item.Model,
+			UnitType:         item.UnitType,
+			PricePerUnit:     item.PricePerUnit,
+			GrossQuantity:    item.GrossQuantity,
+			DiscountQuantity: item.DiscountQuantity,
+			NetQuantity:      item.NetQuantity,
+			GrossAmount:      item.GrossAmount,
+			DiscountAmount:   item.DiscountAmount,
+			NetAmount:        item.NetAmount,
+			RawRecord:        string(raw),
+			LoadedAt:         loadedAt,
+		})
+	}
+
+	if err := inserter.Put(ctx, rows); err != nil {
+		return fmt.Errorf("insert billing daily model rows: %w", err)
+	}
+	return nil
+}
+
+func (c *BigQueryClient) GetLatestBillingUsageDailyModelDay(ctx context.Context, scopeID string) (time.Time, error) {
+	query := c.client.Query(`
+		SELECT MAX(day) as latest_day
+		FROM ` + "`" + c.projectID + "." + c.dataset + "." + billingUsageDailyModelTable + "`" + `
+		WHERE scope_id = @scopeID
+	`)
+	query.Parameters = []bigquery.QueryParameter{
+		{Name: "scopeID", Value: scopeID},
+	}
+
+	it, err := query.Read(ctx)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("query latest billing daily model day: %w", err)
+	}
+
+	var row struct {
+		LatestDay bigquery.NullDate `bigquery:"latest_day"`
+	}
+	if err := it.Next(&row); err != nil {
+		return time.Time{}, fmt.Errorf("read latest billing daily model day: %w", err)
+	}
+	if !row.LatestDay.Valid {
+		return time.Time{}, nil
+	}
+
+	return time.Date(row.LatestDay.Date.Year, row.LatestDay.Date.Month, row.LatestDay.Date.Day, 0, 0, 0, 0, time.UTC), nil
+}

--- a/apps/copilot-metrics/billing_daily_model_test.go
+++ b/apps/copilot-metrics/billing_daily_model_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type mockBillingDailyModelFetcher struct {
+	resp *BillingUsageResponse
+	err  error
+}
+
+func (m *mockBillingDailyModelFetcher) FetchDailyUsage(_ context.Context, _ time.Time) (*BillingUsageResponse, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.resp, nil
+}
+
+type mockBillingDailyModelStore struct {
+	deleteCalls   int
+	insertCalls   int
+	insertedItems []BillingUsageItem
+}
+
+func (m *mockBillingDailyModelStore) DeleteBillingUsageDailyModelDay(_ context.Context, _ time.Time, _ string) error {
+	m.deleteCalls++
+	return nil
+}
+
+func (m *mockBillingDailyModelStore) InsertBillingUsageDailyModelDay(_ context.Context, _ time.Time, _ string, items []BillingUsageItem) error {
+	m.insertCalls++
+	m.insertedItems = items
+	return nil
+}
+
+func (m *mockBillingDailyModelStore) GetLatestBillingUsageDailyModelDay(_ context.Context, _ string) (time.Time, error) {
+	return time.Time{}, nil
+}
+
+func TestIngestBillingModelDay_SkipsOverwriteOnEmptyResponse(t *testing.T) {
+	fetcher := &mockBillingDailyModelFetcher{
+		resp: &BillingUsageResponse{UsageItems: []BillingUsageItem{}},
+	}
+	store := &mockBillingDailyModelStore{}
+	cfg := &Config{EnterpriseSlug: "nav"}
+
+	err := ingestBillingModelDay(context.Background(), fetcher, store, cfg, time.Date(2026, 6, 7, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if store.deleteCalls != 0 {
+		t.Fatalf("expected no delete calls, got %d", store.deleteCalls)
+	}
+	if store.insertCalls != 0 {
+		t.Fatalf("expected no insert calls, got %d", store.insertCalls)
+	}
+}
+
+func TestIngestBillingModelDay_OverwritesWhenUsableRowsExist(t *testing.T) {
+	fetcher := &mockBillingDailyModelFetcher{
+		resp: &BillingUsageResponse{
+			UsageItems: []BillingUsageItem{
+				{Model: "gpt", GrossQuantity: 10},
+				{Model: "zero", GrossQuantity: 0},
+			},
+		},
+	}
+	store := &mockBillingDailyModelStore{}
+	cfg := &Config{EnterpriseSlug: "nav"}
+
+	err := ingestBillingModelDay(context.Background(), fetcher, store, cfg, time.Date(2026, 6, 7, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if store.deleteCalls != 1 {
+		t.Fatalf("expected 1 delete call, got %d", store.deleteCalls)
+	}
+	if store.insertCalls != 1 {
+		t.Fatalf("expected 1 insert call, got %d", store.insertCalls)
+	}
+	if len(store.insertedItems) != 1 {
+		t.Fatalf("expected 1 inserted item, got %d", len(store.insertedItems))
+	}
+}

--- a/apps/copilot-metrics/billing_test.go
+++ b/apps/copilot-metrics/billing_test.go
@@ -125,7 +125,7 @@ func TestBillingUsageItem_Marshaling(t *testing.T) {
 
 func TestBillingClient_FetchOrganizationUsage(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got, want := r.URL.Path, "/organizations/navikt/settings/billing/usage"; got != want {
+		if got, want := r.URL.Path, "/orgs/navikt/settings/billing/usage"; got != want {
 			t.Fatalf("unexpected path: got %s want %s", got, want)
 		}
 		query := r.URL.Query()

--- a/apps/copilot-metrics/billing_test.go
+++ b/apps/copilot-metrics/billing_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestBillingClient_FetchMonthlyUsage(t *testing.T) {
@@ -42,19 +44,16 @@ func TestBillingClient_FetchMonthlyUsage(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Verify auth header
 		if r.Header.Get("Authorization") != "Bearer test-token" {
 			t.Errorf("expected Bearer test-token, got %s", r.Header.Get("Authorization"))
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
 
-		// Verify API version header
 		if r.Header.Get("X-GitHub-Api-Version") != "2026-03-10" {
 			t.Errorf("expected API version 2026-03-10, got %s", r.Header.Get("X-GitHub-Api-Version"))
 		}
 
-		// Verify query params
 		query := r.URL.Query()
 		if query.Get("year") != "2026" {
 			t.Errorf("expected year=2026, got %s", query.Get("year"))
@@ -70,7 +69,6 @@ func TestBillingClient_FetchMonthlyUsage(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// Create client pointing at test server
 	client := &BillingClient{
 		httpClient: server.Client(),
 		enterprise: "nav",
@@ -80,13 +78,11 @@ func TestBillingClient_FetchMonthlyUsage(t *testing.T) {
 		t.Errorf("expected token 'test-token', got %s", client.token)
 	}
 
-	// Test NewBillingClient with empty token returns nil
 	nilClient := NewBillingClient("", "nav")
 	if nilClient != nil {
 		t.Error("expected nil client with empty token")
 	}
 
-	// Test NewBillingClient with token returns non-nil
 	validClient := NewBillingClient("some-token", "nav")
 	if validClient == nil {
 		t.Fatal("expected non-nil client with valid token")
@@ -125,4 +121,68 @@ func TestBillingUsageItem_Marshaling(t *testing.T) {
 	if decoded.GrossQuantity != 163672.33 {
 		t.Errorf("expected gross quantity 163672.33, got %f", decoded.GrossQuantity)
 	}
+}
+
+func TestBillingClient_FetchOrganizationUsage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/organizations/navikt/settings/billing/usage"; got != want {
+			t.Fatalf("unexpected path: got %s want %s", got, want)
+		}
+		query := r.URL.Query()
+		if query.Get("year") != "2026" || query.Get("month") != "6" || query.Get("day") != "7" {
+			t.Fatalf("unexpected query: %s", r.URL.RawQuery)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Fatalf("missing auth header")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(OrganizationBillingUsageResponse{
+			UsageItems: []OrganizationBillingUsageItem{
+				{
+					Date:             "2026-06-07",
+					Product:          "Copilot",
+					SKU:              "Copilot Premium Request",
+					Quantity:         10,
+					UnitType:         "requests",
+					PricePerUnit:     0.04,
+					GrossAmount:      0.4,
+					DiscountAmount:   0,
+					NetAmount:        0.4,
+					OrganizationName: "navikt",
+					RepositoryName:   "navikt/copilot",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := &BillingClient{
+		httpClient: server.Client(),
+		token:      "test-token",
+	}
+	day := time.Date(2026, 6, 7, 0, 0, 0, 0, time.UTC)
+
+	client.httpClient.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		req.URL.Scheme = "http"
+		req.URL.Host = server.Listener.Addr().String()
+		return http.DefaultTransport.RoundTrip(req)
+	})
+
+	resp, err := client.FetchOrganizationUsage(context.Background(), "navikt", day)
+	if err != nil {
+		t.Fatalf("FetchOrganizationUsage error: %v", err)
+	}
+	if len(resp.UsageItems) != 1 {
+		t.Fatalf("expected 1 usage item, got %d", len(resp.UsageItems))
+	}
+	if resp.UsageItems[0].RepositoryName != "navikt/copilot" {
+		t.Fatalf("unexpected repository_name: %s", resp.UsageItems[0].RepositoryName)
+	}
+}
+
+type roundTripFunc func(req *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }

--- a/apps/copilot-metrics/billing_usage_reports.go
+++ b/apps/copilot-metrics/billing_usage_reports.go
@@ -16,7 +16,6 @@ type UsageReportFetcher interface {
 
 // UsageReportStore stores organization billing usage report data.
 type UsageReportStore interface {
-	BillingUsageReportDayExists(ctx context.Context, day time.Time, org string) (bool, error)
 	DeleteBillingUsageReportDay(ctx context.Context, day time.Time, org string) error
 	InsertBillingUsageReportDay(ctx context.Context, day time.Time, org string, items []OrganizationBillingUsageItem) error
 	GetLatestBillingUsageReportDay(ctx context.Context, org string) (time.Time, error)
@@ -33,17 +32,6 @@ func ingestBillingUsageReportDay(
 	day = day.UTC().Truncate(24 * time.Hour)
 	dayStr := day.Format("2006-01-02")
 	org := cfg.OrganizationSlug
-
-	if !force {
-		exists, err := store.BillingUsageReportDayExists(ctx, day, org)
-		if err != nil {
-			return fmt.Errorf("check billing usage report day exists: %w", err)
-		}
-		if exists {
-			slog.Debug("Billing usage report day already ingested, skipping", "day", dayStr, "org", org)
-			return nil
-		}
-	}
 
 	resp, err := fetcher.FetchOrganizationUsage(ctx, org, day)
 	if err != nil {

--- a/apps/copilot-metrics/billing_usage_reports.go
+++ b/apps/copilot-metrics/billing_usage_reports.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+var billingUsageReportRateLimitDelay = 500 * time.Millisecond
+
+// UsageReportFetcher fetches organization billing usage report data for a day.
+type UsageReportFetcher interface {
+	FetchOrganizationUsage(ctx context.Context, org string, day time.Time) (*OrganizationBillingUsageResponse, error)
+}
+
+// UsageReportStore stores organization billing usage report data.
+type UsageReportStore interface {
+	BillingUsageReportDayExists(ctx context.Context, day time.Time, org string) (bool, error)
+	DeleteBillingUsageReportDay(ctx context.Context, day time.Time, org string) error
+	InsertBillingUsageReportDay(ctx context.Context, day time.Time, org string, items []OrganizationBillingUsageItem) error
+	GetLatestBillingUsageReportDay(ctx context.Context, org string) (time.Time, error)
+}
+
+func ingestBillingUsageReportDay(
+	ctx context.Context,
+	fetcher UsageReportFetcher,
+	store UsageReportStore,
+	cfg *Config,
+	day time.Time,
+	force bool,
+) error {
+	day = day.UTC().Truncate(24 * time.Hour)
+	dayStr := day.Format("2006-01-02")
+	org := cfg.OrganizationSlug
+
+	if !force {
+		exists, err := store.BillingUsageReportDayExists(ctx, day, org)
+		if err != nil {
+			return fmt.Errorf("check billing usage report day exists: %w", err)
+		}
+		if exists {
+			slog.Debug("Billing usage report day already ingested, skipping", "day", dayStr, "org", org)
+			return nil
+		}
+	}
+
+	resp, err := fetcher.FetchOrganizationUsage(ctx, org, day)
+	if err != nil {
+		return fmt.Errorf("fetch organization billing usage report: %w", err)
+	}
+
+	if len(resp.UsageItems) == 0 {
+		slog.Info("No billing usage report rows returned", "day", dayStr, "org", org)
+		return nil
+	}
+
+	// Idempotent re-run behavior.
+	if err := store.DeleteBillingUsageReportDay(ctx, day, org); err != nil {
+		slog.Warn("Failed to delete existing billing usage report rows (continuing)", "day", dayStr, "org", org, "error", err)
+	}
+
+	if err := store.InsertBillingUsageReportDay(ctx, day, org, resp.UsageItems); err != nil {
+		return fmt.Errorf("insert billing usage report rows: %w", err)
+	}
+
+	return nil
+}
+
+func ingestMissingBillingUsageReports(ctx context.Context, fetcher UsageReportFetcher, store UsageReportStore, cfg *Config) error {
+	yesterday := time.Now().UTC().AddDate(0, 0, -1).Truncate(24 * time.Hour)
+
+	latestDay, err := store.GetLatestBillingUsageReportDay(ctx, cfg.OrganizationSlug)
+	if err != nil {
+		slog.Warn("Could not get latest billing usage report day, ingesting yesterday only", "error", err)
+		return ingestBillingUsageReportDay(ctx, fetcher, store, cfg, yesterday, false)
+	}
+
+	startDate := yesterday
+	if !latestDay.IsZero() {
+		startDate = latestDay.AddDate(0, 0, 1)
+	}
+
+	if startDate.After(yesterday) {
+		slog.Info("Billing usage reports already up to date", "latest_day", latestDay.Format("2006-01-02"))
+		return nil
+	}
+
+	for day := startDate; !day.After(yesterday); day = day.AddDate(0, 0, 1) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if err := ingestBillingUsageReportDay(ctx, fetcher, store, cfg, day, false); err != nil {
+			return fmt.Errorf("ingest billing usage report day %s: %w", day.Format("2006-01-02"), err)
+		}
+
+		// Keep requests below API thresholds.
+		time.Sleep(billingUsageReportRateLimitDelay)
+	}
+
+	return nil
+}
+
+func runBillingUsageReportBackfill(
+	ctx context.Context,
+	fetcher UsageReportFetcher,
+	store UsageReportStore,
+	cfg *Config,
+	startDate time.Time,
+	force bool,
+) error {
+	endDate := time.Now().UTC().AddDate(0, 0, -1).Truncate(24 * time.Hour)
+	startDate = startDate.UTC().Truncate(24 * time.Hour)
+
+	if !force {
+		latestDay, err := store.GetLatestBillingUsageReportDay(ctx, cfg.OrganizationSlug)
+		if err != nil {
+			slog.Warn("Could not get latest billing usage report day from BigQuery", "error", err)
+		} else if !latestDay.IsZero() {
+			next := latestDay.AddDate(0, 0, 1)
+			if next.After(startDate) {
+				startDate = next
+			}
+		}
+	}
+
+	if startDate.After(endDate) {
+		slog.Info("No billing usage report days to backfill")
+		return nil
+	}
+
+	slog.Info("Starting billing usage report backfill",
+		"from", startDate.Format("2006-01-02"),
+		"to", endDate.Format("2006-01-02"),
+		"force", force,
+	)
+
+	successCount := 0
+	errorCount := 0
+	for day := startDate; !day.After(endDate); day = day.AddDate(0, 0, 1) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if err := ingestBillingUsageReportDay(ctx, fetcher, store, cfg, day, force); err != nil {
+			errorCount++
+			slog.Warn("Billing usage report day ingestion failed",
+				"day", day.Format("2006-01-02"),
+				"error", err,
+			)
+		} else {
+			successCount++
+		}
+
+		time.Sleep(billingUsageReportRateLimitDelay)
+	}
+
+	slog.Info("Billing usage report backfill completed",
+		"success", successCount,
+		"errors", errorCount,
+	)
+
+	if errorCount > 0 && successCount == 0 {
+		return fmt.Errorf("billing usage report backfill failed for all days")
+	}
+	return nil
+}

--- a/apps/copilot-metrics/billing_usage_reports_bigquery.go
+++ b/apps/copilot-metrics/billing_usage_reports_bigquery.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/civil"
+)
+
+const billingUsageReportsTable = "billing_usage_reports"
+
+// BillingUsageReportRow represents one row in the billing_usage_reports table.
+type BillingUsageReportRow struct {
+	ReportDay      civil.Date `bigquery:"report_day"`
+	Organization   string     `bigquery:"organization"`
+	RepositoryName string     `bigquery:"repository_name"`
+	Product        string     `bigquery:"product"`
+	SKU            string     `bigquery:"sku"`
+	Quantity       float64    `bigquery:"quantity"`
+	UnitType       string     `bigquery:"unit_type"`
+	PricePerUnit   float64    `bigquery:"price_per_unit"`
+	GrossAmount    float64    `bigquery:"gross_amount"`
+	DiscountAmount float64    `bigquery:"discount_amount"`
+	NetAmount      float64    `bigquery:"net_amount"`
+	RawRecord      string     `bigquery:"raw_record"`
+	LoadedAt       time.Time  `bigquery:"loaded_at"`
+}
+
+// EnsureBillingUsageReportsTableExists creates the billing_usage_reports table if needed.
+func (c *BigQueryClient) EnsureBillingUsageReportsTableExists(ctx context.Context) error {
+	dataset := c.client.Dataset(c.dataset)
+	table := dataset.Table(billingUsageReportsTable)
+
+	_, err := table.Metadata(ctx)
+	if err == nil {
+		slog.Debug("Billing usage reports table already exists", "table", billingUsageReportsTable)
+		return nil
+	}
+
+	slog.Info("Creating billing_usage_reports table", "dataset", c.dataset)
+
+	schema := bigquery.Schema{
+		{Name: "report_day", Type: bigquery.DateFieldType, Required: true, Description: "Day covered by the billing usage report"},
+		{Name: "organization", Type: bigquery.StringFieldType, Required: true, Description: "Organization login"},
+		{Name: "repository_name", Type: bigquery.StringFieldType, Required: false, Description: "Repository name when usage is repository scoped"},
+		{Name: "product", Type: bigquery.StringFieldType, Required: true, Description: "Product name"},
+		{Name: "sku", Type: bigquery.StringFieldType, Required: true, Description: "SKU name"},
+		{Name: "quantity", Type: bigquery.FloatFieldType, Required: true, Description: "Quantity in the report line item"},
+		{Name: "unit_type", Type: bigquery.StringFieldType, Required: true, Description: "Unit type for quantity"},
+		{Name: "price_per_unit", Type: bigquery.FloatFieldType, Required: true, Description: "Price per unit in USD"},
+		{Name: "gross_amount", Type: bigquery.FloatFieldType, Required: true, Description: "Gross amount in USD"},
+		{Name: "discount_amount", Type: bigquery.FloatFieldType, Required: true, Description: "Discount amount in USD"},
+		{Name: "net_amount", Type: bigquery.FloatFieldType, Required: true, Description: "Net amount in USD"},
+		{Name: "raw_record", Type: bigquery.JSONFieldType, Required: true, Description: "Original usage item JSON"},
+		{Name: "loaded_at", Type: bigquery.TimestampFieldType, Required: true, Description: "Row ingestion timestamp"},
+	}
+
+	metadata := &bigquery.TableMetadata{
+		Schema: schema,
+		TimePartitioning: &bigquery.TimePartitioning{
+			Type:  bigquery.MonthPartitioningType,
+			Field: "report_day",
+		},
+		Clustering: &bigquery.Clustering{
+			Fields: []string{"organization", "product", "sku"},
+		},
+		Description: "Daily organization billing usage report rows from GitHub billing usage API",
+	}
+
+	if err := table.Create(ctx, metadata); err != nil {
+		return fmt.Errorf("failed to create billing_usage_reports table: %w", err)
+	}
+
+	slog.Info("billing_usage_reports table created successfully")
+	return nil
+}
+
+// BillingUsageReportDayExists checks whether data for the given day and org already exists.
+func (c *BigQueryClient) BillingUsageReportDayExists(ctx context.Context, day time.Time, org string) (bool, error) {
+	query := c.client.Query(`
+		SELECT COUNT(*) as cnt
+		FROM ` + "`" + c.projectID + "." + c.dataset + "." + billingUsageReportsTable + "`" + `
+		WHERE report_day = @day AND organization = @org
+	`)
+	query.Parameters = []bigquery.QueryParameter{
+		{Name: "day", Value: civil.DateOf(day)},
+		{Name: "org", Value: org},
+	}
+
+	it, err := query.Read(ctx)
+	if err != nil {
+		return false, fmt.Errorf("check billing usage report day: %w", err)
+	}
+
+	var row struct {
+		Cnt int64 `bigquery:"cnt"`
+	}
+	if err := it.Next(&row); err != nil {
+		return false, fmt.Errorf("read billing usage report day check: %w", err)
+	}
+	return row.Cnt > 0, nil
+}
+
+// DeleteBillingUsageReportDay removes existing rows for day+org so re-runs are idempotent.
+func (c *BigQueryClient) DeleteBillingUsageReportDay(ctx context.Context, day time.Time, org string) error {
+	query := c.client.Query(`
+		DELETE FROM ` + "`" + c.projectID + "." + c.dataset + "." + billingUsageReportsTable + "`" + `
+		WHERE report_day = @day AND organization = @org
+	`)
+	query.Parameters = []bigquery.QueryParameter{
+		{Name: "day", Value: civil.DateOf(day)},
+		{Name: "org", Value: org},
+	}
+
+	job, err := query.Run(ctx)
+	if err != nil {
+		return fmt.Errorf("run billing usage report delete: %w", err)
+	}
+
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("billing usage report delete job failed: %w", err)
+	}
+	if status.Err() != nil {
+		return fmt.Errorf("billing usage report delete query failed: %w", status.Err())
+	}
+
+	slog.Debug("Deleted existing billing usage report rows", "day", day.Format("2006-01-02"), "org", org)
+	return nil
+}
+
+// InsertBillingUsageReportDay inserts one day's usage report rows.
+func (c *BigQueryClient) InsertBillingUsageReportDay(ctx context.Context, day time.Time, org string, items []OrganizationBillingUsageItem) error {
+	if len(items) == 0 {
+		slog.Info("No billing usage report items to insert", "day", day.Format("2006-01-02"), "org", org)
+		return nil
+	}
+
+	table := c.client.Dataset(c.dataset).Table(billingUsageReportsTable)
+	inserter := table.Inserter()
+	reportDay := civil.DateOf(day)
+	loadedAt := time.Now().UTC()
+
+	var rows []*BillingUsageReportRow
+	for _, item := range items {
+		raw, _ := json.Marshal(item)
+		rows = append(rows, &BillingUsageReportRow{
+			ReportDay:      reportDay,
+			Organization:   org,
+			RepositoryName: item.RepositoryName,
+			Product:        item.Product,
+			SKU:            item.SKU,
+			Quantity:       item.Quantity,
+			UnitType:       item.UnitType,
+			PricePerUnit:   item.PricePerUnit,
+			GrossAmount:    item.GrossAmount,
+			DiscountAmount: item.DiscountAmount,
+			NetAmount:      item.NetAmount,
+			RawRecord:      string(raw),
+			LoadedAt:       loadedAt,
+		})
+	}
+
+	if err := inserter.Put(ctx, rows); err != nil {
+		return fmt.Errorf("insert billing usage report rows: %w", err)
+	}
+
+	slog.Info("Inserted billing usage report rows", "day", day.Format("2006-01-02"), "org", org, "rows", len(rows))
+	return nil
+}
+
+// GetLatestBillingUsageReportDay returns latest ingested day for the org.
+func (c *BigQueryClient) GetLatestBillingUsageReportDay(ctx context.Context, org string) (time.Time, error) {
+	query := c.client.Query(`
+		SELECT MAX(report_day) as latest_day
+		FROM ` + "`" + c.projectID + "." + c.dataset + "." + billingUsageReportsTable + "`" + `
+		WHERE organization = @org
+	`)
+	query.Parameters = []bigquery.QueryParameter{
+		{Name: "org", Value: org},
+	}
+
+	it, err := query.Read(ctx)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("query latest billing usage report day: %w", err)
+	}
+
+	var row struct {
+		LatestDay bigquery.NullDate `bigquery:"latest_day"`
+	}
+	if err := it.Next(&row); err != nil {
+		return time.Time{}, fmt.Errorf("read latest billing usage report day: %w", err)
+	}
+
+	if !row.LatestDay.Valid {
+		return time.Time{}, nil
+	}
+
+	return time.Date(
+		row.LatestDay.Date.Year,
+		row.LatestDay.Date.Month,
+		row.LatestDay.Date.Day,
+		0, 0, 0, 0, time.UTC,
+	), nil
+}

--- a/apps/copilot-metrics/billing_usage_reports_bigquery.go
+++ b/apps/copilot-metrics/billing_usage_reports_bigquery.go
@@ -15,19 +15,19 @@ const billingUsageReportsTable = "billing_usage_reports"
 
 // BillingUsageReportRow represents one row in the billing_usage_reports table.
 type BillingUsageReportRow struct {
-	ReportDay      civil.Date `bigquery:"report_day"`
-	Organization   string     `bigquery:"organization"`
-	RepositoryName string     `bigquery:"repository_name"`
-	Product        string     `bigquery:"product"`
-	SKU            string     `bigquery:"sku"`
-	Quantity       float64    `bigquery:"quantity"`
-	UnitType       string     `bigquery:"unit_type"`
-	PricePerUnit   float64    `bigquery:"price_per_unit"`
-	GrossAmount    float64    `bigquery:"gross_amount"`
-	DiscountAmount float64    `bigquery:"discount_amount"`
-	NetAmount      float64    `bigquery:"net_amount"`
-	RawRecord      string     `bigquery:"raw_record"`
-	LoadedAt       time.Time  `bigquery:"loaded_at"`
+	ReportDay      civil.Date          `bigquery:"report_day"`
+	Organization   string              `bigquery:"organization"`
+	RepositoryName bigquery.NullString `bigquery:"repository_name"`
+	Product        string              `bigquery:"product"`
+	SKU            string              `bigquery:"sku"`
+	Quantity       float64             `bigquery:"quantity"`
+	UnitType       string              `bigquery:"unit_type"`
+	PricePerUnit   float64             `bigquery:"price_per_unit"`
+	GrossAmount    float64             `bigquery:"gross_amount"`
+	DiscountAmount float64             `bigquery:"discount_amount"`
+	NetAmount      float64             `bigquery:"net_amount"`
+	RawRecord      string              `bigquery:"raw_record"`
+	LoadedAt       time.Time           `bigquery:"loaded_at"`
 }
 
 // EnsureBillingUsageReportsTableExists creates the billing_usage_reports table if needed.
@@ -79,32 +79,6 @@ func (c *BigQueryClient) EnsureBillingUsageReportsTableExists(ctx context.Contex
 	return nil
 }
 
-// BillingUsageReportDayExists checks whether data for the given day and org already exists.
-func (c *BigQueryClient) BillingUsageReportDayExists(ctx context.Context, day time.Time, org string) (bool, error) {
-	query := c.client.Query(`
-		SELECT COUNT(*) as cnt
-		FROM ` + "`" + c.projectID + "." + c.dataset + "." + billingUsageReportsTable + "`" + `
-		WHERE report_day = @day AND organization = @org
-	`)
-	query.Parameters = []bigquery.QueryParameter{
-		{Name: "day", Value: civil.DateOf(day)},
-		{Name: "org", Value: org},
-	}
-
-	it, err := query.Read(ctx)
-	if err != nil {
-		return false, fmt.Errorf("check billing usage report day: %w", err)
-	}
-
-	var row struct {
-		Cnt int64 `bigquery:"cnt"`
-	}
-	if err := it.Next(&row); err != nil {
-		return false, fmt.Errorf("read billing usage report day check: %w", err)
-	}
-	return row.Cnt > 0, nil
-}
-
 // DeleteBillingUsageReportDay removes existing rows for day+org so re-runs are idempotent.
 func (c *BigQueryClient) DeleteBillingUsageReportDay(ctx context.Context, day time.Time, org string) error {
 	query := c.client.Query(`
@@ -151,7 +125,7 @@ func (c *BigQueryClient) InsertBillingUsageReportDay(ctx context.Context, day ti
 		rows = append(rows, &BillingUsageReportRow{
 			ReportDay:      reportDay,
 			Organization:   org,
-			RepositoryName: item.RepositoryName,
+			RepositoryName: nullableRepositoryName(item.RepositoryName),
 			Product:        item.Product,
 			SKU:            item.SKU,
 			Quantity:       item.Quantity,
@@ -171,6 +145,13 @@ func (c *BigQueryClient) InsertBillingUsageReportDay(ctx context.Context, day ti
 
 	slog.Info("Inserted billing usage report rows", "day", day.Format("2006-01-02"), "org", org, "rows", len(rows))
 	return nil
+}
+
+func nullableRepositoryName(name string) bigquery.NullString {
+	if name == "" {
+		return bigquery.NullString{}
+	}
+	return bigquery.NullString{StringVal: name, Valid: true}
 }
 
 // GetLatestBillingUsageReportDay returns latest ingested day for the org.

--- a/apps/copilot-metrics/billing_usage_reports_test.go
+++ b/apps/copilot-metrics/billing_usage_reports_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type mockUsageReportFetcher struct {
+	resp *OrganizationBillingUsageResponse
+	err  error
+}
+
+func (m *mockUsageReportFetcher) FetchOrganizationUsage(_ context.Context, _ string, _ time.Time) (*OrganizationBillingUsageResponse, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.resp, nil
+}
+
+type mockUsageReportStore struct {
+	exists      bool
+	existsErr   error
+	deleteErr   error
+	insertErr   error
+	latestDay   time.Time
+	latestErr   error
+	deletedDays []time.Time
+	inserted    int
+}
+
+func (m *mockUsageReportStore) BillingUsageReportDayExists(_ context.Context, _ time.Time, _ string) (bool, error) {
+	return m.exists, m.existsErr
+}
+
+func (m *mockUsageReportStore) DeleteBillingUsageReportDay(_ context.Context, day time.Time, _ string) error {
+	m.deletedDays = append(m.deletedDays, day)
+	return m.deleteErr
+}
+
+func (m *mockUsageReportStore) InsertBillingUsageReportDay(_ context.Context, _ time.Time, _ string, items []OrganizationBillingUsageItem) error {
+	m.inserted += len(items)
+	return m.insertErr
+}
+
+func (m *mockUsageReportStore) GetLatestBillingUsageReportDay(_ context.Context, _ string) (time.Time, error) {
+	return m.latestDay, m.latestErr
+}
+
+func TestIngestBillingUsageReportDay_SkipsWhenExists(t *testing.T) {
+	store := &mockUsageReportStore{exists: true}
+	fetcher := &mockUsageReportFetcher{
+		resp: &OrganizationBillingUsageResponse{
+			UsageItems: []OrganizationBillingUsageItem{{Product: "Copilot"}},
+		},
+	}
+	cfg := &Config{OrganizationSlug: "navikt"}
+
+	err := ingestBillingUsageReportDay(context.Background(), fetcher, store, cfg, time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if store.inserted != 0 {
+		t.Fatalf("expected no insert when already exists")
+	}
+}
+
+func TestIngestBillingUsageReportDay_UpsertsRows(t *testing.T) {
+	store := &mockUsageReportStore{}
+	fetcher := &mockUsageReportFetcher{
+		resp: &OrganizationBillingUsageResponse{
+			UsageItems: []OrganizationBillingUsageItem{
+				{Product: "Copilot", SKU: "Copilot Premium Request"},
+				{Product: "Copilot", SKU: "Copilot AI Credits"},
+			},
+		},
+	}
+	cfg := &Config{OrganizationSlug: "navikt"}
+	day := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+
+	err := ingestBillingUsageReportDay(context.Background(), fetcher, store, cfg, day, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(store.deletedDays) != 1 {
+		t.Fatalf("expected delete before insert")
+	}
+	if store.inserted != 2 {
+		t.Fatalf("expected 2 inserted rows, got %d", store.inserted)
+	}
+}
+
+func TestRunBillingUsageReportBackfill_AdjustsStartWithoutForce(t *testing.T) {
+	prevDelay := billingUsageReportRateLimitDelay
+	billingUsageReportRateLimitDelay = 0
+	defer func() { billingUsageReportRateLimitDelay = prevDelay }()
+
+	store := &mockUsageReportStore{
+		latestDay: time.Now().UTC().AddDate(0, 0, -2).Truncate(24 * time.Hour),
+	}
+	fetcher := &mockUsageReportFetcher{
+		resp: &OrganizationBillingUsageResponse{
+			UsageItems: []OrganizationBillingUsageItem{{Product: "Copilot", SKU: "Copilot Premium Request"}},
+		},
+	}
+	cfg := &Config{OrganizationSlug: "navikt"}
+
+	err := runBillingUsageReportBackfill(
+		context.Background(),
+		fetcher,
+		store,
+		cfg,
+		time.Now().UTC().AddDate(0, 0, -5).Truncate(24*time.Hour),
+		false,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if store.inserted == 0 {
+		t.Fatalf("expected at least one inserted row")
+	}
+	for _, d := range store.deletedDays {
+		if d.Before(store.latestDay.AddDate(0, 0, 1)) {
+			t.Fatalf("expected start adjusted to latest+1, got delete for %s", d.Format("2006-01-02"))
+		}
+	}
+}
+
+func TestRunBillingUsageReportBackfill_FailsWhenAllDaysFail(t *testing.T) {
+	prevDelay := billingUsageReportRateLimitDelay
+	billingUsageReportRateLimitDelay = 0
+	defer func() { billingUsageReportRateLimitDelay = prevDelay }()
+
+	store := &mockUsageReportStore{}
+	fetcher := &mockUsageReportFetcher{err: errors.New("boom")}
+	cfg := &Config{OrganizationSlug: "navikt"}
+	start := time.Now().UTC().AddDate(0, 0, -2).Truncate(24 * time.Hour)
+
+	err := runBillingUsageReportBackfill(context.Background(), fetcher, store, cfg, start, true)
+	if err == nil {
+		t.Fatalf("expected error when all days fail")
+	}
+}

--- a/apps/copilot-metrics/billing_usage_reports_test.go
+++ b/apps/copilot-metrics/billing_usage_reports_test.go
@@ -20,18 +20,12 @@ func (m *mockUsageReportFetcher) FetchOrganizationUsage(_ context.Context, _ str
 }
 
 type mockUsageReportStore struct {
-	exists      bool
-	existsErr   error
 	deleteErr   error
 	insertErr   error
 	latestDay   time.Time
 	latestErr   error
 	deletedDays []time.Time
 	inserted    int
-}
-
-func (m *mockUsageReportStore) BillingUsageReportDayExists(_ context.Context, _ time.Time, _ string) (bool, error) {
-	return m.exists, m.existsErr
 }
 
 func (m *mockUsageReportStore) DeleteBillingUsageReportDay(_ context.Context, day time.Time, _ string) error {
@@ -48,8 +42,8 @@ func (m *mockUsageReportStore) GetLatestBillingUsageReportDay(_ context.Context,
 	return m.latestDay, m.latestErr
 }
 
-func TestIngestBillingUsageReportDay_SkipsWhenExists(t *testing.T) {
-	store := &mockUsageReportStore{exists: true}
+func TestIngestBillingUsageReportDay_AlwaysUpserts(t *testing.T) {
+	store := &mockUsageReportStore{}
 	fetcher := &mockUsageReportFetcher{
 		resp: &OrganizationBillingUsageResponse{
 			UsageItems: []OrganizationBillingUsageItem{{Product: "Copilot"}},
@@ -61,8 +55,11 @@ func TestIngestBillingUsageReportDay_SkipsWhenExists(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if store.inserted != 0 {
-		t.Fatalf("expected no insert when already exists")
+	if len(store.deletedDays) != 1 {
+		t.Fatalf("expected delete before insert")
+	}
+	if store.inserted != 1 {
+		t.Fatalf("expected one inserted row")
 	}
 }
 
@@ -141,5 +138,22 @@ func TestRunBillingUsageReportBackfill_FailsWhenAllDaysFail(t *testing.T) {
 	err := runBillingUsageReportBackfill(context.Background(), fetcher, store, cfg, start, true)
 	if err == nil {
 		t.Fatalf("expected error when all days fail")
+	}
+}
+
+func TestNullableRepositoryName_EmptyIsNull(t *testing.T) {
+	got := nullableRepositoryName("")
+	if got.Valid {
+		t.Fatalf("expected invalid null string for empty repository name")
+	}
+}
+
+func TestNullableRepositoryName_ValueIsSet(t *testing.T) {
+	got := nullableRepositoryName("navikt/copilot")
+	if !got.Valid {
+		t.Fatalf("expected valid null string for repository name")
+	}
+	if got.StringVal != "navikt/copilot" {
+		t.Fatalf("unexpected repository name: %s", got.StringVal)
 	}
 }

--- a/apps/copilot-metrics/main.go
+++ b/apps/copilot-metrics/main.go
@@ -18,10 +18,16 @@ func main() {
 	backfill := flag.Bool("backfill", false, "Run historical backfill from Oct 10, 2025 to today")
 	backfillFrom := flag.String("backfill-from", "2025-10-10", "Start date for backfill (YYYY-MM-DD)")
 	backfillForce := flag.Bool("force", false, "Force re-ingestion even if data already exists")
-	billingBackfill := flag.Bool("billing-backfill", false, "Backfill billing data from billing-from month to current month")
-	billingFrom := flag.String("billing-from", "2025-01", "Start month for billing backfill (YYYY-MM)")
-	billingUsageBackfill := flag.Bool("billing-usage-backfill", false, "Backfill daily organization billing usage report data")
-	billingUsageFrom := flag.String("billing-usage-from", "2025-10-10", "Start day for billing usage report backfill (YYYY-MM-DD)")
+	billingMonthlyBackfill := flag.Bool("billing-monthly-backfill", false, "Backfill monthly billing data from billing-monthly-from month to current month")
+	billingMonthlyFrom := flag.String("billing-monthly-from", "2025-01", "Start month for monthly billing backfill (YYYY-MM)")
+	billingDailyReportBackfill := flag.Bool("billing-daily-report-backfill", false, "Backfill daily organization billing usage report data")
+	billingDailyReportFrom := flag.String("billing-daily-report-from", "2025-10-10", "Start day for daily billing usage report backfill (YYYY-MM-DD)")
+	billingModelDailyBackfill := flag.Bool("billing-model-daily-backfill", false, "Backfill daily model billing data")
+	billingModelDailyFrom := flag.String("billing-model-daily-from", "2025-10-10", "Start day for daily model billing backfill (YYYY-MM-DD)")
+	legacyBillingBackfill := flag.Bool("billing-backfill", false, "Deprecated: use --billing-monthly-backfill")
+	legacyBillingFrom := flag.String("billing-from", "", "Deprecated: use --billing-monthly-from")
+	legacyBillingUsageBackfill := flag.Bool("billing-usage-backfill", false, "Deprecated: use --billing-daily-report-backfill")
+	legacyBillingUsageFrom := flag.String("billing-usage-from", "", "Deprecated: use --billing-daily-report-from")
 	runOnce := flag.Bool("run-once", false, "Run single ingestion for yesterday and exit")
 	flag.Parse()
 
@@ -102,39 +108,81 @@ func main() {
 			slog.Error("Failed to ensure billing_usage_reports table exists", "error", err)
 			os.Exit(1)
 		}
+		if err := bqClient.EnsureBillingUsageDailyModelTableExists(ctx); err != nil {
+			slog.Error("Failed to ensure billing_usage_daily_model table exists", "error", err)
+			os.Exit(1)
+		}
 	} else {
 		slog.Warn("No GITHUB_BILLING_TOKEN configured — billing ingestion and budget snapshot ingestion disabled")
 	}
 
-	if *billingUsageBackfill {
+	runBillingMonthlyBackfill := *billingMonthlyBackfill || *legacyBillingBackfill
+	runBillingDailyReportBackfill := *billingDailyReportBackfill || *legacyBillingUsageBackfill
+
+	effectiveBillingMonthlyFrom := *billingMonthlyFrom
+	if *legacyBillingFrom != "" {
+		slog.Warn("Flag --billing-from is deprecated, use --billing-monthly-from")
+		effectiveBillingMonthlyFrom = *legacyBillingFrom
+	}
+	if *legacyBillingBackfill {
+		slog.Warn("Flag --billing-backfill is deprecated, use --billing-monthly-backfill")
+	}
+
+	effectiveBillingDailyReportFrom := *billingDailyReportFrom
+	if *legacyBillingUsageFrom != "" {
+		slog.Warn("Flag --billing-usage-from is deprecated, use --billing-daily-report-from")
+		effectiveBillingDailyReportFrom = *legacyBillingUsageFrom
+	}
+	if *legacyBillingUsageBackfill {
+		slog.Warn("Flag --billing-usage-backfill is deprecated, use --billing-daily-report-backfill")
+	}
+
+	if runBillingDailyReportBackfill {
 		if billingClient == nil {
-			slog.Error("Billing usage report backfill requires GITHUB_BILLING_TOKEN")
+			slog.Error("Billing daily report backfill requires GITHUB_BILLING_TOKEN")
 			os.Exit(1)
 		}
-		startDay, err := time.Parse("2006-01-02", *billingUsageFrom)
+		startDay, err := time.Parse("2006-01-02", effectiveBillingDailyReportFrom)
 		if err != nil {
-			slog.Error("Invalid billing-usage-from day", "error", err)
+			slog.Error("Invalid billing-daily-report-from day", "error", err)
 			os.Exit(1)
 		}
 		if err := runBillingUsageReportBackfill(ctx, billingClient, bqClient, config, startDay, *backfillForce); err != nil {
-			slog.Error("Billing usage report backfill failed", "error", err)
+			slog.Error("Billing daily report backfill failed", "error", err)
 			os.Exit(1)
 		}
 		return
 	}
 
-	if *billingBackfill {
+	if *billingModelDailyBackfill {
 		if billingClient == nil {
-			slog.Error("Billing backfill requires GITHUB_BILLING_TOKEN")
+			slog.Error("Billing model daily backfill requires GITHUB_BILLING_TOKEN")
 			os.Exit(1)
 		}
-		startMonth, err := time.Parse("2006-01", *billingFrom)
+		startDay, err := time.Parse("2006-01-02", *billingModelDailyFrom)
 		if err != nil {
-			slog.Error("Invalid billing-from month", "error", err)
+			slog.Error("Invalid billing-model-daily-from day", "error", err)
+			os.Exit(1)
+		}
+		if err := runBillingDailyModelBackfill(ctx, billingClient, bqClient, config, startDay, *backfillForce); err != nil {
+			slog.Error("Billing model daily backfill failed", "error", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	if runBillingMonthlyBackfill {
+		if billingClient == nil {
+			slog.Error("Billing monthly backfill requires GITHUB_BILLING_TOKEN")
+			os.Exit(1)
+		}
+		startMonth, err := time.Parse("2006-01", effectiveBillingMonthlyFrom)
+		if err != nil {
+			slog.Error("Invalid billing-monthly-from month", "error", err)
 			os.Exit(1)
 		}
 		if err := runBillingBackfill(ctx, billingClient, bqClient, config, startMonth, *backfillForce); err != nil {
-			slog.Error("Billing backfill failed", "error", err)
+			slog.Error("Billing monthly backfill failed", "error", err)
 			os.Exit(1)
 		}
 		return
@@ -167,6 +215,9 @@ func main() {
 			ingestCurrentMonthBilling(ctx, billingClient, bqClient, config)
 			if err := ingestMissingBillingUsageReports(ctx, billingClient, bqClient, config); err != nil {
 				slog.Warn("Billing usage report ingestion failed", "error", err)
+			}
+			if err := ingestRecentBillingModelDaily(ctx, billingClient, bqClient, config); err != nil {
+				slog.Warn("Billing daily model ingestion failed", "error", err)
 			}
 		}
 		// Ingest today's budget snapshot (always re-ingests since consumption is live)
@@ -415,8 +466,8 @@ func metricsHandler(w http.ResponseWriter, _ *http.Request) {
 	_, _ = fmt.Fprint(w, "copilot_metrics_up 1\n")
 }
 
-// ingestCurrentMonthBilling fetches and stores billing data for the current month.
-// Always re-ingests since monthly data is cumulative and updates throughout the month.
+// ingestCurrentMonthBilling fetches and stores billing data for the current and previous month.
+// Always re-ingests to handle cumulative updates and post-month adjustments.
 func ingestCurrentMonthBilling(ctx context.Context, billing *BillingClient, bq *BigQueryClient, cfg *Config) {
 	now := time.Now().UTC()
 	year, month := now.Year(), int(now.Month())
@@ -425,12 +476,9 @@ func ingestCurrentMonthBilling(ctx context.Context, billing *BillingClient, bq *
 		slog.Warn("Failed to ingest current month billing", "year", year, "month", month, "error", err)
 	}
 
-	// Also re-ingest previous month if we're in the first few days (data may still be finalizing)
-	if now.Day() <= 5 {
-		prevMonth := now.AddDate(0, -1, 0)
-		if err := ingestBillingMonth(ctx, billing, bq, cfg, prevMonth.Year(), int(prevMonth.Month()), true); err != nil {
-			slog.Warn("Failed to ingest previous month billing", "error", err)
-		}
+	prevMonth := now.AddDate(0, -1, 0)
+	if err := ingestBillingMonth(ctx, billing, bq, cfg, prevMonth.Year(), int(prevMonth.Month()), true); err != nil {
+		slog.Warn("Failed to ingest previous month billing", "year", prevMonth.Year(), "month", int(prevMonth.Month()), "error", err)
 	}
 }
 
@@ -468,7 +516,7 @@ func ingestBillingMonth(ctx context.Context, billing *BillingClient, bq *BigQuer
 
 	// Delete existing data before re-inserting (idempotent)
 	if err := bq.DeleteBillingMonth(ctx, year, month, cfg.EnterpriseSlug); err != nil {
-		slog.Warn("Failed to delete existing billing data (continuing)", "error", err)
+		return fmt.Errorf("delete existing billing data: %w", err)
 	}
 
 	if err := bq.InsertBillingUsage(ctx, year, month, cfg.EnterpriseSlug, items); err != nil {

--- a/apps/copilot-metrics/main.go
+++ b/apps/copilot-metrics/main.go
@@ -103,7 +103,7 @@ func main() {
 			os.Exit(1)
 		}
 	} else {
-		slog.Warn("No GITHUB_BILLING_TOKEN configured — billing usage and budget snapshot ingestion disabled")
+		slog.Warn("No GITHUB_BILLING_TOKEN configured — billing ingestion and budget snapshot ingestion disabled")
 	}
 
 	if *billingUsageBackfill {

--- a/apps/copilot-metrics/main.go
+++ b/apps/copilot-metrics/main.go
@@ -20,6 +20,8 @@ func main() {
 	backfillForce := flag.Bool("force", false, "Force re-ingestion even if data already exists")
 	billingBackfill := flag.Bool("billing-backfill", false, "Backfill billing data from billing-from month to current month")
 	billingFrom := flag.String("billing-from", "2025-01", "Start month for billing backfill (YYYY-MM)")
+	billingUsageBackfill := flag.Bool("billing-usage-backfill", false, "Backfill daily organization billing usage report data")
+	billingUsageFrom := flag.String("billing-usage-from", "2025-10-10", "Start day for billing usage report backfill (YYYY-MM-DD)")
 	runOnce := flag.Bool("run-once", false, "Run single ingestion for yesterday and exit")
 	flag.Parse()
 
@@ -96,8 +98,29 @@ func main() {
 			slog.Error("Failed to ensure user_budget_snapshots table exists", "error", err)
 			os.Exit(1)
 		}
+		if err := bqClient.EnsureBillingUsageReportsTableExists(ctx); err != nil {
+			slog.Error("Failed to ensure billing_usage_reports table exists", "error", err)
+			os.Exit(1)
+		}
 	} else {
 		slog.Warn("No GITHUB_BILLING_TOKEN configured — billing usage and budget snapshot ingestion disabled")
+	}
+
+	if *billingUsageBackfill {
+		if billingClient == nil {
+			slog.Error("Billing usage report backfill requires GITHUB_BILLING_TOKEN")
+			os.Exit(1)
+		}
+		startDay, err := time.Parse("2006-01-02", *billingUsageFrom)
+		if err != nil {
+			slog.Error("Invalid billing-usage-from day", "error", err)
+			os.Exit(1)
+		}
+		if err := runBillingUsageReportBackfill(ctx, billingClient, bqClient, config, startDay, *backfillForce); err != nil {
+			slog.Error("Billing usage report backfill failed", "error", err)
+			os.Exit(1)
+		}
+		return
 	}
 
 	if *billingBackfill {
@@ -142,6 +165,9 @@ func main() {
 		// Ingest current month's billing data (always re-ingests since it's cumulative)
 		if billingClient != nil {
 			ingestCurrentMonthBilling(ctx, billingClient, bqClient, config)
+			if err := ingestMissingBillingUsageReports(ctx, billingClient, bqClient, config); err != nil {
+				slog.Warn("Billing usage report ingestion failed", "error", err)
+			}
 		}
 		// Ingest today's budget snapshot (always re-ingests since consumption is live)
 		if budgetClient != nil {

--- a/apps/copilot-metrics/main.go
+++ b/apps/copilot-metrics/main.go
@@ -217,7 +217,11 @@ func main() {
 				slog.Warn("Billing usage report ingestion failed", "error", err)
 			}
 			if err := ingestRecentBillingModelDaily(ctx, billingClient, bqClient, config); err != nil {
-				slog.Warn("Billing daily model ingestion failed", "error", err)
+				if slack != nil {
+					slack.NotifyError(ctx, fmt.Sprintf("Billing daily model ingestion failed: %v", err))
+				}
+				slog.Error("Billing daily model ingestion failed", "error", err)
+				os.Exit(1)
 			}
 		}
 		// Ingest today's budget snapshot (always re-ingests since consumption is live)

--- a/apps/my-copilot/scripts/publish-video.ts
+++ b/apps/my-copilot/scripts/publish-video.ts
@@ -90,9 +90,10 @@ function resolvePublishEnvironment(): PublishEnvironment {
 }
 
 function resolveEnvValue(baseName: string, environment: PublishEnvironment): string {
-  const value = process.env[`${baseName}_${environment.toUpperCase()}`] ?? process.env[baseName];
+  // Explicit env value should always win to make one-off overrides predictable.
+  const value = process.env[baseName] ?? process.env[`${baseName}_${environment.toUpperCase()}`];
   if (!value) {
-    throw new Error(`Missing required environment variable ${baseName}_${environment.toUpperCase()}`);
+    throw new Error(`Missing required environment variable ${baseName} or ${baseName}_${environment.toUpperCase()}`);
   }
   return value;
 }

--- a/apps/my-copilot/src/app/statistikk/page.tsx
+++ b/apps/my-copilot/src/app/statistikk/page.tsx
@@ -169,20 +169,16 @@ async function UsageContent({ usage, token }: { usage: EnterpriseMetrics[]; toke
   const modelChartData = buildModelChartData(usage);
   const generationModeTrendData = buildGenerationModeTrendData(usage);
 
-  // Fetch monthly trends and model usage for the dashboard
+  // Fetch monthly datasets first
   const [
     { trends: monthlyTrends, error: monthlyError },
     { usage: monthlyModelUsage, error: modelUsageError },
     { usage: billingUsage, error: billingError },
-    { usage: billingModelDaily, error: billingModelDailyError },
-    { forecast: billingModelForecast, error: billingModelForecastError },
     { cohorts: adoptionCohorts, error: cohortsError },
   ] = await Promise.all([
     getMonthlyTrends(token),
     getMonthlyModelUsage(token),
     getMonthlyBillingUsage(token),
-    getBillingModelDaily(token),
-    getBillingModelForecast(token),
     getAdoptionCohorts(token),
   ]);
   if (monthlyError) {
@@ -197,12 +193,41 @@ async function UsageContent({ usage, token }: { usage: EnterpriseMetrics[]; toke
   if (cohortsError) {
     console.error("[statistikk] Adoption cohorts failed:", cohortsError);
   }
-  if (billingModelDailyError) {
-    console.error("[statistikk] Billing model daily failed:", billingModelDailyError);
+  // Latest complete billing month summary
+  const latestBillingMonth = (() => {
+    if (!billingUsage || billingUsage.length === 0) return null;
+    const months = [...new Set(billingUsage.map((r) => r.month))].sort();
+    const latest = months[months.length - 1];
+    const rows = billingUsage.filter((r) => r.month === latest);
+    const netAmount = rows.reduce((sum, r) => sum + r.net_amount, 0);
+    const grossAmount = rows.reduce((sum, r) => sum + r.gross_amount, 0);
+    const label = new Date(latest + "-01").toLocaleDateString("nb-NO", { month: "long", year: "numeric" });
+    return { month: latest, label, netAmount, grossAmount };
+  })();
+
+  // Prefer current month for "Måned hittil"; fall back to latest complete month if needed.
+  const currentBillingMonth = new Date().toISOString().slice(0, 7);
+  let { usage: billingModelDaily, error: billingModelDailyError } = await getBillingModelDaily(
+    token,
+    currentBillingMonth
+  );
+  let { forecast: billingModelForecast, error: billingModelForecastError } = await getBillingModelForecast(
+    token,
+    currentBillingMonth
+  );
+
+  if (billingModelDaily.length === 0 && latestBillingMonth?.month && latestBillingMonth.month !== currentBillingMonth) {
+    const fallbackDaily = await getBillingModelDaily(token, latestBillingMonth.month);
+    const fallbackForecast = await getBillingModelForecast(token, latestBillingMonth.month);
+    billingModelDaily = fallbackDaily.usage;
+    billingModelForecast = fallbackForecast.forecast;
+    billingModelDailyError = billingModelDailyError ?? fallbackDaily.error;
+    billingModelForecastError = billingModelForecastError ?? fallbackForecast.error;
   }
-  if (billingModelForecastError) {
+
+  if (billingModelDailyError) console.error("[statistikk] Billing model daily failed:", billingModelDailyError);
+  if (billingModelForecastError)
     console.error("[statistikk] Billing model forecast failed:", billingModelForecastError);
-  }
 
   // Find the last COMPLETE month (not the current partial month)
   // A month is "complete" if it has 28+ days of data or isn't the current calendar month
@@ -245,18 +270,6 @@ async function UsageContent({ usage, token }: { usage: EnterpriseMetrics[]; toke
   const heroMonthLabel = latestComplete
     ? new Date(latestComplete.month + "-01").toLocaleDateString("nb-NO", { month: "long", year: "numeric" })
     : undefined;
-
-  // Latest complete billing month summary
-  const latestBillingMonth = (() => {
-    if (!billingUsage || billingUsage.length === 0) return null;
-    const months = [...new Set(billingUsage.map((r) => r.month))].sort();
-    const latest = months[months.length - 1];
-    const rows = billingUsage.filter((r) => r.month === latest);
-    const netAmount = rows.reduce((sum, r) => sum + r.net_amount, 0);
-    const grossAmount = rows.reduce((sum, r) => sum + r.gross_amount, 0);
-    const label = new Date(latest + "-01").toLocaleDateString("nb-NO", { month: "long", year: "numeric" });
-    return { month: latest, label, netAmount, grossAmount };
-  })();
 
   // ─── TAB 1: DASHBOARD (Key Indicators + Trends) ───
   const dashboardContent = (

--- a/apps/my-copilot/src/app/statistikk/page.tsx
+++ b/apps/my-copilot/src/app/statistikk/page.tsx
@@ -6,6 +6,8 @@ import {
   getMonthlyTrends,
   getMonthlyModelUsage,
   getMonthlyBillingUsage,
+  getBillingModelDaily,
+  getBillingModelForecast,
   getUserWeeklyTrends,
   getAdoptionCohorts,
 } from "@/lib/cached-bigquery";
@@ -18,6 +20,7 @@ import ModelUsageChart from "@/components/charts/ModelUsageChart";
 import GenerationModeChart from "@/components/charts/GenerationModeChart";
 import MonthlyTrendsChart from "@/components/charts/MonthlyTrendsChart";
 import MonthlyModelChart from "@/components/charts/MonthlyModelChart";
+import BillingMonthNowChart from "@/components/charts/BillingMonthNowChart";
 import AdoptionCohortsChart from "@/components/charts/AdoptionCohortsChart";
 import MetricCard from "@/components/metric-card";
 import ErrorState from "@/components/error-state";
@@ -171,11 +174,15 @@ async function UsageContent({ usage, token }: { usage: EnterpriseMetrics[]; toke
     { trends: monthlyTrends, error: monthlyError },
     { usage: monthlyModelUsage, error: modelUsageError },
     { usage: billingUsage, error: billingError },
+    { usage: billingModelDaily, error: billingModelDailyError },
+    { forecast: billingModelForecast, error: billingModelForecastError },
     { cohorts: adoptionCohorts, error: cohortsError },
   ] = await Promise.all([
     getMonthlyTrends(token),
     getMonthlyModelUsage(token),
     getMonthlyBillingUsage(token),
+    getBillingModelDaily(token),
+    getBillingModelForecast(token),
     getAdoptionCohorts(token),
   ]);
   if (monthlyError) {
@@ -189,6 +196,12 @@ async function UsageContent({ usage, token }: { usage: EnterpriseMetrics[]; toke
   }
   if (cohortsError) {
     console.error("[statistikk] Adoption cohorts failed:", cohortsError);
+  }
+  if (billingModelDailyError) {
+    console.error("[statistikk] Billing model daily failed:", billingModelDailyError);
+  }
+  if (billingModelForecastError) {
+    console.error("[statistikk] Billing model forecast failed:", billingModelForecastError);
   }
 
   // Find the last COMPLETE month (not the current partial month)
@@ -320,7 +333,20 @@ async function UsageContent({ usage, token }: { usage: EnterpriseMetrics[]; toke
       {/* Monthly trends — THE story */}
       {monthlyTrends.length > 0 && <MonthlyTrendsChart data={monthlyTrends} />}
 
-      {/* Monthly model/token usage */}
+      {/* Current month model cost + forecast */}
+      {Array.isArray(billingModelDaily) && billingModelDaily.length > 0 && billingModelForecast ? (
+        <BillingMonthNowChart dailyData={billingModelDaily} forecast={billingModelForecast} />
+      ) : (
+        <Box background="neutral-soft" padding="space-16" borderRadius="8">
+          <BodyShort size="small" className="text-gray-600">
+            Måned hittil-grafene er ikke tilgjengelige ennå.
+            {billingModelDailyError || billingModelForecastError
+              ? " Nye API-endepunkter eller data er ikke tilgjengelige i dette miljøet ennå."
+              : " Daglige modellkost-data for inneværende måned er ikke ingestert ennå."}
+          </BodyShort>
+        </Box>
+      )}
+
       {monthlyModelUsage.length > 0 && <MonthlyModelChart data={monthlyModelUsage} billingData={billingUsage} />}
 
       {/* Generation mode: user-initiated vs agent-initiated */}

--- a/apps/my-copilot/src/components/charts/BillingMonthNowChart.tsx
+++ b/apps/my-copilot/src/components/charts/BillingMonthNowChart.tsx
@@ -12,22 +12,50 @@ interface BillingMonthNowChartProps {
   forecast: BillingModelForecast | null;
 }
 
+function tail(values: number[], n: number): number[] {
+  if (n <= 0 || values.length === 0) return [];
+  return values.length <= n ? values : values.slice(values.length - n);
+}
+
+function weightedRunRate(series: number[], window = 7): number {
+  const values = tail(series, window);
+  if (values.length === 0) return 0;
+  let weightedSum = 0;
+  let weightTotal = 0;
+  values.forEach((value, index) => {
+    const weight = index + 1;
+    weightedSum += value * weight;
+    weightTotal += weight;
+  });
+  return weightTotal > 0 ? weightedSum / weightTotal : 0;
+}
+
+function sampleStdDev(values: number[]): number {
+  if (values.length < 2) return 0;
+  const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
+  const variance = values.reduce((sum, value) => sum + (value - mean) ** 2, 0) / (values.length - 1);
+  return Math.sqrt(variance);
+}
+
 const BillingMonthNowChart: React.FC<BillingMonthNowChartProps> = ({ dailyData, forecast }) => {
   if (!dailyData || dailyData.length === 0 || !forecast) {
     return <div className="text-center text-gray-500">{NO_DATA_MESSAGE}</div>;
   }
+  const monthLabel = new Date(`${forecast.month}-01`).toLocaleDateString("nb-NO", { month: "long", year: "numeric" });
 
   const normalizeModel = (model: string) => model.replace(/^Auto: /, "");
   const labels = [...new Set(dailyData.map((d) => d.day))].sort();
   const modelTotals = new Map<string, number>();
   const byModelByDay = new Map<string, Map<string, number>>();
+  const grossByDay = new Map<string, number>();
 
   for (const row of dailyData) {
     const model = normalizeModel(row.model);
-    modelTotals.set(model, (modelTotals.get(model) || 0) + row.net_amount);
+    modelTotals.set(model, (modelTotals.get(model) || 0) + row.gross_amount);
     if (!byModelByDay.has(model)) byModelByDay.set(model, new Map());
     const dayMap = byModelByDay.get(model)!;
-    dayMap.set(row.day, (dayMap.get(row.day) || 0) + row.net_amount);
+    dayMap.set(row.day, (dayMap.get(row.day) || 0) + row.gross_amount);
+    grossByDay.set(row.day, (grossByDay.get(row.day) || 0) + row.gross_amount);
   }
 
   const topModels = [...modelTotals.entries()]
@@ -41,46 +69,65 @@ const BillingMonthNowChart: React.FC<BillingMonthNowChartProps> = ({ dailyData, 
     backgroundColor: getBackgroundColor(chartColors[index % chartColors.length], 0.7),
     borderColor: chartColors[index % chartColors.length],
     borderWidth: 1,
-    stack: "net",
+    stack: "gross",
   }));
 
-  const points = forecast.points ?? [];
-  const cumulativeLabels = points.map((p) => p.day.slice(8));
-  const actual = points.map((p) => p.actual_cumulative ?? null);
-  const projected = points.map((p) => Number(p.projected_cumulative.toFixed(2)));
+  const dayNumbers = labels.map((label) => Number(label.slice(8))).filter((d) => Number.isFinite(d));
+  const daysElapsed = dayNumbers.length > 0 ? Math.max(...dayNumbers) : 0;
+  const daysInMonth = forecast.days_in_month;
+  const cumulativeLabels = Array.from({ length: daysInMonth }, (_, index) => String(index + 1).padStart(2, "0"));
 
-  const bandUpper = points.map((p) => {
-    if (p.is_actual) return p.projected_cumulative;
-    const step = Math.max(0, Number(p.day.slice(8)) - forecast.days_elapsed);
-    const spread =
-      forecast.days_in_month > forecast.days_elapsed
-        ? ((forecast.upper_eom_net_amount - forecast.projected_eom_net_amount) /
-            (forecast.days_in_month - forecast.days_elapsed)) *
-          step
-        : 0;
-    return Number((p.projected_cumulative + spread).toFixed(2));
+  const dailyGrossSeries = Array.from({ length: Math.max(daysElapsed, 0) }, (_, index) => {
+    const day = String(index + 1).padStart(2, "0");
+    const date = `${forecast.month}-${day}`;
+    return grossByDay.get(date) || 0;
   });
-  const bandLower = points.map((p) => {
-    if (p.is_actual) return p.projected_cumulative;
-    const step = Math.max(0, Number(p.day.slice(8)) - forecast.days_elapsed);
-    const spread =
-      forecast.days_in_month > forecast.days_elapsed
-        ? ((forecast.projected_eom_net_amount - forecast.lower_eom_net_amount) /
-            (forecast.days_in_month - forecast.days_elapsed)) *
-          step
-        : 0;
-    return Number((p.projected_cumulative - spread).toFixed(2));
-  });
+  const actualMTDGross = dailyGrossSeries.reduce((sum, value) => sum + value, 0);
+  let runRate = weightedRunRate(dailyGrossSeries, 7);
+  if (runRate <= 0 && daysElapsed > 0) {
+    runRate = actualMTDGross / daysElapsed;
+  }
+  const projectedEOMGross = actualMTDGross + runRate * (daysInMonth - daysElapsed);
+  const dailyVolatility = sampleStdDev(tail(dailyGrossSeries, 14));
+
+  const actual: Array<number | null> = [];
+  const projected: number[] = [];
+  const bandUpper: number[] = [];
+  const bandLower: number[] = [];
+  let cumulative = 0;
+  for (let day = 1; day <= daysInMonth; day++) {
+    if (day <= daysElapsed) {
+      const dayValue = dailyGrossSeries[day - 1] || 0;
+      cumulative += dayValue;
+      actual.push(Number(cumulative.toFixed(2)));
+      projected.push(Number(cumulative.toFixed(2)));
+      bandUpper.push(Number(cumulative.toFixed(2)));
+      bandLower.push(Number(cumulative.toFixed(2)));
+      continue;
+    }
+    const projectedValue = cumulative + runRate * (day - daysElapsed);
+    const spread = dailyVolatility * (day - daysElapsed);
+    actual.push(null);
+    projected.push(Number(projectedValue.toFixed(2)));
+    bandUpper.push(Number((projectedValue + spread).toFixed(2)));
+    bandLower.push(Number(Math.max(actualMTDGross, projectedValue - spread).toFixed(2)));
+  }
 
   return (
     <VStack gap="space-16">
       <Heading size="small" level="3">
         Måned hittil: modeller og kostnad
       </Heading>
+      <BodyShort size="small" className="text-gray-500">
+        Viser {monthLabel}
+      </BodyShort>
       <HGrid columns={{ xs: 1, md: 2 }} gap="space-16">
         <Box background="neutral-soft" padding="space-16" borderRadius="8">
           <VStack gap="space-8">
-            <BodyShort weight="semibold">Daglig netto kostnad per modell (USD)</BodyShort>
+            <BodyShort weight="semibold">Daglig brutto kostnad per modell (USD)</BodyShort>
+            <BodyShort size="small" className="text-gray-500">
+              Brutto kostnad (før credits/rabatt)
+            </BodyShort>
             <div className="aspect-[2/1]">
               <Bar
                 data={{ labels: labels.map((d) => d.slice(8)), datasets: stackedDatasets }}
@@ -101,10 +148,11 @@ const BillingMonthNowChart: React.FC<BillingMonthNowChartProps> = ({ dailyData, 
           <VStack gap="space-8">
             <BodyShort weight="semibold">Prognose månedsslutt (USD)</BodyShort>
             <BodyShort size="small" className="text-gray-500">
-              MTD {formatNumber(Math.round(forecast.actual_mtd_net_amount))} • Prognose{" "}
-              {formatNumber(Math.round(forecast.projected_eom_net_amount))} (
-              {formatNumber(Math.round(forecast.lower_eom_net_amount))} –{" "}
-              {formatNumber(Math.round(forecast.upper_eom_net_amount))})
+              MTD {formatNumber(Math.round(actualMTDGross))} • Prognose {formatNumber(Math.round(projectedEOMGross))} (
+              {formatNumber(
+                Math.round(Math.max(actualMTDGross, projectedEOMGross - dailyVolatility * (daysInMonth - daysElapsed)))
+              )}{" "}
+              – {formatNumber(Math.round(projectedEOMGross + dailyVolatility * (daysInMonth - daysElapsed)))})
             </BodyShort>
             <div className="aspect-[2/1]">
               <Line
@@ -112,7 +160,7 @@ const BillingMonthNowChart: React.FC<BillingMonthNowChartProps> = ({ dailyData, 
                   labels: cumulativeLabels,
                   datasets: [
                     {
-                      label: "Faktisk kumulativ",
+                      label: "Faktisk kumulativ (brutto)",
                       data: actual,
                       borderColor: "#2563eb",
                       backgroundColor: "transparent",
@@ -121,7 +169,7 @@ const BillingMonthNowChart: React.FC<BillingMonthNowChartProps> = ({ dailyData, 
                       spanGaps: false,
                     },
                     {
-                      label: "Prognose kumulativ",
+                      label: "Prognose kumulativ (brutto)",
                       data: projected,
                       borderColor: "#16a34a",
                       borderDash: [5, 5],

--- a/apps/my-copilot/src/components/charts/BillingMonthNowChart.tsx
+++ b/apps/my-copilot/src/components/charts/BillingMonthNowChart.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import type { BillingModelDailyCost, BillingModelForecast } from "@/lib/types";
+import { chartColors, getBackgroundColor, NO_DATA_MESSAGE } from "@/lib/chart-utils";
+import { formatNumber } from "@/lib/format";
+import { BodyShort, Box, HGrid, Heading, VStack } from "@navikt/ds-react";
+import React from "react";
+import { Bar, Line } from "react-chartjs-2";
+
+interface BillingMonthNowChartProps {
+  dailyData: BillingModelDailyCost[];
+  forecast: BillingModelForecast | null;
+}
+
+const BillingMonthNowChart: React.FC<BillingMonthNowChartProps> = ({ dailyData, forecast }) => {
+  if (!dailyData || dailyData.length === 0 || !forecast) {
+    return <div className="text-center text-gray-500">{NO_DATA_MESSAGE}</div>;
+  }
+
+  const normalizeModel = (model: string) => model.replace(/^Auto: /, "");
+  const labels = [...new Set(dailyData.map((d) => d.day))].sort();
+  const modelTotals = new Map<string, number>();
+  const byModelByDay = new Map<string, Map<string, number>>();
+
+  for (const row of dailyData) {
+    const model = normalizeModel(row.model);
+    modelTotals.set(model, (modelTotals.get(model) || 0) + row.net_amount);
+    if (!byModelByDay.has(model)) byModelByDay.set(model, new Map());
+    const dayMap = byModelByDay.get(model)!;
+    dayMap.set(row.day, (dayMap.get(row.day) || 0) + row.net_amount);
+  }
+
+  const topModels = [...modelTotals.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([model]) => model);
+
+  const stackedDatasets = topModels.map((model, index) => ({
+    label: model,
+    data: labels.map((day) => Number((byModelByDay.get(model)?.get(day) || 0).toFixed(2))),
+    backgroundColor: getBackgroundColor(chartColors[index % chartColors.length], 0.7),
+    borderColor: chartColors[index % chartColors.length],
+    borderWidth: 1,
+    stack: "net",
+  }));
+
+  const points = forecast.points ?? [];
+  const cumulativeLabels = points.map((p) => p.day.slice(8));
+  const actual = points.map((p) => p.actual_cumulative ?? null);
+  const projected = points.map((p) => Number(p.projected_cumulative.toFixed(2)));
+
+  const bandUpper = points.map((p) => {
+    if (p.is_actual) return p.projected_cumulative;
+    const step = Math.max(0, Number(p.day.slice(8)) - forecast.days_elapsed);
+    const spread =
+      forecast.days_in_month > forecast.days_elapsed
+        ? ((forecast.upper_eom_net_amount - forecast.projected_eom_net_amount) /
+            (forecast.days_in_month - forecast.days_elapsed)) *
+          step
+        : 0;
+    return Number((p.projected_cumulative + spread).toFixed(2));
+  });
+  const bandLower = points.map((p) => {
+    if (p.is_actual) return p.projected_cumulative;
+    const step = Math.max(0, Number(p.day.slice(8)) - forecast.days_elapsed);
+    const spread =
+      forecast.days_in_month > forecast.days_elapsed
+        ? ((forecast.projected_eom_net_amount - forecast.lower_eom_net_amount) /
+            (forecast.days_in_month - forecast.days_elapsed)) *
+          step
+        : 0;
+    return Number((p.projected_cumulative - spread).toFixed(2));
+  });
+
+  return (
+    <VStack gap="space-16">
+      <Heading size="small" level="3">
+        Måned hittil: modeller og kostnad
+      </Heading>
+      <HGrid columns={{ xs: 1, md: 2 }} gap="space-16">
+        <Box background="neutral-soft" padding="space-16" borderRadius="8">
+          <VStack gap="space-8">
+            <BodyShort weight="semibold">Daglig netto kostnad per modell (USD)</BodyShort>
+            <div className="aspect-[2/1]">
+              <Bar
+                data={{ labels: labels.map((d) => d.slice(8)), datasets: stackedDatasets }}
+                options={{
+                  responsive: true,
+                  maintainAspectRatio: true,
+                  plugins: { legend: { position: "top", labels: { boxWidth: 10, font: { size: 10 } } } },
+                  scales: {
+                    x: { stacked: true, grid: { display: false } },
+                    y: { stacked: true, beginAtZero: true, grid: { color: "rgba(0,0,0,0.06)" } },
+                  },
+                }}
+              />
+            </div>
+          </VStack>
+        </Box>
+        <Box background="neutral-soft" padding="space-16" borderRadius="8">
+          <VStack gap="space-8">
+            <BodyShort weight="semibold">Prognose månedsslutt (USD)</BodyShort>
+            <BodyShort size="small" className="text-gray-500">
+              MTD {formatNumber(Math.round(forecast.actual_mtd_net_amount))} • Prognose{" "}
+              {formatNumber(Math.round(forecast.projected_eom_net_amount))} (
+              {formatNumber(Math.round(forecast.lower_eom_net_amount))} –{" "}
+              {formatNumber(Math.round(forecast.upper_eom_net_amount))})
+            </BodyShort>
+            <div className="aspect-[2/1]">
+              <Line
+                data={{
+                  labels: cumulativeLabels,
+                  datasets: [
+                    {
+                      label: "Faktisk kumulativ",
+                      data: actual,
+                      borderColor: "#2563eb",
+                      backgroundColor: "transparent",
+                      borderWidth: 2,
+                      pointRadius: 2,
+                      spanGaps: false,
+                    },
+                    {
+                      label: "Prognose kumulativ",
+                      data: projected,
+                      borderColor: "#16a34a",
+                      borderDash: [5, 5],
+                      backgroundColor: "transparent",
+                      borderWidth: 2,
+                      pointRadius: 0,
+                    },
+                    {
+                      label: "Øvre estimat",
+                      data: bandUpper,
+                      borderColor: "rgba(22, 163, 74, 0.2)",
+                      backgroundColor: "rgba(22, 163, 74, 0.15)",
+                      pointRadius: 0,
+                      fill: "+1",
+                    },
+                    {
+                      label: "Nedre estimat",
+                      data: bandLower,
+                      borderColor: "rgba(22, 163, 74, 0.2)",
+                      backgroundColor: "rgba(22, 163, 74, 0.15)",
+                      pointRadius: 0,
+                      fill: false,
+                    },
+                  ],
+                }}
+                options={{
+                  responsive: true,
+                  maintainAspectRatio: true,
+                  plugins: { legend: { position: "top", labels: { boxWidth: 10, font: { size: 10 } } } },
+                  scales: {
+                    x: { grid: { display: false } },
+                    y: { beginAtZero: true, grid: { color: "rgba(0,0,0,0.06)" } },
+                  },
+                }}
+              />
+            </div>
+          </VStack>
+        </Box>
+      </HGrid>
+    </VStack>
+  );
+};
+
+export default BillingMonthNowChart;

--- a/apps/my-copilot/src/lib/cached-bigquery.ts
+++ b/apps/my-copilot/src/lib/cached-bigquery.ts
@@ -15,6 +15,8 @@ import type {
   EnterpriseMetrics,
   LanguageAdoption,
   MonthlyBillingUsage,
+  BillingModelDailyCost,
+  BillingModelForecast,
   MonthlyModelUsage,
   MonthlyTrend,
   StalenessSummary,
@@ -181,4 +183,32 @@ export async function getAdoptionCohorts(token: string): Promise<{
     backendRequest<AdoptionCohortDay[]>("/api/v1/copilot/adoption/cohorts", token)
   );
   return { cohorts: result.data, error: result.error };
+}
+
+export async function getBillingModelDaily(
+  token: string,
+  month?: string
+): Promise<{
+  usage: BillingModelDailyCost[];
+  error: string | null;
+}> {
+  const query = month ? `?month=${encodeURIComponent(month)}` : "";
+  const result = await fetchNullable("getBillingModelDaily", () =>
+    backendRequest<BillingModelDailyCost[] | null>(`/api/v1/copilot/billing/model-daily${query}`, token)
+  );
+  return { usage: Array.isArray(result.data) ? result.data : [], error: result.error };
+}
+
+export async function getBillingModelForecast(
+  token: string,
+  month?: string
+): Promise<{
+  forecast: BillingModelForecast | null;
+  error: string | null;
+}> {
+  const query = month ? `?month=${encodeURIComponent(month)}` : "";
+  const result = await fetchNullable("getBillingModelForecast", () =>
+    backendRequest<BillingModelForecast>(`/api/v1/copilot/billing/model-forecast${query}`, token)
+  );
+  return { forecast: result.data, error: result.error };
 }

--- a/apps/my-copilot/src/lib/types.ts
+++ b/apps/my-copilot/src/lib/types.ts
@@ -435,6 +435,35 @@ export interface MonthlyBillingUsage {
   net_amount: number;
 }
 
+export interface BillingModelDailyCost {
+  day: string;
+  model: string;
+  gross_requests: number;
+  net_requests: number;
+  gross_amount: number;
+  net_amount: number;
+}
+
+export interface BillingModelForecastPoint {
+  day: string;
+  actual_cumulative?: number;
+  projected_cumulative: number;
+  is_actual: boolean;
+}
+
+export interface BillingModelForecast {
+  month: string;
+  days_in_month: number;
+  days_elapsed: number;
+  last_actual_day?: string;
+  actual_mtd_net_amount: number;
+  projected_daily_run_rate: number;
+  projected_eom_net_amount: number;
+  lower_eom_net_amount: number;
+  upper_eom_net_amount: number;
+  points: BillingModelForecastPoint[];
+}
+
 export interface WeeklyTrend {
   week: string;
   interactions: number;


### PR DESCRIPTION
## Purpose
Implement and stabilize GitHub Copilot billing data from ingestion to presentation:

- ingest and backfill daily billing model/report data in `apps/copilot-metrics`
- expose and harden billing stats endpoints in `apps/copilot-api`
- visualize current-month MTD + forecast in `apps/my-copilot`

Closes #280

## Scope
### Included
- One-off and resumable backfill flows for billing data in `copilot-metrics`.
- Ongoing daily ingestion paths in `--run-once`.
- BigQuery table setup and idempotent write behavior.
- New billing stats endpoints and query hardening in `copilot-api`.
- Current-month billing charts and forecast behavior in `my-copilot`.
- Tests and documentation updates tied to the above.

### Explicitly out of scope
- New auth mechanisms or auth boundary changes.
- Non-billing feature work unrelated to stats/ingestion.

## What changed
### `apps/copilot-metrics`
- Added/updated billing backfill + ingestion routines for daily report/model data.
- Improved ingestion robustness and run-once failure handling.
- Added/updated BigQuery helpers and tests.
- Updated mise tasks and README usage examples.

### `apps/copilot-api`
- Added billing endpoints for model daily data and forecast.
- Hardened month validation.
- Updated billing queries for partition-friendly month range filtering.
- Added/updated handler tests.

### `apps/my-copilot`
- Added current-month MTD billing chart + forecast rendering.
- Updated month selection and chart semantics to match gross/brutto view.
- Improved fallback/visibility behavior when data is missing.

## Validation
- `cd apps/copilot-metrics && rtk mise check`
- `cd apps/copilot-api && rtk mise check`
- `cd <repo-root> && rtk mise all`

## Operational notes
- Requires `GITHUB_BILLING_TOKEN` for billing-related ingestion paths.
- Re-runs are safe with day-level delete + insert semantics.
- Org billing usage report endpoint availability may vary by org/entitlements.
