### PR TITLE
fix(metrics): address review comments on PR review-velocity metrics

### DIFF
--- a/apps/copilot-api/bigquery_stats.go
+++ b/apps/copilot-api/bigquery_stats.go
@@ -1158,8 +1158,11 @@ type DailySummary struct {
 	CliSessionCount         int64   `bigquery:"cli_session_count" json:"cli_session_count"`
 	CliRequestCount         int64   `bigquery:"cli_request_count" json:"cli_request_count"`
 	PrMedianMinutesToMerge  float64 `bigquery:"pr_median_minutes_to_merge" json:"pr_median_minutes_to_merge"`
-	PrAvgMinutesToReview    float64 `bigquery:"pr_avg_minutes_to_review" json:"pr_avg_minutes_to_review"`
-	PrAvgReviewCycles       float64 `bigquery:"pr_avg_review_cycles" json:"pr_avg_review_cycles"`
+	// These live per AI adoption phase and were added to the usage API 2026-07-07;
+	// they are NULL for days ingested before then. Use pointers so a missing metric
+	// serializes as JSON null instead of a misleading 0.
+	PrAvgMinutesToReview *float64 `bigquery:"pr_avg_minutes_to_review" json:"pr_avg_minutes_to_review"`
+	PrAvgReviewCycles    *float64 `bigquery:"pr_avg_review_cycles" json:"pr_avg_review_cycles"`
 }
 
 func (bq *BigQueryClient) GetDailySummary(ctx context.Context) (*DailySummary, error) {

--- a/apps/copilot-api/bqscan.go
+++ b/apps/copilot-api/bqscan.go
@@ -124,6 +124,16 @@ func assignBQRecord(field reflect.Value, val bigquery.Value, fs *bigquery.FieldS
 }
 
 func assignBQScalar(field reflect.Value, val bigquery.Value) error {
+	// Nullable scalar: allocate the pointee and assign into it. A NULL column is
+	// already handled upstream (val == nil leaves the pointer as its nil zero
+	// value), so reaching here means we have a concrete value to store.
+	if field.Kind() == reflect.Pointer {
+		if field.IsNil() {
+			field.Set(reflect.New(field.Type().Elem()))
+		}
+		return assignBQScalar(field.Elem(), val)
+	}
+
 	// Fast path: directly assignable (string, civil.Date, time.Time, matching numeric).
 	vv := reflect.ValueOf(val)
 	if vv.Type().AssignableTo(field.Type()) {

--- a/apps/copilot-metrics/views/v_daily_summary.sql
+++ b/apps/copilot-metrics/views/v_daily_summary.sql
@@ -37,7 +37,8 @@ SELECT
           * CAST(JSON_VALUE(phase, '$.total_pull_requests_merged') AS INT64)),
       SUM(CAST(JSON_VALUE(phase, '$.total_pull_requests_merged') AS INT64))
     )
-    FROM UNNEST(JSON_QUERY_ARRAY(raw_record, '$.totals_by_ai_adoption_phase')) AS phase
+    FROM UNNEST(IFNULL(JSON_QUERY_ARRAY(raw_record, '$.totals_by_ai_adoption_phase'), [])) AS phase
+    WHERE JSON_VALUE(phase, '$.avg_pull_requests_minutes_to_review') IS NOT NULL
   ) AS pr_avg_minutes_to_review,
   (
     SELECT SAFE_DIVIDE(
@@ -45,7 +46,8 @@ SELECT
           * CAST(JSON_VALUE(phase, '$.total_pull_requests_merged') AS INT64)),
       SUM(CAST(JSON_VALUE(phase, '$.total_pull_requests_merged') AS INT64))
     )
-    FROM UNNEST(JSON_QUERY_ARRAY(raw_record, '$.totals_by_ai_adoption_phase')) AS phase
+    FROM UNNEST(IFNULL(JSON_QUERY_ARRAY(raw_record, '$.totals_by_ai_adoption_phase'), [])) AS phase
+    WHERE JSON_VALUE(phase, '$.avg_pull_requests_review_cycles') IS NOT NULL
   ) AS pr_avg_review_cycles,
   CAST(JSON_VALUE(raw_record, '$.pull_requests.total_suggestions') AS INT64) AS pr_total_suggestions,
   CAST(JSON_VALUE(raw_record, '$.pull_requests.total_copilot_suggestions') AS INT64) AS pr_copilot_suggestions,

--- a/apps/my-copilot/src/app/statistikk/page.tsx
+++ b/apps/my-copilot/src/app/statistikk/page.tsx
@@ -446,7 +446,7 @@ async function DashboardTabContent({ usage, token }: { usage: EnterpriseMetrics[
               helpText="Median tid fra en pull request opprettes til den får sin første review, snittet over AI-adopsjonsfaser og vektet på antall merget PR-er. Kun merget PR-er. Kilde: v_daily_summary (usage-API, fra 2026-07-07)."
             />
             <MetricCard
-              value={dailySummary.pr_avg_review_cycles > 0 ? dailySummary.pr_avg_review_cycles.toFixed(1) : "–"}
+              value={dailySummary.pr_avg_review_cycles != null ? dailySummary.pr_avg_review_cycles.toFixed(1) : "–"}
               label="Review-runder per PR"
               helpTitle="Review-runder per PR"
               helpText="Median antall review-innsendinger en pull request får før den merges, snittet over AI-adopsjonsfaser og vektet på antall merget PR-er. Kilde: v_daily_summary (usage-API, fra 2026-07-07)."

--- a/apps/my-copilot/src/lib/types.ts
+++ b/apps/my-copilot/src/lib/types.ts
@@ -439,8 +439,8 @@ export interface DailySummary {
   cli_session_count: number;
   cli_request_count: number;
   pr_median_minutes_to_merge: number;
-  pr_avg_minutes_to_review: number;
-  pr_avg_review_cycles: number;
+  pr_avg_minutes_to_review: number | null;
+  pr_avg_review_cycles: number | null;
 }
 
 // Privacy-preserving, aggregate-only usage spread for a given month.


### PR DESCRIPTION
Follow-up to #369. That PR merged from the merge queue before these review-comment fixes could be pushed (GitHub blocks branch updates while a PR is queued), so the 5 fixes from Copilot's review land here instead. Applies cleanly on top of #369.

## Fixes (all 5 review comments from #369)

1. **`v_daily_summary.sql`** (`pr_avg_minutes_to_review`) — wrap the phase array in `IFNULL(JSON_QUERY_ARRAY(…), [])` and add `WHERE … avg_pull_requests_minutes_to_review IS NOT NULL`, so both the numerator **and** the `total_pull_requests_merged` weight only count phases that report the metric (no downward bias); `SAFE_DIVIDE` → NULL when no phase has it.
2. **`v_daily_summary.sql`** (`pr_avg_review_cycles`) — same treatment for `avg_pull_requests_review_cycles`.
3. **`types.ts`** — `pr_avg_minutes_to_review` / `pr_avg_review_cycles` typed as `number | null` to match view/backend semantics (NULL pre-2026-07-07).
4. **`statistikk/page.tsx`** — explicit `!= null` check for the review-cycles card, so a real `0` renders `"0.0"` and null renders `"–"` without throwing.
5. **`bigquery_stats.go`** + **`bqscan.go`** — fields changed to `*float64` and the custom BigQuery decoder extended to allocate pointer scalars, so missing data serializes as JSON `null` instead of `0` (distinguishes missing vs. a real 0-value metric).

## Verification

- `copilot-api`: `go build` / `go test` ✅
- `copilot-metrics`: `go build` / `go test` ✅
- `my-copilot`: `tsc --noEmit` ✅, eslint ✅, vitest (474 tests) ✅

Refs #369.