### PR TITLE
feat(my-copilot): cplt security-hardening update — landing page, config explorer parser fix, news article

### DIFF
--- a/apps/my-copilot/src/app/cplt/page.tsx
+++ b/apps/my-copilot/src/app/cplt/page.tsx
@@ -483,6 +483,41 @@ function ProtectionsSection() {
               </div>
             ))}
           </HGrid>
+
+          {/* Bubblewrap defense-in-depth (Linux) */}
+          <div
+            className="rounded-xl flex items-start gap-4"
+            style={{
+              padding: "1.25rem",
+              background: "rgba(255,255,255,0.03)",
+              border: "1px solid rgba(255,255,255,0.06)",
+            }}
+          >
+            <div
+              className="flex items-center justify-center rounded-lg shrink-0"
+              style={{
+                width: "2.5rem",
+                height: "2.5rem",
+                background: "#a78bfa15",
+                border: "1px solid #a78bfa30",
+              }}
+            >
+              <ShieldLockIcon fontSize="1.25rem" style={{ color: "#a78bfa" }} aria-hidden />
+            </div>
+            <div>
+              <p className="font-semibold mb-1" style={{ color: "white", fontSize: "0.9rem", margin: 0 }}>
+                Bubblewrap namespace isolation (Linux, defense-in-depth)
+              </p>
+              <p style={{ color: "#94a3b8", fontSize: "0.8125rem", lineHeight: 1.6, margin: 0 }}>
+                On top of Landlock + seccomp, cplt can wrap the agent in PID, IPC, UTS, cgroup, and user namespaces with
+                a private <code style={{ fontSize: "0.75rem" }}>/tmp</code>. Auto-detected when{" "}
+                <code style={{ fontSize: "0.75rem" }}>bwrap</code> is installed, with graceful fallback to
+                Landlock-only. It is not a network boundary and not a full-filesystem-confidentiality boundary: the host
+                network is shared by design so the proxy keeps working, and the root filesystem is bind-mounted
+                read-only with Landlock as the access-control layer.
+              </p>
+            </div>
+          </div>
         </VStack>
       </Box>
 
@@ -672,6 +707,59 @@ function ProxySection() {
               </defs>
             </svg>
           </div>
+
+          {/* Proxy-forced mode + upstream chaining */}
+          <HGrid columns={{ xs: 1, md: 2 }} gap="space-16" className="items-stretch">
+            <div
+              className="rounded-xl overflow-hidden flex flex-col"
+              style={{ background: "white", border: "1px solid #e2e8f0", boxShadow: "0 1px 3px rgba(0,0,0,0.04)" }}
+            >
+              <div className="px-5 py-4 flex-1" style={{ borderBottom: "1px solid #e2e8f0" }}>
+                <Heading size="xsmall" level="3">
+                  Proxy-forced mode — opt-in
+                </Heading>
+                <p style={{ color: "#64748b", fontSize: "0.8125rem", lineHeight: 1.6, margin: "0.25rem 0 0" }}>
+                  By default the kernel still allows direct outbound <code style={{ fontSize: "0.75rem" }}>:443</code>,
+                  so a raw socket or an unset <code style={{ fontSize: "0.75rem" }}>HTTPS_PROXY</code> can skip the
+                  proxy. <code style={{ fontSize: "0.75rem" }}>proxy.forced</code> closes that bypass: the proxy becomes
+                  mandatory and kernel-level egress is restricted to the proxy port only. Fails closed — if the proxy
+                  cannot start, the agent does not launch. macOS pins fully to{" "}
+                  <code style={{ fontSize: "0.75rem" }}>localhost:&lt;proxy_port&gt;</code>; Linux drops the direct{" "}
+                  <code style={{ fontSize: "0.75rem" }}>:443</code> allow, but Landlock filtering is port-based, so a
+                  narrow port-based residual remains — a deliberate limitation, tracked upstream.
+                </p>
+              </div>
+              <div className="px-5 py-3 flex items-center gap-3" style={{ background: "#f8fafc" }}>
+                <code className="font-mono flex-1" style={{ fontSize: "0.6875rem", color: "#475569" }}>
+                  cplt config set proxy.forced true
+                </code>
+                <CopyButton copyText="cplt config set proxy.forced true" size="xsmall" />
+              </div>
+            </div>
+
+            <div
+              className="rounded-xl overflow-hidden flex flex-col"
+              style={{ background: "white", border: "1px solid #e2e8f0", boxShadow: "0 1px 3px rgba(0,0,0,0.04)" }}
+            >
+              <div className="px-5 py-4 flex-1" style={{ borderBottom: "1px solid #e2e8f0" }}>
+                <Heading size="xsmall" level="3">
+                  Corporate / upstream proxy chaining
+                </Heading>
+                <p style={{ color: "#64748b", fontSize: "0.8125rem", lineHeight: 1.6, margin: "0.25rem 0 0" }}>
+                  Behind a corporate proxy? <code style={{ fontSize: "0.75rem" }}>proxy.upstream</code> forwards CONNECT
+                  tunnels through it instead of forcing you to disable the cplt proxy. cplt applies its own domain
+                  filtering, logging, and port checks <em>before</em> forwarding the tunnel upstream — a blocked target
+                  never reaches the corporate proxy. Optional basic-auth userinfo is supported; http scheme only.
+                </p>
+              </div>
+              <div className="px-5 py-3 flex items-center gap-3" style={{ background: "#f8fafc" }}>
+                <code className="font-mono flex-1" style={{ fontSize: "0.6875rem", color: "#475569" }}>
+                  cplt config set proxy.upstream &quot;http://proxy.example.com:8080&quot;
+                </code>
+                <CopyButton copyText='cplt config set proxy.upstream "http://proxy.example.com:8080"' size="xsmall" />
+              </div>
+            </div>
+          </HGrid>
         </VStack>
       </Box>
     </section>

--- a/apps/my-copilot/src/lib/cplt-config.ts
+++ b/apps/my-copilot/src/lib/cplt-config.ts
@@ -26,10 +26,16 @@ export async function fetchCpltConfigKeys(): Promise<CpltConfigKey[]> {
   }
 }
 
+/** Unescape the string escapes we expect in registry.rs literals (\" and \\). */
+function unescapeRustString(value: string): string {
+  return value.replace(/\\(["\\])/g, "$1");
+}
+
 function parseConfigKeys(source: string): CpltConfigKey[] {
   const keys: CpltConfigKey[] = [];
+  // default_display and description may contain escaped quotes (\") in the Rust source.
   const pattern =
-    /section:\s*"([^"]+)",\s*key:\s*"([^"]+)",\s*value_type:\s*ConfigValueType::([a-zA-Z0-9]+),\s*dangerous:\s*(true|false),\s*default_display:\s*"([^"]*)",\s*description:\s*"([^"]+)",/g;
+    /section:\s*"([^"]+)",\s*key:\s*"([^"]+)",\s*value_type:\s*ConfigValueType::([a-zA-Z0-9]+),\s*dangerous:\s*(true|false),\s*default_display:\s*"((?:[^"\\]|\\.)*)",\s*description:\s*"((?:[^"\\]|\\.)+)",/g;
   let match: RegExpExecArray | null;
 
   while ((match = pattern.exec(source)) !== null) {
@@ -37,11 +43,12 @@ function parseConfigKeys(source: string): CpltConfigKey[] {
     const key = match[2];
     const kind = match[3];
     const dangerous = match[4] === "true";
-    const defaultDisplay = match[5];
-    const description = match[6];
+    const defaultDisplay = unescapeRustString(match[5]);
+    const description = unescapeRustString(match[6]);
 
     let typeStr = "string";
     if (kind === "U16") typeStr = "integer";
+    if (kind === "U64") typeStr = "integer";
     if (kind === "U16Array") typeStr = "integer[]";
     if (kind === "Bool") typeStr = "bool";
     if (kind === "StrArray") typeStr = "string[]";

--- a/docs/news/articles/cplt-juli-2026-sikkerhetsoppdatering.md
+++ b/docs/news/articles/cplt-juli-2026-sikkerhetsoppdatering.md
@@ -1,0 +1,77 @@
+---
+title: "cplt sikkerhetsoppdatering — Bubblewrap-namespaces, proxy-forced og upstream proxy"
+date: 2026-07-05
+author: starefossen
+category: praksis
+excerpt: "En bølge med sikkerhetsherding i cplt: namespace-isolasjon på Linux, opt-in kernel-tvunget proxy og støtte for bedriftsproxy — uten å overselge hva lagene faktisk garanterer."
+tags:
+  - cplt
+  - security
+  - sandbox
+  - proxy
+---
+
+[cplt](https://github.com/navikt/cplt) — sandboxen for AI-kodingsagenter — har fått en runde med sikkerhetsherding og tre nye funksjoner. Som alltid: dette er lag i et forsvar-i-dybden-oppsett, ikke sølvkuler. [SECURITY.md](https://github.com/navikt/cplt/blob/main/SECURITY.md) beskriver den ærlige trusselmodellen.
+
+---
+
+## Bubblewrap namespace-isolasjon (Linux)
+
+På Linux kan cplt nå pakke agenten inn i [Bubblewrap](https://github.com/containers/bubblewrap)-namespaces (PID/IPC/UTS/cgroup/user) med en privat `/tmp` — **oppå** Landlock + seccomp-BPF, ikke som erstatning. Agenten kan ikke lenger se eller signalisere prosesser på verten, og `/tmp` er en fersk tmpfs uten exec.
+
+Aktiveres automatisk når `bwrap` er installert, med graceful fallback til kun Landlock + seccomp hvis ikke. Eksplisitt styring med `sandbox.use_bubblewrap`:
+
+```sh
+cplt config set sandbox.use_bubblewrap true   # hard krav — feiler om bwrap mangler
+cplt config set sandbox.use_bubblewrap false  # kun Landlock + seccomp
+```
+
+Viktige avgrensninger, med vilje:
+
+- **Ikke en nettverksgrense.** Det opprettes ingen network namespace — vertsnettverket deles slik at agenten når CONNECT-proxyen på `127.0.0.1`. Nettverkskontrollen ligger fortsatt hos proxyen og Landlock-portregler.
+- **Ikke full filsystem-konfidensialitet.** Hele rotfilsystemet bind-mountes read-only og er synlig i mount-tabellen; det er Landlock (deny-by-default) som nekter lesing, ikke mount-namespacet.
+
+Kilde: [navikt/cplt#64](https://github.com/navikt/cplt/pull/64)
+
+---
+
+## Proxy-forced modus (opt-in)
+
+Til nå har proxyen vært rådgivende på kernel-nivå: sandboxen tillater utgående `*:443`, og trafikken går gjennom proxyen fordi cplt injiserer `HTTPS_PROXY`. En rå socket — eller `env -u HTTPS_PROXY` — kunne dermed nå nettet utenom domenefiltreringen.
+
+`proxy.forced` lukker den bypassen: proxyen blir obligatorisk, og kernel-egress begrenses til proxy-porten alene (ingen direkte `*:443`). Feiler proxyen ved oppstart, starter ikke agenten — fail-closed.
+
+```sh
+cplt config set proxy.forced true
+```
+
+Håndhevingen er asymmetrisk mellom plattformene:
+
+- **macOS** pinner fullt til `localhost:<proxy_port>` — ingen restkanal.
+- **Linux** dropper `*:443`-regelen, men Landlock er portbasert og kan ikke pinne til localhost, så en smal portbasert restkanal (`evil.com:<proxy_port>`) gjenstår. Dette er en kjent og bevisst begrensning, sporet oppstrøms i [navikt/cplt#114](https://github.com/navikt/cplt/issues/114).
+
+Av som standard. Kilde: [navikt/cplt#117](https://github.com/navikt/cplt/pull/117)
+
+---
+
+## Upstream proxy-chaining for bedriftsnettverk
+
+Team bak en bedriftsproxy har til nå måttet skru av cplt-proxyen. Med `proxy.upstream` (i merge-køen) videresender cplt CONNECT-tunneler gjennom bedriftsproxyen i stedet — og beholder egen domenefiltrering, logging og portsjekker. Policyen håndheves **før** videresending: et blokkert domene når aldri bedriftsproxyen.
+
+```sh
+cplt config set proxy.upstream "http://corporate-proxy.example.com:8080"
+```
+
+Basic-auth i URL-en støttes; kun `http`-skjema mot upstream.
+
+Kilde: [navikt/cplt#125](https://github.com/navikt/cplt/pull/125)
+
+---
+
+## Andre forbedringer i samme bølge
+
+- **Landlock best-effort ABI** — sandboxen bruker beste tilgjengelige Landlock-ABI på eldre kjerner i stedet for å kreve nyeste ([#119](https://github.com/navikt/cplt/pull/119))
+- **Guard- og sikkerhetsfikser** — tetting av gh/git guard-bypasses og parsing-feil, pluss en runde med fikser for loopback-SSRF, trust pinning og en token-lekkasje ([#118](https://github.com/navikt/cplt/pull/118))
+- **Verktøystier fra miljøvariabler** — `GOPATH` og tilsvarende respekteres for ikke-standard plasseringer (på vei, [#124](https://github.com/navikt/cplt/pull/124))
+
+Se [cplt-siden](/cplt) for oppdatert funksjonsoversikt og interaktiv config-utforsker.


### PR DESCRIPTION
## Summary

Implements #350: the cplt config explorer and landing page now reflect the recent security-hardening wave (bubblewrap namespace isolation, proxy-forced mode, upstream proxy chaining), plus a Norwegian news article.

Closes #350.

## Bonus find: the config explorer parser was silently dropping 9 of 53 keys

`cplt-config.ts` fetches and regex-parses cplt's `registry.rs` at runtime — and its description regex (`"([^"]+)"`) broke on Rust escaped quotes (`\"`), silently dropping every key whose description contains one: `proxy.log_level`, `proxy.allow_private_domains`, `sandbox.allow_cache_exec`, `gh_guard.mode`, `gh_guard.unknown_command`, `git_guard.mode`, `audit.destination`, `audit.level`, `audit.format`. Fixed with a proper escaped-string regex + unescaping, and `ConfigValueType::U64` now maps to integer (`proxy.timeout` displayed as "string" before). Verified live against real registry.rs: **53/53 keys parse** (was 44).

This matters for #350 specifically: `proxy.upstream`'s description contains `\"`, so the old parser would have dropped it the moment navikt/cplt#125 merges. The new parser handles its exact registry entry (verified against the PR branch); the key appears automatically when the merge queue drains — no follow-up needed here.

## Landing page (`/cplt`)

Three additions, each cross-checked against cplt's `SECURITY.md` (the honest-threat-model source of truth), keeping the deliberately precise framing:

- **Bubblewrap** — defense-in-depth *on top of* Landlock+seccomp (Linux, auto-detect, graceful fallback); explicitly *not* a network or filesystem-confidentiality boundary (shared host network is by design so the proxy works; Landlock owns confidentiality)
- **Proxy-forced mode** — opt-in, off by default, fails closed; closes the raw-socket/unset-`HTTPS_PROXY` bypass; macOS pins fully to `localhost:<port>`, Linux keeps a narrow port-based residual (deliberate, tracked upstream)
- **Upstream proxy chaining** — cplt applies its own domain/port/logging policy *before* forwarding CONNECT tunnels upstream (marked as in-merge-queue pending navikt/cplt#125)

## News article

`docs/news/articles/cplt-juli-2026-sikkerhetsoppdatering.md` — Norwegian, dated 2026-07-05, matching the existing cplt article cadence; auto-discovered by `src/lib/news.ts`.

## Verification

- `pnpm check`: eslint/tsc/prettier/knip pass; vitest 534/534
- `pnpm build`: passes; `hack/generate-check.sh`: manifest up to date
- Live parse of real registry.rs: 53/53 keys, `sandbox.use_bubblewrap` + `proxy.forced` present with verbatim descriptions