### PR TITLE
ci: add gitleaks secret scanning and harden .gitignore

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -1,0 +1,43 @@
+name: gitleaks
+
+# Skanner hele git-historikken for hemmeligheter med gitleaks.
+# Vi kjører gitleaks-binæren direkte i stedet for gitleaks/gitleaks-action,
+# fordi actionen krever en betalt GITLEAKS_LICENSE for organisasjoner.
+# Falske positiver håndteres i .gitleaks.toml (plukkes opp automatisk).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: gitleaks secret scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+        with:
+          # Full historikk slik at gitleaks kan skanne alle commits
+          fetch-depth: 0
+
+      - name: Download gitleaks
+        env:
+          GITLEAKS_VERSION: "8.30.1"
+          GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+        run: |
+          curl -fsSL -o "${RUNNER_TEMP}/gitleaks.tar.gz" \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  ${RUNNER_TEMP}/gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf "${RUNNER_TEMP}/gitleaks.tar.gz" -C "${RUNNER_TEMP}" gitleaks
+
+      - name: Scan full git history
+        run: '"${RUNNER_TEMP}/gitleaks" git --redact --verbose --exit-code 1 .'

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,7 @@ apps/copilot-api/copilot-api
 
 # Local test directories
 .local/
+
+# Guardrails mot utilsiktede commits (#343)
+# *.pem, secret*.yaml og .DS_Store dekkes allerede lenger opp i filen.
+*.log

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,35 @@
+# Gitleaks-konfigurasjon for navikt/copilot
+# Utvider standard-regelsettet. Oppføringene under er KUN bekreftede
+# falske positiver — aldri allowlist ekte hemmeligheter her.
+
+[extend]
+useDefault = true
+
+# Falsk positiv: avkortet, falsk JWT-header brukt som testfixture i
+# copilot-api sine auth-tester. Strengen er kun base64 av
+# {"alg":"RS256","typ":"JWT"} etterfulgt av "..." — ingen payload
+# eller signatur, altså ikke et gyldig token.
+[[allowlists]]
+description = "Testfixture: avkortet falsk JWT-header i auth-tester"
+regexTarget = "line"
+regexes = ['''eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9\.\.\.''']
+
+# Falsk positiv: dokumentasjonseksempel som viser FEIL måte å håndtere
+# hemmeligheter på ("❌ Feil — hardkodet hemmelighet") i
+# instructions/github-actions.instructions.md (lå tidligere under
+# .github/instructions/, derav valgfritt prefiks i path-regexen).
+# Verdien er en åpenbar placeholder, ikke en ekte nøkkel.
+[[allowlists]]
+description = "Dokumentasjonseksempel på hardkodet nøkkel (bevisst feileksempel)"
+condition = "AND"
+paths = ['''(\.github/)?instructions/github-actions\.instructions\.md''']
+regexes = ['''sk-1234567890''']
+
+# Falsk positiv: ren prosa i copilot-instructions.md — generic-api-key-
+# regelen matcher "installation tokens, billing/seat/SAML" i en
+# punktliste som beskriver github.go. Ingen hemmelighet.
+[[allowlists]]
+description = "Prosa i copilot-instructions.md matchet av generic-api-key"
+condition = "AND"
+paths = ['''\.github/copilot-instructions\.md''']
+regexes = ['''billing/seat/SAML''']

--- a/README.md
+++ b/README.md
@@ -233,6 +233,16 @@ Tilpasningene dekker Navs kjernestack:
 
 Kjør `mise check` etter endringer for å validere alt.
 
+### Unngå å committe hemmeligheter
+
+CI skanner hele historikken med [gitleaks](https://github.com/gitleaks/gitleaks). Vil du fange lekkasjer allerede før commit, installer gitleaks lokalt (`brew install gitleaks`) og legg til en valgfri pre-commit-sjekk:
+
+```bash
+gitleaks git --pre-commit --staged    # Skanner kun stagede endringer
+```
+
+Falske positiver håndteres i [.gitleaks.toml](.gitleaks.toml).
+
 <details>
 <summary>Utvikleroppsett for applikasjonene</summary>
 


### PR DESCRIPTION
## Summary

Phase 1 of #343: secret-scanning guardrails. The repo previously had **no secret scanning in CI** and relied on discipline alone to keep credential files (k8s Secret manifests, `.pem` keys observed in local working trees) out of history.

Implements the guardrail half of #343 only — the dead-surface cleanup (Phase 2) is separate.

## What's included

- **`.github/workflows/gitleaks.yaml`** — full-history gitleaks scan on push/PR to main + manual dispatch. Uses the gitleaks **binary directly** (v8.30.1, version and SHA-256 pinned, checksum-verified at runtime) rather than `gitleaks-action`, because the action requires a paid `GITLEAKS_LICENSE` for organizations. Minimal `contents: read` permissions; checkout SHA-pinned with `# ratchet:` matching repo conventions. Validated with actionlint.
- **`.gitleaks.toml`** — extends the default ruleset with 3 allowlist entries, each commented with why it's a false positive
- **`.gitignore`** — adds `*.log` (verified `*.pem`, `secret*.yaml`, `.DS_Store` were already covered — no duplication)
- **`README.md`** — short "Unngå å committe hemmeligheter" subsection under *Bidra* documenting the optional `gitleaks git --pre-commit --staged` hook (note: `gitleaks protect` no longer exists in v8.x)

## Full-history scan result (1,479 commits)

**No real secrets — ever.** 7 findings, all confirmed false positives: a truncated fake JWT header fixture in `apps/copilot-api/auth_test.go`, the deliberate "❌ hardkodet hemmelighet" documentation example in `instructions/github-actions.instructions.md`, and prose in `.github/copilot-instructions.md` that pattern-matched `generic-api-key`. All allowlisted; both `gitleaks git` (full history) and `gitleaks dir` (working tree) now report zero leaks, so CI passes on the current state.

Also verified via the API: GitHub secret scanning **and push protection are already enabled** on this repo, so this workflow is the second independent layer, not the only one.