### PR TITLE
feat(nav-pilot): add nav.repo join key to session OTel resource attributes

### DIFF
--- a/cli/nav-pilot/TELEMETRY.md
+++ b/cli/nav-pilot/TELEMETRY.md
@@ -64,6 +64,7 @@ Klassifisering prioriterer:
 
 **Hva sendes IKKE:**
 - ✗ Filstier, reponavn, eller prosjektkontekst
+  (unntak: `nav.repo`-slug for navikt-repoer på agent-sessions, se seksjon 3)
 - ✗ Innhold fra Copilot-instruksjoner eller agenter
 - ✗ Bruker-ID (aldri NAVident, e-post, GitHub-brukernavn)
 - ✗ Git-commit-info eller miljøvariabler
@@ -132,9 +133,24 @@ nav-pilot. Eksisterende nøkler beholdes (append-merge, ingen overskriving):
 | `nav.pilot.launcher` | `nav-pilot` | Isolere Copilot-sessions startet via nav-pilot |
 | `nav.pilot.version` | nav-pilot-versjon | Adopsjon/versjon av launcheren |
 | `nav.pilot.device_id` | pseudonymt `nav-pilot-<hash>` | Join (på verdi) mot nav-pilots egen `device_id`-attributt |
+| `nav.repo` | `navikt/<repo>`-slug fra `origin`-remote | Join (server-side, ved spørring) mot repo→team-mapping, slik at sessionsdata kan aggregeres per team (issue #344) |
 
 `nav.pilot.device_id` injiseres kun når nav-pilot-telemetri er aktiv; med
 `NAV_PILOT_TELEMETRY_ENABLED=false` utelates den (launcher/version beholdes).
+
+`nav.repo` settes kun når nav-pilot startes inne i et git-repo hvis
+`origin`-remote peker på GitHub-organisasjonen `navikt` (både ssh-formen
+`git@github.com:navikt/foo.git` og https-formen `https://github.com/navikt/foo`,
+med eller uten `.git`, gjenkjennes). Attributten identifiserer en **kodebase,
+ikke en person**.
+
+**Hva `nav.repo` IKKE samler inn:**
+- ✗ Ingen brukernavn, e-post eller NAVident
+- ✗ Ingen hostname
+- ✗ Ingen filstier — kun `owner/navn`-slug utledet fra remote-URL-en
+- ✗ Utenfor navikt-repoer utelates attributten **helt** (ikke et git-repo,
+  ingen `origin`-remote, eller remote utenfor navikt-org) — det gjettes aldri
+- ✗ En bruker-satt `nav.repo` i `OTEL_RESOURCE_ATTRIBUTES` overskrives aldri
 
 #### Per-device-spørringer på Copilot-data («vis brukeren egne data»)
 

--- a/cli/nav-pilot/internal/telemetry/copilot_otel.go
+++ b/cli/nav-pilot/internal/telemetry/copilot_otel.go
@@ -31,7 +31,7 @@ func ApplyCopilotOTelEnv(env []string, cliVersion string) ([]string, bool) {
 	if TelemetryEnabled() {
 		deviceID = CopilotDeviceID()
 	}
-	env, updated = applyCopilotResourceAttributes(env, normalizeTelemetryDimension(cliVersion, "dev"), deviceID)
+	env, updated = applyCopilotResourceAttributes(env, normalizeTelemetryDimension(cliVersion, "dev"), deviceID, detectNavRepo())
 	changed = changed || updated
 
 	return env, changed
@@ -59,7 +59,7 @@ func ApplyOpenCodeOTelEnv(env []string, cliVersion string) ([]string, bool) {
 	if TelemetryEnabled() {
 		deviceID = CopilotDeviceID()
 	}
-	env, updated = applyCopilotResourceAttributes(env, normalizeTelemetryDimension(cliVersion, "dev"), deviceID)
+	env, updated = applyCopilotResourceAttributes(env, normalizeTelemetryDimension(cliVersion, "dev"), deviceID, detectNavRepo())
 	changed = changed || updated
 
 	env, updated = SetEnvIfAbsent(env, "OPENCODE_CLIENT", "nav-pilot")
@@ -87,11 +87,14 @@ func CopilotDeviceID() string {
 // OTEL_RESOURCE_ATTRIBUTES so Copilot's spans and metrics can be attributed
 // back to nav-pilot. It only appends keys that are not already present, so
 // values set by the user or CI environment are never overwritten.
-func applyCopilotResourceAttributes(env []string, version, deviceID string) ([]string, bool) {
+func applyCopilotResourceAttributes(env []string, version, deviceID, repo string) ([]string, bool) {
 	pairs := []struct{ key, value string }{
 		{"nav.pilot.launcher", "nav-pilot"},
 		{"nav.pilot.version", strings.TrimSpace(version)},
 		{"nav.pilot.device_id", strings.TrimSpace(deviceID)},
+		// repo is empty (and the attribute omitted) outside navikt repos, so
+		// it identifies a codebase for team-level joins — never a person.
+		{"nav.repo", strings.TrimSpace(repo)},
 	}
 
 	existing := LookupEnvValue(env, "OTEL_RESOURCE_ATTRIBUTES")

--- a/cli/nav-pilot/internal/telemetry/copilot_otel_test.go
+++ b/cli/nav-pilot/internal/telemetry/copilot_otel_test.go
@@ -110,6 +110,7 @@ func TestApplyCopilotOTelEnv(t *testing.T) {
 	})
 
 	t.Run("injects nav-pilot resource attributes", func(t *testing.T) {
+		stubDetectNavRepo(t, "")
 		envOut, _ := ApplyCopilotOTelEnv([]string{}, "dev")
 		got := LookupEnvValue(envOut, "OTEL_RESOURCE_ATTRIBUTES")
 		if !strings.Contains(got, "nav.pilot.launcher=nav-pilot") {
@@ -134,12 +135,42 @@ func TestApplyCopilotOTelEnv(t *testing.T) {
 			t.Fatalf("launcher should still be present: %q", got)
 		}
 	})
+
+	t.Run("injects nav.repo when launched inside a navikt repo", func(t *testing.T) {
+		stubDetectNavRepo(t, "navikt/foo")
+		envOut, _ := ApplyCopilotOTelEnv([]string{}, "dev")
+		got := LookupEnvValue(envOut, "OTEL_RESOURCE_ATTRIBUTES")
+		if !strings.Contains(got, "nav.repo=navikt%2Ffoo") {
+			t.Fatalf("OTEL_RESOURCE_ATTRIBUTES = %q, want nav.repo=navikt%%2Ffoo", got)
+		}
+	})
+
+	t.Run("omits nav.repo outside navikt repos", func(t *testing.T) {
+		stubDetectNavRepo(t, "")
+		envOut, _ := ApplyCopilotOTelEnv([]string{}, "dev")
+		got := LookupEnvValue(envOut, "OTEL_RESOURCE_ATTRIBUTES")
+		if strings.Contains(got, "nav.repo=") {
+			t.Fatalf("nav.repo should be omitted when no navikt repo is detected: %q", got)
+		}
+	})
+}
+
+// stubDetectNavRepo pins repo detection for the duration of a test so the
+// outcome does not depend on which git checkout the tests happen to run
+// inside. Mutating the package variable is safe because the telemetry
+// package tests are sequential-only by design (t.Setenv is used throughout,
+// which is incompatible with t.Parallel).
+func stubDetectNavRepo(t *testing.T, repo string) {
+	t.Helper()
+	prev := detectNavRepo
+	detectNavRepo = func() string { return repo }
+	t.Cleanup(func() { detectNavRepo = prev })
 }
 
 func TestApplyCopilotResourceAttributes(t *testing.T) {
 	t.Run("appends to existing attributes without clobbering", func(t *testing.T) {
 		envIn := []string{"OTEL_RESOURCE_ATTRIBUTES=team=foo,nav.pilot.version=9.9.9"}
-		envOut, changed := applyCopilotResourceAttributes(envIn, "1.2.3", "nav-pilot-abc123")
+		envOut, changed := applyCopilotResourceAttributes(envIn, "1.2.3", "nav-pilot-abc123", "")
 		if !changed {
 			t.Fatal("expected env to be changed")
 		}
@@ -159,7 +190,7 @@ func TestApplyCopilotResourceAttributes(t *testing.T) {
 	})
 
 	t.Run("skips empty values", func(t *testing.T) {
-		envOut, changed := applyCopilotResourceAttributes([]string{}, "", "")
+		envOut, changed := applyCopilotResourceAttributes([]string{}, "", "", "")
 		if !changed {
 			t.Fatal("expected launcher attribute to be added")
 		}
@@ -170,7 +201,7 @@ func TestApplyCopilotResourceAttributes(t *testing.T) {
 	})
 
 	t.Run("percent-encodes unsafe characters", func(t *testing.T) {
-		envOut, _ := applyCopilotResourceAttributes([]string{}, "1.0 beta,rc=1", "id")
+		envOut, _ := applyCopilotResourceAttributes([]string{}, "1.0 beta,rc=1", "id", "")
 		got := LookupEnvValue(envOut, "OTEL_RESOURCE_ATTRIBUTES")
 		if !strings.Contains(got, "nav.pilot.version=1.0%20beta%2Crc%3D1") {
 			t.Fatalf("value not percent-encoded: %q", got)
@@ -178,11 +209,11 @@ func TestApplyCopilotResourceAttributes(t *testing.T) {
 	})
 
 	t.Run("is idempotent across relaunch", func(t *testing.T) {
-		env1, changed1 := applyCopilotResourceAttributes([]string{}, "1.2.3", "nav-pilot-abc123")
+		env1, changed1 := applyCopilotResourceAttributes([]string{}, "1.2.3", "nav-pilot-abc123", "")
 		if !changed1 {
 			t.Fatal("expected first call to change env")
 		}
-		env2, changed2 := applyCopilotResourceAttributes(env1, "1.2.3", "nav-pilot-abc123")
+		env2, changed2 := applyCopilotResourceAttributes(env1, "1.2.3", "nav-pilot-abc123", "")
 		if changed2 {
 			t.Fatal("expected second call to be a no-op")
 		}
@@ -193,7 +224,7 @@ func TestApplyCopilotResourceAttributes(t *testing.T) {
 
 	t.Run("recognises a bare existing key without value", func(t *testing.T) {
 		envIn := []string{"OTEL_RESOURCE_ATTRIBUTES=nav.pilot.launcher"}
-		envOut, _ := applyCopilotResourceAttributes(envIn, "1.2.3", "nav-pilot-abc123")
+		envOut, _ := applyCopilotResourceAttributes(envIn, "1.2.3", "nav-pilot-abc123", "")
 		got := LookupEnvValue(envOut, "OTEL_RESOURCE_ATTRIBUTES")
 		if strings.Contains(got, "nav.pilot.launcher=nav-pilot") {
 			t.Fatalf("bare existing key should not be re-added with a value: %q", got)
@@ -202,7 +233,7 @@ func TestApplyCopilotResourceAttributes(t *testing.T) {
 
 	t.Run("tolerates whitespace and trailing commas in existing value", func(t *testing.T) {
 		envIn := []string{"OTEL_RESOURCE_ATTRIBUTES= team = foo ,"}
-		envOut, changed := applyCopilotResourceAttributes(envIn, "1.2.3", "nav-pilot-abc123")
+		envOut, changed := applyCopilotResourceAttributes(envIn, "1.2.3", "nav-pilot-abc123", "")
 		if !changed {
 			t.Fatal("expected env to be changed")
 		}
@@ -212,6 +243,37 @@ func TestApplyCopilotResourceAttributes(t *testing.T) {
 		}
 		if !strings.Contains(got, "nav.pilot.launcher=nav-pilot") {
 			t.Fatalf("missing launcher attribute: %q", got)
+		}
+	})
+
+	t.Run("appends nav.repo when a repo is detected", func(t *testing.T) {
+		envOut, changed := applyCopilotResourceAttributes([]string{}, "1.2.3", "nav-pilot-abc123", "navikt/foo")
+		if !changed {
+			t.Fatal("expected env to be changed")
+		}
+		got := LookupEnvValue(envOut, "OTEL_RESOURCE_ATTRIBUTES")
+		if !strings.Contains(got, "nav.repo=navikt%2Ffoo") {
+			t.Fatalf("missing nav.repo attribute: %q", got)
+		}
+	})
+
+	t.Run("omits nav.repo when no repo is detected", func(t *testing.T) {
+		envOut, _ := applyCopilotResourceAttributes([]string{}, "1.2.3", "nav-pilot-abc123", "")
+		got := LookupEnvValue(envOut, "OTEL_RESOURCE_ATTRIBUTES")
+		if strings.Contains(got, "nav.repo=") {
+			t.Fatalf("nav.repo should be omitted when empty: %q", got)
+		}
+	})
+
+	t.Run("preserves a user-set nav.repo", func(t *testing.T) {
+		envIn := []string{"OTEL_RESOURCE_ATTRIBUTES=nav.repo=custom/override"}
+		envOut, _ := applyCopilotResourceAttributes(envIn, "1.2.3", "nav-pilot-abc123", "navikt/foo")
+		got := LookupEnvValue(envOut, "OTEL_RESOURCE_ATTRIBUTES")
+		if strings.Count(got, "nav.repo=") != 1 {
+			t.Fatalf("user-set nav.repo was overwritten: %q", got)
+		}
+		if !strings.Contains(got, "nav.repo=custom/override") {
+			t.Fatalf("user-set nav.repo value not preserved: %q", got)
 		}
 	})
 }

--- a/cli/nav-pilot/internal/telemetry/repo.go
+++ b/cli/nav-pilot/internal/telemetry/repo.go
@@ -1,0 +1,71 @@
+package telemetry
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// navRepoGitTimeout bounds the git invocation used for repo detection so a
+// hung git (e.g. slow credential helper or network filesystem) can never
+// delay a session launch noticeably.
+const navRepoGitTimeout = 2 * time.Second
+
+// detectNavRepo resolves the navikt repo slug for the current working
+// directory. It is a package-level variable so tests can stub it and stay
+// independent of whichever git checkout the tests happen to run inside
+// (the telemetry tests are sequential-only, so save/restore is safe).
+var detectNavRepo = func() string { return navRepoFromDir("") }
+
+// navRepoFromDir returns the "owner/name" slug of the git origin remote in
+// dir (or the process working directory when dir is empty), but only when
+// the remote points to the navikt GitHub org. On any other outcome — not a
+// git repo, no origin remote, git missing, timeout, non-navikt remote — it
+// returns "" so the caller omits the attribute entirely: we never guess and
+// never leak local paths or third-party remotes into telemetry.
+func navRepoFromDir(dir string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), navRepoGitTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "remote", "get-url", "origin")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return parseNavRepo(string(out))
+}
+
+// parseNavRepo extracts a "navikt/<name>" slug from a git remote URL,
+// accepting the common ssh (git@github.com:navikt/foo.git), ssh-URL
+// (ssh://git@github.com/navikt/foo.git) and https
+// (https://github.com/navikt/foo, with or without .git) forms. Any remote
+// outside the navikt GitHub org yields "".
+func parseNavRepo(remote string) string {
+	remote = strings.TrimSpace(remote)
+
+	var path string
+	switch {
+	case strings.HasPrefix(remote, "git@github.com:"):
+		path = strings.TrimPrefix(remote, "git@github.com:")
+	case strings.HasPrefix(remote, "ssh://git@github.com/"):
+		path = strings.TrimPrefix(remote, "ssh://git@github.com/")
+	case strings.HasPrefix(remote, "https://github.com/"):
+		path = strings.TrimPrefix(remote, "https://github.com/")
+	default:
+		return ""
+	}
+
+	path = strings.TrimSuffix(strings.Trim(path, "/"), ".git")
+	parts := strings.Split(path, "/")
+	if len(parts) != 2 || parts[1] == "" {
+		return ""
+	}
+	if !strings.EqualFold(parts[0], "navikt") {
+		return ""
+	}
+	return "navikt/" + parts[1]
+}

--- a/cli/nav-pilot/internal/telemetry/repo_test.go
+++ b/cli/nav-pilot/internal/telemetry/repo_test.go
@@ -1,0 +1,94 @@
+package telemetry
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestParseNavRepo(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "ssh form", in: "git@github.com:navikt/foo.git", want: "navikt/foo"},
+		{name: "ssh form without .git", in: "git@github.com:navikt/foo", want: "navikt/foo"},
+		{name: "ssh url form", in: "ssh://git@github.com/navikt/foo.git", want: "navikt/foo"},
+		{name: "https form with .git", in: "https://github.com/navikt/foo.git", want: "navikt/foo"},
+		{name: "https form without .git", in: "https://github.com/navikt/foo", want: "navikt/foo"},
+		{name: "https form with trailing slash", in: "https://github.com/navikt/foo/", want: "navikt/foo"},
+		{name: "owner casing normalized", in: "git@github.com:NAVIKT/foo.git", want: "navikt/foo"},
+		{name: "surrounding whitespace trimmed", in: "  git@github.com:navikt/foo.git\n", want: "navikt/foo"},
+		{name: "non-navikt org omitted", in: "git@github.com:otherorg/foo.git", want: ""},
+		{name: "non-navikt https omitted", in: "https://github.com/otherorg/foo.git", want: ""},
+		{name: "non-github host omitted", in: "git@gitlab.com:navikt/foo.git", want: ""},
+		{name: "local path omitted", in: "/home/user/repos/foo", want: ""},
+		{name: "missing repo name omitted", in: "https://github.com/navikt", want: ""},
+		{name: "extra path segments omitted", in: "https://github.com/navikt/foo/bar", want: ""},
+		{name: "empty omitted", in: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseNavRepo(tt.in); got != tt.want {
+				t.Fatalf("parseNavRepo(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNavRepoFromDir(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available on PATH")
+	}
+
+	// initGitRepo creates a git repository in a temp dir, optionally with an
+	// origin remote, and returns the dir.
+	initGitRepo := func(t *testing.T, originURL string) string {
+		t.Helper()
+		dir := t.TempDir()
+		if out, err := exec.Command("git", "-C", dir, "init", "--quiet").CombinedOutput(); err != nil {
+			t.Fatalf("git init: %v\n%s", err, out)
+		}
+		if originURL != "" {
+			if out, err := exec.Command("git", "-C", dir, "remote", "add", "origin", originURL).CombinedOutput(); err != nil {
+				t.Fatalf("git remote add: %v\n%s", err, out)
+			}
+		}
+		return dir
+	}
+
+	t.Run("navikt ssh remote resolves to slug", func(t *testing.T) {
+		dir := initGitRepo(t, "git@github.com:navikt/foo.git")
+		if got := navRepoFromDir(dir); got != "navikt/foo" {
+			t.Fatalf("navRepoFromDir() = %q, want navikt/foo", got)
+		}
+	})
+
+	t.Run("navikt https remote resolves to slug", func(t *testing.T) {
+		dir := initGitRepo(t, "https://github.com/navikt/foo")
+		if got := navRepoFromDir(dir); got != "navikt/foo" {
+			t.Fatalf("navRepoFromDir() = %q, want navikt/foo", got)
+		}
+	})
+
+	t.Run("non-navikt remote yields empty", func(t *testing.T) {
+		dir := initGitRepo(t, "git@github.com:otherorg/foo.git")
+		if got := navRepoFromDir(dir); got != "" {
+			t.Fatalf("navRepoFromDir() = %q, want empty", got)
+		}
+	})
+
+	t.Run("repo without origin remote yields empty", func(t *testing.T) {
+		dir := initGitRepo(t, "")
+		if got := navRepoFromDir(dir); got != "" {
+			t.Fatalf("navRepoFromDir() = %q, want empty", got)
+		}
+	})
+
+	t.Run("not a git repo yields empty", func(t *testing.T) {
+		if got := navRepoFromDir(t.TempDir()); got != "" {
+			t.Fatalf("navRepoFromDir() = %q, want empty", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds a `nav.repo` OpenTelemetry resource attribute to agent sessions launched by nav-pilot, so session telemetry can be joined — server-side, at query time — to the repo→team mapping. This is Phase 0 of the measurement program (#344): every session recorded without this attribute is permanently unjoinable to teams and outcomes, so it needs to land before the OTel rollout accumulates history.

Closes #346.

## What's included

- `internal/telemetry/repo.go` (new) — `navRepoFromDir` runs `git remote get-url origin` with a 2s timeout and `GIT_TERMINAL_PROMPT=0` (a hung git or credential prompt can never delay a session launch); `parseNavRepo` accepts ssh (`git@github.com:`), ssh-URL (`ssh://git@github.com/`) and https forms, with or without `.git`
- `internal/telemetry/copilot_otel.go` — `applyCopilotResourceAttributes` appends `nav.repo` with the same only-if-absent semantics as the existing keys (a user-set value is never overwritten); wired into both the Copilot and OpenCode launch paths
- `TELEMETRY.md` — documents the new attribute, its rationale (team-level joining per #344), and explicitly what is **not** collected

## Privacy posture

Fail-to-omit on everything: not a git repo, no origin remote, git missing, timeout, or a remote outside the `navikt` org all result in the attribute being omitted entirely — never guessed, no local paths or third-party remotes leaked. `nav.repo` identifies a codebase, not a person; `device_id` stays pseudonymous; nothing else is added.

## Testing

- 15-case `parseNavRepo` table (ssh/https ± `.git`, casing, non-navikt, non-github, local path, malformed) plus real-git tests for `navRepoFromDir` (navikt ssh/https → slug; non-navikt / no remote / not-a-repo → omitted)
- `go build`, `go vet`, `staticcheck`, `gofmt` clean; `go test -race` — 974 tests pass; coverage 67.1% (CI floor: 65%)

Query-time note for analysts: repo *name* casing is preserved from the remote URL, so BigQuery joins against the adoption mapping should compare with `LOWER()` on both sides.