### PR TITLE
Replaces all references to running npx with pnx

### DIFF
--- a/.github/agents/accessibility.agent.md
+++ b/.github/agents/accessibility.agent.md
@@ -199,7 +199,7 @@ test("page should be accessible", async ({ page }) => {
 ### Lighthouse CI
 
 ```bash
-npx lighthouse http://localhost:3000 \
+pnx lighthouse http://localhost:3000 \
   --only-categories=accessibility \
   --output=json \
   --chrome-flags="--headless"

--- a/.github/agents/accessibility.agent.md
+++ b/.github/agents/accessibility.agent.md
@@ -199,7 +199,7 @@ test("page should be accessible", async ({ page }) => {
 ### Lighthouse CI
 
 ```bash
-pnx lighthouse http://localhost:3000 \
+pnpm dlx lighthouse http://localhost:3000 \
   --only-categories=accessibility \
   --output=json \
   --chrome-flags="--headless"

--- a/.github/agents/aksel.agent.md
+++ b/.github/agents/aksel.agent.md
@@ -79,7 +79,7 @@ pnpm add @navikt/aksel-icons
 pnpm add -D @navikt/aksel
 
 # Run codemods (e.g. v7 → v8 migration)
-npx @navikt/aksel codemod v8-spacing-tokens ./src
+pnx @navikt/aksel codemod v8-spacing-tokens ./src
 ```
 
 ## Packages & setup

--- a/.github/agents/aksel.agent.md
+++ b/.github/agents/aksel.agent.md
@@ -79,7 +79,7 @@ pnpm add @navikt/aksel-icons
 pnpm add -D @navikt/aksel
 
 # Run codemods (e.g. v7 → v8 migration)
-pnx @navikt/aksel codemod v8-spacing-tokens ./src
+pnpm exec aksel codemod v8-spacing-tokens ./src
 ```
 
 ## Packages & setup

--- a/.github/skills/aksel-spacing/SKILL.md
+++ b/.github/skills/aksel-spacing/SKILL.md
@@ -319,7 +319,7 @@ Props: `above` | `below` (breakpoint-nøkkel: `sm` | `md` | `lg` | `xl` | `2xl`)
 Tokens er ikke bakoverkompatible. Bruk codemod:
 
 ```bash
-npx @navikt/aksel codemod v8-spacing-tokens ./src
+pnx @navikt/aksel codemod v8-spacing-tokens ./src
 ```
 
 | v7 (feil i v8) | v8 (korrekt) | px   |

--- a/.github/skills/aksel-spacing/SKILL.md
+++ b/.github/skills/aksel-spacing/SKILL.md
@@ -319,7 +319,7 @@ Props: `above` | `below` (breakpoint-nøkkel: `sm` | `md` | `lg` | `xl` | `2xl`)
 Tokens er ikke bakoverkompatible. Bruk codemod:
 
 ```bash
-pnx @navikt/aksel codemod v8-spacing-tokens ./src
+pnpm exec aksel codemod v8-spacing-tokens ./src
 ```
 
 | v7 (feil i v8) | v8 (korrekt) | px   |

--- a/.github/skills/playwright-testing/SKILL.md
+++ b/.github/skills/playwright-testing/SKILL.md
@@ -25,10 +25,10 @@ Generate Playwright tests for Nav web applications. Covers page object pattern, 
 ```bash
 # Install Playwright
 pnpm add -D @playwright/test
-pnx playwright install --with-deps chromium
+pnpm exec playwright install --with-deps chromium
 
 # Create configuration
-pnx playwright init
+pnpm exec playwright init
 ```
 
 ### playwright.config.ts
@@ -238,7 +238,7 @@ e2e:
         node-version: 22
         cache: pnpm
     - run: pnpm install --frozen-lockfile
-    - run: pnx playwright install --with-deps chromium
+    - run: pnpm exec playwright install --with-deps chromium
     - run: pnpm exec playwright test
     - uses: actions/upload-artifact@v4
       if: failure()

--- a/.github/skills/playwright-testing/SKILL.md
+++ b/.github/skills/playwright-testing/SKILL.md
@@ -25,10 +25,10 @@ Generate Playwright tests for Nav web applications. Covers page object pattern, 
 ```bash
 # Install Playwright
 pnpm add -D @playwright/test
-npx playwright install --with-deps chromium
+pnx playwright install --with-deps chromium
 
 # Create configuration
-npx playwright init
+pnx playwright init
 ```
 
 ### playwright.config.ts
@@ -238,7 +238,7 @@ e2e:
         node-version: 22
         cache: pnpm
     - run: pnpm install --frozen-lockfile
-    - run: npx playwright install --with-deps chromium
+    - run: pnx playwright install --with-deps chromium
     - run: pnpm exec playwright test
     - uses: actions/upload-artifact@v4
       if: failure()

--- a/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
+++ b/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
@@ -16,7 +16,7 @@
         "ui"
       ],
       "filePath": ".github/agents/accessibility.agent.md",
-      "contentHash": "243143499e16befb52c2e8ef7488dc49698da011c8f2a061d5ff6bdc57396c27",
+      "contentHash": "f76d4cd4ec121c139e67c69381948de3b351fe6a1481ed71d001030338c8faeb",
       "useCases": [
         "Converting Tailwind to Aksel tokens",
         "Responsive layouts"
@@ -38,7 +38,7 @@
         "ui"
       ],
       "filePath": ".github/agents/aksel.agent.md",
-      "contentHash": "7103fb8df66fb0b14be4b723a949cac5cdf668793de91dfcf1e8a362b68ab525",
+      "contentHash": "65e8683113919255fa4b51172ae3b70dfcf31c4e0b8766eeef64c6354242b5b5",
       "useCases": [
         "Converting Tailwind to Aksel tokens",
         "Responsive layouts"
@@ -658,7 +658,7 @@
       "displayName": "aksel-spacing",
       "description": "Lag responsive layouts med Aksel Design System v8: spacing tokens, layout primitives (Box, HStack, VStack, HGrid, Page, Bleed, Show/Hide) og ResponsiveProp-mønsteret",
       "filePath": ".github/skills/aksel-spacing/SKILL.md",
-      "contentHash": "6d9a5ccb34884f110d1cfb2949bfdd3982318820780b41d68e824f3f85539263",
+      "contentHash": "d4e08ca183b2cde791ed54b401f642bea83485123d3e2f37815fe61832c67bf9",
       "installUrl": "",
       "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/aksel-spacing/SKILL.md"
     },
@@ -906,7 +906,7 @@
       "displayName": "playwright-testing",
       "description": "Generer og kjør Playwright E2E-tester for webapplikasjoner med page objects, auth fixtures og tilgjengelighetstester",
       "filePath": ".github/skills/playwright-testing/SKILL.md",
-      "contentHash": "28bd1aa68b19cf6a07693efdc81daea421f60ec2c2d4ae7e89c5f829e710dec4",
+      "contentHash": "1d7f13809c2955a870b56a4d49fd83b2913ee8fbf2145402eb934787c94e345c",
       "installUrl": "",
       "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/playwright-testing/SKILL.md"
     },

--- a/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
+++ b/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
@@ -16,7 +16,7 @@
         "ui"
       ],
       "filePath": ".github/agents/accessibility.agent.md",
-      "contentHash": "f76d4cd4ec121c139e67c69381948de3b351fe6a1481ed71d001030338c8faeb",
+      "contentHash": "c35b6db4d15e6f9fd0134667d83a1084cbc596cca40560715503c47d50f962df",
       "useCases": [
         "Converting Tailwind to Aksel tokens",
         "Responsive layouts"
@@ -38,7 +38,7 @@
         "ui"
       ],
       "filePath": ".github/agents/aksel.agent.md",
-      "contentHash": "65e8683113919255fa4b51172ae3b70dfcf31c4e0b8766eeef64c6354242b5b5",
+      "contentHash": "5619d05aa37ec8f9d74020d52a39607b2b55e89b72f78bf77a1eeb399865226f",
       "useCases": [
         "Converting Tailwind to Aksel tokens",
         "Responsive layouts"
@@ -658,7 +658,7 @@
       "displayName": "aksel-spacing",
       "description": "Lag responsive layouts med Aksel Design System v8: spacing tokens, layout primitives (Box, HStack, VStack, HGrid, Page, Bleed, Show/Hide) og ResponsiveProp-mønsteret",
       "filePath": ".github/skills/aksel-spacing/SKILL.md",
-      "contentHash": "d4e08ca183b2cde791ed54b401f642bea83485123d3e2f37815fe61832c67bf9",
+      "contentHash": "9f0fc46fef61440bd9b9eb11c475b94cc5a554e2cc360282b78557eec2bf4ae2",
       "installUrl": "",
       "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/aksel-spacing/SKILL.md"
     },
@@ -906,7 +906,7 @@
       "displayName": "playwright-testing",
       "description": "Generer og kjør Playwright E2E-tester for webapplikasjoner med page objects, auth fixtures og tilgjengelighetstester",
       "filePath": ".github/skills/playwright-testing/SKILL.md",
-      "contentHash": "1d7f13809c2955a870b56a4d49fd83b2913ee8fbf2145402eb934787c94e345c",
+      "contentHash": "2f5bb75962fafb02b22d9da56271e8de8e3eb1b28617ada88f8763b5cc962843",
       "installUrl": "",
       "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/playwright-testing/SKILL.md"
     },

--- a/apps/mcp-onboarding/internal/readiness/readiness.go
+++ b/apps/mcp-onboarding/internal/readiness/readiness.go
@@ -154,7 +154,7 @@ func recommend(c *RepoContents) []string {
 	if !c.AgentsMD {
 		rec := "Create AGENTS.md at the repo root — this is the most impactful first step. Works across Copilot, Claude, Codex, and other agents. Include build commands, testing patterns, project structure, code style, and git workflow."
 		if isNextJS(c) {
-			rec += " For Next.js projects, include `<!-- BEGIN:nextjs-agent-rules -->` markers and point agents to bundled docs at `node_modules/next/dist/docs/`. Run `npx @next/codemod@canary agents-md` to auto-generate."
+			rec += " For Next.js projects, include `<!-- BEGIN:nextjs-agent-rules -->` markers and point agents to bundled docs at `node_modules/next/dist/docs/`. Run `pnx @next/codemod@canary agents-md` to auto-generate."
 		}
 		if isSpringBoot(c) {
 			rec += " For Spring Boot, document layered architecture (Controllers → Services → Repositories), testing patterns (@WebMvcTest, @DataJpaTest), and bean configuration conventions."

--- a/apps/mcp-onboarding/internal/readiness/readiness.go
+++ b/apps/mcp-onboarding/internal/readiness/readiness.go
@@ -154,7 +154,7 @@ func recommend(c *RepoContents) []string {
 	if !c.AgentsMD {
 		rec := "Create AGENTS.md at the repo root — this is the most impactful first step. Works across Copilot, Claude, Codex, and other agents. Include build commands, testing patterns, project structure, code style, and git workflow."
 		if isNextJS(c) {
-			rec += " For Next.js projects, include `<!-- BEGIN:nextjs-agent-rules -->` markers and point agents to bundled docs at `node_modules/next/dist/docs/`. Run `pnx @next/codemod@canary agents-md` to auto-generate."
+			rec += " For Next.js projects, include `<!-- BEGIN:nextjs-agent-rules -->` markers and point agents to bundled docs at `node_modules/next/dist/docs/`. Run `pnpm dlx @next/codemod@canary agents-md` to auto-generate."
 		}
 		if isSpringBoot(c) {
 			rec += " For Spring Boot, document layered architecture (Controllers → Services → Repositories), testing patterns (@WebMvcTest, @DataJpaTest), and bean configuration conventions."

--- a/apps/mcp-registry/README.md
+++ b/apps/mcp-registry/README.md
@@ -152,7 +152,7 @@ For MCP servers accessible over the network via Streamable HTTP or SSE:
 
 ### Local Servers (stdio via packages)
 
-For MCP servers that run locally as processes (e.g. via `pnx`), use the `packages` field instead of `remotes`. This follows the [MCP Registry Package Types](https://modelcontextprotocol.io/specification/draft/basic/transports#stdio) specification.
+For MCP servers that run locally as processes (e.g. via `pnpm dlx`), use the `packages` field instead of `remotes`. This follows the [MCP Registry Package Types](https://modelcontextprotocol.io/specification/draft/basic/transports#stdio) specification.
 
 ```json
 {
@@ -176,7 +176,7 @@ For MCP servers that run locally as processes (e.g. via `pnx`), use the `package
 | `registryType`         | Yes      | Package registry: `npm`, `pypi`, `oci`, `nuget`, or `mcpb`                |
 | `identifier`           | Yes      | Package name (e.g. `@playwright/mcp`, `mcp-server-fetch`)                 |
 | `version`              | No       | Specific version to pin                                                   |
-| `runtimeHint`          | No       | Runtime command hint (e.g. `pnx`, `uvx`)                                  |
+| `runtimeHint`          | No       | Runtime command hint (e.g. `pnpm dlx`, `uvx`)                             |
 | `transport.type`       | Yes      | Transport type: `stdio` for local, `streamable-http` or `sse` for network |
 | `environmentVariables` | No       | Array of env vars the server needs (API keys, config)                     |
 

--- a/apps/mcp-registry/README.md
+++ b/apps/mcp-registry/README.md
@@ -152,7 +152,7 @@ For MCP servers accessible over the network via Streamable HTTP or SSE:
 
 ### Local Servers (stdio via packages)
 
-For MCP servers that run locally as processes (e.g. via `npx`), use the `packages` field instead of `remotes`. This follows the [MCP Registry Package Types](https://modelcontextprotocol.io/specification/draft/basic/transports#stdio) specification.
+For MCP servers that run locally as processes (e.g. via `pnx`), use the `packages` field instead of `remotes`. This follows the [MCP Registry Package Types](https://modelcontextprotocol.io/specification/draft/basic/transports#stdio) specification.
 
 ```json
 {
@@ -176,7 +176,7 @@ For MCP servers that run locally as processes (e.g. via `npx`), use the `package
 | `registryType`         | Yes      | Package registry: `npm`, `pypi`, `oci`, `nuget`, or `mcpb`                |
 | `identifier`           | Yes      | Package name (e.g. `@playwright/mcp`, `mcp-server-fetch`)                 |
 | `version`              | No       | Specific version to pin                                                   |
-| `runtimeHint`          | No       | Runtime command hint (e.g. `npx`, `uvx`)                                  |
+| `runtimeHint`          | No       | Runtime command hint (e.g. `pnx`, `uvx`)                                  |
 | `transport.type`       | Yes      | Transport type: `stdio` for local, `streamable-http` or `sse` for network |
 | `environmentVariables` | No       | Array of env vars the server needs (API keys, config)                     |
 

--- a/apps/mcp-registry/handlers_test.go
+++ b/apps/mcp-registry/handlers_test.go
@@ -548,7 +548,7 @@ func TestServerVersionHandler_PackageServer(t *testing.T) {
 					"registryType": "npm",
 					"identifier": "@test/mcp-server",
 					"version": "1.2.3",
-					"runtimeHint": "pnx",
+					"runtimeHint": "pnpm dlx",
 					"transport": {"type": "stdio"},
 					"environmentVariables": [
 						{"name": "API_KEY", "description": "API key", "isRequired": true, "isSecret": true}
@@ -607,8 +607,8 @@ func TestServerVersionHandler_PackageServer(t *testing.T) {
 	if pkg.Version != "1.2.3" {
 		t.Errorf("expected version '1.2.3', got '%s'", pkg.Version)
 	}
-	if pkg.RuntimeHint != "pnx" {
-		t.Errorf("expected runtimeHint 'pnx', got '%s'", pkg.RuntimeHint)
+	if pkg.RuntimeHint != "pnpm dlx" {
+		t.Errorf("expected runtimeHint 'pnpm dlx', got '%s'", pkg.RuntimeHint)
 	}
 	if pkg.Transport.Type != "stdio" {
 		t.Errorf("expected transport type 'stdio', got '%s'", pkg.Transport.Type)

--- a/apps/mcp-registry/handlers_test.go
+++ b/apps/mcp-registry/handlers_test.go
@@ -548,7 +548,7 @@ func TestServerVersionHandler_PackageServer(t *testing.T) {
 					"registryType": "npm",
 					"identifier": "@test/mcp-server",
 					"version": "1.2.3",
-					"runtimeHint": "npx",
+					"runtimeHint": "pnx",
 					"transport": {"type": "stdio"},
 					"environmentVariables": [
 						{"name": "API_KEY", "description": "API key", "isRequired": true, "isSecret": true}
@@ -607,8 +607,8 @@ func TestServerVersionHandler_PackageServer(t *testing.T) {
 	if pkg.Version != "1.2.3" {
 		t.Errorf("expected version '1.2.3', got '%s'", pkg.Version)
 	}
-	if pkg.RuntimeHint != "npx" {
-		t.Errorf("expected runtimeHint 'npx', got '%s'", pkg.RuntimeHint)
+	if pkg.RuntimeHint != "pnx" {
+		t.Errorf("expected runtimeHint 'pnx', got '%s'", pkg.RuntimeHint)
 	}
 	if pkg.Transport.Type != "stdio" {
 		t.Errorf("expected transport type 'stdio', got '%s'", pkg.Transport.Type)

--- a/apps/my-copilot/.mise.toml
+++ b/apps/my-copilot/.mise.toml
@@ -1,6 +1,6 @@
 [tools]
 node = "24"
-pnpm = "10.24.0"
+pnpm = "11.5.1"
 fnox = "latest"
 
 [env]

--- a/apps/my-copilot/.npmrc
+++ b/apps/my-copilot/.npmrc
@@ -1,3 +1,3 @@
-auto-install-peers=false
+auto-install-peers=true
 frozen-lockfile=true
 @navikt:registry=https://registry.npmjs.org/

--- a/apps/my-copilot/Dockerfile
+++ b/apps/my-copilot/Dockerfile
@@ -5,7 +5,7 @@ RUN corepack enable
 FROM base AS deps
 WORKDIR /app
 
-COPY apps/my-copilot/package.json apps/my-copilot/pnpm-lock.yaml apps/my-copilot/.npmrc ./
+COPY apps/my-copilot/package.json apps/my-copilot/pnpm-lock.yaml apps/my-copilot/pnpm-workspace.yaml apps/my-copilot/.npmrc ./
 RUN pnpm install --frozen-lockfile
 
 FROM base AS builder

--- a/apps/my-copilot/package.json
+++ b/apps/my-copilot/package.json
@@ -2,7 +2,7 @@
   "name": "my-copilot",
   "version": "1.0.0",
   "type": "module",
-  "packageManager": "pnpm@10.24.0",
+  "packageManager": "pnpm@11.5.1",
   "scripts": {
     "dev": "next dev",
     "build": "next build --experimental-build-mode compile",

--- a/apps/my-copilot/pnpm-lock.yaml
+++ b/apps/my-copilot/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '9.0'
 
 settings:
-  autoInstallPeers: false
+  autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
@@ -43,7 +43,7 @@ importers:
         version: 4.0.3
       next:
         specifier: 16.2.7
-        version: 16.2.7(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -71,7 +71,7 @@ importers:
         version: 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.0)(postcss@8.5.15))
       '@storybook/nextjs':
         specifier: ^10.4.3
-        version: 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(next@16.2.7(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(type-fest@2.19.0)(typescript@6.0.3)(webpack-hot-middleware@2.26.1)(webpack@5.107.2(esbuild@0.28.0)(postcss@8.5.15))
+        version: 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(type-fest@2.19.0)(typescript@6.0.3)(webpack-hot-middleware@2.26.1)(webpack@5.107.2(esbuild@0.28.0)(postcss@8.5.15))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -98,7 +98,7 @@ importers:
         version: 10.4.1(jiti@2.7.0)
       eslint-config-next:
         specifier: 16.2.7
-        version: 16.2.7(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+        version: 16.2.7(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       happy-dom:
         specifier: ^20.9.0
         version: 20.9.0
@@ -128,7 +128,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(happy-dom@20.9.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(happy-dom@20.9.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
 packages:
 
@@ -1169,89 +1169,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1361,24 +1377,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.7':
     resolution: {integrity: sha512-qyogG9QtBzWxgJfeGBvOEHI3851gTfCF3wLZ5RDLTBJGAmE9p1qDwKCOdrBrvBzRvYDT+gUDp72pzlSEfAXgNA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.7':
     resolution: {integrity: sha512-Vhe4ZDuBpmMogrGi5D4R2Kq4JAQlj6+wvgaFYy31zfES0zPmt6TLA+cuYpM/OLrPZjo2MYQTHVqNUSCR6+fDZQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.7':
     resolution: {integrity: sha512-srvian89JahFLw1YLBEuhvPJ0DO5lpUeJQMXy4xYo7g628ZlNgXdNkqoxSAv9OYrBfByh6vxISMwW/mRbzCY+g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.7':
     resolution: {integrity: sha512-GX3wvLpULFuRFJzwHaKfm7QZJ18F4ZSuxlPJ96BoBglCzBmdSjyeBKF+ZhWhvL/ckxNfLnNa7bsObO2ipYpszw==}
@@ -1581,96 +1601,112 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-gnu@0.133.0':
     resolution: {integrity: sha512-hvpbqT5pN2rR+3+xtWeizwfR/aZ0vGceg6TqYMl+ToxMpk9/tmnX7kSvQnfEUkoua8mhogzvIKsAkn0wxgblBA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.127.0':
     resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-arm64-musl@0.133.0':
     resolution: {integrity: sha512-wJQGamIosQBoJHW9+S5XxrtKRo3eyJxsnS1XCPrqN0LHi8uw1pTqqTfn3t/NVuvbBg7Pumn4ez9Eidgcn0xbEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
     resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.133.0':
     resolution: {integrity: sha512-Koaz32/O5+abIfrNGdyndgRvdOZ9jEf5/z3Ep9h3h2QWpdDiUQpVwgH0OcMXCs+l9aXxPLtkupqyVig9W6FDKw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
     resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.133.0':
     resolution: {integrity: sha512-R4vOjWzxhnNWHnVLeiB6jNuIifdy9vcMXZGPc7StXcxBovI+U2zg1QhZ9o8OjV80oGivs1lX5NfPLzk4IPqlRA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
     resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.133.0':
     resolution: {integrity: sha512-iwgBNUTHiMdxARLYuM0SBlnYeb19iw1Ea5M+4ERZupCsBMLArti6FyZ6UfFjJxIiTDr2oW2DGQFxlQVQ/dW9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
     resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.133.0':
     resolution: {integrity: sha512-ZwZNo8FZmB/gVfboQl+wXilBigGl+6nQQs+nITOeAP/HcAOjiHl6XZJL9F/KXNEspODQcbjAiyjUbeCJd9a0fA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.127.0':
     resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.133.0':
     resolution: {integrity: sha512-govCvWx1dBlED3uu4qXctxpRcouu9I8Kn+DBktGCl760JtlGJzc9l/OmPJKlYWSbrRqKkMZehNeZ/4Wfma7uSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.127.0':
     resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-x64-musl@0.133.0':
     resolution: {integrity: sha512-ssTlpXD5Mq9uCssDJPzlRWqBt4Y7Zzd9i+XZhWmK/9Y6KUIuAxVYTYiI8lxcGWi0+3/Cz4A8q9UrD4NK9Y2j7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.127.0':
     resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
@@ -1775,41 +1811,49 @@ packages:
     resolution: {integrity: sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
     resolution: {integrity: sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
     resolution: {integrity: sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
     resolution: {integrity: sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
     resolution: {integrity: sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
     resolution: {integrity: sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
     resolution: {integrity: sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.20.0':
     resolution: {integrity: sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.20.0':
     resolution: {integrity: sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==}
@@ -1912,36 +1956,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -2147,24 +2197,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -2425,51 +2479,61 @@ packages:
     resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
     resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
     resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
     resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
     resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
     resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
     resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
     resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
     resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.12.2':
     resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-openharmony-arm64@1.12.2':
     resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
@@ -2622,6 +2686,11 @@ packages:
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv-keywords@3.5.2:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -4064,24 +4133,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -5557,6 +5630,7 @@ packages:
       '@vitest/ui': 4.1.8
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -7462,7 +7536,7 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@storybook/nextjs@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(next@16.2.7(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(type-fest@2.19.0)(typescript@6.0.3)(webpack-hot-middleware@2.26.1)(webpack@5.107.2(esbuild@0.28.0)(postcss@8.5.15))':
+  '@storybook/nextjs@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(type-fest@2.19.0)(typescript@6.0.3)(webpack-hot-middleware@2.26.1)(webpack@5.107.2(esbuild@0.28.0)(postcss@8.5.15))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.7)
@@ -7486,7 +7560,7 @@ snapshots:
       css-loader: 6.11.0(webpack@5.107.2(esbuild@0.28.0)(postcss@8.5.15))
       image-size: 2.0.2
       loader-utils: 3.3.1
-      next: 16.2.7(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       node-polyfill-webpack-plugin: 2.0.1(webpack@5.107.2(esbuild@0.28.0)(postcss@8.5.15))
       postcss: 8.5.15
       postcss-loader: 8.2.1(postcss@8.5.15)(typescript@6.0.3)(webpack@5.107.2(esbuild@0.28.0)(postcss@8.5.15))
@@ -8148,8 +8222,8 @@ snapshots:
       loader-utils: 2.0.4
       regex-parser: 2.3.1
 
-  ajv-formats@2.1.1:
-    dependencies:
+  ajv-formats@2.1.1(ajv@8.20.0):
+    optionalDependencies:
       ajv: 8.20.0
 
   ajv-keywords@3.5.2(ajv@6.15.0):
@@ -9015,13 +9089,13 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-next@16.2.7(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3):
+  eslint-config-next@16.2.7(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
       '@next/eslint-plugin-next': 16.2.7
       eslint: 10.4.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.1(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.4.1(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@10.4.1(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@10.4.1(jiti@2.7.0))
@@ -9054,21 +9128,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       eslint: 10.4.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.1(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9079,7 +9154,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.4.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -9090,6 +9165,8 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -10372,7 +10449,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@16.2.7(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.7
       '@swc/helpers': 0.5.15
@@ -11202,7 +11279,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
       ajv: 8.20.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1(ajv@8.20.0)
       ajv-keywords: 5.1.0(ajv@8.20.0)
 
   section-matter@1.0.0:
@@ -11800,7 +11877,7 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(happy-dom@20.9.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(happy-dom@20.9.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
       '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -11827,18 +11904,7 @@ snapshots:
       '@types/node': 25.9.1
       happy-dom: 20.9.0
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   vm-browserify@1.1.2: {}
 

--- a/apps/my-copilot/pnpm-workspace.yaml
+++ b/apps/my-copilot/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  core-js-pure: set this to true or false
+  esbuild: true
+  sharp: true
+  unrs-resolver: true

--- a/apps/my-copilot/pnpm-workspace.yaml
+++ b/apps/my-copilot/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 allowBuilds:
-  core-js-pure: set this to true or false
+  core-js-pure: false
   esbuild: true
   sharp: true
   unrs-resolver: true

--- a/apps/my-copilot/src/app/praksis/sections/verification.tsx
+++ b/apps/my-copilot/src/app/praksis/sections/verification.tsx
@@ -71,7 +71,7 @@ Sjekk for:
               Installer og kjør
             </BodyShort>
             <Box background="default" padding="space-8" borderRadius="4" className="mt-1">
-              <code className="text-xs block font-mono">npx knip</code>
+              <code className="text-xs block font-mono">pnx knip</code>
             </Box>
           </div>
           <div>

--- a/apps/my-copilot/src/app/praksis/sections/verification.tsx
+++ b/apps/my-copilot/src/app/praksis/sections/verification.tsx
@@ -71,7 +71,7 @@ Sjekk for:
               Installer og kjør
             </BodyShort>
             <Box background="default" padding="space-8" borderRadius="4" className="mt-1">
-              <code className="text-xs block font-mono">pnx knip</code>
+              <code className="text-xs block font-mono">pnpm knip</code>
             </Box>
           </div>
           <div>

--- a/apps/my-copilot/src/lib/copilot-manifest.json
+++ b/apps/my-copilot/src/lib/copilot-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-06-11T08:06:05.941Z",
+  "generatedAt": "2026-06-11T09:04:57.828Z",
   "items": [
     {
       "id": "accessibility-agent",
@@ -25,16 +25,8 @@
         "com.figma/figma-mcp/get_design_context",
         "com.figma/figma-mcp/get_screenshot"
       ],
-      "model": [
-        "Claude Sonnet 4.6"
-      ],
-      "tags": [
-        "wcag",
-        "a11y",
-        "universell-utforming",
-        "aksel",
-        "aria"
-      ],
+      "model": ["Claude Sonnet 4.6"],
+      "tags": ["wcag", "a11y", "universell-utforming", "aksel", "aria"],
       "examples": [
         "Sjekk denne komponenten for tilgjengelighetsfeil",
         "Gå gjennom WCAG-krav for denne sida",
@@ -80,12 +72,8 @@
         "io.github.navikt/github-mcp/get_latest_release",
         "io.github.navikt/github-mcp/list_releases"
       ],
-      "model": [
-        "Claude Sonnet 4.6"
-      ],
-      "agentReferences": [
-        "nais-agent"
-      ],
+      "model": ["Claude Sonnet 4.6"],
+      "agentReferences": ["nais-agent"],
       "tags": [
         "aksel",
         "design-system",
@@ -146,21 +134,9 @@
         "io.github.navikt/github-mcp/pull_request_read",
         "io.github.navikt/github-mcp/search_pull_requests"
       ],
-      "model": [
-        "Claude Sonnet 4.6"
-      ],
-      "agentReferences": [
-        "nais-agent",
-        "observability-agent",
-        "security-champion-agent"
-      ],
-      "tags": [
-        "auth",
-        "azure-ad",
-        "tokenx",
-        "id-porten",
-        "security"
-      ],
+      "model": ["Claude Sonnet 4.6"],
+      "agentReferences": ["nais-agent", "observability-agent", "security-champion-agent"],
+      "tags": ["auth", "azure-ad", "tokenx", "id-porten", "security"],
       "examples": [
         {
           "prompt": "@auth-agent Sett opp Azure AD-autentisering i fp-sak",
@@ -198,9 +174,7 @@
         "io.github.navikt/github-mcp/list_pull_requests",
         "io.github.navikt/github-mcp/search_pull_requests"
       ],
-      "model": [
-        "GPT-5.3-Codex"
-      ],
+      "model": ["GPT-5.3-Codex"],
       "agentReferences": [
         "accessibility-agent",
         "aksel-agent",
@@ -208,12 +182,7 @@
         "observability-agent",
         "security-champion-agent"
       ],
-      "tags": [
-        "code-review",
-        "quality",
-        "conventions",
-        "pre-merge"
-      ],
+      "tags": ["code-review", "quality", "conventions", "pre-merge"],
       "examples": [
         {
           "prompt": "@code-review-agent Gå gjennom endringene mine før jeg lager PR",
@@ -249,17 +218,8 @@
         "io.github.navikt/github-mcp/get_file_contents",
         "io.github.navikt/github-mcp/search_code"
       ],
-      "model": [
-        "Claude Sonnet 4.6"
-      ],
-      "tags": [
-        "norsk",
-        "teknisk-skriving",
-        "redigering",
-        "språk",
-        "klarspråk",
-        "ai-markører"
-      ],
+      "model": ["Claude Sonnet 4.6"],
+      "tags": ["norsk", "teknisk-skriving", "redigering", "språk", "klarspråk", "ai-markører"],
       "examples": [
         {
           "prompt": "@forfatter Sjekk feilmeldingene og hjelpetekstene i denne React-komponenten for klarspråk",
@@ -282,11 +242,7 @@
           "scenario": "Feilmeldinger i backend-API"
         }
       ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "nextjs-frontend"
-      ]
+      "collections": ["frontend", "fullstack", "nextjs-frontend"]
     },
     {
       "id": "kafka-agent",
@@ -317,20 +273,9 @@
         "io.github.navikt/github-mcp/pull_request_read",
         "io.github.navikt/github-mcp/search_pull_requests"
       ],
-      "model": [
-        "GPT-5.3-Codex"
-      ],
-      "agentReferences": [
-        "nais-agent",
-        "observability-agent",
-        "security-champion-agent"
-      ],
-      "tags": [
-        "kafka",
-        "events",
-        "rapids-rivers",
-        "streaming"
-      ],
+      "model": ["GPT-5.3-Codex"],
+      "agentReferences": ["nais-agent", "observability-agent", "security-champion-agent"],
+      "tags": ["kafka", "events", "rapids-rivers", "streaming"],
       "examples": [
         {
           "prompt": "@kafka-agent Lag en Rapids & Rivers consumer for sykmeldingshendelser i syfosmmanuell-backend",
@@ -376,21 +321,9 @@
         "io.github.navikt/github-mcp/list_releases",
         "io.github.navikt/github-mcp/list_tags"
       ],
-      "model": [
-        "GPT-5.3-Codex"
-      ],
-      "agentReferences": [
-        "auth-agent",
-        "kafka-agent",
-        "observability-agent",
-        "security-champion-agent"
-      ],
-      "tags": [
-        "nais",
-        "kubernetes",
-        "deployment",
-        "infrastructure"
-      ],
+      "model": ["GPT-5.3-Codex"],
+      "agentReferences": ["auth-agent", "kafka-agent", "observability-agent", "security-champion-agent"],
+      "tags": ["nais", "kubernetes", "deployment", "infrastructure"],
       "examples": [
         {
           "prompt": "@nais-agent Lag et Nais-manifest for dp-soknad med PostgreSQL og Redis",
@@ -435,16 +368,8 @@
         "io.github.navikt/github-mcp/get_latest_release",
         "io.github.navikt/github-mcp/list_releases"
       ],
-      "model": [
-        "Claude Opus 4.6"
-      ],
-      "tags": [
-        "planning",
-        "architecture",
-        "review",
-        "security",
-        "nav-pilot"
-      ],
+      "model": ["Claude Opus 4.6"],
+      "tags": ["planning", "architecture", "review", "security", "nav-pilot"],
       "examples": [
         {
           "prompt": "@nav-pilot-opus Vurder auth-arkitekturen vår (TokenX vs Azure) for denne flyten",
@@ -491,9 +416,7 @@
         "io.github.navikt/github-mcp/get_latest_release",
         "io.github.navikt/github-mcp/list_releases"
       ],
-      "model": [
-        "Claude Sonnet 4.6"
-      ],
+      "model": ["Claude Sonnet 4.6"],
       "agentReferences": [
         "accessibility-agent",
         "aksel-agent",
@@ -504,13 +427,7 @@
         "research-agent",
         "security-champion-agent"
       ],
-      "tags": [
-        "planning",
-        "architecture",
-        "scaffold",
-        "onboarding",
-        "nav-pilot"
-      ],
+      "tags": ["planning", "architecture", "scaffold", "onboarding", "nav-pilot"],
       "examples": [
         {
           "prompt": "@nav-pilot Jeg trenger en ny tjeneste som behandler dagpengesøknader",
@@ -533,13 +450,7 @@
           "scenario": "Planlegg hendelsedrevet tjeneste"
         }
       ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "kotlin-backend",
-        "nextjs-frontend",
-        "platform"
-      ]
+      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
     },
     {
       "id": "observability-agent",
@@ -570,21 +481,9 @@
         "io.github.navikt/github-mcp/pull_request_read",
         "io.github.navikt/github-mcp/search_pull_requests"
       ],
-      "model": [
-        "Claude Sonnet 4.6"
-      ],
-      "agentReferences": [
-        "kafka-agent",
-        "nais-agent",
-        "security-champion-agent"
-      ],
-      "tags": [
-        "observability",
-        "metrics",
-        "logging",
-        "tracing",
-        "prometheus"
-      ],
+      "model": ["Claude Sonnet 4.6"],
+      "agentReferences": ["kafka-agent", "nais-agent", "security-champion-agent"],
+      "tags": ["observability", "metrics", "logging", "tracing", "prometheus"],
       "examples": [
         {
           "prompt": "@observability-agent Sett opp Prometheus-metrikker for REST-endepunktene i mulighetsrommet",
@@ -630,9 +529,7 @@
         "io.github.navikt/github-mcp/list_tags",
         "io.github.navikt/github-mcp/list_branches"
       ],
-      "model": [
-        "GPT-5.3-Codex"
-      ],
+      "model": ["GPT-5.3-Codex"],
       "agentReferences": [
         "aksel-agent",
         "auth-agent",
@@ -641,11 +538,7 @@
         "observability-agent",
         "security-champion-agent"
       ],
-      "tags": [
-        "research",
-        "analysis",
-        "codebase-exploration"
-      ],
+      "tags": ["research", "analysis", "codebase-exploration"],
       "examples": [
         {
           "prompt": "@research-agent Finn alle steder fp-sak bruker deprecated Kafka-APIet",
@@ -680,22 +573,9 @@
         "io.github.navikt/github-mcp/search_code",
         "io.github.navikt/github-mcp/search_repositories"
       ],
-      "model": [
-        "GPT-5.3-Codex"
-      ],
-      "agentReferences": [
-        "code-review-agent",
-        "nais-agent",
-        "observability-agent",
-        "security-champion-agent"
-      ],
-      "tags": [
-        "rust",
-        "cargo",
-        "clippy",
-        "async",
-        "tokio"
-      ],
+      "model": ["GPT-5.3-Codex"],
+      "agentReferences": ["code-review-agent", "nais-agent", "observability-agent", "security-champion-agent"],
+      "tags": ["rust", "cargo", "clippy", "async", "tokio"],
       "deprecated": true,
       "deprecatedMessage": "Bruk /rust-development skill i stedet. Agenten har ingen verktøybegrensning som rettferdiggjør agent-formatet."
     },
@@ -734,20 +614,9 @@
         "io.github.navikt/github-mcp/list_tags",
         "io.github.navikt/github-mcp/list_branches"
       ],
-      "model": [
-        "Claude Opus 4.6"
-      ],
-      "agentReferences": [
-        "auth-agent",
-        "nais-agent",
-        "observability-agent"
-      ],
-      "tags": [
-        "security",
-        "compliance",
-        "gdpr",
-        "threat-modeling"
-      ],
+      "model": ["Claude Opus 4.6"],
+      "agentReferences": ["auth-agent", "nais-agent", "observability-agent"],
+      "tags": ["security", "compliance", "gdpr", "threat-modeling"],
       "examples": [
         {
           "prompt": "@security-champion-agent Gjennomfør en trusselmodell for sosialhjelp-innsyn-api",
@@ -771,20 +640,9 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Faccessibility.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Faccessibility.instructions.md",
       "applyTo": "src/**/*.{tsx,jsx}",
-      "tags": [
-        "accessibility",
-        "wcag",
-        "a11y",
-        "universell-utforming"
-      ],
-      "examples": [
-        "Legg til riktige ARIA-attributter på dette skjemaet"
-      ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "nextjs-frontend"
-      ]
+      "tags": ["accessibility", "wcag", "a11y", "universell-utforming"],
+      "examples": ["Legg til riktige ARIA-attributter på dette skjemaet"],
+      "collections": ["frontend", "fullstack", "nextjs-frontend"]
     },
     {
       "id": "code-review",
@@ -798,23 +656,12 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fcode-review.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fcode-review.instructions.md",
       "applyTo": "**",
-      "tags": [
-        "code-review",
-        "security",
-        "nais",
-        "github-actions"
-      ],
+      "tags": ["code-review", "security", "nais", "github-actions"],
       "examples": [
         "Flagg sikkerhetskritiske endringer i PR-er som hemmeligheter, PII i logger og auth-endringer",
         "Identifiser risiko i NAIS-konfig, GitHub Actions og testdekning"
       ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "kotlin-backend",
-        "nextjs-frontend",
-        "platform"
-      ]
+      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
     },
     {
       "id": "database",
@@ -828,19 +675,9 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fdatabase.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fdatabase.instructions.md",
       "applyTo": "**/db/migration/**/*.sql",
-      "tags": [
-        "database",
-        "flyway",
-        "sql",
-        "migration"
-      ],
-      "examples": [
-        "Lag en Flyway-migrasjon som legger til en status-kolonne i vedtak-tabellen i dp-inntekt"
-      ],
-      "collections": [
-        "fullstack",
-        "kotlin-backend"
-      ]
+      "tags": ["database", "flyway", "sql", "migration"],
+      "examples": ["Lag en Flyway-migrasjon som legger til en status-kolonne i vedtak-tabellen i dp-inntekt"],
+      "collections": ["fullstack", "kotlin-backend"]
     },
     {
       "id": "deliberate-ai-use",
@@ -854,23 +691,12 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fdeliberate-ai-use.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fdeliberate-ai-use.instructions.md",
       "applyTo": "**",
-      "tags": [
-        "ai",
-        "skill-preservation",
-        "learning",
-        "practices"
-      ],
+      "tags": ["ai", "skill-preservation", "learning", "practices"],
       "examples": [
         "Vurder om denne oppgaven bør gjøres manuelt for læringsverdi",
         "Forklar valgene og tradeoffene i den genererte koden"
       ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "kotlin-backend",
-        "nextjs-frontend",
-        "platform"
-      ]
+      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
     },
     {
       "id": "docker",
@@ -884,22 +710,9 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fdocker.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fdocker.instructions.md",
       "applyTo": "**/Dockerfile",
-      "tags": [
-        "docker",
-        "dockerfile",
-        "container",
-        "multi-stage"
-      ],
-      "examples": [
-        "Lag en multi-stage Dockerfile for en Spring Boot-applikasjon"
-      ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "kotlin-backend",
-        "nextjs-frontend",
-        "platform"
-      ]
+      "tags": ["docker", "dockerfile", "container", "multi-stage"],
+      "examples": ["Lag en multi-stage Dockerfile for en Spring Boot-applikasjon"],
+      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
     },
     {
       "id": "github-actions",
@@ -913,22 +726,9 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fgithub-actions.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fgithub-actions.instructions.md",
       "applyTo": ".github/workflows/*.{yml,yaml}",
-      "tags": [
-        "github-actions",
-        "ci-cd",
-        "workflow",
-        "deployment"
-      ],
-      "examples": [
-        "Lag en GitHub Actions workflow som bygger og deployer til Nais"
-      ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "kotlin-backend",
-        "nextjs-frontend",
-        "platform"
-      ]
+      "tags": ["github-actions", "ci-cd", "workflow", "deployment"],
+      "examples": ["Lag en GitHub Actions workflow som bygger og deployer til Nais"],
+      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
     },
     {
       "id": "golang",
@@ -942,21 +742,12 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fgolang.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fgolang.instructions.md",
       "applyTo": "**/*.go",
-      "tags": [
-        "go",
-        "nais",
-        "pgx",
-        "sqlc",
-        "slog"
-      ],
+      "tags": ["go", "nais", "pgx", "sqlc", "slog"],
       "examples": [
         "Lag en Go HTTP-tjeneste med pgx og sqlc for dp-inntekt",
         "Sett opp slog med strukturert logging og OpenTelemetry-integrasjon"
       ],
-      "collections": [
-        "fullstack",
-        "platform"
-      ]
+      "collections": ["fullstack", "platform"]
     },
     {
       "id": "kotlin-ktor",
@@ -970,18 +761,9 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fkotlin-ktor.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fkotlin-ktor.instructions.md",
       "applyTo": "**/*.kt",
-      "tags": [
-        "kotlin",
-        "ktor",
-        "backend"
-      ],
-      "examples": [
-        "Lag et nytt endepunkt i fp-sak med Azure AD-autentisering og feilhåndtering"
-      ],
-      "collections": [
-        "fullstack",
-        "kotlin-backend"
-      ]
+      "tags": ["kotlin", "ktor", "backend"],
+      "examples": ["Lag et nytt endepunkt i fp-sak med Azure AD-autentisering og feilhåndtering"],
+      "collections": ["fullstack", "kotlin-backend"]
     },
     {
       "id": "kotlin-spring",
@@ -995,18 +777,9 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fkotlin-spring.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fkotlin-spring.instructions.md",
       "applyTo": "**/*.kt",
-      "tags": [
-        "kotlin",
-        "spring",
-        "backend"
-      ],
-      "examples": [
-        "Lag en REST-controller i kursportalen-backend med Spring Boot og validering"
-      ],
-      "collections": [
-        "fullstack",
-        "kotlin-backend"
-      ]
+      "tags": ["kotlin", "spring", "backend"],
+      "examples": ["Lag en REST-controller i kursportalen-backend med Spring Boot og validering"],
+      "collections": ["fullstack", "kotlin-backend"]
     },
     {
       "id": "nextjs-aksel",
@@ -1020,24 +793,12 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fnextjs-aksel.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fnextjs-aksel.instructions.md",
       "applyTo": "src/**/*.{tsx,ts}",
-      "tags": [
-        "aksel",
-        "design-system",
-        "nextjs",
-        "react",
-        "ui",
-        "spacing",
-        "tokens",
-        "responsive"
-      ],
+      "tags": ["aksel", "design-system", "nextjs", "react", "ui", "spacing", "tokens", "responsive"],
       "examples": [
         "Lag en responsiv søknadsoversikt med Aksel Box og VStack",
         "Hva er riktig bakgrunnsfarge-token for en lys grå boks i Aksel v8?"
       ],
-      "collections": [
-        "fullstack",
-        "nextjs-frontend"
-      ]
+      "collections": ["fullstack", "nextjs-frontend"]
     },
     {
       "id": "norwegian-text",
@@ -1051,22 +812,9 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fnorwegian-text.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fnorwegian-text.instructions.md",
       "applyTo": "**/*.md",
-      "tags": [
-        "norwegian",
-        "klarspråk",
-        "ai-markers",
-        "anglicisms",
-        "markdown"
-      ],
-      "examples": [
-        "Fjern AI-markører fra denne teksten",
-        "Sjekk klarspråk i denne README-en"
-      ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "nextjs-frontend"
-      ]
+      "tags": ["norwegian", "klarspråk", "ai-markers", "anglicisms", "markdown"],
+      "examples": ["Fjern AI-markører fra denne teksten", "Sjekk klarspråk i denne README-en"],
+      "collections": ["frontend", "fullstack", "nextjs-frontend"]
     },
     {
       "id": "performance",
@@ -1080,20 +828,12 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fperformance.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fperformance.instructions.md",
       "applyTo": "src/**/*.{tsx,ts}",
-      "tags": [
-        "performance",
-        "nextjs",
-        "typescript",
-        "core-web-vitals"
-      ],
+      "tags": ["performance", "nextjs", "typescript", "core-web-vitals"],
       "examples": [
         "Optimaliser lasting av bilder og fonter i Next.js-appen",
         "Analyser og reduser bundle-størrelsen for dp-soknad"
       ],
-      "collections": [
-        "fullstack",
-        "nextjs-frontend"
-      ]
+      "collections": ["fullstack", "nextjs-frontend"]
     },
     {
       "id": "security-owasp",
@@ -1107,26 +847,12 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fsecurity-owasp.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fsecurity-owasp.instructions.md",
       "applyTo": "**/*.{kt,go,java,ts,tsx}",
-      "tags": [
-        "security",
-        "owasp",
-        "kotlin",
-        "go",
-        "java",
-        "nodejs",
-        "typescript"
-      ],
+      "tags": ["security", "owasp", "kotlin", "go", "java", "nodejs", "typescript"],
       "examples": [
         "Forebygg SQL- og kommandoinjeksjon med parameteriserte spørringer og trygg inputvalidering",
         "Verifiser tilgangskontroll eksplisitt og unngå logging av hemmeligheter"
       ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "kotlin-backend",
-        "nextjs-frontend",
-        "platform"
-      ]
+      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
     },
     {
       "id": "testing-kotlin",
@@ -1140,10 +866,7 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Ftesting-kotlin.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Ftesting-kotlin.instructions.md",
       "applyTo": "**/*.test.{kt,kts}",
-      "collections": [
-        "fullstack",
-        "kotlin-backend"
-      ]
+      "collections": ["fullstack", "kotlin-backend"]
     },
     {
       "id": "testing-typescript",
@@ -1157,11 +880,7 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Ftesting-typescript.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Ftesting-typescript.instructions.md",
       "applyTo": "**/*.test.{ts,tsx}",
-      "collections": [
-        "frontend",
-        "fullstack",
-        "nextjs-frontend"
-      ]
+      "collections": ["frontend", "fullstack", "nextjs-frontend"]
     },
     {
       "id": "testing",
@@ -1175,22 +894,9 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Ftesting.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Ftesting.instructions.md",
       "applyTo": "**/*.test.{ts,tsx,kt,kts}",
-      "tags": [
-        "testing",
-        "vitest",
-        "kotest",
-        "quality"
-      ],
-      "examples": [
-        "Skriv en test for validateSøknad() med grensetilfeller"
-      ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "kotlin-backend",
-        "nextjs-frontend",
-        "platform"
-      ]
+      "tags": ["testing", "vitest", "kotest", "quality"],
+      "examples": ["Skriv en test for validateSøknad() med grensetilfeller"],
+      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
     },
     {
       "id": "aksel-component",
@@ -1204,23 +910,10 @@
       "installUrl": "/install/prompt?url=vscode%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Faksel-component.prompt.md",
       "insidersInstallUrl": "/install/prompt?url=vscode-insiders%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Faksel-component.prompt.md",
       "invocation": "#aksel-component",
-      "model": [
-        "Claude Haiku 4.5"
-      ],
-      "tags": [
-        "aksel",
-        "design-system",
-        "react",
-        "component"
-      ],
-      "examples": [
-        "#aksel-component Lag en varslingsbanner med ikon og lukkeknapp"
-      ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "nextjs-frontend"
-      ]
+      "model": ["Claude Haiku 4.5"],
+      "tags": ["aksel", "design-system", "react", "component"],
+      "examples": ["#aksel-component Lag en varslingsbanner med ikon og lukkeknapp"],
+      "collections": ["frontend", "fullstack", "nextjs-frontend"]
     },
     {
       "id": "golang-service",
@@ -1234,13 +927,8 @@
       "installUrl": "/install/prompt?url=vscode%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fgolang-service.prompt.md",
       "insidersInstallUrl": "/install/prompt?url=vscode-insiders%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fgolang-service.prompt.md",
       "invocation": "#golang-service",
-      "model": [
-        "Claude Haiku 4.5"
-      ],
-      "collections": [
-        "fullstack",
-        "platform"
-      ]
+      "model": ["Claude Haiku 4.5"],
+      "collections": ["fullstack", "platform"]
     },
     {
       "id": "kafka-topic",
@@ -1254,22 +942,10 @@
       "installUrl": "/install/prompt?url=vscode%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fkafka-topic.prompt.md",
       "insidersInstallUrl": "/install/prompt?url=vscode-insiders%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fkafka-topic.prompt.md",
       "invocation": "#kafka-topic",
-      "model": [
-        "GPT-5.3-Codex"
-      ],
-      "tags": [
-        "nais",
-        "kafka",
-        "rapids-rivers",
-        "infrastructure"
-      ],
-      "examples": [
-        "#kafka-topic Legg til et topic for sykmeldingshendelser"
-      ],
-      "collections": [
-        "fullstack",
-        "kotlin-backend"
-      ]
+      "model": ["GPT-5.3-Codex"],
+      "tags": ["nais", "kafka", "rapids-rivers", "infrastructure"],
+      "examples": ["#kafka-topic Legg til et topic for sykmeldingshendelser"],
+      "collections": ["fullstack", "kotlin-backend"]
     },
     {
       "id": "ktor-endpoint",
@@ -1283,13 +959,8 @@
       "installUrl": "/install/prompt?url=vscode%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fktor-endpoint.prompt.md",
       "insidersInstallUrl": "/install/prompt?url=vscode-insiders%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fktor-endpoint.prompt.md",
       "invocation": "#ktor-endpoint",
-      "model": [
-        "Claude Haiku 4.5"
-      ],
-      "collections": [
-        "fullstack",
-        "kotlin-backend"
-      ]
+      "model": ["Claude Haiku 4.5"],
+      "collections": ["fullstack", "kotlin-backend"]
     },
     {
       "id": "nais-manifest",
@@ -1303,25 +974,10 @@
       "installUrl": "/install/prompt?url=vscode%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fnais-manifest.prompt.md",
       "insidersInstallUrl": "/install/prompt?url=vscode-insiders%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fnais-manifest.prompt.md",
       "invocation": "#nais-manifest",
-      "model": [
-        "GPT-5.3-Codex"
-      ],
-      "tags": [
-        "nais",
-        "kubernetes",
-        "deployment",
-        "infrastructure"
-      ],
-      "examples": [
-        "#nais-manifest Generer et manifest for dp-soknad i prod-gcp"
-      ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "kotlin-backend",
-        "nextjs-frontend",
-        "platform"
-      ]
+      "model": ["GPT-5.3-Codex"],
+      "tags": ["nais", "kubernetes", "deployment", "infrastructure"],
+      "examples": ["#nais-manifest Generer et manifest for dp-soknad i prod-gcp"],
+      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
     },
     {
       "id": "nextjs-api-route",
@@ -1335,22 +991,10 @@
       "installUrl": "/install/prompt?url=vscode%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fnextjs-api-route.prompt.md",
       "insidersInstallUrl": "/install/prompt?url=vscode-insiders%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fnextjs-api-route.prompt.md",
       "invocation": "#nextjs-api-route",
-      "model": [
-        "Claude Haiku 4.5"
-      ],
-      "tags": [
-        "nextjs",
-        "api-route",
-        "app-router",
-        "scaffold"
-      ],
-      "examples": [
-        "#api-route Lag en API-route for å hente brukerdata fra BigQuery"
-      ],
-      "collections": [
-        "fullstack",
-        "nextjs-frontend"
-      ]
+      "model": ["Claude Haiku 4.5"],
+      "tags": ["nextjs", "api-route", "app-router", "scaffold"],
+      "examples": ["#api-route Lag en API-route for å hente brukerdata fra BigQuery"],
+      "collections": ["fullstack", "nextjs-frontend"]
     },
     {
       "id": "spring-boot-endpoint",
@@ -1364,23 +1008,10 @@
       "installUrl": "/install/prompt?url=vscode%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fspring-boot-endpoint.prompt.md",
       "insidersInstallUrl": "/install/prompt?url=vscode-insiders%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fspring-boot-endpoint.prompt.md",
       "invocation": "#spring-boot-endpoint",
-      "model": [
-        "Claude Haiku 4.5"
-      ],
-      "tags": [
-        "spring-boot",
-        "kotlin",
-        "rest",
-        "endpoint",
-        "scaffold"
-      ],
-      "examples": [
-        "#spring-boot-endpoint Lag et CRUD-endepunkt for vedtak med PostgreSQL"
-      ],
-      "collections": [
-        "fullstack",
-        "kotlin-backend"
-      ]
+      "model": ["Claude Haiku 4.5"],
+      "tags": ["spring-boot", "kotlin", "rest", "endpoint", "scaffold"],
+      "examples": ["#spring-boot-endpoint Lag et CRUD-endepunkt for vedtak med PostgreSQL"],
+      "collections": ["fullstack", "kotlin-backend"]
     },
     {
       "id": "aksel-spacing",
@@ -1393,17 +1024,7 @@
       "contentHash": "d4e08ca183b2cde791ed54b401f642bea83485123d3e2f37815fe61832c67bf9",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "aksel",
-        "design-system",
-        "nav",
-        "react",
-        "spacing",
-        "tokens",
-        "layout",
-        "responsive",
-        "primitives"
-      ],
+      "tags": ["aksel", "design-system", "nav", "react", "spacing", "tokens", "layout", "responsive", "primitives"],
       "examples": [
         "Lag en responsiv to-kolonne layout med HGrid og Aksel spacing tokens",
         "Bygg en mobil-first sidelayout med Page.Block og VStack",
@@ -1411,11 +1032,7 @@
         "Bruk Bleed til å la et banner strekke seg forbi container-padding",
         "Sett riktig padding med space-tokens - hva er space-16 i v8?"
       ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "nextjs-frontend"
-      ]
+      "collections": ["frontend", "fullstack", "nextjs-frontend"]
     },
     {
       "id": "api-design",
@@ -1428,13 +1045,7 @@
       "contentHash": "696738e209f8127d8b16d31a1d424fd3be0fbfd2486db782eb013192c4f054c2",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "api",
-        "rest",
-        "design",
-        "openapi",
-        "error-handling"
-      ],
+      "tags": ["api", "rest", "design", "openapi", "error-handling"],
       "examples": [
         {
           "scenario": "REST API-design",
@@ -1457,10 +1068,7 @@
           "prompt": "Lag OpenAPI-annotasjoner for endepunktene"
         }
       ],
-      "collections": [
-        "fullstack",
-        "kotlin-backend"
-      ]
+      "collections": ["fullstack", "kotlin-backend"]
     },
     {
       "id": "conventional-commit",
@@ -1473,12 +1081,7 @@
       "contentHash": "7ff77862da5510a426758adab92663e987695d3fa2ff8e029f38584f9ea39f93",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "git",
-        "commit",
-        "conventional-commits",
-        "changelog"
-      ],
+      "tags": ["git", "commit", "conventional-commits", "changelog"],
       "examples": [
         {
           "scenario": "Commit-melding",
@@ -1497,13 +1100,7 @@
           "prompt": "Hva slags type commit er denne endringen?"
         }
       ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "kotlin-backend",
-        "nextjs-frontend",
-        "platform"
-      ]
+      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
     },
     {
       "id": "flyway-migration",
@@ -1516,19 +1113,9 @@
       "contentHash": "6c5eebc88484b687dafab5d848f16b3cffa6345e19eb3e12428b167da4e23293",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "database",
-        "flyway",
-        "sql",
-        "migration"
-      ],
-      "examples": [
-        "Lag en Flyway-migrasjon som legger til en indeks på fødselsnummer"
-      ],
-      "collections": [
-        "fullstack",
-        "kotlin-backend"
-      ]
+      "tags": ["database", "flyway", "sql", "migration"],
+      "examples": ["Lag en Flyway-migrasjon som legger til en indeks på fødselsnummer"],
+      "collections": ["fullstack", "kotlin-backend"]
     },
     {
       "id": "java-to-kotlin",
@@ -1541,14 +1128,7 @@
       "contentHash": "b8305c1d1251223b25bf5b30d418cd6c1898017a0abfe5742e7f80a1d87ad36d",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "kotlin",
-        "java",
-        "migration",
-        "refactoring",
-        "ktor",
-        "spring"
-      ],
+      "tags": ["kotlin", "java", "migration", "refactoring", "ktor", "spring"],
       "examples": [
         {
           "prompt": "Konverter UserService.java til idiomatic Kotlin med Ktor-mønstre",
@@ -1559,10 +1139,7 @@
           "scenario": "Fullstendig migrasjonsplanlegging"
         }
       ],
-      "collections": [
-        "fullstack",
-        "kotlin-backend"
-      ]
+      "collections": ["fullstack", "kotlin-backend"]
     },
     {
       "id": "kafka",
@@ -1575,17 +1152,8 @@
       "contentHash": "17ebbc88c85f02427a544ffce9d08afb839ec4e32335555bec1ee8d5f7bcd211",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "kafka",
-        "events",
-        "rapids-rivers",
-        "streaming",
-        "event-driven"
-      ],
-      "collections": [
-        "fullstack",
-        "kotlin-backend"
-      ]
+      "tags": ["kafka", "events", "rapids-rivers", "streaming", "event-driven"],
+      "collections": ["fullstack", "kotlin-backend"]
     },
     {
       "id": "kotlin-app-config",
@@ -1598,19 +1166,9 @@
       "contentHash": "ea6651cebef6be6a58069df6de2be1a2a248af41a0fd556382c90f4a02e63394",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "kotlin",
-        "configuration",
-        "sealed-class",
-        "environment"
-      ],
-      "examples": [
-        "Sett opp miljøkonfigurasjon med sealed classes i fp-sak for dev, prod og local"
-      ],
-      "collections": [
-        "fullstack",
-        "kotlin-backend"
-      ]
+      "tags": ["kotlin", "configuration", "sealed-class", "environment"],
+      "examples": ["Sett opp miljøkonfigurasjon med sealed classes i fp-sak for dev, prod og local"],
+      "collections": ["fullstack", "kotlin-backend"]
     },
     {
       "id": "ktor-scaffold",
@@ -1623,13 +1181,7 @@
       "contentHash": "2cd6b7744d5b595542746e77b6a2232655430a7cd4f0b5037894ecc25cba493f",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "kotlin",
-        "ktor",
-        "scaffold",
-        "nais",
-        "kotliquery"
-      ],
+      "tags": ["kotlin", "ktor", "scaffold", "nais", "kotliquery"],
       "examples": [
         {
           "prompt": "Scaffold en ny Ktor-tjeneste for dp-behandling med database og Kafka",
@@ -1640,10 +1192,7 @@
           "scenario": "API-tjeneste med database"
         }
       ],
-      "collections": [
-        "fullstack",
-        "kotlin-backend"
-      ]
+      "collections": ["fullstack", "kotlin-backend"]
     },
     {
       "id": "nais",
@@ -1656,19 +1205,8 @@
       "contentHash": "67a61515e9bd372b4ff1324914b8eb3ba3c06c4b114814002f9a6dee83ae1fb1",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "nais",
-        "kubernetes",
-        "deployment",
-        "gcp",
-        "infrastructure",
-        "troubleshooting"
-      ],
-      "collections": [
-        "fullstack",
-        "kotlin-backend",
-        "platform"
-      ]
+      "tags": ["nais", "kubernetes", "deployment", "gcp", "infrastructure", "troubleshooting"],
+      "collections": ["fullstack", "kotlin-backend", "platform"]
     },
     {
       "id": "nav-architecture-review",
@@ -1681,13 +1219,7 @@
       "contentHash": "49053632149735a80f4cbf0f94a8bd652648ef622a375d14e45e592216899ce6",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "architecture",
-        "adr",
-        "review",
-        "planning",
-        "nav-pilot"
-      ],
+      "tags": ["architecture", "adr", "review", "planning", "nav-pilot"],
       "examples": [
         {
           "prompt": "Generer en ADR for å bytte fra REST til Kafka for vedtakshendelser",
@@ -1708,13 +1240,7 @@
           "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/nav-architecture-review/references/nav-principles.md"
         }
       ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "kotlin-backend",
-        "nextjs-frontend",
-        "platform"
-      ]
+      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
     },
     {
       "id": "nav-auth",
@@ -1727,19 +1253,8 @@
       "contentHash": "61990d2e9ea8f1ee3160239725fb9dfc67410d65551da8112e5ed7cf724742fc",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "auth",
-        "azure-ad",
-        "tokenx",
-        "id-porten",
-        "maskinporten",
-        "jwt",
-        "oasis"
-      ],
-      "collections": [
-        "fullstack",
-        "kotlin-backend"
-      ]
+      "tags": ["auth", "azure-ad", "tokenx", "id-porten", "maskinporten", "jwt", "oasis"],
+      "collections": ["fullstack", "kotlin-backend"]
     },
     {
       "id": "nav-deep-interview",
@@ -1752,13 +1267,7 @@
       "contentHash": "836d0873167176e2dcff40402e2513c185f55323fe5d8dc37e1974de0eb3ca87",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "planning",
-        "requirements",
-        "interview",
-        "onboarding",
-        "nav-pilot"
-      ],
+      "tags": ["planning", "requirements", "interview", "onboarding", "nav-pilot"],
       "examples": [
         {
           "prompt": "Kjør et dypintervju for den nye dp-behandling-tjenesten",
@@ -1779,13 +1288,7 @@
           "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/nav-deep-interview/references/blind-spots.md"
         }
       ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "kotlin-backend",
-        "nextjs-frontend",
-        "platform"
-      ]
+      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
     },
     {
       "id": "nav-dekoratoren",
@@ -1798,16 +1301,7 @@
       "contentHash": "aa85d1a436d77c3ca4e451554f2a79b07fe26722103fda6e500836922ea8eaea",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "nav",
-        "dekoratoren",
-        "header",
-        "footer",
-        "integration",
-        "ssr",
-        "analytics",
-        "consent"
-      ],
+      "tags": ["nav", "dekoratoren", "header", "footer", "integration", "ssr", "analytics", "consent"],
       "references": [
         {
           "path": "references/params.md",
@@ -1838,15 +1332,7 @@
       "contentHash": "a10798e1cdc522558c6fa4de9fb4b8da2267965e483873ee12362c7186949295",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "planning",
-        "architecture",
-        "scaffold",
-        "nais",
-        "nav-pilot",
-        "modernization",
-        "migration"
-      ],
+      "tags": ["planning", "architecture", "scaffold", "nais", "nav-pilot", "modernization", "migration"],
       "examples": [
         {
           "prompt": "Lag en arkitekturplan for en ny dagpenge-API med PostgreSQL og Kafka",
@@ -1883,13 +1369,7 @@
           "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/nav-plan/references/modernization-patterns.md"
         }
       ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "kotlin-backend",
-        "nextjs-frontend",
-        "platform"
-      ]
+      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
     },
     {
       "id": "nav-troubleshoot",
@@ -1902,13 +1382,7 @@
       "contentHash": "eb50649eeb5b58401c306e0c00c698dd6ef97c788a0b67443dbb1d3e8b2cc66d",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "troubleshooting",
-        "diagnostics",
-        "nais",
-        "kubernetes",
-        "nav-pilot"
-      ],
+      "tags": ["troubleshooting", "diagnostics", "nais", "kubernetes", "nav-pilot"],
       "examples": [
         {
           "prompt": "Poden min krasjer med CrashLoopBackOff i dev-gcp, hjelp meg feilsøke",
@@ -1929,13 +1403,7 @@
           "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/nav-troubleshoot/references/diagnostic-trees.md"
         }
       ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "kotlin-backend",
-        "nextjs-frontend",
-        "platform"
-      ]
+      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
     },
     {
       "id": "observability-debugging",
@@ -1948,18 +1416,7 @@
       "contentHash": "b93058442cb1d65247446e6736250a9747b792b833f50176a8e61d6f32685abd",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "debugging",
-        "mimir",
-        "loki",
-        "tempo",
-        "prometheus",
-        "traces",
-        "logs",
-        "kubectl",
-        "nais",
-        "nav-pilot"
-      ],
+      "tags": ["debugging", "mimir", "loki", "tempo", "prometheus", "traces", "logs", "kubectl", "nais", "nav-pilot"],
       "examples": [
         {
           "prompt": "Appen min har plutselig høy feilrate i prod, hjelp meg feilsøke",
@@ -1984,11 +1441,7 @@
           "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/observability-debugging/references/query-library.md"
         }
       ],
-      "collections": [
-        "fullstack",
-        "kotlin-backend",
-        "platform"
-      ]
+      "collections": ["fullstack", "kotlin-backend", "platform"]
     },
     {
       "id": "observability-setup",
@@ -2001,15 +1454,8 @@
       "contentHash": "de63b0e140e841442ca0569c5cddbb62f435c6ef848d788c54343bd1bb22145a",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "prometheus",
-        "opentelemetry",
-        "health",
-        "metrics"
-      ],
-      "examples": [
-        "Sett opp Prometheus-metrikker og helseendepunkter for dp-soknad"
-      ],
+      "tags": ["prometheus", "opentelemetry", "health", "metrics"],
+      "examples": ["Sett opp Prometheus-metrikker og helseendepunkter for dp-soknad"],
       "references": [
         {
           "path": "references/grafana-queries.md",
@@ -2020,11 +1466,7 @@
           "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/observability-setup/references/production-patterns.md"
         }
       ],
-      "collections": [
-        "fullstack",
-        "kotlin-backend",
-        "platform"
-      ]
+      "collections": ["fullstack", "kotlin-backend", "platform"]
     },
     {
       "id": "playwright-testing",
@@ -2037,13 +1479,7 @@
       "contentHash": "1d7f13809c2955a870b56a4d49fd83b2913ee8fbf2145402eb934787c94e345c",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "playwright",
-        "e2e",
-        "testing",
-        "accessibility",
-        "responsive"
-      ],
+      "tags": ["playwright", "e2e", "testing", "accessibility", "responsive"],
       "examples": [
         {
           "scenario": "Innlogging",
@@ -2066,11 +1502,7 @@
           "prompt": "Test responsiv layout med Playwright"
         }
       ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "nextjs-frontend"
-      ]
+      "collections": ["frontend", "fullstack", "nextjs-frontend"]
     },
     {
       "id": "postgresql-review",
@@ -2083,13 +1515,7 @@
       "contentHash": "fcd00261cd892df20fa5facbbdcef5e17181c4269f7c0473728e29e584721730",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "postgresql",
-        "sql",
-        "optimization",
-        "review",
-        "indexing"
-      ],
+      "tags": ["postgresql", "sql", "optimization", "review", "indexing"],
       "examples": [
         {
           "scenario": "Ytelsesgjennomgang",
@@ -2112,10 +1538,7 @@
           "prompt": "Gå gjennom bruk av JSONB"
         }
       ],
-      "collections": [
-        "fullstack",
-        "kotlin-backend"
-      ]
+      "collections": ["fullstack", "kotlin-backend"]
     },
     {
       "id": "readme-review",
@@ -2128,12 +1551,7 @@
       "contentHash": "36fe844fd272d4035d7629b95a267ae8e8a24d4bb49f88c557d4cc45e2512167",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "readme",
-        "documentation",
-        "review",
-        "scaffold"
-      ],
+      "tags": ["readme", "documentation", "review", "scaffold"],
       "examples": [
         "Gå gjennom README-en vår og foreslå forbedringer",
         "Lag en README for denne tjenesten",
@@ -2167,13 +1585,7 @@
           "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/readme-review/references/template-naisjob.md"
         }
       ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "kotlin-backend",
-        "nextjs-frontend",
-        "platform"
-      ]
+      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
     },
     {
       "id": "rust-development",
@@ -2186,13 +1598,7 @@
       "contentHash": "1b98a4c1653e164a2ca4acad3c2f5d8ce0c72f07b2bee6ca3418ca99cc2df2f3",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "rust",
-        "cargo",
-        "clippy",
-        "async",
-        "tokio"
-      ],
+      "tags": ["rust", "cargo", "clippy", "async", "tokio"],
       "examples": [
         {
           "prompt": "Sett opp et nytt Rust-prosjekt med anbefalte lints",
@@ -2211,9 +1617,7 @@
           "scenario": "Review av unsafe-kode"
         }
       ],
-      "collections": [
-        "platform"
-      ]
+      "collections": ["platform"]
     },
     {
       "id": "security-owasp",
@@ -2226,16 +1630,7 @@
       "contentHash": "1d72bcd9d530e5cd28e8683384a356024375d71f6a5b849c2c28049635b75d30",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "security",
-        "owasp",
-        "kotlin",
-        "go",
-        "java",
-        "nodejs",
-        "nais",
-        "supply-chain"
-      ],
+      "tags": ["security", "owasp", "kotlin", "go", "java", "nodejs", "nais", "supply-chain"],
       "examples": [
         {
           "prompt": "Vis sikre mønstre for tilgangskontroll i Ktor-endepunktene mine",
@@ -2258,13 +1653,7 @@
           "scenario": "OWASP — Node.js/Next.js-mønstre"
         }
       ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "kotlin-backend",
-        "nextjs-frontend",
-        "platform"
-      ]
+      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
     },
     {
       "id": "security-review",
@@ -2277,12 +1666,7 @@
       "contentHash": "d6a6bbddfc7f18c09f1e062ad9207dc05ff1fc58c111ce1bb9b88b3277806c75",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "security",
-        "pre-commit",
-        "vulnerability-scanning",
-        "code-review"
-      ],
+      "tags": ["security", "pre-commit", "vulnerability-scanning", "code-review"],
       "examples": [
         {
           "prompt": "Kjør en sikkerhetssjekk på endringene i fp-sak før jeg pusher",
@@ -2293,11 +1677,7 @@
           "scenario": "Sikkerhetssjekk av PR"
         }
       ],
-      "collections": [
-        "fullstack",
-        "kotlin-backend",
-        "platform"
-      ]
+      "collections": ["fullstack", "kotlin-backend", "platform"]
     },
     {
       "id": "spring-boot-scaffold",
@@ -2310,13 +1690,7 @@
       "contentHash": "8fd5a5713062c0c5fb2c1c1679847d3e791f9cea3bc45a12121daa57cd5fec60",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "spring-boot",
-        "kotlin",
-        "scaffold",
-        "nais",
-        "project-setup"
-      ],
+      "tags": ["spring-boot", "kotlin", "scaffold", "nais", "project-setup"],
       "examples": [
         {
           "scenario": "Nytt prosjekt",
@@ -2335,10 +1709,7 @@
           "prompt": "Generer prosjektstruktur for ny backend-tjeneste"
         }
       ],
-      "collections": [
-        "fullstack",
-        "kotlin-backend"
-      ]
+      "collections": ["fullstack", "kotlin-backend"]
     },
     {
       "id": "terse-mode",
@@ -2351,12 +1722,7 @@
       "contentHash": "26ec6b397bdd2e9611c00be143354bc76997102bfa7eea18b5483e69c01f1865",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "token-optimization",
-        "output",
-        "conciseness",
-        "communication-style"
-      ],
+      "tags": ["token-optimization", "output", "conciseness", "communication-style"],
       "examples": [
         {
           "scenario": "Aktiver terse mode",
@@ -2375,13 +1741,7 @@
           "prompt": "Forklar connection pooling med $terse-mode"
         }
       ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "kotlin-backend",
-        "nextjs-frontend",
-        "platform"
-      ]
+      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
     },
     {
       "id": "threat-model",
@@ -2394,13 +1754,7 @@
       "contentHash": "347f2167d828793a968ffcf208b698bcd2b37c6c0321096b7bc9eb2dd4ed15ea",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "threat-modeling",
-        "stride",
-        "security",
-        "nais",
-        "architecture"
-      ],
+      "tags": ["threat-modeling", "stride", "security", "nais", "architecture"],
       "examples": [
         {
           "prompt": "Lag en trusselmodell for dp-soknad som behandler søknader om dagpenger",
@@ -2417,11 +1771,7 @@
           "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/threat-model/references/nav-mitigations.md"
         }
       ],
-      "collections": [
-        "fullstack",
-        "kotlin-backend",
-        "platform"
-      ]
+      "collections": ["fullstack", "kotlin-backend", "platform"]
     },
     {
       "id": "tokenx-auth",
@@ -2434,19 +1784,9 @@
       "contentHash": "efa91db0fb79778288ad17a1ef0b8a6e8437cc73912be0a40dc513554921e201",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "tokenx",
-        "auth",
-        "service-to-service",
-        "nais"
-      ],
-      "examples": [
-        "Sett opp TokenX-utveksling mellom dp-soknad og dp-inntekt"
-      ],
-      "collections": [
-        "fullstack",
-        "kotlin-backend"
-      ]
+      "tags": ["tokenx", "auth", "service-to-service", "nais"],
+      "examples": ["Sett opp TokenX-utveksling mellom dp-soknad og dp-inntekt"],
+      "collections": ["fullstack", "kotlin-backend"]
     },
     {
       "id": "web-design-reviewer",
@@ -2459,13 +1799,7 @@
       "contentHash": "1cb4e5b4bad72ca84b0e47b02f96fa33a3e3d86523328fbe493cf7d44ac46857",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "design-review",
-        "responsive",
-        "accessibility",
-        "layout",
-        "visual-inspection"
-      ],
+      "tags": ["design-review", "responsive", "accessibility", "layout", "visual-inspection"],
       "examples": [
         {
           "prompt": "Sjekk designet på localhost:3000 og finn layout-problemer",
@@ -2486,11 +1820,7 @@
           "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/web-design-reviewer/references/visual-checklist.md"
         }
       ],
-      "collections": [
-        "frontend",
-        "fullstack",
-        "nextjs-frontend"
-      ]
+      "collections": ["frontend", "fullstack", "nextjs-frontend"]
     },
     {
       "id": "workstation-security",
@@ -2503,13 +1833,7 @@
       "contentHash": "f3cd4b414201ace0853c695d8369bd6ee353ae469d1d7eccf02332e9dc97ef04",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": [
-        "security",
-        "macos",
-        "developer-tools",
-        "audit",
-        "hardening"
-      ],
+      "tags": ["security", "macos", "developer-tools", "audit", "hardening"],
       "examples": [
         {
           "prompt": "Kjør en sikkerhetssjekk av Mac-en min",
@@ -2528,11 +1852,7 @@
           "scenario": "Klarsjekk for Nav-plattformen"
         }
       ],
-      "collections": [
-        "fullstack",
-        "kotlin-backend",
-        "platform"
-      ]
+      "collections": ["fullstack", "kotlin-backend", "platform"]
     }
   ]
 }

--- a/apps/my-copilot/src/lib/copilot-manifest.json
+++ b/apps/my-copilot/src/lib/copilot-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-06-11T09:04:57.828Z",
+  "generatedAt": "2026-06-11T12:22:20.514Z",
   "items": [
     {
       "id": "accessibility-agent",
@@ -10,7 +10,7 @@
       "domain": "frontend",
       "filePath": ".github/agents/accessibility.agent.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/agents/accessibility.agent.md",
-      "contentHash": "f76d4cd4ec121c139e67c69381948de3b351fe6a1481ed71d001030338c8faeb",
+      "contentHash": "c35b6db4d15e6f9fd0134667d83a1084cbc596cca40560715503c47d50f962df",
       "installUrl": "/install/agent?url=vscode%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fagents%2Faccessibility.agent.md",
       "insidersInstallUrl": "/install/agent?url=vscode-insiders%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fagents%2Faccessibility.agent.md",
       "tools": [
@@ -43,7 +43,7 @@
       "domain": "frontend",
       "filePath": ".github/agents/aksel.agent.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/agents/aksel.agent.md",
-      "contentHash": "65e8683113919255fa4b51172ae3b70dfcf31c4e0b8766eeef64c6354242b5b5",
+      "contentHash": "5619d05aa37ec8f9d74020d52a39607b2b55e89b72f78bf77a1eeb399865226f",
       "installUrl": "/install/agent?url=vscode%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fagents%2Faksel.agent.md",
       "insidersInstallUrl": "/install/agent?url=vscode-insiders%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fagents%2Faksel.agent.md",
       "tools": [
@@ -1021,7 +1021,7 @@
       "domain": "frontend",
       "filePath": ".github/skills/aksel-spacing/SKILL.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/aksel-spacing/SKILL.md",
-      "contentHash": "d4e08ca183b2cde791ed54b401f642bea83485123d3e2f37815fe61832c67bf9",
+      "contentHash": "9f0fc46fef61440bd9b9eb11c475b94cc5a554e2cc360282b78557eec2bf4ae2",
       "installUrl": null,
       "insidersInstallUrl": null,
       "tags": ["aksel", "design-system", "nav", "react", "spacing", "tokens", "layout", "responsive", "primitives"],
@@ -1476,7 +1476,7 @@
       "domain": "testing",
       "filePath": ".github/skills/playwright-testing/SKILL.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/playwright-testing/SKILL.md",
-      "contentHash": "1d7f13809c2955a870b56a4d49fd83b2913ee8fbf2145402eb934787c94e345c",
+      "contentHash": "2f5bb75962fafb02b22d9da56271e8de8e3eb1b28617ada88f8763b5cc962843",
       "installUrl": null,
       "insidersInstallUrl": null,
       "tags": ["playwright", "e2e", "testing", "accessibility", "responsive"],

--- a/apps/my-copilot/src/lib/copilot-manifest.json
+++ b/apps/my-copilot/src/lib/copilot-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-06-09T19:17:11.499Z",
+  "generatedAt": "2026-06-11T08:06:05.941Z",
   "items": [
     {
       "id": "accessibility-agent",
@@ -10,7 +10,7 @@
       "domain": "frontend",
       "filePath": ".github/agents/accessibility.agent.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/agents/accessibility.agent.md",
-      "contentHash": "243143499e16befb52c2e8ef7488dc49698da011c8f2a061d5ff6bdc57396c27",
+      "contentHash": "f76d4cd4ec121c139e67c69381948de3b351fe6a1481ed71d001030338c8faeb",
       "installUrl": "/install/agent?url=vscode%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fagents%2Faccessibility.agent.md",
       "insidersInstallUrl": "/install/agent?url=vscode-insiders%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fagents%2Faccessibility.agent.md",
       "tools": [
@@ -25,8 +25,16 @@
         "com.figma/figma-mcp/get_design_context",
         "com.figma/figma-mcp/get_screenshot"
       ],
-      "model": ["Claude Sonnet 4.6"],
-      "tags": ["wcag", "a11y", "universell-utforming", "aksel", "aria"],
+      "model": [
+        "Claude Sonnet 4.6"
+      ],
+      "tags": [
+        "wcag",
+        "a11y",
+        "universell-utforming",
+        "aksel",
+        "aria"
+      ],
       "examples": [
         "Sjekk denne komponenten for tilgjengelighetsfeil",
         "Gå gjennom WCAG-krav for denne sida",
@@ -43,7 +51,7 @@
       "domain": "frontend",
       "filePath": ".github/agents/aksel.agent.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/agents/aksel.agent.md",
-      "contentHash": "7103fb8df66fb0b14be4b723a949cac5cdf668793de91dfcf1e8a362b68ab525",
+      "contentHash": "65e8683113919255fa4b51172ae3b70dfcf31c4e0b8766eeef64c6354242b5b5",
       "installUrl": "/install/agent?url=vscode%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fagents%2Faksel.agent.md",
       "insidersInstallUrl": "/install/agent?url=vscode-insiders%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fagents%2Faksel.agent.md",
       "tools": [
@@ -72,8 +80,12 @@
         "io.github.navikt/github-mcp/get_latest_release",
         "io.github.navikt/github-mcp/list_releases"
       ],
-      "model": ["Claude Sonnet 4.6"],
-      "agentReferences": ["nais-agent"],
+      "model": [
+        "Claude Sonnet 4.6"
+      ],
+      "agentReferences": [
+        "nais-agent"
+      ],
       "tags": [
         "aksel",
         "design-system",
@@ -134,9 +146,21 @@
         "io.github.navikt/github-mcp/pull_request_read",
         "io.github.navikt/github-mcp/search_pull_requests"
       ],
-      "model": ["Claude Sonnet 4.6"],
-      "agentReferences": ["nais-agent", "observability-agent", "security-champion-agent"],
-      "tags": ["auth", "azure-ad", "tokenx", "id-porten", "security"],
+      "model": [
+        "Claude Sonnet 4.6"
+      ],
+      "agentReferences": [
+        "nais-agent",
+        "observability-agent",
+        "security-champion-agent"
+      ],
+      "tags": [
+        "auth",
+        "azure-ad",
+        "tokenx",
+        "id-porten",
+        "security"
+      ],
       "examples": [
         {
           "prompt": "@auth-agent Sett opp Azure AD-autentisering i fp-sak",
@@ -174,7 +198,9 @@
         "io.github.navikt/github-mcp/list_pull_requests",
         "io.github.navikt/github-mcp/search_pull_requests"
       ],
-      "model": ["GPT-5.3-Codex"],
+      "model": [
+        "GPT-5.3-Codex"
+      ],
       "agentReferences": [
         "accessibility-agent",
         "aksel-agent",
@@ -182,7 +208,12 @@
         "observability-agent",
         "security-champion-agent"
       ],
-      "tags": ["code-review", "quality", "conventions", "pre-merge"],
+      "tags": [
+        "code-review",
+        "quality",
+        "conventions",
+        "pre-merge"
+      ],
       "examples": [
         {
           "prompt": "@code-review-agent Gå gjennom endringene mine før jeg lager PR",
@@ -218,8 +249,17 @@
         "io.github.navikt/github-mcp/get_file_contents",
         "io.github.navikt/github-mcp/search_code"
       ],
-      "model": ["Claude Sonnet 4.6"],
-      "tags": ["norsk", "teknisk-skriving", "redigering", "språk", "klarspråk", "ai-markører"],
+      "model": [
+        "Claude Sonnet 4.6"
+      ],
+      "tags": [
+        "norsk",
+        "teknisk-skriving",
+        "redigering",
+        "språk",
+        "klarspråk",
+        "ai-markører"
+      ],
       "examples": [
         {
           "prompt": "@forfatter Sjekk feilmeldingene og hjelpetekstene i denne React-komponenten for klarspråk",
@@ -242,7 +282,11 @@
           "scenario": "Feilmeldinger i backend-API"
         }
       ],
-      "collections": ["frontend", "fullstack", "nextjs-frontend"]
+      "collections": [
+        "frontend",
+        "fullstack",
+        "nextjs-frontend"
+      ]
     },
     {
       "id": "kafka-agent",
@@ -273,9 +317,20 @@
         "io.github.navikt/github-mcp/pull_request_read",
         "io.github.navikt/github-mcp/search_pull_requests"
       ],
-      "model": ["GPT-5.3-Codex"],
-      "agentReferences": ["nais-agent", "observability-agent", "security-champion-agent"],
-      "tags": ["kafka", "events", "rapids-rivers", "streaming"],
+      "model": [
+        "GPT-5.3-Codex"
+      ],
+      "agentReferences": [
+        "nais-agent",
+        "observability-agent",
+        "security-champion-agent"
+      ],
+      "tags": [
+        "kafka",
+        "events",
+        "rapids-rivers",
+        "streaming"
+      ],
       "examples": [
         {
           "prompt": "@kafka-agent Lag en Rapids & Rivers consumer for sykmeldingshendelser i syfosmmanuell-backend",
@@ -321,9 +376,21 @@
         "io.github.navikt/github-mcp/list_releases",
         "io.github.navikt/github-mcp/list_tags"
       ],
-      "model": ["GPT-5.3-Codex"],
-      "agentReferences": ["auth-agent", "kafka-agent", "observability-agent", "security-champion-agent"],
-      "tags": ["nais", "kubernetes", "deployment", "infrastructure"],
+      "model": [
+        "GPT-5.3-Codex"
+      ],
+      "agentReferences": [
+        "auth-agent",
+        "kafka-agent",
+        "observability-agent",
+        "security-champion-agent"
+      ],
+      "tags": [
+        "nais",
+        "kubernetes",
+        "deployment",
+        "infrastructure"
+      ],
       "examples": [
         {
           "prompt": "@nais-agent Lag et Nais-manifest for dp-soknad med PostgreSQL og Redis",
@@ -368,8 +435,16 @@
         "io.github.navikt/github-mcp/get_latest_release",
         "io.github.navikt/github-mcp/list_releases"
       ],
-      "model": ["Claude Opus 4.6"],
-      "tags": ["planning", "architecture", "review", "security", "nav-pilot"],
+      "model": [
+        "Claude Opus 4.6"
+      ],
+      "tags": [
+        "planning",
+        "architecture",
+        "review",
+        "security",
+        "nav-pilot"
+      ],
       "examples": [
         {
           "prompt": "@nav-pilot-opus Vurder auth-arkitekturen vår (TokenX vs Azure) for denne flyten",
@@ -416,7 +491,9 @@
         "io.github.navikt/github-mcp/get_latest_release",
         "io.github.navikt/github-mcp/list_releases"
       ],
-      "model": ["Claude Sonnet 4.6"],
+      "model": [
+        "Claude Sonnet 4.6"
+      ],
       "agentReferences": [
         "accessibility-agent",
         "aksel-agent",
@@ -427,7 +504,13 @@
         "research-agent",
         "security-champion-agent"
       ],
-      "tags": ["planning", "architecture", "scaffold", "onboarding", "nav-pilot"],
+      "tags": [
+        "planning",
+        "architecture",
+        "scaffold",
+        "onboarding",
+        "nav-pilot"
+      ],
       "examples": [
         {
           "prompt": "@nav-pilot Jeg trenger en ny tjeneste som behandler dagpengesøknader",
@@ -450,7 +533,13 @@
           "scenario": "Planlegg hendelsedrevet tjeneste"
         }
       ],
-      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
+      "collections": [
+        "frontend",
+        "fullstack",
+        "kotlin-backend",
+        "nextjs-frontend",
+        "platform"
+      ]
     },
     {
       "id": "observability-agent",
@@ -481,9 +570,21 @@
         "io.github.navikt/github-mcp/pull_request_read",
         "io.github.navikt/github-mcp/search_pull_requests"
       ],
-      "model": ["Claude Sonnet 4.6"],
-      "agentReferences": ["kafka-agent", "nais-agent", "security-champion-agent"],
-      "tags": ["observability", "metrics", "logging", "tracing", "prometheus"],
+      "model": [
+        "Claude Sonnet 4.6"
+      ],
+      "agentReferences": [
+        "kafka-agent",
+        "nais-agent",
+        "security-champion-agent"
+      ],
+      "tags": [
+        "observability",
+        "metrics",
+        "logging",
+        "tracing",
+        "prometheus"
+      ],
       "examples": [
         {
           "prompt": "@observability-agent Sett opp Prometheus-metrikker for REST-endepunktene i mulighetsrommet",
@@ -529,7 +630,9 @@
         "io.github.navikt/github-mcp/list_tags",
         "io.github.navikt/github-mcp/list_branches"
       ],
-      "model": ["GPT-5.3-Codex"],
+      "model": [
+        "GPT-5.3-Codex"
+      ],
       "agentReferences": [
         "aksel-agent",
         "auth-agent",
@@ -538,7 +641,11 @@
         "observability-agent",
         "security-champion-agent"
       ],
-      "tags": ["research", "analysis", "codebase-exploration"],
+      "tags": [
+        "research",
+        "analysis",
+        "codebase-exploration"
+      ],
       "examples": [
         {
           "prompt": "@research-agent Finn alle steder fp-sak bruker deprecated Kafka-APIet",
@@ -573,9 +680,22 @@
         "io.github.navikt/github-mcp/search_code",
         "io.github.navikt/github-mcp/search_repositories"
       ],
-      "model": ["GPT-5.3-Codex"],
-      "agentReferences": ["code-review-agent", "nais-agent", "observability-agent", "security-champion-agent"],
-      "tags": ["rust", "cargo", "clippy", "async", "tokio"],
+      "model": [
+        "GPT-5.3-Codex"
+      ],
+      "agentReferences": [
+        "code-review-agent",
+        "nais-agent",
+        "observability-agent",
+        "security-champion-agent"
+      ],
+      "tags": [
+        "rust",
+        "cargo",
+        "clippy",
+        "async",
+        "tokio"
+      ],
       "deprecated": true,
       "deprecatedMessage": "Bruk /rust-development skill i stedet. Agenten har ingen verktøybegrensning som rettferdiggjør agent-formatet."
     },
@@ -614,9 +734,20 @@
         "io.github.navikt/github-mcp/list_tags",
         "io.github.navikt/github-mcp/list_branches"
       ],
-      "model": ["Claude Opus 4.6"],
-      "agentReferences": ["auth-agent", "nais-agent", "observability-agent"],
-      "tags": ["security", "compliance", "gdpr", "threat-modeling"],
+      "model": [
+        "Claude Opus 4.6"
+      ],
+      "agentReferences": [
+        "auth-agent",
+        "nais-agent",
+        "observability-agent"
+      ],
+      "tags": [
+        "security",
+        "compliance",
+        "gdpr",
+        "threat-modeling"
+      ],
       "examples": [
         {
           "prompt": "@security-champion-agent Gjennomfør en trusselmodell for sosialhjelp-innsyn-api",
@@ -640,9 +771,20 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Faccessibility.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Faccessibility.instructions.md",
       "applyTo": "src/**/*.{tsx,jsx}",
-      "tags": ["accessibility", "wcag", "a11y", "universell-utforming"],
-      "examples": ["Legg til riktige ARIA-attributter på dette skjemaet"],
-      "collections": ["frontend", "fullstack", "nextjs-frontend"]
+      "tags": [
+        "accessibility",
+        "wcag",
+        "a11y",
+        "universell-utforming"
+      ],
+      "examples": [
+        "Legg til riktige ARIA-attributter på dette skjemaet"
+      ],
+      "collections": [
+        "frontend",
+        "fullstack",
+        "nextjs-frontend"
+      ]
     },
     {
       "id": "code-review",
@@ -656,12 +798,23 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fcode-review.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fcode-review.instructions.md",
       "applyTo": "**",
-      "tags": ["code-review", "security", "nais", "github-actions"],
+      "tags": [
+        "code-review",
+        "security",
+        "nais",
+        "github-actions"
+      ],
       "examples": [
         "Flagg sikkerhetskritiske endringer i PR-er som hemmeligheter, PII i logger og auth-endringer",
         "Identifiser risiko i NAIS-konfig, GitHub Actions og testdekning"
       ],
-      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
+      "collections": [
+        "frontend",
+        "fullstack",
+        "kotlin-backend",
+        "nextjs-frontend",
+        "platform"
+      ]
     },
     {
       "id": "database",
@@ -675,9 +828,19 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fdatabase.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fdatabase.instructions.md",
       "applyTo": "**/db/migration/**/*.sql",
-      "tags": ["database", "flyway", "sql", "migration"],
-      "examples": ["Lag en Flyway-migrasjon som legger til en status-kolonne i vedtak-tabellen i dp-inntekt"],
-      "collections": ["fullstack", "kotlin-backend"]
+      "tags": [
+        "database",
+        "flyway",
+        "sql",
+        "migration"
+      ],
+      "examples": [
+        "Lag en Flyway-migrasjon som legger til en status-kolonne i vedtak-tabellen i dp-inntekt"
+      ],
+      "collections": [
+        "fullstack",
+        "kotlin-backend"
+      ]
     },
     {
       "id": "deliberate-ai-use",
@@ -691,12 +854,23 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fdeliberate-ai-use.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fdeliberate-ai-use.instructions.md",
       "applyTo": "**",
-      "tags": ["ai", "skill-preservation", "learning", "practices"],
+      "tags": [
+        "ai",
+        "skill-preservation",
+        "learning",
+        "practices"
+      ],
       "examples": [
         "Vurder om denne oppgaven bør gjøres manuelt for læringsverdi",
         "Forklar valgene og tradeoffene i den genererte koden"
       ],
-      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
+      "collections": [
+        "frontend",
+        "fullstack",
+        "kotlin-backend",
+        "nextjs-frontend",
+        "platform"
+      ]
     },
     {
       "id": "docker",
@@ -710,9 +884,22 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fdocker.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fdocker.instructions.md",
       "applyTo": "**/Dockerfile",
-      "tags": ["docker", "dockerfile", "container", "multi-stage"],
-      "examples": ["Lag en multi-stage Dockerfile for en Spring Boot-applikasjon"],
-      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
+      "tags": [
+        "docker",
+        "dockerfile",
+        "container",
+        "multi-stage"
+      ],
+      "examples": [
+        "Lag en multi-stage Dockerfile for en Spring Boot-applikasjon"
+      ],
+      "collections": [
+        "frontend",
+        "fullstack",
+        "kotlin-backend",
+        "nextjs-frontend",
+        "platform"
+      ]
     },
     {
       "id": "github-actions",
@@ -726,9 +913,22 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fgithub-actions.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fgithub-actions.instructions.md",
       "applyTo": ".github/workflows/*.{yml,yaml}",
-      "tags": ["github-actions", "ci-cd", "workflow", "deployment"],
-      "examples": ["Lag en GitHub Actions workflow som bygger og deployer til Nais"],
-      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
+      "tags": [
+        "github-actions",
+        "ci-cd",
+        "workflow",
+        "deployment"
+      ],
+      "examples": [
+        "Lag en GitHub Actions workflow som bygger og deployer til Nais"
+      ],
+      "collections": [
+        "frontend",
+        "fullstack",
+        "kotlin-backend",
+        "nextjs-frontend",
+        "platform"
+      ]
     },
     {
       "id": "golang",
@@ -742,12 +942,21 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fgolang.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fgolang.instructions.md",
       "applyTo": "**/*.go",
-      "tags": ["go", "nais", "pgx", "sqlc", "slog"],
+      "tags": [
+        "go",
+        "nais",
+        "pgx",
+        "sqlc",
+        "slog"
+      ],
       "examples": [
         "Lag en Go HTTP-tjeneste med pgx og sqlc for dp-inntekt",
         "Sett opp slog med strukturert logging og OpenTelemetry-integrasjon"
       ],
-      "collections": ["fullstack", "platform"]
+      "collections": [
+        "fullstack",
+        "platform"
+      ]
     },
     {
       "id": "kotlin-ktor",
@@ -761,9 +970,18 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fkotlin-ktor.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fkotlin-ktor.instructions.md",
       "applyTo": "**/*.kt",
-      "tags": ["kotlin", "ktor", "backend"],
-      "examples": ["Lag et nytt endepunkt i fp-sak med Azure AD-autentisering og feilhåndtering"],
-      "collections": ["fullstack", "kotlin-backend"]
+      "tags": [
+        "kotlin",
+        "ktor",
+        "backend"
+      ],
+      "examples": [
+        "Lag et nytt endepunkt i fp-sak med Azure AD-autentisering og feilhåndtering"
+      ],
+      "collections": [
+        "fullstack",
+        "kotlin-backend"
+      ]
     },
     {
       "id": "kotlin-spring",
@@ -777,9 +995,18 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fkotlin-spring.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fkotlin-spring.instructions.md",
       "applyTo": "**/*.kt",
-      "tags": ["kotlin", "spring", "backend"],
-      "examples": ["Lag en REST-controller i kursportalen-backend med Spring Boot og validering"],
-      "collections": ["fullstack", "kotlin-backend"]
+      "tags": [
+        "kotlin",
+        "spring",
+        "backend"
+      ],
+      "examples": [
+        "Lag en REST-controller i kursportalen-backend med Spring Boot og validering"
+      ],
+      "collections": [
+        "fullstack",
+        "kotlin-backend"
+      ]
     },
     {
       "id": "nextjs-aksel",
@@ -793,12 +1020,24 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fnextjs-aksel.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fnextjs-aksel.instructions.md",
       "applyTo": "src/**/*.{tsx,ts}",
-      "tags": ["aksel", "design-system", "nextjs", "react", "ui", "spacing", "tokens", "responsive"],
+      "tags": [
+        "aksel",
+        "design-system",
+        "nextjs",
+        "react",
+        "ui",
+        "spacing",
+        "tokens",
+        "responsive"
+      ],
       "examples": [
         "Lag en responsiv søknadsoversikt med Aksel Box og VStack",
         "Hva er riktig bakgrunnsfarge-token for en lys grå boks i Aksel v8?"
       ],
-      "collections": ["fullstack", "nextjs-frontend"]
+      "collections": [
+        "fullstack",
+        "nextjs-frontend"
+      ]
     },
     {
       "id": "norwegian-text",
@@ -812,9 +1051,22 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fnorwegian-text.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fnorwegian-text.instructions.md",
       "applyTo": "**/*.md",
-      "tags": ["norwegian", "klarspråk", "ai-markers", "anglicisms", "markdown"],
-      "examples": ["Fjern AI-markører fra denne teksten", "Sjekk klarspråk i denne README-en"],
-      "collections": ["frontend", "fullstack", "nextjs-frontend"]
+      "tags": [
+        "norwegian",
+        "klarspråk",
+        "ai-markers",
+        "anglicisms",
+        "markdown"
+      ],
+      "examples": [
+        "Fjern AI-markører fra denne teksten",
+        "Sjekk klarspråk i denne README-en"
+      ],
+      "collections": [
+        "frontend",
+        "fullstack",
+        "nextjs-frontend"
+      ]
     },
     {
       "id": "performance",
@@ -828,12 +1080,20 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fperformance.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fperformance.instructions.md",
       "applyTo": "src/**/*.{tsx,ts}",
-      "tags": ["performance", "nextjs", "typescript", "core-web-vitals"],
+      "tags": [
+        "performance",
+        "nextjs",
+        "typescript",
+        "core-web-vitals"
+      ],
       "examples": [
         "Optimaliser lasting av bilder og fonter i Next.js-appen",
         "Analyser og reduser bundle-størrelsen for dp-soknad"
       ],
-      "collections": ["fullstack", "nextjs-frontend"]
+      "collections": [
+        "fullstack",
+        "nextjs-frontend"
+      ]
     },
     {
       "id": "security-owasp",
@@ -847,12 +1107,26 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fsecurity-owasp.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Fsecurity-owasp.instructions.md",
       "applyTo": "**/*.{kt,go,java,ts,tsx}",
-      "tags": ["security", "owasp", "kotlin", "go", "java", "nodejs", "typescript"],
+      "tags": [
+        "security",
+        "owasp",
+        "kotlin",
+        "go",
+        "java",
+        "nodejs",
+        "typescript"
+      ],
       "examples": [
         "Forebygg SQL- og kommandoinjeksjon med parameteriserte spørringer og trygg inputvalidering",
         "Verifiser tilgangskontroll eksplisitt og unngå logging av hemmeligheter"
       ],
-      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
+      "collections": [
+        "frontend",
+        "fullstack",
+        "kotlin-backend",
+        "nextjs-frontend",
+        "platform"
+      ]
     },
     {
       "id": "testing-kotlin",
@@ -866,7 +1140,10 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Ftesting-kotlin.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Ftesting-kotlin.instructions.md",
       "applyTo": "**/*.test.{kt,kts}",
-      "collections": ["fullstack", "kotlin-backend"]
+      "collections": [
+        "fullstack",
+        "kotlin-backend"
+      ]
     },
     {
       "id": "testing-typescript",
@@ -880,7 +1157,11 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Ftesting-typescript.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Ftesting-typescript.instructions.md",
       "applyTo": "**/*.test.{ts,tsx}",
-      "collections": ["frontend", "fullstack", "nextjs-frontend"]
+      "collections": [
+        "frontend",
+        "fullstack",
+        "nextjs-frontend"
+      ]
     },
     {
       "id": "testing",
@@ -894,9 +1175,22 @@
       "installUrl": "/install/instructions?url=vscode%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Ftesting.instructions.md",
       "insidersInstallUrl": "/install/instructions?url=vscode-insiders%3Achat-instructions%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Finstructions%2Ftesting.instructions.md",
       "applyTo": "**/*.test.{ts,tsx,kt,kts}",
-      "tags": ["testing", "vitest", "kotest", "quality"],
-      "examples": ["Skriv en test for validateSøknad() med grensetilfeller"],
-      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
+      "tags": [
+        "testing",
+        "vitest",
+        "kotest",
+        "quality"
+      ],
+      "examples": [
+        "Skriv en test for validateSøknad() med grensetilfeller"
+      ],
+      "collections": [
+        "frontend",
+        "fullstack",
+        "kotlin-backend",
+        "nextjs-frontend",
+        "platform"
+      ]
     },
     {
       "id": "aksel-component",
@@ -910,10 +1204,23 @@
       "installUrl": "/install/prompt?url=vscode%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Faksel-component.prompt.md",
       "insidersInstallUrl": "/install/prompt?url=vscode-insiders%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Faksel-component.prompt.md",
       "invocation": "#aksel-component",
-      "model": ["Claude Haiku 4.5"],
-      "tags": ["aksel", "design-system", "react", "component"],
-      "examples": ["#aksel-component Lag en varslingsbanner med ikon og lukkeknapp"],
-      "collections": ["frontend", "fullstack", "nextjs-frontend"]
+      "model": [
+        "Claude Haiku 4.5"
+      ],
+      "tags": [
+        "aksel",
+        "design-system",
+        "react",
+        "component"
+      ],
+      "examples": [
+        "#aksel-component Lag en varslingsbanner med ikon og lukkeknapp"
+      ],
+      "collections": [
+        "frontend",
+        "fullstack",
+        "nextjs-frontend"
+      ]
     },
     {
       "id": "golang-service",
@@ -927,8 +1234,13 @@
       "installUrl": "/install/prompt?url=vscode%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fgolang-service.prompt.md",
       "insidersInstallUrl": "/install/prompt?url=vscode-insiders%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fgolang-service.prompt.md",
       "invocation": "#golang-service",
-      "model": ["Claude Haiku 4.5"],
-      "collections": ["fullstack", "platform"]
+      "model": [
+        "Claude Haiku 4.5"
+      ],
+      "collections": [
+        "fullstack",
+        "platform"
+      ]
     },
     {
       "id": "kafka-topic",
@@ -942,10 +1254,22 @@
       "installUrl": "/install/prompt?url=vscode%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fkafka-topic.prompt.md",
       "insidersInstallUrl": "/install/prompt?url=vscode-insiders%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fkafka-topic.prompt.md",
       "invocation": "#kafka-topic",
-      "model": ["GPT-5.3-Codex"],
-      "tags": ["nais", "kafka", "rapids-rivers", "infrastructure"],
-      "examples": ["#kafka-topic Legg til et topic for sykmeldingshendelser"],
-      "collections": ["fullstack", "kotlin-backend"]
+      "model": [
+        "GPT-5.3-Codex"
+      ],
+      "tags": [
+        "nais",
+        "kafka",
+        "rapids-rivers",
+        "infrastructure"
+      ],
+      "examples": [
+        "#kafka-topic Legg til et topic for sykmeldingshendelser"
+      ],
+      "collections": [
+        "fullstack",
+        "kotlin-backend"
+      ]
     },
     {
       "id": "ktor-endpoint",
@@ -959,8 +1283,13 @@
       "installUrl": "/install/prompt?url=vscode%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fktor-endpoint.prompt.md",
       "insidersInstallUrl": "/install/prompt?url=vscode-insiders%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fktor-endpoint.prompt.md",
       "invocation": "#ktor-endpoint",
-      "model": ["Claude Haiku 4.5"],
-      "collections": ["fullstack", "kotlin-backend"]
+      "model": [
+        "Claude Haiku 4.5"
+      ],
+      "collections": [
+        "fullstack",
+        "kotlin-backend"
+      ]
     },
     {
       "id": "nais-manifest",
@@ -974,10 +1303,25 @@
       "installUrl": "/install/prompt?url=vscode%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fnais-manifest.prompt.md",
       "insidersInstallUrl": "/install/prompt?url=vscode-insiders%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fnais-manifest.prompt.md",
       "invocation": "#nais-manifest",
-      "model": ["GPT-5.3-Codex"],
-      "tags": ["nais", "kubernetes", "deployment", "infrastructure"],
-      "examples": ["#nais-manifest Generer et manifest for dp-soknad i prod-gcp"],
-      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
+      "model": [
+        "GPT-5.3-Codex"
+      ],
+      "tags": [
+        "nais",
+        "kubernetes",
+        "deployment",
+        "infrastructure"
+      ],
+      "examples": [
+        "#nais-manifest Generer et manifest for dp-soknad i prod-gcp"
+      ],
+      "collections": [
+        "frontend",
+        "fullstack",
+        "kotlin-backend",
+        "nextjs-frontend",
+        "platform"
+      ]
     },
     {
       "id": "nextjs-api-route",
@@ -991,10 +1335,22 @@
       "installUrl": "/install/prompt?url=vscode%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fnextjs-api-route.prompt.md",
       "insidersInstallUrl": "/install/prompt?url=vscode-insiders%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fnextjs-api-route.prompt.md",
       "invocation": "#nextjs-api-route",
-      "model": ["Claude Haiku 4.5"],
-      "tags": ["nextjs", "api-route", "app-router", "scaffold"],
-      "examples": ["#api-route Lag en API-route for å hente brukerdata fra BigQuery"],
-      "collections": ["fullstack", "nextjs-frontend"]
+      "model": [
+        "Claude Haiku 4.5"
+      ],
+      "tags": [
+        "nextjs",
+        "api-route",
+        "app-router",
+        "scaffold"
+      ],
+      "examples": [
+        "#api-route Lag en API-route for å hente brukerdata fra BigQuery"
+      ],
+      "collections": [
+        "fullstack",
+        "nextjs-frontend"
+      ]
     },
     {
       "id": "spring-boot-endpoint",
@@ -1008,10 +1364,23 @@
       "installUrl": "/install/prompt?url=vscode%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fspring-boot-endpoint.prompt.md",
       "insidersInstallUrl": "/install/prompt?url=vscode-insiders%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2F.github%2Fprompts%2Fspring-boot-endpoint.prompt.md",
       "invocation": "#spring-boot-endpoint",
-      "model": ["Claude Haiku 4.5"],
-      "tags": ["spring-boot", "kotlin", "rest", "endpoint", "scaffold"],
-      "examples": ["#spring-boot-endpoint Lag et CRUD-endepunkt for vedtak med PostgreSQL"],
-      "collections": ["fullstack", "kotlin-backend"]
+      "model": [
+        "Claude Haiku 4.5"
+      ],
+      "tags": [
+        "spring-boot",
+        "kotlin",
+        "rest",
+        "endpoint",
+        "scaffold"
+      ],
+      "examples": [
+        "#spring-boot-endpoint Lag et CRUD-endepunkt for vedtak med PostgreSQL"
+      ],
+      "collections": [
+        "fullstack",
+        "kotlin-backend"
+      ]
     },
     {
       "id": "aksel-spacing",
@@ -1021,10 +1390,20 @@
       "domain": "frontend",
       "filePath": ".github/skills/aksel-spacing/SKILL.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/aksel-spacing/SKILL.md",
-      "contentHash": "6d9a5ccb34884f110d1cfb2949bfdd3982318820780b41d68e824f3f85539263",
+      "contentHash": "d4e08ca183b2cde791ed54b401f642bea83485123d3e2f37815fe61832c67bf9",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["aksel", "design-system", "nav", "react", "spacing", "tokens", "layout", "responsive", "primitives"],
+      "tags": [
+        "aksel",
+        "design-system",
+        "nav",
+        "react",
+        "spacing",
+        "tokens",
+        "layout",
+        "responsive",
+        "primitives"
+      ],
       "examples": [
         "Lag en responsiv to-kolonne layout med HGrid og Aksel spacing tokens",
         "Bygg en mobil-first sidelayout med Page.Block og VStack",
@@ -1032,7 +1411,11 @@
         "Bruk Bleed til å la et banner strekke seg forbi container-padding",
         "Sett riktig padding med space-tokens - hva er space-16 i v8?"
       ],
-      "collections": ["frontend", "fullstack", "nextjs-frontend"]
+      "collections": [
+        "frontend",
+        "fullstack",
+        "nextjs-frontend"
+      ]
     },
     {
       "id": "api-design",
@@ -1045,7 +1428,13 @@
       "contentHash": "696738e209f8127d8b16d31a1d424fd3be0fbfd2486db782eb013192c4f054c2",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["api", "rest", "design", "openapi", "error-handling"],
+      "tags": [
+        "api",
+        "rest",
+        "design",
+        "openapi",
+        "error-handling"
+      ],
       "examples": [
         {
           "scenario": "REST API-design",
@@ -1068,7 +1457,10 @@
           "prompt": "Lag OpenAPI-annotasjoner for endepunktene"
         }
       ],
-      "collections": ["fullstack", "kotlin-backend"]
+      "collections": [
+        "fullstack",
+        "kotlin-backend"
+      ]
     },
     {
       "id": "conventional-commit",
@@ -1081,7 +1473,12 @@
       "contentHash": "7ff77862da5510a426758adab92663e987695d3fa2ff8e029f38584f9ea39f93",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["git", "commit", "conventional-commits", "changelog"],
+      "tags": [
+        "git",
+        "commit",
+        "conventional-commits",
+        "changelog"
+      ],
       "examples": [
         {
           "scenario": "Commit-melding",
@@ -1100,7 +1497,13 @@
           "prompt": "Hva slags type commit er denne endringen?"
         }
       ],
-      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
+      "collections": [
+        "frontend",
+        "fullstack",
+        "kotlin-backend",
+        "nextjs-frontend",
+        "platform"
+      ]
     },
     {
       "id": "flyway-migration",
@@ -1113,9 +1516,19 @@
       "contentHash": "6c5eebc88484b687dafab5d848f16b3cffa6345e19eb3e12428b167da4e23293",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["database", "flyway", "sql", "migration"],
-      "examples": ["Lag en Flyway-migrasjon som legger til en indeks på fødselsnummer"],
-      "collections": ["fullstack", "kotlin-backend"]
+      "tags": [
+        "database",
+        "flyway",
+        "sql",
+        "migration"
+      ],
+      "examples": [
+        "Lag en Flyway-migrasjon som legger til en indeks på fødselsnummer"
+      ],
+      "collections": [
+        "fullstack",
+        "kotlin-backend"
+      ]
     },
     {
       "id": "java-to-kotlin",
@@ -1128,7 +1541,14 @@
       "contentHash": "b8305c1d1251223b25bf5b30d418cd6c1898017a0abfe5742e7f80a1d87ad36d",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["kotlin", "java", "migration", "refactoring", "ktor", "spring"],
+      "tags": [
+        "kotlin",
+        "java",
+        "migration",
+        "refactoring",
+        "ktor",
+        "spring"
+      ],
       "examples": [
         {
           "prompt": "Konverter UserService.java til idiomatic Kotlin med Ktor-mønstre",
@@ -1139,7 +1559,10 @@
           "scenario": "Fullstendig migrasjonsplanlegging"
         }
       ],
-      "collections": ["fullstack", "kotlin-backend"]
+      "collections": [
+        "fullstack",
+        "kotlin-backend"
+      ]
     },
     {
       "id": "kafka",
@@ -1152,8 +1575,17 @@
       "contentHash": "17ebbc88c85f02427a544ffce9d08afb839ec4e32335555bec1ee8d5f7bcd211",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["kafka", "events", "rapids-rivers", "streaming", "event-driven"],
-      "collections": ["fullstack", "kotlin-backend"]
+      "tags": [
+        "kafka",
+        "events",
+        "rapids-rivers",
+        "streaming",
+        "event-driven"
+      ],
+      "collections": [
+        "fullstack",
+        "kotlin-backend"
+      ]
     },
     {
       "id": "kotlin-app-config",
@@ -1166,9 +1598,19 @@
       "contentHash": "ea6651cebef6be6a58069df6de2be1a2a248af41a0fd556382c90f4a02e63394",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["kotlin", "configuration", "sealed-class", "environment"],
-      "examples": ["Sett opp miljøkonfigurasjon med sealed classes i fp-sak for dev, prod og local"],
-      "collections": ["fullstack", "kotlin-backend"]
+      "tags": [
+        "kotlin",
+        "configuration",
+        "sealed-class",
+        "environment"
+      ],
+      "examples": [
+        "Sett opp miljøkonfigurasjon med sealed classes i fp-sak for dev, prod og local"
+      ],
+      "collections": [
+        "fullstack",
+        "kotlin-backend"
+      ]
     },
     {
       "id": "ktor-scaffold",
@@ -1181,7 +1623,13 @@
       "contentHash": "2cd6b7744d5b595542746e77b6a2232655430a7cd4f0b5037894ecc25cba493f",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["kotlin", "ktor", "scaffold", "nais", "kotliquery"],
+      "tags": [
+        "kotlin",
+        "ktor",
+        "scaffold",
+        "nais",
+        "kotliquery"
+      ],
       "examples": [
         {
           "prompt": "Scaffold en ny Ktor-tjeneste for dp-behandling med database og Kafka",
@@ -1192,7 +1640,10 @@
           "scenario": "API-tjeneste med database"
         }
       ],
-      "collections": ["fullstack", "kotlin-backend"]
+      "collections": [
+        "fullstack",
+        "kotlin-backend"
+      ]
     },
     {
       "id": "nais",
@@ -1205,8 +1656,19 @@
       "contentHash": "67a61515e9bd372b4ff1324914b8eb3ba3c06c4b114814002f9a6dee83ae1fb1",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["nais", "kubernetes", "deployment", "gcp", "infrastructure", "troubleshooting"],
-      "collections": ["fullstack", "kotlin-backend", "platform"]
+      "tags": [
+        "nais",
+        "kubernetes",
+        "deployment",
+        "gcp",
+        "infrastructure",
+        "troubleshooting"
+      ],
+      "collections": [
+        "fullstack",
+        "kotlin-backend",
+        "platform"
+      ]
     },
     {
       "id": "nav-architecture-review",
@@ -1219,7 +1681,13 @@
       "contentHash": "49053632149735a80f4cbf0f94a8bd652648ef622a375d14e45e592216899ce6",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["architecture", "adr", "review", "planning", "nav-pilot"],
+      "tags": [
+        "architecture",
+        "adr",
+        "review",
+        "planning",
+        "nav-pilot"
+      ],
       "examples": [
         {
           "prompt": "Generer en ADR for å bytte fra REST til Kafka for vedtakshendelser",
@@ -1240,7 +1708,13 @@
           "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/nav-architecture-review/references/nav-principles.md"
         }
       ],
-      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
+      "collections": [
+        "frontend",
+        "fullstack",
+        "kotlin-backend",
+        "nextjs-frontend",
+        "platform"
+      ]
     },
     {
       "id": "nav-auth",
@@ -1253,8 +1727,19 @@
       "contentHash": "61990d2e9ea8f1ee3160239725fb9dfc67410d65551da8112e5ed7cf724742fc",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["auth", "azure-ad", "tokenx", "id-porten", "maskinporten", "jwt", "oasis"],
-      "collections": ["fullstack", "kotlin-backend"]
+      "tags": [
+        "auth",
+        "azure-ad",
+        "tokenx",
+        "id-porten",
+        "maskinporten",
+        "jwt",
+        "oasis"
+      ],
+      "collections": [
+        "fullstack",
+        "kotlin-backend"
+      ]
     },
     {
       "id": "nav-deep-interview",
@@ -1267,7 +1752,13 @@
       "contentHash": "836d0873167176e2dcff40402e2513c185f55323fe5d8dc37e1974de0eb3ca87",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["planning", "requirements", "interview", "onboarding", "nav-pilot"],
+      "tags": [
+        "planning",
+        "requirements",
+        "interview",
+        "onboarding",
+        "nav-pilot"
+      ],
       "examples": [
         {
           "prompt": "Kjør et dypintervju for den nye dp-behandling-tjenesten",
@@ -1288,7 +1779,13 @@
           "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/nav-deep-interview/references/blind-spots.md"
         }
       ],
-      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
+      "collections": [
+        "frontend",
+        "fullstack",
+        "kotlin-backend",
+        "nextjs-frontend",
+        "platform"
+      ]
     },
     {
       "id": "nav-dekoratoren",
@@ -1301,7 +1798,16 @@
       "contentHash": "aa85d1a436d77c3ca4e451554f2a79b07fe26722103fda6e500836922ea8eaea",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["nav", "dekoratoren", "header", "footer", "integration", "ssr", "analytics", "consent"],
+      "tags": [
+        "nav",
+        "dekoratoren",
+        "header",
+        "footer",
+        "integration",
+        "ssr",
+        "analytics",
+        "consent"
+      ],
       "references": [
         {
           "path": "references/params.md",
@@ -1332,7 +1838,15 @@
       "contentHash": "a10798e1cdc522558c6fa4de9fb4b8da2267965e483873ee12362c7186949295",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["planning", "architecture", "scaffold", "nais", "nav-pilot", "modernization", "migration"],
+      "tags": [
+        "planning",
+        "architecture",
+        "scaffold",
+        "nais",
+        "nav-pilot",
+        "modernization",
+        "migration"
+      ],
       "examples": [
         {
           "prompt": "Lag en arkitekturplan for en ny dagpenge-API med PostgreSQL og Kafka",
@@ -1369,7 +1883,13 @@
           "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/nav-plan/references/modernization-patterns.md"
         }
       ],
-      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
+      "collections": [
+        "frontend",
+        "fullstack",
+        "kotlin-backend",
+        "nextjs-frontend",
+        "platform"
+      ]
     },
     {
       "id": "nav-troubleshoot",
@@ -1382,7 +1902,13 @@
       "contentHash": "eb50649eeb5b58401c306e0c00c698dd6ef97c788a0b67443dbb1d3e8b2cc66d",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["troubleshooting", "diagnostics", "nais", "kubernetes", "nav-pilot"],
+      "tags": [
+        "troubleshooting",
+        "diagnostics",
+        "nais",
+        "kubernetes",
+        "nav-pilot"
+      ],
       "examples": [
         {
           "prompt": "Poden min krasjer med CrashLoopBackOff i dev-gcp, hjelp meg feilsøke",
@@ -1403,7 +1929,13 @@
           "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/nav-troubleshoot/references/diagnostic-trees.md"
         }
       ],
-      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
+      "collections": [
+        "frontend",
+        "fullstack",
+        "kotlin-backend",
+        "nextjs-frontend",
+        "platform"
+      ]
     },
     {
       "id": "observability-debugging",
@@ -1416,7 +1948,18 @@
       "contentHash": "b93058442cb1d65247446e6736250a9747b792b833f50176a8e61d6f32685abd",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["debugging", "mimir", "loki", "tempo", "prometheus", "traces", "logs", "kubectl", "nais", "nav-pilot"],
+      "tags": [
+        "debugging",
+        "mimir",
+        "loki",
+        "tempo",
+        "prometheus",
+        "traces",
+        "logs",
+        "kubectl",
+        "nais",
+        "nav-pilot"
+      ],
       "examples": [
         {
           "prompt": "Appen min har plutselig høy feilrate i prod, hjelp meg feilsøke",
@@ -1441,7 +1984,11 @@
           "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/observability-debugging/references/query-library.md"
         }
       ],
-      "collections": ["fullstack", "kotlin-backend", "platform"]
+      "collections": [
+        "fullstack",
+        "kotlin-backend",
+        "platform"
+      ]
     },
     {
       "id": "observability-setup",
@@ -1454,8 +2001,15 @@
       "contentHash": "de63b0e140e841442ca0569c5cddbb62f435c6ef848d788c54343bd1bb22145a",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["prometheus", "opentelemetry", "health", "metrics"],
-      "examples": ["Sett opp Prometheus-metrikker og helseendepunkter for dp-soknad"],
+      "tags": [
+        "prometheus",
+        "opentelemetry",
+        "health",
+        "metrics"
+      ],
+      "examples": [
+        "Sett opp Prometheus-metrikker og helseendepunkter for dp-soknad"
+      ],
       "references": [
         {
           "path": "references/grafana-queries.md",
@@ -1466,7 +2020,11 @@
           "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/observability-setup/references/production-patterns.md"
         }
       ],
-      "collections": ["fullstack", "kotlin-backend", "platform"]
+      "collections": [
+        "fullstack",
+        "kotlin-backend",
+        "platform"
+      ]
     },
     {
       "id": "playwright-testing",
@@ -1476,10 +2034,16 @@
       "domain": "testing",
       "filePath": ".github/skills/playwright-testing/SKILL.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/playwright-testing/SKILL.md",
-      "contentHash": "28bd1aa68b19cf6a07693efdc81daea421f60ec2c2d4ae7e89c5f829e710dec4",
+      "contentHash": "1d7f13809c2955a870b56a4d49fd83b2913ee8fbf2145402eb934787c94e345c",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["playwright", "e2e", "testing", "accessibility", "responsive"],
+      "tags": [
+        "playwright",
+        "e2e",
+        "testing",
+        "accessibility",
+        "responsive"
+      ],
       "examples": [
         {
           "scenario": "Innlogging",
@@ -1502,7 +2066,11 @@
           "prompt": "Test responsiv layout med Playwright"
         }
       ],
-      "collections": ["frontend", "fullstack", "nextjs-frontend"]
+      "collections": [
+        "frontend",
+        "fullstack",
+        "nextjs-frontend"
+      ]
     },
     {
       "id": "postgresql-review",
@@ -1515,7 +2083,13 @@
       "contentHash": "fcd00261cd892df20fa5facbbdcef5e17181c4269f7c0473728e29e584721730",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["postgresql", "sql", "optimization", "review", "indexing"],
+      "tags": [
+        "postgresql",
+        "sql",
+        "optimization",
+        "review",
+        "indexing"
+      ],
       "examples": [
         {
           "scenario": "Ytelsesgjennomgang",
@@ -1538,7 +2112,10 @@
           "prompt": "Gå gjennom bruk av JSONB"
         }
       ],
-      "collections": ["fullstack", "kotlin-backend"]
+      "collections": [
+        "fullstack",
+        "kotlin-backend"
+      ]
     },
     {
       "id": "readme-review",
@@ -1551,7 +2128,12 @@
       "contentHash": "36fe844fd272d4035d7629b95a267ae8e8a24d4bb49f88c557d4cc45e2512167",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["readme", "documentation", "review", "scaffold"],
+      "tags": [
+        "readme",
+        "documentation",
+        "review",
+        "scaffold"
+      ],
       "examples": [
         "Gå gjennom README-en vår og foreslå forbedringer",
         "Lag en README for denne tjenesten",
@@ -1585,7 +2167,13 @@
           "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/readme-review/references/template-naisjob.md"
         }
       ],
-      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
+      "collections": [
+        "frontend",
+        "fullstack",
+        "kotlin-backend",
+        "nextjs-frontend",
+        "platform"
+      ]
     },
     {
       "id": "rust-development",
@@ -1598,7 +2186,13 @@
       "contentHash": "1b98a4c1653e164a2ca4acad3c2f5d8ce0c72f07b2bee6ca3418ca99cc2df2f3",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["rust", "cargo", "clippy", "async", "tokio"],
+      "tags": [
+        "rust",
+        "cargo",
+        "clippy",
+        "async",
+        "tokio"
+      ],
       "examples": [
         {
           "prompt": "Sett opp et nytt Rust-prosjekt med anbefalte lints",
@@ -1617,7 +2211,9 @@
           "scenario": "Review av unsafe-kode"
         }
       ],
-      "collections": ["platform"]
+      "collections": [
+        "platform"
+      ]
     },
     {
       "id": "security-owasp",
@@ -1630,7 +2226,16 @@
       "contentHash": "1d72bcd9d530e5cd28e8683384a356024375d71f6a5b849c2c28049635b75d30",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["security", "owasp", "kotlin", "go", "java", "nodejs", "nais", "supply-chain"],
+      "tags": [
+        "security",
+        "owasp",
+        "kotlin",
+        "go",
+        "java",
+        "nodejs",
+        "nais",
+        "supply-chain"
+      ],
       "examples": [
         {
           "prompt": "Vis sikre mønstre for tilgangskontroll i Ktor-endepunktene mine",
@@ -1653,7 +2258,13 @@
           "scenario": "OWASP — Node.js/Next.js-mønstre"
         }
       ],
-      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
+      "collections": [
+        "frontend",
+        "fullstack",
+        "kotlin-backend",
+        "nextjs-frontend",
+        "platform"
+      ]
     },
     {
       "id": "security-review",
@@ -1666,7 +2277,12 @@
       "contentHash": "d6a6bbddfc7f18c09f1e062ad9207dc05ff1fc58c111ce1bb9b88b3277806c75",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["security", "pre-commit", "vulnerability-scanning", "code-review"],
+      "tags": [
+        "security",
+        "pre-commit",
+        "vulnerability-scanning",
+        "code-review"
+      ],
       "examples": [
         {
           "prompt": "Kjør en sikkerhetssjekk på endringene i fp-sak før jeg pusher",
@@ -1677,7 +2293,11 @@
           "scenario": "Sikkerhetssjekk av PR"
         }
       ],
-      "collections": ["fullstack", "kotlin-backend", "platform"]
+      "collections": [
+        "fullstack",
+        "kotlin-backend",
+        "platform"
+      ]
     },
     {
       "id": "spring-boot-scaffold",
@@ -1690,7 +2310,13 @@
       "contentHash": "8fd5a5713062c0c5fb2c1c1679847d3e791f9cea3bc45a12121daa57cd5fec60",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["spring-boot", "kotlin", "scaffold", "nais", "project-setup"],
+      "tags": [
+        "spring-boot",
+        "kotlin",
+        "scaffold",
+        "nais",
+        "project-setup"
+      ],
       "examples": [
         {
           "scenario": "Nytt prosjekt",
@@ -1709,7 +2335,10 @@
           "prompt": "Generer prosjektstruktur for ny backend-tjeneste"
         }
       ],
-      "collections": ["fullstack", "kotlin-backend"]
+      "collections": [
+        "fullstack",
+        "kotlin-backend"
+      ]
     },
     {
       "id": "terse-mode",
@@ -1722,7 +2351,12 @@
       "contentHash": "26ec6b397bdd2e9611c00be143354bc76997102bfa7eea18b5483e69c01f1865",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["token-optimization", "output", "conciseness", "communication-style"],
+      "tags": [
+        "token-optimization",
+        "output",
+        "conciseness",
+        "communication-style"
+      ],
       "examples": [
         {
           "scenario": "Aktiver terse mode",
@@ -1741,7 +2375,13 @@
           "prompt": "Forklar connection pooling med $terse-mode"
         }
       ],
-      "collections": ["frontend", "fullstack", "kotlin-backend", "nextjs-frontend", "platform"]
+      "collections": [
+        "frontend",
+        "fullstack",
+        "kotlin-backend",
+        "nextjs-frontend",
+        "platform"
+      ]
     },
     {
       "id": "threat-model",
@@ -1754,7 +2394,13 @@
       "contentHash": "347f2167d828793a968ffcf208b698bcd2b37c6c0321096b7bc9eb2dd4ed15ea",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["threat-modeling", "stride", "security", "nais", "architecture"],
+      "tags": [
+        "threat-modeling",
+        "stride",
+        "security",
+        "nais",
+        "architecture"
+      ],
       "examples": [
         {
           "prompt": "Lag en trusselmodell for dp-soknad som behandler søknader om dagpenger",
@@ -1771,7 +2417,11 @@
           "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/threat-model/references/nav-mitigations.md"
         }
       ],
-      "collections": ["fullstack", "kotlin-backend", "platform"]
+      "collections": [
+        "fullstack",
+        "kotlin-backend",
+        "platform"
+      ]
     },
     {
       "id": "tokenx-auth",
@@ -1784,9 +2434,19 @@
       "contentHash": "efa91db0fb79778288ad17a1ef0b8a6e8437cc73912be0a40dc513554921e201",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["tokenx", "auth", "service-to-service", "nais"],
-      "examples": ["Sett opp TokenX-utveksling mellom dp-soknad og dp-inntekt"],
-      "collections": ["fullstack", "kotlin-backend"]
+      "tags": [
+        "tokenx",
+        "auth",
+        "service-to-service",
+        "nais"
+      ],
+      "examples": [
+        "Sett opp TokenX-utveksling mellom dp-soknad og dp-inntekt"
+      ],
+      "collections": [
+        "fullstack",
+        "kotlin-backend"
+      ]
     },
     {
       "id": "web-design-reviewer",
@@ -1799,7 +2459,13 @@
       "contentHash": "1cb4e5b4bad72ca84b0e47b02f96fa33a3e3d86523328fbe493cf7d44ac46857",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["design-review", "responsive", "accessibility", "layout", "visual-inspection"],
+      "tags": [
+        "design-review",
+        "responsive",
+        "accessibility",
+        "layout",
+        "visual-inspection"
+      ],
       "examples": [
         {
           "prompt": "Sjekk designet på localhost:3000 og finn layout-problemer",
@@ -1820,7 +2486,11 @@
           "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/.github/skills/web-design-reviewer/references/visual-checklist.md"
         }
       ],
-      "collections": ["frontend", "fullstack", "nextjs-frontend"]
+      "collections": [
+        "frontend",
+        "fullstack",
+        "nextjs-frontend"
+      ]
     },
     {
       "id": "workstation-security",
@@ -1833,7 +2503,13 @@
       "contentHash": "f3cd4b414201ace0853c695d8369bd6ee353ae469d1d7eccf02332e9dc97ef04",
       "installUrl": null,
       "insidersInstallUrl": null,
-      "tags": ["security", "macos", "developer-tools", "audit", "hardening"],
+      "tags": [
+        "security",
+        "macos",
+        "developer-tools",
+        "audit",
+        "hardening"
+      ],
       "examples": [
         {
           "prompt": "Kjør en sikkerhetssjekk av Mac-en min",
@@ -1852,7 +2528,11 @@
           "scenario": "Klarsjekk for Nav-plattformen"
         }
       ],
-      "collections": ["fullstack", "kotlin-backend", "platform"]
+      "collections": [
+        "fullstack",
+        "kotlin-backend",
+        "platform"
+      ]
     }
   ]
 }

--- a/apps/my-copilot/src/lib/install-commands.test.ts
+++ b/apps/my-copilot/src/lib/install-commands.test.ts
@@ -348,8 +348,8 @@ describe("getMcpServerConfig", () => {
 
   it("generates stdio config for npm package", () => {
     const config = JSON.parse(getMcpServerConfig(npmMcp));
-    expect(config["figma-mcp"].command).toBe("pnx");
-    expect(config["figma-mcp"].args).toContain("-y");
+    expect(config["figma-mcp"].command).toBe("pnpm");
+    expect(config["figma-mcp"].args).toContain("dlx");
     expect(config["figma-mcp"].args).toContain("@anthropic/figma-mcp");
     expect(config["figma-mcp"].args).toContain("--port");
     expect(config["figma-mcp"].args).toContain("3333");
@@ -386,7 +386,8 @@ describe("getVsCodeAddMcpCommand", () => {
     const cmd = getVsCodeAddMcpCommand(npmMcp);
     const json = JSON.parse(cmd.replace("code --add-mcp '", "").replace(/'$/, ""));
     expect(json.name).toBe("figma-mcp");
-    expect(json.command).toBe("pnx");
+    expect(json.command).toBe("pnpm");
+    expect(json.args).toContain("dlx");
     expect(json.env.FIGMA_TOKEN).toBe("${input:FIGMA_TOKEN}");
     expect(json.env.DEBUG).toBe("Enable debug logging");
   });
@@ -410,7 +411,7 @@ describe("getMcpAddFields", () => {
     const fields = getMcpAddFields(npmMcp)!;
     expect(fields.name).toBe("figma-mcp");
     expect(fields.type).toBe("STDIO");
-    expect(fields.command).toContain("pnx");
+    expect(fields.command).toContain("pnpm dlx");
     expect(fields.command).toContain("@anthropic/figma-mcp");
     expect(fields.env).toContain("FIGMA_TOKEN=...");
     expect(fields.env).toContain("DEBUG=Enable debug logging");

--- a/apps/my-copilot/src/lib/install-commands.test.ts
+++ b/apps/my-copilot/src/lib/install-commands.test.ts
@@ -348,7 +348,7 @@ describe("getMcpServerConfig", () => {
 
   it("generates stdio config for npm package", () => {
     const config = JSON.parse(getMcpServerConfig(npmMcp));
-    expect(config["figma-mcp"].command).toBe("npx");
+    expect(config["figma-mcp"].command).toBe("pnx");
     expect(config["figma-mcp"].args).toContain("-y");
     expect(config["figma-mcp"].args).toContain("@anthropic/figma-mcp");
     expect(config["figma-mcp"].args).toContain("--port");
@@ -386,7 +386,7 @@ describe("getVsCodeAddMcpCommand", () => {
     const cmd = getVsCodeAddMcpCommand(npmMcp);
     const json = JSON.parse(cmd.replace("code --add-mcp '", "").replace(/'$/, ""));
     expect(json.name).toBe("figma-mcp");
-    expect(json.command).toBe("npx");
+    expect(json.command).toBe("pnx");
     expect(json.env.FIGMA_TOKEN).toBe("${input:FIGMA_TOKEN}");
     expect(json.env.DEBUG).toBe("Enable debug logging");
   });
@@ -410,7 +410,7 @@ describe("getMcpAddFields", () => {
     const fields = getMcpAddFields(npmMcp)!;
     expect(fields.name).toBe("figma-mcp");
     expect(fields.type).toBe("STDIO");
-    expect(fields.command).toContain("npx");
+    expect(fields.command).toContain("pnx");
     expect(fields.command).toContain("@anthropic/figma-mcp");
     expect(fields.env).toContain("FIGMA_TOKEN=...");
     expect(fields.env).toContain("DEBUG=Enable debug logging");

--- a/apps/my-copilot/src/lib/install-commands.ts
+++ b/apps/my-copilot/src/lib/install-commands.ts
@@ -119,9 +119,9 @@ function buildPackageArgs(pkg: NonNullable<Extract<AnyCustomization, { type: "mc
   runtime: string;
   args: string[];
 } | null {
-  const runtime = pkg.registryType === "npm" ? "pnx" : pkg.registryType === "pypi" ? "uvx" : null;
+  const runtime = pkg.registryType === "npm" ? "pnpm" : pkg.registryType === "pypi" ? "uvx" : null;
   if (!runtime) return null;
-  const args: string[] = pkg.registryType === "npm" ? ["-y", pkg.identifier] : [pkg.identifier];
+  const args: string[] = pkg.registryType === "npm" ? ["dlx", pkg.identifier] : [pkg.identifier];
   if (pkg.packageArguments) {
     for (const arg of pkg.packageArguments) {
       if (arg.name) args.push(arg.name);

--- a/apps/my-copilot/src/lib/install-commands.ts
+++ b/apps/my-copilot/src/lib/install-commands.ts
@@ -119,7 +119,7 @@ function buildPackageArgs(pkg: NonNullable<Extract<AnyCustomization, { type: "mc
   runtime: string;
   args: string[];
 } | null {
-  const runtime = pkg.registryType === "npm" ? "npx" : pkg.registryType === "pypi" ? "uvx" : null;
+  const runtime = pkg.registryType === "npm" ? "pnx" : pkg.registryType === "pypi" ? "uvx" : null;
   if (!runtime) return null;
   const args: string[] = pkg.registryType === "npm" ? ["-y", pkg.identifier] : [pkg.identifier];
   if (pkg.packageArguments) {

--- a/skills/aksel-spacing/SKILL.md
+++ b/skills/aksel-spacing/SKILL.md
@@ -319,7 +319,7 @@ Props: `above` | `below` (breakpoint-nøkkel: `sm` | `md` | `lg` | `xl` | `2xl`)
 Tokens er ikke bakoverkompatible. Bruk codemod:
 
 ```bash
-npx @navikt/aksel codemod v8-spacing-tokens ./src
+pnx @navikt/aksel codemod v8-spacing-tokens ./src
 ```
 
 | v7 (feil i v8) | v8 (korrekt) | px   |

--- a/skills/aksel-spacing/SKILL.md
+++ b/skills/aksel-spacing/SKILL.md
@@ -319,7 +319,7 @@ Props: `above` | `below` (breakpoint-nøkkel: `sm` | `md` | `lg` | `xl` | `2xl`)
 Tokens er ikke bakoverkompatible. Bruk codemod:
 
 ```bash
-pnx @navikt/aksel codemod v8-spacing-tokens ./src
+pnpm exec aksel codemod v8-spacing-tokens ./src
 ```
 
 | v7 (feil i v8) | v8 (korrekt) | px   |

--- a/skills/playwright-testing/SKILL.md
+++ b/skills/playwright-testing/SKILL.md
@@ -25,10 +25,10 @@ Generate Playwright tests for Nav web applications. Covers page object pattern, 
 ```bash
 # Install Playwright
 pnpm add -D @playwright/test
-pnx playwright install --with-deps chromium
+pnpm exec playwright install --with-deps chromium
 
 # Create configuration
-pnx playwright init
+pnpm exec playwright init
 ```
 
 ### playwright.config.ts
@@ -238,7 +238,7 @@ e2e:
         node-version: 22
         cache: pnpm
     - run: pnpm install --frozen-lockfile
-    - run: pnx playwright install --with-deps chromium
+    - run: pnpm exec playwright install --with-deps chromium
     - run: pnpm exec playwright test
     - uses: actions/upload-artifact@v4
       if: failure()

--- a/skills/playwright-testing/SKILL.md
+++ b/skills/playwright-testing/SKILL.md
@@ -25,10 +25,10 @@ Generate Playwright tests for Nav web applications. Covers page object pattern, 
 ```bash
 # Install Playwright
 pnpm add -D @playwright/test
-npx playwright install --with-deps chromium
+pnx playwright install --with-deps chromium
 
 # Create configuration
-npx playwright init
+pnx playwright init
 ```
 
 ### playwright.config.ts
@@ -238,7 +238,7 @@ e2e:
         node-version: 22
         cache: pnpm
     - run: pnpm install --frozen-lockfile
-    - run: npx playwright install --with-deps chromium
+    - run: pnx playwright install --with-deps chromium
     - run: pnpm exec playwright test
     - uses: actions/upload-artifact@v4
       if: failure()


### PR DESCRIPTION
`npx` respekterer ikke settings for cooldowns og lifecycle scripts

```
Since v11.0.0, pnx (and its pnpm dlx / pnpx aliases) honors the project-level security and trust policy settings when resolving and fetching the requested package:

[minimumReleaseAge](https://pnpm.io/settings#minimumreleaseage), [minimumReleaseAgeExclude](https://pnpm.io/settings#minimumreleaseageexclude), [minimumReleaseAgeStrict](https://pnpm.io/settings#minimumreleaseage)
[trustPolicy](https://pnpm.io/settings#trustpolicy), [trustPolicyExclude](https://pnpm.io/settings#trustpolicyexclude), [trustPolicyIgnoreAfter](https://pnpm.io/settings#trustpolicyignoreafter)
This means pnx will refuse to execute freshly published or insufficiently trusted packages the same way a regular pnpm install would.
```