### PR TITLE
fix(observability-debugging): use global Loki endpoint with cluster label

### DIFF
--- a/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
+++ b/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
@@ -922,7 +922,7 @@
       "displayName": "observability-debugging",
       "description": "Feilsøk produksjonsproblemer med Mimir-metrikker, Loki-logger og Tempo-traces — strukturerte debugging-workflows for Nav-utviklere",
       "filePath": "skills/observability-debugging/SKILL.md",
-      "contentHash": "b93058442cb1d65247446e6736250a9747b792b833f50176a8e61d6f32685abd",
+      "contentHash": "bf5661705b6dbeadd81e7511162c71a06d48c944b31025db7debc12cca03ac36",
       "installUrl": "",
       "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/skills/observability-debugging/SKILL.md",
       "references": [

--- a/apps/my-copilot/src/lib/copilot-manifest.json
+++ b/apps/my-copilot/src/lib/copilot-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-06-26T05:43:22.315Z",
+  "generatedAt": "2026-07-14T20:20:25.228Z",
   "items": [
     {
       "id": "accessibility-agent",
@@ -1508,7 +1508,7 @@
       "domain": "observability",
       "filePath": "skills/observability-debugging/SKILL.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/skills/observability-debugging/SKILL.md",
-      "contentHash": "b93058442cb1d65247446e6736250a9747b792b833f50176a8e61d6f32685abd",
+      "contentHash": "bf5661705b6dbeadd81e7511162c71a06d48c944b31025db7debc12cca03ac36",
       "installUrl": null,
       "insidersInstallUrl": null,
       "tags": ["debugging", "mimir", "loki", "tempo", "prometheus", "traces", "logs", "kubectl", "nais", "nav-pilot"],

--- a/skills/observability-debugging/SKILL.md
+++ b/skills/observability-debugging/SKILL.md
@@ -61,17 +61,21 @@ curl -s -H "User-Agent: nav-pilot/observability-debugging" -H "X-Scope-OrgID: te
 > **Log line fields (require `| json`, slower):** `level`, `message`, `trace_id`, `span_id`, `logger_name`, `thread_name`
 > Always narrow with labels first, then filter metadata/fields.
 
+> **One global endpoint** (`loki.nav.cloud.nais.io`) — like Mimir. Pick the cluster with the
+> `k8s_cluster_name="$CLUSTER"` label (`dev-gcp`, `prod-gcp`, `dev-fss`, `prod-fss`, …), not an
+> environment-specific host.
+
 ```bash
-# Query via Loki API (dev environment)
+# Query via the global Loki endpoint — select the cluster with k8s_cluster_name
 curl -s -H "User-Agent: nav-pilot/observability-debugging" -H "X-Scope-OrgID: tenant" \
   "https://loki.nav.cloud.nais.io/loki/api/v1/query_range" \
-  --data-urlencode "query={k8s_cluster_name=~\"dev.*\",service_name=\"$APP\"} |= \"ERROR\"" \
+  --data-urlencode "query={k8s_cluster_name=\"$CLUSTER\",service_name=\"$APP\"} |= \"ERROR\"" \
   --data-urlencode "limit=50" | jq .
 
-# Prod environment
+# Parse structured fields for level/detail
 curl -s -H "User-Agent: nav-pilot/observability-debugging" -H "X-Scope-OrgID: tenant" \
   "https://loki.nav.cloud.nais.io/loki/api/v1/query_range" \
-  --data-urlencode "query={k8s_cluster_name=~\"prod.*\",service_name=\"$APP\"} | json | level=\"error\"" | jq .
+  --data-urlencode "query={k8s_cluster_name=\"$CLUSTER\",service_name=\"$APP\"} | json | level=\"error\"" | jq .
 ```
 
 ### Tempo — Trace Search


### PR DESCRIPTION
## What

Aligns the **Loki Quick Access** examples in the `observability-debugging` skill with the **Mimir** pattern: query the single global endpoint (`loki.nav.cloud.nais.io`) and select the cluster with an exact-match `k8s_cluster_name="$CLUSTER"` label — instead of framing queries per-environment with `=~"dev.*"` / `=~"prod.*"` regex and "dev/prod environment" comments.

## Why

Loki is already served from one global endpoint, and the rest of the skill (`references/query-library.md`, Correlation Pattern 1) already uses `k8s_cluster_name="$CLUSTER"`. Only the Quick Access block was inconsistent. This makes cluster selection work identically across Mimir and Loki.

The two examples now differ by **query intent** (raw `|= "ERROR"` filter vs. `| json | level="error"` parsing) rather than by environment.

## Notes

- **Tempo** still uses env-specific hosts (`tempo.$env.nav.cloud.nais.io`) — left unchanged, as that appears to be a real infra constraint rather than a documentation choice.