### PR TITLE
feat(models): legg til GPT-5.6 Luna/Sol/Terra, Kimi K2.7 Code og Gemini 3.6 Flash

### DIFF
--- a/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
+++ b/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
@@ -556,7 +556,7 @@
         "ui"
       ],
       "filePath": "prompts/aksel-component.prompt.md",
-      "contentHash": "68c1da8a387cdffe7871268f7039075015a927deecec25217ce1d03bc96265ae",
+      "contentHash": "721f879cfd8e89da6bf407d2febbbe98b4f579a6ab49b9c6898bb9c5af37876c",
       "installUrl": "vscode:chat-prompt/install?url=https://raw.githubusercontent.com/navikt/copilot/main/prompts/aksel-component.prompt.md",
       "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/prompts/aksel-component.prompt.md"
     },

--- a/apps/my-copilot/src/app/priser/page.tsx
+++ b/apps/my-copilot/src/app/priser/page.tsx
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
   },
 };
 
-const PROVIDER_ORDER = ["OpenAI", "Anthropic", "Google", "GitHub"] as const;
+const PROVIDER_ORDER = ["OpenAI", "Anthropic", "Google", "GitHub", "Moonshot AI", "Microsoft"] as const;
 
 function formatPrice(price: number): string {
   if (price < 0.1) return `$${price.toFixed(3)}`;

--- a/apps/my-copilot/src/lib/billing-calculator.ts
+++ b/apps/my-copilot/src/lib/billing-calculator.ts
@@ -33,11 +33,19 @@ export const MODEL_PRICING: Record<string, TokenRate> = {
   "GPT-5.3-Codex": { input: 1.75, cached: 0.175, output: 14.0 },
   "GPT-5.4": { input: 2.5, cached: 0.25, output: 15.0 },
   "GPT-5.4 mini": { input: 0.75, cached: 0.075, output: 4.5 },
+  "GPT-5.5": { input: 5.0, cached: 0.5, output: 30.0 },
   "GPT-5 mini": { input: 0.75, cached: 0.075, output: 4.5 },
+  "GPT-5.6 Luna": { input: 1.0, cached: 0.1, output: 6.0 },
+  "GPT-5.6 Terra": { input: 2.5, cached: 0.25, output: 15.0 },
+  "GPT-5.6 Sol": { input: 5.0, cached: 0.5, output: 30.0 },
   // Google Gemini
   "Gemini 2.5 Pro": { input: 1.25, cached: 0.31, output: 10.0 },
   "Gemini 3 Flash": { input: 0.15, cached: 0.02, output: 0.6 },
   "Gemini 3.1 Pro": { input: 1.25, cached: 0.31, output: 10.0 },
+  "Gemini 3.5 Flash": { input: 1.5, cached: 0.15, output: 9.0 },
+  "Gemini 3.6 Flash": { input: 1.5, cached: 0.15, output: 7.5 },
+  // Moonshot AI
+  "Kimi K2.7 Code": { input: 0.95, cached: 0.19, output: 4.0 },
   // xAI
   "Grok Code Fast 1": { input: 0.5, cached: 0.05, output: 2.0 },
   // Copilot internal models (estimate: Sonnet-tier pricing)
@@ -220,6 +228,9 @@ export function getModelCategory(modelName: string): ModelCategory {
   if (name.includes("grok")) return "grok";
   if (name.includes("gemini") && name.includes("flash")) return "gemini_flash";
   if (name.includes("gemini")) return "gemini_pro";
+  if (name.includes("kimi")) return "gpt_standard"; // versatile tier
+  if (name.includes("5.6 sol")) return "opus"; // powerful tier
+  if (name.includes("5.6 luna")) return "gpt_mini"; // lightweight tier
   if (name.includes("mini")) return "gpt_mini";
   return "gpt_standard";
 }

--- a/apps/my-copilot/src/lib/copilot-manifest.json
+++ b/apps/my-copilot/src/lib/copilot-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-07-14T20:20:25.228Z",
+  "generatedAt": "2026-07-22T21:09:31.391Z",
   "items": [
     {
       "id": "accessibility-agent",
@@ -902,11 +902,11 @@
       "domain": "frontend",
       "filePath": ".github/prompts/aksel-component.prompt.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/prompts/aksel-component.prompt.md",
-      "contentHash": "68c1da8a387cdffe7871268f7039075015a927deecec25217ce1d03bc96265ae",
+      "contentHash": "721f879cfd8e89da6bf407d2febbbe98b4f579a6ab49b9c6898bb9c5af37876c",
       "installUrl": "/install/prompt?url=vscode%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fprompts%2Faksel-component.prompt.md",
       "insidersInstallUrl": "/install/prompt?url=vscode-insiders%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fprompts%2Faksel-component.prompt.md",
       "invocation": "#aksel-component",
-      "model": ["Gemini 3.5 Flash"],
+      "model": ["Gemini 3.6 Flash"],
       "tags": [
         "aksel",
         "design-system",

--- a/apps/my-copilot/src/lib/model-pricing.ts
+++ b/apps/my-copilot/src/lib/model-pricing.ts
@@ -1,7 +1,7 @@
 /**
  * GitHub Copilot model pricing data.
  * Source: https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
- * Last updated: 2026-07-01
+ * Last updated: 2026-07-22
  *
  * All prices are per 1 million tokens in USD.
  * 1 AI credit = $0.01 USD.
@@ -11,7 +11,7 @@
 
 export interface ModelPrice {
   model: string;
-  provider: "OpenAI" | "Anthropic" | "Google" | "GitHub";
+  provider: "OpenAI" | "Anthropic" | "Google" | "GitHub" | "Microsoft" | "Moonshot AI";
   category: "Lightweight" | "Versatile" | "Powerful";
   status: "GA" | "Public preview";
   input: number;
@@ -94,6 +94,60 @@ export const MODEL_PRICING: ModelPrice[] = [
     input: 10,
     cachedInput: 1,
     output: 45,
+  },
+  {
+    model: "GPT-5.6 Luna (Default, ≤ 200K)",
+    provider: "OpenAI",
+    category: "Lightweight",
+    status: "GA",
+    input: 1,
+    cachedInput: 0.1,
+    output: 6,
+  },
+  {
+    model: "GPT-5.6 Luna (Long context, 200K)",
+    provider: "OpenAI",
+    category: "Lightweight",
+    status: "GA",
+    input: 2,
+    cachedInput: 0.2,
+    output: 9,
+  },
+  {
+    model: "GPT-5.6 Sol (Default, ≤ 272K)",
+    provider: "OpenAI",
+    category: "Powerful",
+    status: "GA",
+    input: 5,
+    cachedInput: 0.5,
+    output: 30,
+  },
+  {
+    model: "GPT-5.6 Sol (Long context, 272K)",
+    provider: "OpenAI",
+    category: "Powerful",
+    status: "GA",
+    input: 10,
+    cachedInput: 1,
+    output: 45,
+  },
+  {
+    model: "GPT-5.6 Terra (Default, ≤ 272K)",
+    provider: "OpenAI",
+    category: "Versatile",
+    status: "GA",
+    input: 2.5,
+    cachedInput: 0.25,
+    output: 15,
+  },
+  {
+    model: "GPT-5.6 Terra (Long context, 272K)",
+    provider: "OpenAI",
+    category: "Versatile",
+    status: "GA",
+    input: 5,
+    cachedInput: 0.5,
+    output: 22.5,
   },
   // Anthropic
   {
@@ -252,6 +306,15 @@ export const MODEL_PRICING: ModelPrice[] = [
     cachedInput: 0.15,
     output: 9,
   },
+  {
+    model: "Gemini 3.6 Flash (Default)",
+    provider: "Google",
+    category: "Versatile",
+    status: "GA",
+    input: 1.5,
+    cachedInput: 0.15,
+    output: 7.5,
+  },
   // GitHub
   {
     model: "Raptor mini",
@@ -262,7 +325,27 @@ export const MODEL_PRICING: ModelPrice[] = [
     cachedInput: 0.025,
     output: 2,
   },
+  // Microsoft
+  {
+    model: "MAI-Code-1-Flash",
+    provider: "Microsoft",
+    category: "Lightweight",
+    status: "GA",
+    input: 0.75,
+    cachedInput: 0.075,
+    output: 4.5,
+  },
+  // Moonshot AI
+  {
+    model: "Kimi K2.7 Code",
+    provider: "Moonshot AI",
+    category: "Versatile",
+    status: "GA",
+    input: 0.95,
+    cachedInput: 0.19,
+    output: 4,
+  },
 ];
 
 export const PRICING_SOURCE_URL = "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing";
-export const PRICING_LAST_UPDATED = "2026-07-01";
+export const PRICING_LAST_UPDATED = "2026-07-22";

--- a/docs/ai-bruk-oversikt.md
+++ b/docs/ai-bruk-oversikt.md
@@ -2,6 +2,8 @@
 
 > Kartlegging av hvordan vi bruker AI-verktøy i utviklingsarbeidet, og hvor vi bevisst *ikke* bruker dem.
 
+Se også [modellvalg.md](modellvalg.md) for gjeldende modellpinning per agent og prompt, kriterier for å bytte modell og sjekkliste for nye modeller.
+
 ## Agenter — domeneeksperter for utviklere
 
 | Agent | Formål | Domene | Sone |

--- a/docs/modellvalg.md
+++ b/docs/modellvalg.md
@@ -1,0 +1,112 @@
+# Modellvalg i Nav Copilot
+
+Levende referansedokument for hvilke modeller vi bruker, hvorfor, og hvordan vi evaluerer oppdateringer.
+
+---
+
+## Gjeldende modellpinning
+
+Alle agenter og prompts har et eksplisitt `model:`-felt i YAML-frontmatter. Valget er gjort ut fra oppgavetype, kostnad og ytelse — ikke leverandørpreferanse.
+
+### Agenter
+
+| Agent | Modell | Kategori | Input | Output | Begrunnelse |
+|-------|--------|----------|-------|--------|-------------|
+| `@nav-pilot` | Claude Sonnet 4.6 | Versatile | $3.00 | $15.00 | Sterk på norsk, god på planlegging og arkitektur |
+| `@nav-pilot-opus` | Claude Opus 4.6 | Powerful | $5.00 | $25.00 | Dypest resonnering for høy-risiko beslutninger |
+| `@security-champion` | Claude Opus 4.6 | Powerful | $5.00 | $25.00 | Sikkerhetskritiske vurderinger krever høyeste presisjon |
+| `@code-review` | GPT-5.3-Codex | Powerful | $1.75 | $14.00 | Sterkest på kodeforståelse og terminal-oppgaver |
+| `@kafka` | GPT-5.3-Codex | Powerful | $1.75 | $14.00 | Teknisk presis på hendelsesdrevne mønstre |
+| `@nais` | GPT-5.3-Codex | Powerful | $1.75 | $14.00 | God på infrastruktur og YAML-konfigurasjon |
+| `@research` | GPT-5.3-Codex | Powerful | $1.75 | $14.00 | Effektiv på bred kodebase-søk og oppsummering |
+| `@rust` | GPT-5.3-Codex | Powerful | $1.75 | $14.00 | Terminal-Bench-leder for kompilert kode |
+| `@auth` | Claude Sonnet 4.6 | Versatile | $3.00 | $15.00 | Nyansert på sikkerhetsmønstre og token-flyt |
+| `@aksel` | Claude Sonnet 4.6 | Versatile | $3.00 | $15.00 | Sterk på komponentstruktur og designsystem-konvensjoner |
+| `@accessibility` | Claude Sonnet 4.6 | Versatile | $3.00 | $15.00 | God på WCAG-tolkning og semantisk HTML |
+| `@observability` | Claude Sonnet 4.6 | Versatile | $3.00 | $15.00 | Presis på metrikk-mønstre og PromQL |
+| `@forfatter` | Claude Sonnet 4.6 | Versatile | $3.00 | $15.00 | Anthropic-modellene er best på norsk klarspråk |
+
+### Prompts
+
+| Prompt | Modell | Kategori | Input | Output | Begrunnelse |
+|--------|--------|----------|-------|--------|-------------|
+| `kafka-topic` | GPT-5.3-Codex | Powerful | $1.75 | $14.00 | Konsistent med kafka-agenten |
+| `nais-manifest` | GPT-5.3-Codex | Powerful | $1.75 | $14.00 | Konsistent med nais-agenten |
+| `aksel-component` | Gemini 3.6 Flash | Versatile | $1.50 | $7.50 | Rask og billig for scaffolding av Aksel-komponenter |
+| `ktor-endpoint` | Claude Haiku 4.5 | Versatile | $1.00 | $5.00 | Enkel strukturert mal, trenger ikke tung modell |
+| `nextjs-api-route` | Claude Haiku 4.5 | Versatile | $1.00 | $5.00 | Enkel strukturert mal |
+| `spring-boot-endpoint` | Claude Haiku 4.5 | Versatile | $1.00 | $5.00 | Enkel strukturert mal |
+| `golang-service` | Claude Haiku 4.5 | Versatile | $1.00 | $5.00 | Enkel strukturert mal |
+
+---
+
+## Tilgjengelige modeller og bruksområder
+
+Oversikt over hele modellflåten — ikke bare de som er pinnet i agenter.
+
+| Modell | Kategori | Input | Output | Best for |
+|--------|----------|-------|--------|----------|
+| Claude Opus 4.6 / 4.8 | Powerful | $5.00 | $25.00 | Dyp risikovurdering, sikkerhetskritisk kode, kompleks arkitektur |
+| Claude Sonnet 4.6 | Versatile | $3.00 | $15.00 | Daglig koding, norsk tekst, planlegging |
+| Claude Sonnet 5 | Versatile | $2.00 | $10.00 | Samme som Sonnet 4.6, lavere pris (kampanje t.o.m. 31. aug 2026) |
+| Claude Haiku 4.5 | Versatile | $1.00 | $5.00 | Sjekklister, maler, scaffold-prompts |
+| GPT-5.3-Codex | Powerful | $1.75 | $14.00 | Kodeforståelse, terminal, infrastruktur |
+| GPT-5.6 Luna | Lightweight | $1.00 | $6.00 | Raske rutineoppgaver, enkel autofullfør |
+| GPT-5.6 Terra | Versatile | $2.50 | $15.00 | Allround daglig koding i GPT-familien |
+| GPT-5.6 Sol | Powerful | $5.00 | $30.00 | Tung reasoning over store kodebaser (krever Pro+) |
+| Gemini 2.5 Pro | Powerful | $1.25 | $10.00 | Beste pris/ytelse for research og lange kontekstvinduer |
+| Gemini 3.5 Flash | Lightweight | $1.50 | $9.00 | Rask og billig for enkle oppgaver |
+| Gemini 3.6 Flash | Versatile | $1.50 | $7.50 | Agentiske workflows med parallell verktøybruk |
+| Kimi K2.7 Code | Versatile | $0.95 | $4.00 | Rimeligste alternativ for kode-agent-løkker (open-weight) |
+
+Se [prissiden](/priser) for fullstendig og oppdatert pristabell.
+
+---
+
+## Kriterier for å bytte modell
+
+Vi bytter **ikke** modell automatisk når noe nytt lanseres. Et bytte krever at alle tre er oppfylt:
+
+1. **Bekreftet ID** — modellnavnet i `model:`-feltet er verifisert mot faktisk model picker-oppførsel, ikke bare dokumentasjon
+2. **Kostnad er lik eller lavere** — eller ytelsesgevinsten er dokumentert og rettferdiggjør økt kostnad
+3. **Testet på reell oppgave** — minst én oppgave av typen agenten brukes til, ikke benchmark-tall fra leverandøren
+
+### Eksempel: GPT-5.3-Codex → GPT-5.6 Terra
+
+| Kriterium | Status |
+|-----------|--------|
+| Bekreftet ID | ❌ Ikke verifisert i model picker |
+| Kostnad | ❌ Terra er 43 % dyrere på input ($2.50 vs $1.75) |
+| Testet | ❌ Ikke testet |
+
+**Konklusjon:** Ikke byttet. GPT-5.3-Codex beholdes inntil videre.
+
+---
+
+## Sjekkliste for nye modeller
+
+Når nye modeller slås på (som nå med GPT-5.6-familien, Kimi K2.7 og Gemini 3.6 Flash):
+
+- [ ] Bekreft eksakt modell-ID i model picker (ikke bare dokumentasjonsnavn)
+- [ ] Sammenlign pris mot eksisterende pinnet modell for samme agent
+- [ ] Sjekk om modellen er tilgjengelig på riktig Copilot-plan (Pro vs Pro+/Business)
+- [ ] Test på en reell oppgave av typen agenten brukes til
+- [ ] Oppdater tabell over pinning og begrunnelse i dette dokumentet
+- [ ] Oppdater `model:`-feltet i agent/prompt-filen
+
+---
+
+## Modell-ID-format
+
+Eksisterende observasjon av navnekonvensjoner i `model:`-feltet:
+
+| Modell | Format | Merk |
+|--------|--------|------|
+| `GPT-5.3-Codex` | Bindestrek mellom versjon og variant | Fungerer |
+| `Claude Sonnet 4.6` | Mellomrom | Fungerer |
+| `Claude Opus 4.6` | Mellomrom | Fungerer |
+| `Gemini 3.5 Flash` | Mellomrom | Fungerer |
+| `Gemini 3.6 Flash` | Mellomrom | Antatt — ikke verifisert i praksis |
+| `GPT-5.6 Terra` | Mellomrom | Antatt — ikke verifisert i praksis |
+
+Frem til en modell er verifisert i praksis, merkes den som «Antatt» og bør ikke brukes i produksjonspinning.

--- a/docs/news/articles/gemini-3-6-flash-ga.md
+++ b/docs/news/articles/gemini-3-6-flash-ga.md
@@ -1,0 +1,36 @@
+---
+title: "Gemini 3.6 Flash er tilgjengelig i GitHub Copilot"
+date: 2026-07-21
+category: copilot
+excerpt: "Googles nyeste Flash-modell er optimalisert for web- og apputvikling, koding og lengre agentoppgaver — med konfigurerbar reasoning og parallell verktøybruk."
+url: "https://github.blog/changelog/2026-07-21-gemini-3-6-flash-is-now-available-in-github-copilot"
+tags:
+  - models
+  - gemini
+  - coding-agents
+---
+
+Gemini 3.6 Flash fra Google er nå under gradvis utrulling i GitHub Copilot. Modellen er designet for web- og apputvikling, koding og lengre agentoppgaver.
+
+## Nøkkelfakta
+
+| Egenskap | Detalj |
+| --- | --- |
+| **Kategori** | Versatile |
+| **Status** | GA |
+| **Input-pris** | $1.50 per 1M tokens |
+| **Cached input** | $0.15 per 1M tokens |
+| **Output-pris** | $7.50 per 1M tokens |
+| **Standard for Business/Enterprise** | Av — må aktiveres av administrator |
+
+## Hva er nytt sammenlignet med Gemini 3.5 Flash
+
+- **Konfigurerbar reasoning-innsats** — tilpass hvor mye modellen tenker basert på oppgavens kompleksitet
+- **Parallell verktøybruk** — håndterer komplekse arbeidsflyter med flere samtidige verktøykall
+- I tidlige tester viste Gemini 3.6 Flash høyere fullføringsgrad og bedre token-effektivitet enn Gemini 3.5 Flash på koding og agentoppgaver
+
+## Aktivering for Business og Enterprise
+
+Copilot Business- og Enterprise-administratorer må aktivere «Gemini 3.6 Flash Preview»-policyen i Copilot-innstillingene.
+
+Tilgjengelig i: VS Code, Visual Studio, Copilot CLI, GitHub Copilot cloud agent, GitHub Copilot-appen, JetBrains, Xcode, Eclipse.

--- a/docs/news/articles/gpt-5-6-luna-sol-terra-ga.md
+++ b/docs/news/articles/gpt-5-6-luna-sol-terra-ga.md
@@ -1,0 +1,40 @@
+---
+title: "GPT-5.6 Sol, Terra og Luna er tilgjengelig i GitHub Copilot"
+date: 2026-07-09
+category: copilot
+excerpt: "OpenAIs GPT-5.6-familie lanseres i Copilot med tre varianter: Sol for tung reasoning, Terra for daglig bruk og Luna for raske, kostnadseffektive oppgaver."
+url: "https://github.blog/changelog/2026-07-09-openais-gpt-5-6-sol-terra-and-luna-are-now-available-in-github-copilot"
+tags:
+  - models
+  - gpt
+  - coding-agents
+---
+
+OpenAIs GPT-5.6-familie ruller nå ut i GitHub Copilot i tre varianter — Sol, Terra og Luna — slik at du kan matche modell mot oppgave.
+
+## De tre variantene
+
+| Modell | Kategori | Styrke | Tilgjengelig for |
+| --- | --- | --- | --- |
+| **GPT-5.6 Sol** | Powerful | Høyest reasoning-kapasitet. Best for kompleks reasoning over store kodebaser og langvarige agentoppgaver. | Pro+, Max, Business, Enterprise |
+| **GPT-5.6 Terra** | Versatile | Balansert standardvalg. Sterk allrounder for daglig interaktiv og agentisk koding. | Pro, Pro+, Max, Business, Enterprise |
+| **GPT-5.6 Luna** | Lightweight | Rask og kostnadseffektiv for mindre, enkle oppgaver. Laveste pris i familien. | Pro, Pro+, Max, Business, Enterprise |
+
+## Priser (per 1M tokens)
+
+| Modell | Kontekst | Input | Cached | Output |
+| --- | --- | --- | --- | --- |
+| GPT-5.6 Luna | ≤ 200K | $1.00 | $0.10 | $6.00 |
+| GPT-5.6 Luna | > 200K (lang kontekst) | $2.00 | $0.20 | $9.00 |
+| GPT-5.6 Terra | ≤ 272K | $2.50 | $0.25 | $15.00 |
+| GPT-5.6 Terra | > 272K (lang kontekst) | $5.00 | $0.50 | $22.50 |
+| GPT-5.6 Sol | ≤ 272K | $5.00 | $0.50 | $30.00 |
+| GPT-5.6 Sol | > 272K (lang kontekst) | $10.00 | $1.00 | $45.00 |
+
+## Aktivering for Business og Enterprise
+
+Copilot Business- og Enterprise-administratorer må aktivere policyen for GPT-5.6-modellene i Copilot-innstillingene. Policyen er av som standard.
+
+Tilgjengelig i: VS Code, Visual Studio, Copilot CLI, GitHub Copilot cloud agent, GitHub.com, GitHub Mobile, JetBrains, Xcode, Eclipse.
+
+Utrullingen er gradvis — hvis du ikke ser modellene ennå, sjekk igjen om litt.

--- a/docs/news/articles/kimi-k2-7-code-ga.md
+++ b/docs/news/articles/kimi-k2-7-code-ga.md
@@ -1,0 +1,39 @@
+---
+title: "Kimi K2.7 Code er generelt tilgjengelig i GitHub Copilot"
+date: 2026-07-01
+category: copilot
+excerpt: "Moonshot AIs Kimi K2.7 Code er den første open-weight-modellen i Copilots modellvelger — et rimeligere alternativ for kodingsoppgaver."
+url: "https://github.blog/changelog/2026-07-01-kimi-k2-7-is-now-available-in-github-copilot"
+tags:
+  - models
+  - kimi
+  - open-weight
+---
+
+Kimi K2.7 Code fra Moonshot AI er nå generelt tilgjengelig i GitHub Copilot. Det er den første open-weight-modellen som kan velges direkte i modellvelgeren — det gir flere valgmuligheter og et rimeligere alternativ for kodingsarbeidsflyter.
+
+Modellen er hostet av GitHub på Microsoft Azure og faktureres til provider list pricing under bruksbasert fakturering.
+
+## Nøkkelfakta
+
+| Egenskap | Detalj |
+| --- | --- |
+| **Kategori** | Versatile |
+| **Status** | GA |
+| **Input-pris** | $0.95 per 1M tokens |
+| **Cached input** | $0.19 per 1M tokens |
+| **Output-pris** | $4.00 per 1M tokens |
+| **Modelltype** | Open-weight |
+| **Standard for Business/Enterprise** | Av — må aktiveres av administrator |
+
+## Aktivering for Business og Enterprise
+
+Kimi K2.7 Code er av som standard for Copilot Business og Enterprise. Planadministratorer må aktivere Kimi K2.7 Code-policyen i Copilot-innstillingene før noen i organisasjonen kan velge modellen.
+
+> **Anbefaling fra GitHub:** Administratorer bør vurdere open-weight-modeller opp mot egne krav til sikkerhet, compliance og dataforvaltning før de aktiverer dem.
+
+## Tilgjengelighet
+
+Tilgjengelig i: VS Code (≥ 1.127.0), Visual Studio (≥ 17.14.6), Copilot CLI, GitHub Copilot cloud agent, GitHub.com, GitHub Mobile (iOS og Android), JetBrains (≥ 1.9.1-251), Xcode, Eclipse.
+
+Utrullingen startet med Pro, Pro+ og Max — Business og Enterprise følger.

--- a/docs/news/articles/nye-modeller-juli-2026.md
+++ b/docs/news/articles/nye-modeller-juli-2026.md
@@ -1,0 +1,101 @@
+---
+title: "Fem nye modeller i Copilot — slik tester du dem uten å sprenge kvoten"
+date: 2026-07-22
+author: starefossen
+category: nav
+excerpt: "GPT-5.6 Luna, Sol og Terra, Kimi K2.7 Code og Gemini 3.6 Flash er nå tilgjengelig. Her er en rask oversikt over hva hver modell er god for, hva de koster — og hvordan du prøver dem ansvarlig."
+url: "https://github.com/navikt/copilot/discussions"
+tags:
+  - models
+  - cost-optimization
+  - guide
+---
+
+Fem nye modeller er slått på i Copilot for Nav. Her er en ærlig oversikt over hva de koster og når du faktisk bør bruke dem — uten salgsprat fra leverandørene.
+
+---
+
+## Oversikt: Hva koster de, og hva er de gode for?
+
+| Modell | Kategori | Input | Output | Styrke | Bruk til |
+| --- | --- | --- | --- | --- | --- |
+| **GPT-5.6 Luna** | Lightweight | $1.00 | $6.00 | Rask og billig | Enkle spørsmål, boilerplate, lette tester |
+| **GPT-5.6 Terra** | Versatile | $2.50 | $15.00 | Balansert allrounder | Daglig koding, PR-beskrivelser, refaktorering |
+| **GPT-5.6 Sol** | Powerful | $5.00 | $30.00 | Dypest resonnering | Store kodebaser, arkitektur, seige bugs |
+| **Kimi K2.7 Code** | Versatile | $0.95 | $4.00 | Kodeforståelse og visuell koding | Tunge agent-looper og "mockup til kode" |
+| **Gemini 3.6 Flash** | Versatile | $1.50 | $7.50 | Token-gjerrig agent | Raske agent-oppgaver med mange verktøy |
+
+*Priser per 1M tokens i USD. Sammenlign med Claude Sonnet 4.6: $3.00 inn / $15.00 ut.*
+
+> **Tips:** GPT-5.6 Sol er bare tilgjengelig for **Pro+, Max, Business og Enterprise** — ikke Pro.
+
+---
+
+## GPT-5.6-familien: Ikke bruk Sol til alt
+
+OpenAI lanserer én modellfamilie delt inn i tre «gir». Tanken er at du skal bytte gir etter hvor vanskelig oppgaven er, slik at du ikke kaster bort penger på unødvendig prosessering. 
+
+*   **Luna (1. gir):** Ekstremt rask og billig. **Men:** Den er ikke spesielt smart. Bruk den til rutinearbeid, enkel dokumentasjon og når du bare trenger rask autofullfør. Styr unna kompleks logikk.
+*   **Terra (2. gir):** Standardvalget for hverdagskoding. Den klarer de fleste jobber godt nok, og erstatter typiske "velg og glem"-modeller. 
+*   **Sol (3. gir):** Modellen med tyngst resonnering, men som koster mye. Fantastisk til å beholde fokus over lang tid og til å vurdere arkitektur. Den drar også stor fordel av *prompt caching*, som gjør den billigere hvis du sender inn samme, store kodebase gjentatte ganger. **Men:** Ikke bruk den til enkle oppgaver. Den er overpriset ("overkill") for hverdagskoding.
+
+---
+
+## Kimi K2.7 Code: Den tvungne tenkeren
+
+Kimi K2.7 Code er den første open-weight-modellen i Copilots modellvelger. Den er spesielt trent for langvarige kodeprosjekter. 
+
+*   **Det som fungerer:** Den er veldig god på å følge lange instruksjoner og holde kontekst over mange steg. Som open-weight-modell gir den dessuten en interessant pris/ytelse-ratio i agent-løkker der mange kall kjøres i sekvens.
+*   **Haken:** Den må *alltid* «tenke». Du kan ikke skru av tenkemodusen for å få et umiddelbart, lynraskt svar. Den når heller ikke helt opp til de dyreste toppmodellene på komplekse kodingstester.
+
+---
+
+## Gemini 3.6 Flash: En token-gjerrig arbeidshest
+
+Google fokuserer på effektivitet med Gemini 3.6 Flash. Dette er modellen du vil bruke til agent-arbeidsflyter (der AI-en jobber selvstendig i mange steg).
+
+*   **Det som fungerer:** Den kaster bort færre tokens enn forgjengeren. Der andre modeller «kavner» (thrashing) med å prøve og feile mange ganger, treffer Gemini 3.6 Flash oftere på første eller andre forsøk. Google rapporterer høyere fullføringsgrad og bedre token-effektivitet enn 3.5 Flash på koding og agentoppgaver. Den er dessuten svært god på å bruke flere verktøy parallelt.
+*   **Haken:** Dette er en arbeidshest, ikke et geni. Den vil slite hvis du ber den om å løse dype, arkitektoniske problemer som krever ekstrem resonnering. Den har også en tendens til å bli litt «pratsom» og overformatere svar hvis du ikke ber den være kort.
+
+---
+
+## Slik velger du modell i VS Code
+
+1. Åpne Copilot Chat (`Ctrl+Alt+I` / `Cmd+Option+I`)
+2. Klikk på modellnavnet øverst i chat-vinduet
+3. Velg modell fra listen
+
+Modellvelgeren er også tilgjengelig i Copilot CLI, JetBrains, Visual Studio og GitHub.com.
+
+---
+
+## Rask huskeregel
+
+Ikke sikker på hvilken modell du skal velge? 
+
+*   **Rask rutinejobb?** Luna. (Eller Kimi hvis det er greit at den må tenke litt først).
+*   **Vanlig feature-utvikling?** Terra. (Eller Auto).
+*   **Agent som skal rydde opp med mange verktøy?** Gemini 3.6 Flash (den roter minst).
+*   **Kompleks arkitektur og vriene bugs i store repoer?** Sol. (Men bare da).
+
+Og husk: **Auto-modus** velger en passende modell for deg med innebygd kostnadsrabatt. Men med disse retningslinjene vet du i alle fall *hvorfor* du eventuelt overstyrer den.
+
+---
+
+## Kontekst: Hvordan passer de inn i resten?
+
+Disse fem modellene er tillegg til det vi allerede har — ikke erstatninger. Det er fortsatt mange gode grunner til å bruke Anthropic- og Google-modellene du kjenner fra før.
+
+| Bruksmønster | Gode valg | Hvorfor |
+| --- | --- | --- |
+| Norsk tekst, microcopy, PR-beskrivelser | Claude Sonnet 4.6 / Sonnet 5 | Anthropic-modellene er best på norsk |
+| Dyp risikovurdering, sikkerhetskritisk kode | Claude Opus 4.6 / 4.8 | Sterkest på resonering og nyanserte vurderinger |
+| Research, store kodebaser med mye kontekst | Gemini 2.5 Pro | Beste pris/ytelse på lange kontekstvinduer |
+| Sjekklister, templates, scaffold-prompts | Claude Haiku 4.5 | Rask og billig for enkle strukturerte oppgaver |
+| Daglig koding, refaktorering | Terra, Sonnet 5, Auto | Alle tre er solide allroundere i samme prisklasse |
+| Agentiske workflows med mange verktøykall | Gemini 3.6 Flash, Sol | Flash for parallelle verktøy, Sol for tung kontekst |
+| Kostnadseffektiv agent-looping | Kimi K2.7 Code | Rimeligste alternativ i Versatile-kategorien |
+
+De nye GPT-5.6-modellene er et godt supplement — særlig for utviklere som allerede er vant til GPT-familien eller vil ha et OpenAI-alternativ til Sonnet-klassen. Men Claude Sonnet 5 til $2/$10 (kampanjepris til 31. august) og Gemini 2.5 Pro til $1.25/$10 er fortsatt svært konkurransedyktige valg i den samme klassen.
+
+Se [prissiden](/priser) for fullstendig sammenligning av alle modeller og priser.

--- a/prompts/aksel-component.prompt.md
+++ b/prompts/aksel-component.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: aksel-component
 description: Scaffold en responsiv React-komponent med Aksel Design System, riktige tokens og props verifisert via Aksel MCP / aksel-builder-skillen
-model: Gemini 3.5 Flash
+model: Gemini 3.6 Flash
 ---
 
 You scaffold a new React component using Nav's Aksel design system (`@navikt/ds-react`, v8+).

--- a/scripts/sync-model-pricing.mjs
+++ b/scripts/sync-model-pricing.mjs
@@ -39,6 +39,8 @@ function parsePricingTables(html) {
     { provider: "Anthropic", anchorId: "anthropic" },
     { provider: "Google", anchorId: "google" },
     { provider: "GitHub", anchorId: "fine-tuned-github" },
+    { provider: "Microsoft", anchorId: "microsoft" },
+    { provider: "Moonshot AI", anchorId: "moonshot-ai" },
   ];
 
   for (const section of sections) {
@@ -212,7 +214,7 @@ function parsePrice(str) {
 function generateTypeScript(models) {
   const today = new Date().toISOString().split("T")[0];
 
-  const providerOrder = ["OpenAI", "Anthropic", "Google", "GitHub"];
+  const providerOrder = ["OpenAI", "Anthropic", "Google", "GitHub", "Microsoft", "Moonshot AI"];
   const grouped = {};
   for (const m of models) {
     if (!grouped[m.provider]) grouped[m.provider] = [];
@@ -256,7 +258,7 @@ function generateTypeScript(models) {
 
 export interface ModelPrice {
   model: string;
-  provider: "OpenAI" | "Anthropic" | "Google" | "GitHub";
+  provider: "OpenAI" | "Anthropic" | "Google" | "GitHub" | "Microsoft" | "Moonshot AI";
   category: "Lightweight" | "Versatile" | "Powerful";
   status: "GA" | "Public preview";
   input: number;


### PR DESCRIPTION
Fem nye modeller er slått på for Nav i GitHub Copilot.

Nyhetsartikler:
- docs/news/articles/gpt-5-6-luna-sol-terra-ga.md — offisiell kunngjøring
- docs/news/articles/kimi-k2-7-code-ga.md — første open-weight-modell i Copilot
- docs/news/articles/gemini-3-6-flash-ga.md — ny Flash med konfigurerbar reasoning
- docs/news/articles/nye-modeller-juli-2026.md — utviklerguide med kontekst for hele modellflåten

Prising og kalkulator:
- model-pricing.ts: regenerert via sync-scriptet (34 modeller)
- billing-calculator.ts: nye modeller og getModelCategory() for Sol/Luna/Kimi
- priser/page.tsx: PROVIDER_ORDER utvidet med Moonshot AI og Microsoft
- scripts/sync-model-pricing.mjs: støtte for Moonshot AI og Microsoft seksjoner

Modellvalg og dokumentasjon:
- docs/modellvalg.md: nytt referansedokument med pinning-tabell, byttekriterier og sjekkliste for nye modeller
- docs/ai-bruk-oversikt.md: lenke til modellvalg.md

Agent- og prompt-pinning:
- GPT-5.3-Codex beholdt (Terra ikke verifisert og dyrere)
- Gemini 3.5 Flash → Gemini 3.6 Flash på aksel-component prompt