### PR TITLE
ci(lefthook): regenerate manifests and docs on source changes

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,6 +4,20 @@
 pre-commit:
   parallel: true
   commands:
+    # Regenerate the app manifests and docs tables whenever a source file
+    # (agent/skill/instruction/prompt/collection) changes. These outputs embed
+    # a contentHash of each file, so an edit that isn't regenerated fails the
+    # `generate:check` and `Docs in sync` CI jobs. Keeps them in sync at commit.
+    generated-files:
+      glob: "{agents,collections,instructions,prompts,skills}/**"
+      run: |
+        mise run generate
+        git add \
+          apps/my-copilot/src/lib/copilot-manifest.json \
+          apps/mcp-onboarding/internal/discovery/copilot-manifest.json \
+          docs/README.agents.md docs/README.instructions.md \
+          docs/README.prompts.md docs/README.skills.md README.md
+
     gofmt:
       glob: "**/*.go"
       run: gofmt -w {staged_files}


### PR DESCRIPTION
## What

Adds a `pre-commit` command to `lefthook.yml` that runs `mise run generate` and stages the generated app manifests and docs tables whenever an **agent / skill / instruction / prompt / collection** source file is staged.

Staged outputs:
- `apps/my-copilot/src/lib/copilot-manifest.json`
- `apps/mcp-onboarding/internal/discovery/copilot-manifest.json`
- `docs/README.{agents,instructions,prompts,skills}.md` and root `README.md`

## Why

These generated files embed a `contentHash` of each source file. Editing a source file without regenerating leaves them stale, which fails the `generate:check` (in the `my-copilot` / `mcp-onboarding` jobs) and `Docs in sync` CI checks — a footgun that just bit #362 (the manifests had to be regenerated in a follow-up commit). The hook keeps them in sync at commit time so the failure can't reach CI.

## Notes

- Only triggers when a matching source file is staged (glob-scoped), so unrelated commits are unaffected.
- Requires the local hooks to be installed (`lefthook install`) and the app mise configs to be trusted (`mise trust`), consistent with the existing `eslint`/`prettier` pre-commit commands.
- Verified locally: staging a skill edit regenerated and auto-staged both manifests via the hook.