### PR TITLE
feat(metrics): surface PR review-velocity metrics from usage API

### DIFF
--- a/apps/copilot-api/bigquery_stats.go
+++ b/apps/copilot-api/bigquery_stats.go
@@ -1158,6 +1158,8 @@ type DailySummary struct {
 	CliSessionCount         int64   `bigquery:"cli_session_count" json:"cli_session_count"`
 	CliRequestCount         int64   `bigquery:"cli_request_count" json:"cli_request_count"`
 	PrMedianMinutesToMerge  float64 `bigquery:"pr_median_minutes_to_merge" json:"pr_median_minutes_to_merge"`
+	PrAvgMinutesToReview    float64 `bigquery:"pr_avg_minutes_to_review" json:"pr_avg_minutes_to_review"`
+	PrAvgReviewCycles       float64 `bigquery:"pr_avg_review_cycles" json:"pr_avg_review_cycles"`
 }
 
 func (bq *BigQueryClient) GetDailySummary(ctx context.Context) (*DailySummary, error) {
@@ -1168,7 +1170,8 @@ func (bq *BigQueryClient) GetDailySummary(ctx context.Context) (*DailySummary, e
         daily_active_users, weekly_active_users, monthly_active_users,
         monthly_active_chat_users, monthly_active_agent_users, daily_active_cli_users,
         pr_reviewed_by_copilot, pr_created_by_copilot, pr_merged_copilot_authored,
-        cli_session_count, cli_request_count, pr_median_minutes_to_merge
+        cli_session_count, cli_request_count, pr_median_minutes_to_merge,
+        pr_avg_minutes_to_review, pr_avg_review_cycles
       FROM %s
       WHERE scope = 'organization' AND scope_id = 'navikt'
       ORDER BY day DESC

--- a/apps/copilot-metrics/views/v_daily_summary.sql
+++ b/apps/copilot-metrics/views/v_daily_summary.sql
@@ -27,6 +27,26 @@ SELECT
   CAST(JSON_VALUE(raw_record, '$.pull_requests.median_minutes_to_merge') AS FLOAT64) AS pr_median_minutes_to_merge,
   CAST(JSON_VALUE(raw_record, '$.pull_requests.median_minutes_to_merge_copilot_authored') AS FLOAT64) AS pr_median_minutes_to_merge_copilot,
   CAST(JSON_VALUE(raw_record, '$.pull_requests.median_minutes_to_merge_copilot_reviewed') AS FLOAT64) AS pr_median_minutes_to_merge_copilot_reviewed,
+  -- Code-review velocity (added to the usage API 2026-07-07). These live per AI
+  -- adoption phase in totals_by_ai_adoption_phase[], so we roll them up to a daily
+  -- figure weighted by each phase's merged-PR count. NULL for days ingested before
+  -- the fields existed (the array or fields are simply absent).
+  (
+    SELECT SAFE_DIVIDE(
+      SUM(CAST(JSON_VALUE(phase, '$.avg_pull_requests_minutes_to_review') AS FLOAT64)
+          * CAST(JSON_VALUE(phase, '$.total_pull_requests_merged') AS INT64)),
+      SUM(CAST(JSON_VALUE(phase, '$.total_pull_requests_merged') AS INT64))
+    )
+    FROM UNNEST(JSON_QUERY_ARRAY(raw_record, '$.totals_by_ai_adoption_phase')) AS phase
+  ) AS pr_avg_minutes_to_review,
+  (
+    SELECT SAFE_DIVIDE(
+      SUM(CAST(JSON_VALUE(phase, '$.avg_pull_requests_review_cycles') AS FLOAT64)
+          * CAST(JSON_VALUE(phase, '$.total_pull_requests_merged') AS INT64)),
+      SUM(CAST(JSON_VALUE(phase, '$.total_pull_requests_merged') AS INT64))
+    )
+    FROM UNNEST(JSON_QUERY_ARRAY(raw_record, '$.totals_by_ai_adoption_phase')) AS phase
+  ) AS pr_avg_review_cycles,
   CAST(JSON_VALUE(raw_record, '$.pull_requests.total_suggestions') AS INT64) AS pr_total_suggestions,
   CAST(JSON_VALUE(raw_record, '$.pull_requests.total_copilot_suggestions') AS INT64) AS pr_copilot_suggestions,
   CAST(JSON_VALUE(raw_record, '$.pull_requests.total_applied_suggestions') AS INT64) AS pr_applied_suggestions,

--- a/apps/my-copilot/src/app/statistikk/page.tsx
+++ b/apps/my-copilot/src/app/statistikk/page.tsx
@@ -439,6 +439,18 @@ async function DashboardTabContent({ usage, token }: { usage: EnterpriseMetrics[
               helpTitle="Chat-brukere"
               helpText="Unike brukere som har brukt Copilot Chat i inneværende måned. Kilde: v_daily_summary."
             />
+            <MetricCard
+              value={formatMinutes(dailySummary.pr_avg_minutes_to_review)}
+              label="Tid til første PR-review"
+              helpTitle="Tid til første PR-review"
+              helpText="Median tid fra en pull request opprettes til den får sin første review, snittet over AI-adopsjonsfaser og vektet på antall merget PR-er. Kun merget PR-er. Kilde: v_daily_summary (usage-API, fra 2026-07-07)."
+            />
+            <MetricCard
+              value={dailySummary.pr_avg_review_cycles > 0 ? dailySummary.pr_avg_review_cycles.toFixed(1) : "–"}
+              label="Review-runder per PR"
+              helpTitle="Review-runder per PR"
+              helpText="Median antall review-innsendinger en pull request får før den merges, snittet over AI-adopsjonsfaser og vektet på antall merget PR-er. Kilde: v_daily_summary (usage-API, fra 2026-07-07)."
+            />
           </HGrid>
         </div>
       )}

--- a/apps/my-copilot/src/lib/types.ts
+++ b/apps/my-copilot/src/lib/types.ts
@@ -466,6 +466,8 @@ export interface DailySummary {
   cli_session_count: number;
   cli_request_count: number;
   pr_median_minutes_to_merge: number;
+  pr_avg_minutes_to_review: number;
+  pr_avg_review_cycles: number;
 }
 
 // Privacy-preserving, aggregate-only usage spread for a given month.


### PR DESCRIPTION
## What

Surfaces the two code-review velocity metrics GitHub added to the Copilot usage metrics API on **2026-07-07**:

- `avg_pull_requests_minutes_to_review` — median time from PR creation to first review
- `avg_pull_requests_review_cycles` — median review submissions before merge

Both live per-phase in the `totals_by_ai_adoption_phase[]` breakdown of the enterprise/org aggregated reports (merged PRs only, attributed by merge date).

## Changes

- **`v_daily_summary.sql`** — two new columns (`pr_avg_minutes_to_review`, `pr_avg_review_cycles`) that roll the per-phase values up to a daily figure, **weighted by each phase's `total_pull_requests_merged`**. `UNNEST(JSON_QUERY_ARRAY(...))` over the same `raw_record`; `SAFE_DIVIDE` → NULL when the array/fields are absent.
- **`bigquery_stats.go`** — two `DailySummary` fields + SELECT columns.
- **`types.ts`** — two fields on the `DailySummary` interface.
- **`statistikk/page.tsx`** — two `MetricCard`s in the daily-snapshot grid ("Tid til første PR-review", "Review-runder per PR").

## Notes

- **No pipeline/backfill change** — raw JSON is already ingested. The columns are **NULL for days ingested before 2026-07-07** (the fields simply aren't in those records), and populate going forward as the nightly job ingests newer reports.
- **Aggregation choice:** these are per-phase medians; the daily rollup is a merged-PR-weighted mean across phases — a reasonable headline number. If per-phase fidelity is wanted later, a dedicated `v_adoption_phase_pr_velocity` view is the natural follow-up.
- **Deploy coupling** (existing pattern): `GetDailySummary` selects the new columns, so the `v_daily_summary` view must be recreated (happens when `copilot-metrics` runs `EnsureViewsExist`) before/with the `copilot-api` deploy — same coupling as the existing `pr_median_minutes_to_merge` column.

## Verification

- `copilot-api`: `go build` / `go vet` / `go test` ✅
- `copilot-metrics`: `go build` / `go vet` / `go test` ✅
- `my-copilot`: `tsc --noEmit` ✅, eslint ✅, prettier ✅, vitest (534 tests) ✅

Field placement confirmed against the [2026-07-07 changelog](https://github.blog/changelog/2026-07-07-add-review-cycles-and-time-to-adoption-phases-in-the-usage-api/) and the [usage metrics schema docs](https://docs.github.com/en/copilot/reference/copilot-usage-metrics/copilot-usage-metrics).