### PR TITLE
feat(copilot-metrics): ingest repository-level Copilot usage metrics

### DIFF
--- a/apps/copilot-metrics/README.md
+++ b/apps/copilot-metrics/README.md
@@ -133,6 +133,7 @@ rtk go run . --run-once
 | `GCP_TEAM_PROJECT_ID`        | GCP project (from NAIS)              | (required)        |
 | `BIGQUERY_DATASET`           | BigQuery dataset name                | `copilot_metrics` |
 | `BIGQUERY_TABLE`             | BigQuery table name                  | `usage_metrics`   |
+| `BIGQUERY_REPO_METRICS_TABLE` | Per-repository metrics table name   | `repository_metrics` |
 | `SLACK_WEBHOOK_URL`          | Slack webhook for failure alerts     | (optional)        |
 
 ## BigQuery Schema
@@ -145,6 +146,25 @@ rtk go run . --run-once
 | `scope`      | STRING    | `enterprise` or `organization` |
 | `scope_id`   | STRING    | Enterprise/org identifier      |
 | `raw_record` | JSON      | Full NDJSON record as-is       |
+| `loaded_at`  | TIMESTAMP | When the row was inserted      |
+
+Table is partitioned by `day` and clustered by `scope`, `scope_id`.
+
+### `repository_metrics` table
+
+Per-repository, PR-only Copilot lifecycle activity from the `repos-1-day`
+Usage Metrics report (coding-agent authored/merged PRs and Copilot code-review
+suggestions). One row per repository per day. Ingested as a supplementary report
+alongside `users-1-day` / `user-teams-1-day`, so it flows through the nightly
+gap-fill and historical backfill automatically (data available from GitHub's
+GA on 2026-07-17).
+
+| Column       | Type      | Description                    |
+| ------------ | --------- | ------------------------------ |
+| `day`        | DATE      | Calendar day of the metrics    |
+| `scope`      | STRING    | `enterprise` or `organization` (fetch source) |
+| `scope_id`   | STRING    | Enterprise/org identifier      |
+| `raw_record` | JSON      | Full per-repo NDJSON record as-is (includes `repo_id`, `repo_name`) |
 | `loaded_at`  | TIMESTAMP | When the row was inserted      |
 
 Table is partitioned by `day` and clustered by `scope`, `scope_id`.

--- a/apps/copilot-metrics/backfill_test.go
+++ b/apps/copilot-metrics/backfill_test.go
@@ -93,6 +93,10 @@ func (f *countingFetcher) FetchDailyUserMetrics(_ context.Context, _ time.Time) 
 	return nil, ErrReportNotAvailable
 }
 
+func (f *countingFetcher) FetchDailyRepoMetrics(_ context.Context, _ time.Time) (*FetchResult, error) {
+	return nil, ErrReportNotAvailable
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }

--- a/apps/copilot-metrics/bigquery.go
+++ b/apps/copilot-metrics/bigquery.go
@@ -24,6 +24,7 @@ type BigQueryClient struct {
 	table            string
 	userTeamsTable   string
 	userMetricsTable string
+	repoMetricsTable string
 }
 
 type UsageMetricsRow struct {
@@ -47,6 +48,7 @@ func NewBigQueryClient(ctx context.Context, cfg *Config) (*BigQueryClient, error
 		table:            cfg.BigQueryTable,
 		userTeamsTable:   cfg.BigQueryUserTeamsTable,
 		userMetricsTable: cfg.BigQueryUserMetricsTable,
+		repoMetricsTable: cfg.BigQueryRepoMetricsTable,
 	}, nil
 }
 
@@ -64,6 +66,10 @@ func (c *BigQueryClient) EnsureUserTeamsTableExists(ctx context.Context) error {
 
 func (c *BigQueryClient) EnsureUserMetricsTableExists(ctx context.Context) error {
 	return c.ensureMetricsTable(ctx, c.userMetricsTable, "GitHub Copilot per-user usage metrics from the Usage Metrics API")
+}
+
+func (c *BigQueryClient) EnsureRepoMetricsTableExists(ctx context.Context) error {
+	return c.ensureMetricsTable(ctx, c.repoMetricsTable, "GitHub Copilot per-repository usage metrics from the Usage Metrics API")
 }
 
 // ensureMetricsTable creates a table with the standard metrics schema if it doesn't exist.
@@ -119,6 +125,10 @@ func (c *BigQueryClient) InsertUserMetrics(ctx context.Context, day time.Time, s
 	return c.insertRecords(ctx, c.userMetricsTable, day, scope, scopeID, records)
 }
 
+func (c *BigQueryClient) InsertRepoMetrics(ctx context.Context, day time.Time, scope, scopeID string, records []json.RawMessage) error {
+	return c.insertRecords(ctx, c.repoMetricsTable, day, scope, scopeID, records)
+}
+
 func (c *BigQueryClient) insertRecords(ctx context.Context, tableName string, day time.Time, scope, scopeID string, records []json.RawMessage) error {
 	if len(records) == 0 {
 		slog.Warn("No records to insert", "table", tableName, "day", day.Format("2006-01-02"))
@@ -162,6 +172,10 @@ func (c *BigQueryClient) UserMetricsDayExists(ctx context.Context, day time.Time
 	return c.dayExistsInTable(ctx, c.userMetricsTable, day, scopeID)
 }
 
+func (c *BigQueryClient) RepoMetricsDayExists(ctx context.Context, day time.Time, scopeID string) (bool, error) {
+	return c.dayExistsInTable(ctx, c.repoMetricsTable, day, scopeID)
+}
+
 func (c *BigQueryClient) dayExistsInTable(ctx context.Context, tableName string, day time.Time, scopeID string) (bool, error) {
 	dayStr := day.Format("2006-01-02")
 
@@ -200,6 +214,10 @@ func (c *BigQueryClient) DeleteUserTeamsDay(ctx context.Context, day time.Time, 
 
 func (c *BigQueryClient) DeleteUserMetricsDay(ctx context.Context, day time.Time, scopeID string) error {
 	return c.deleteDayFromTable(ctx, c.userMetricsTable, day, scopeID)
+}
+
+func (c *BigQueryClient) DeleteRepoMetricsDay(ctx context.Context, day time.Time, scopeID string) error {
+	return c.deleteDayFromTable(ctx, c.repoMetricsTable, day, scopeID)
 }
 
 func (c *BigQueryClient) deleteDayFromTable(ctx context.Context, tableName string, day time.Time, scopeID string) error {

--- a/apps/copilot-metrics/config.go
+++ b/apps/copilot-metrics/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	BigQueryTable              string
 	BigQueryUserTeamsTable     string
 	BigQueryUserMetricsTable   string
+	BigQueryRepoMetricsTable   string
 	SlackWebhookURL            string
 }
 
@@ -41,6 +42,7 @@ func loadConfig() *Config {
 		BigQueryTable:              getEnv("BIGQUERY_TABLE", "usage_metrics"),
 		BigQueryUserTeamsTable:     getEnv("BIGQUERY_USER_TEAMS_TABLE", "user_teams"),
 		BigQueryUserMetricsTable:   getEnv("BIGQUERY_USER_METRICS_TABLE", "user_metrics"),
+		BigQueryRepoMetricsTable:   getEnv("BIGQUERY_REPO_METRICS_TABLE", "repository_metrics"),
 		SlackWebhookURL:            getEnv("SLACK_WEBHOOK_URL", ""),
 	}
 }

--- a/apps/copilot-metrics/config_test.go
+++ b/apps/copilot-metrics/config_test.go
@@ -13,6 +13,8 @@ func TestLoadConfig_DefaultValues(t *testing.T) {
 		"GITHUB_ENTERPRISE_SLUG", "GITHUB_ORG",
 		"GITHUB_APP_ID", "GITHUB_APP_PRIVATE_KEY", "GITHUB_APP_INSTALLATION_ID",
 		"GCP_TEAM_PROJECT_ID", "BIGQUERY_DATASET", "BIGQUERY_TABLE",
+		"BIGQUERY_USER_TEAMS_TABLE", "BIGQUERY_USER_METRICS_TABLE",
+		"BIGQUERY_REPO_METRICS_TABLE",
 		"SLACK_WEBHOOK_URL",
 	} {
 		t.Setenv(key, "")
@@ -30,6 +32,9 @@ func TestLoadConfig_DefaultValues(t *testing.T) {
 		{"OrganizationSlug", cfg.OrganizationSlug, "navikt"},
 		{"BigQueryDataset", cfg.BigQueryDataset, "copilot_metrics"},
 		{"BigQueryTable", cfg.BigQueryTable, "usage_metrics"},
+		{"BigQueryUserTeamsTable", cfg.BigQueryUserTeamsTable, "user_teams"},
+		{"BigQueryUserMetricsTable", cfg.BigQueryUserMetricsTable, "user_metrics"},
+		{"BigQueryRepoMetricsTable", cfg.BigQueryRepoMetricsTable, "repository_metrics"},
 	}
 
 	for _, tt := range tests {
@@ -62,6 +67,7 @@ func TestLoadConfig_CustomEnvValues(t *testing.T) {
 	t.Setenv("GCP_TEAM_PROJECT_ID", "my-project")
 	t.Setenv("BIGQUERY_DATASET", "custom_dataset")
 	t.Setenv("BIGQUERY_TABLE", "custom_table")
+	t.Setenv("BIGQUERY_REPO_METRICS_TABLE", "custom_repos")
 	t.Setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.com/test")
 
 	cfg := loadConfig()
@@ -95,6 +101,9 @@ func TestLoadConfig_CustomEnvValues(t *testing.T) {
 	}
 	if cfg.BigQueryTable != "custom_table" {
 		t.Errorf("BigQueryTable = %q, want %q", cfg.BigQueryTable, "custom_table")
+	}
+	if cfg.BigQueryRepoMetricsTable != "custom_repos" {
+		t.Errorf("BigQueryRepoMetricsTable = %q, want %q", cfg.BigQueryRepoMetricsTable, "custom_repos")
 	}
 	if cfg.SlackWebhookURL != "https://hooks.slack.com/test" {
 		t.Errorf("SlackWebhookURL = %q, want %q", cfg.SlackWebhookURL, "https://hooks.slack.com/test")

--- a/apps/copilot-metrics/github.go
+++ b/apps/copilot-metrics/github.go
@@ -440,6 +440,15 @@ func (c *GitHubClient) FetchDailyUserMetrics(ctx context.Context, day time.Time)
 	return c.fetchDailyReport(ctx, day, "users-1-day")
 }
 
+// FetchDailyRepoMetrics fetches the repos-1-day report for the given day.
+// This report contains per-repository, PR-only Copilot lifecycle activity
+// (coding-agent authored/merged PRs and Copilot code-review suggestions).
+// It uses the same enterprise-first-then-org fallback and NDJSON transport as
+// the other daily reports.
+func (c *GitHubClient) FetchDailyRepoMetrics(ctx context.Context, day time.Time) (*FetchResult, error) {
+	return c.fetchDailyReport(ctx, day, "repos-1-day")
+}
+
 // fetchDailyReport fetches a daily report by type, trying enterprise first then org.
 func (c *GitHubClient) fetchDailyReport(ctx context.Context, day time.Time, reportType string) (*FetchResult, error) {
 	dayStr := day.Format("2006-01-02")

--- a/apps/copilot-metrics/github_test.go
+++ b/apps/copilot-metrics/github_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestDownloadAndParseNDJSON(t *testing.T) {
@@ -189,6 +190,104 @@ func TestFetchMetricsFromURL_ValidResponse(t *testing.T) {
 	}
 	if len(records) != 1 {
 		t.Errorf("got %d records, want 1", len(records))
+	}
+}
+
+func TestFetchDailyRepoMetrics_EnterpriseScope(t *testing.T) {
+	// One NDJSON record per repository, PR-only shape as documented for repos-1-day.
+	downloadHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"repo_id":1,"repo_name":"foo","pull_requests":{"total_created_by_copilot":3}}` + "\n" +
+			`{"repo_id":2,"repo_name":"bar","pull_requests":{"total_created_by_copilot":1}}` + "\n"))
+	})
+
+	reportResp := MetricsReportResponse{
+		DownloadLinks: []string{"http://test/ndjson"},
+		ReportDay:     "2026-07-20",
+	}
+	reportJSON, _ := json.Marshal(reportResp)
+
+	var requestedPath string
+	reportHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(reportJSON)
+	})
+
+	client := &GitHubClient{
+		httpClient:     mockClient(reportHandler),
+		downloadClient: mockClient(downloadHandler),
+		enterprise:     "nav",
+		org:            "navikt",
+	}
+
+	day := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	result, err := client.FetchDailyRepoMetrics(context.Background(), day)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Scope != "enterprise" {
+		t.Errorf("scope = %q, want %q", result.Scope, "enterprise")
+	}
+	if result.ScopeID != "nav" {
+		t.Errorf("scope_id = %q, want %q", result.ScopeID, "nav")
+	}
+	if len(result.Records) != 2 {
+		t.Errorf("got %d records, want 2", len(result.Records))
+	}
+	if want := "/enterprises/nav/copilot/metrics/reports/repos-1-day"; requestedPath != want {
+		t.Errorf("requested path = %q, want %q", requestedPath, want)
+	}
+}
+
+func TestFetchDailyRepoMetrics_OrgFallback(t *testing.T) {
+	downloadHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"repo_id":1,"repo_name":"foo"}` + "\n"))
+	})
+
+	reportResp := MetricsReportResponse{DownloadLinks: []string{"http://test/ndjson"}, ReportDay: "2026-07-20"}
+	reportJSON, _ := json.Marshal(reportResp)
+
+	var paths []string
+	reportHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		// Enterprise endpoint fails with a report-not-available string, org succeeds.
+		if strings.HasPrefix(r.URL.Path, "/enterprises/") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`"No report available for this day"`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(reportJSON)
+	})
+
+	client := &GitHubClient{
+		httpClient:     mockClient(reportHandler),
+		downloadClient: mockClient(downloadHandler),
+		enterprise:     "nav",
+		org:            "navikt",
+	}
+
+	day := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	result, err := client.FetchDailyRepoMetrics(context.Background(), day)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Scope != "organization" {
+		t.Errorf("scope = %q, want %q", result.Scope, "organization")
+	}
+	if result.ScopeID != "navikt" {
+		t.Errorf("scope_id = %q, want %q", result.ScopeID, "navikt")
+	}
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 requests (enterprise then org), got %d: %v", len(paths), paths)
+	}
+	if want := "/orgs/navikt/copilot/metrics/reports/repos-1-day"; paths[1] != want {
+		t.Errorf("org fallback path = %q, want %q", paths[1], want)
 	}
 }
 

--- a/apps/copilot-metrics/interfaces.go
+++ b/apps/copilot-metrics/interfaces.go
@@ -12,6 +12,7 @@ type MetricsFetcher interface {
 	FetchDailyMetrics(ctx context.Context, day time.Time) (*FetchResult, error)
 	FetchDailyUserTeams(ctx context.Context, day time.Time) (*FetchResult, error)
 	FetchDailyUserMetrics(ctx context.Context, day time.Time) (*FetchResult, error)
+	FetchDailyRepoMetrics(ctx context.Context, day time.Time) (*FetchResult, error)
 	FetchLatest28DayReport(ctx context.Context) (*FetchResult, error)
 }
 
@@ -21,15 +22,19 @@ type MetricsStore interface {
 	EnsureTableExists(ctx context.Context) error
 	EnsureUserTeamsTableExists(ctx context.Context) error
 	EnsureUserMetricsTableExists(ctx context.Context) error
+	EnsureRepoMetricsTableExists(ctx context.Context) error
 	InsertMetrics(ctx context.Context, day time.Time, scope, scopeID string, records []json.RawMessage) error
 	InsertUserTeams(ctx context.Context, day time.Time, scope, scopeID string, records []json.RawMessage) error
 	InsertUserMetrics(ctx context.Context, day time.Time, scope, scopeID string, records []json.RawMessage) error
+	InsertRepoMetrics(ctx context.Context, day time.Time, scope, scopeID string, records []json.RawMessage) error
 	DayExists(ctx context.Context, day time.Time, scopeID string) (bool, error)
 	UserTeamsDayExists(ctx context.Context, day time.Time, scopeID string) (bool, error)
 	UserMetricsDayExists(ctx context.Context, day time.Time, scopeID string) (bool, error)
+	RepoMetricsDayExists(ctx context.Context, day time.Time, scopeID string) (bool, error)
 	DeleteDay(ctx context.Context, day time.Time, scopeID string) error
 	DeleteUserTeamsDay(ctx context.Context, day time.Time, scopeID string) error
 	DeleteUserMetricsDay(ctx context.Context, day time.Time, scopeID string) error
+	DeleteRepoMetricsDay(ctx context.Context, day time.Time, scopeID string) error
 	GetLatestDay(ctx context.Context, scopeID string) (time.Time, error)
 	Close() error
 }

--- a/apps/copilot-metrics/main.go
+++ b/apps/copilot-metrics/main.go
@@ -83,6 +83,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err := bqClient.EnsureRepoMetricsTableExists(ctx); err != nil {
+		slog.Error("Failed to ensure repository_metrics table exists", "error", err)
+		os.Exit(1)
+	}
+
 	if err := bqClient.EnsureViewsExist(ctx); err != nil {
 		slog.Warn("Failed to ensure views exist (continuing without views)", "error", err)
 	}
@@ -448,6 +453,27 @@ func ingestSupplementary(ctx context.Context, gh MetricsFetcher, bq MetricsStore
 			slog.Info("Ingested per-user metrics report", "day", dayStr, "records", len(usersResult.Records))
 		}
 	}
+
+	// Per-repository metrics report (repos-1-day) — PR-only, may lag like the
+	// other supplementary reports (available from GA on 2026-07-17 onwards).
+	if reposResult, err := gh.FetchDailyRepoMetrics(ctx, day); err != nil {
+		if errors.Is(err, ErrReportNotAvailable) {
+			slog.Info("Per-repository metrics report not available yet", "day", dayStr)
+		} else {
+			slog.Warn("Failed to fetch per-repository metrics report", "day", dayStr, "error", err)
+		}
+	} else if len(reposResult.Records) > 0 {
+		if err := upsertReport(ctx, bq.RepoMetricsDayExists, bq.DeleteRepoMetricsDay, bq.InsertRepoMetrics,
+			day, reposResult); err != nil {
+			if errors.Is(err, ErrStreamingBuffer) {
+				slog.Info("Skipping repo-metrics re-import (streaming buffer not yet flushed, re-run in ~90 min)", "day", dayStr)
+			} else {
+				slog.Warn("Failed to store per-repository metrics report", "day", dayStr, "error", err)
+			}
+		} else {
+			slog.Info("Ingested per-repository metrics report", "day", dayStr, "records", len(reposResult.Records))
+		}
+	}
 }
 
 // ingestMissingSupplementary checks the last 7 days for days that have entity
@@ -509,6 +535,25 @@ func ingestMissingSupplementary(ctx context.Context, gh MetricsFetcher, bq Metri
 					slog.Warn("Failed to insert missing user-metrics", "day", dayStr, "error", insertErr)
 				} else {
 					slog.Info("Backfilled missing user-metrics", "day", dayStr, "records", len(usersResult.Records))
+					filled++
+				}
+			}
+		}
+
+		// Check and fill per-repository metrics
+		reposExists, err := bq.RepoMetricsDayExists(ctx, day, scopeID)
+		if err != nil {
+			slog.Warn("Failed to check repo-metrics existence", "day", dayStr, "error", err)
+		} else if !reposExists {
+			if reposResult, fetchErr := gh.FetchDailyRepoMetrics(ctx, day); fetchErr != nil {
+				if !errors.Is(fetchErr, ErrReportNotAvailable) {
+					slog.Warn("Failed to fetch missing repo-metrics", "day", dayStr, "error", fetchErr)
+				}
+			} else if len(reposResult.Records) > 0 {
+				if insertErr := bq.InsertRepoMetrics(ctx, day, reposResult.Scope, reposResult.ScopeID, reposResult.Records); insertErr != nil {
+					slog.Warn("Failed to insert missing repo-metrics", "day", dayStr, "error", insertErr)
+				} else {
+					slog.Info("Backfilled missing repo-metrics", "day", dayStr, "records", len(reposResult.Records))
 					filled++
 				}
 			}

--- a/apps/copilot-metrics/main_test.go
+++ b/apps/copilot-metrics/main_test.go
@@ -17,6 +17,8 @@ type mockFetcher struct {
 	userTeamsErr      error
 	userMetricsResult *FetchResult
 	userMetricsErr    error
+	repoMetricsResult *FetchResult
+	repoMetricsErr    error
 }
 
 func (m *mockFetcher) FetchDailyMetrics(_ context.Context, _ time.Time) (*FetchResult, error) {
@@ -33,6 +35,13 @@ func (m *mockFetcher) FetchDailyUserTeams(_ context.Context, _ time.Time) (*Fetc
 func (m *mockFetcher) FetchDailyUserMetrics(_ context.Context, _ time.Time) (*FetchResult, error) {
 	if m.userMetricsResult != nil || m.userMetricsErr != nil {
 		return m.userMetricsResult, m.userMetricsErr
+	}
+	return nil, ErrReportNotAvailable
+}
+
+func (m *mockFetcher) FetchDailyRepoMetrics(_ context.Context, _ time.Time) (*FetchResult, error) {
+	if m.repoMetricsResult != nil || m.repoMetricsErr != nil {
+		return m.repoMetricsResult, m.repoMetricsErr
 	}
 	return nil, ErrReportNotAvailable
 }
@@ -58,6 +67,8 @@ type mockStore struct {
 	// Supplementary report tracking
 	userTeamsInserted   int
 	userMetricsInserted int
+	repoMetricsInserted int
+	repoMetricsExists   bool
 }
 
 func (m *mockStore) EnsureTableExists(_ context.Context) error {
@@ -69,6 +80,10 @@ func (m *mockStore) EnsureUserTeamsTableExists(_ context.Context) error {
 }
 
 func (m *mockStore) EnsureUserMetricsTableExists(_ context.Context) error {
+	return m.tableExistsErr
+}
+
+func (m *mockStore) EnsureRepoMetricsTableExists(_ context.Context) error {
 	return m.tableExistsErr
 }
 
@@ -89,6 +104,11 @@ func (m *mockStore) InsertUserMetrics(_ context.Context, _ time.Time, _, _ strin
 	return nil
 }
 
+func (m *mockStore) InsertRepoMetrics(_ context.Context, _ time.Time, _, _ string, records []json.RawMessage) error {
+	m.repoMetricsInserted = len(records)
+	return nil
+}
+
 func (m *mockStore) DayExists(_ context.Context, _ time.Time, _ string) (bool, error) {
 	return m.dayExists, m.dayExistsErr
 }
@@ -101,6 +121,10 @@ func (m *mockStore) UserMetricsDayExists(_ context.Context, _ time.Time, _ strin
 	return false, nil
 }
 
+func (m *mockStore) RepoMetricsDayExists(_ context.Context, _ time.Time, _ string) (bool, error) {
+	return m.repoMetricsExists, nil
+}
+
 func (m *mockStore) DeleteDay(_ context.Context, day time.Time, _ string) error {
 	m.deletedDay = day
 	return m.deleteErr
@@ -111,6 +135,10 @@ func (m *mockStore) DeleteUserTeamsDay(_ context.Context, _ time.Time, _ string)
 }
 
 func (m *mockStore) DeleteUserMetricsDay(_ context.Context, _ time.Time, _ string) error {
+	return nil
+}
+
+func (m *mockStore) DeleteRepoMetricsDay(_ context.Context, _ time.Time, _ string) error {
 	return nil
 }
 
@@ -404,6 +432,67 @@ func TestIngestDay_WithSupplementaryReports(t *testing.T) {
 	}
 }
 
+func TestIngestDay_WithRepoMetricsReport(t *testing.T) {
+	ctx := context.Background()
+	day := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+
+	fetcher := &mockFetcher{
+		result: &FetchResult{
+			Records: []json.RawMessage{json.RawMessage(`{"daily_active_users":30}`)},
+			Scope:   "enterprise",
+			ScopeID: "nav",
+		},
+		repoMetricsResult: &FetchResult{
+			Records: []json.RawMessage{
+				json.RawMessage(`{"repo_id":1,"repo_name":"foo","pull_requests":{"total_created_by_copilot":3}}`),
+				json.RawMessage(`{"repo_id":2,"repo_name":"bar","pull_requests":{"total_created_by_copilot":1}}`),
+			},
+			Scope:   "enterprise",
+			ScopeID: "nav",
+		},
+	}
+
+	store := &mockStore{}
+
+	err := ingestDay(ctx, fetcher, store, &Config{EnterpriseSlug: "nav"}, day)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if store.repoMetricsInserted != 2 {
+		t.Errorf("expected 2 repo-metrics records, got %d", store.repoMetricsInserted)
+	}
+}
+
+func TestIngestDay_RepoMetricsNotAvailableDoesNotFail(t *testing.T) {
+	ctx := context.Background()
+	day := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+
+	// Repo metrics unavailable (pre-GA day) — defaults to ErrReportNotAvailable
+	// via mockFetcher when repoMetricsResult/Err are unset.
+	fetcher := &mockFetcher{
+		result: &FetchResult{
+			Records: []json.RawMessage{json.RawMessage(`{"daily_active_users":30}`)},
+			Scope:   "enterprise",
+			ScopeID: "nav",
+		},
+	}
+
+	store := &mockStore{}
+
+	err := ingestDay(ctx, fetcher, store, &Config{EnterpriseSlug: "nav"}, day)
+	if err != nil {
+		t.Fatalf("repo-metrics unavailability should not fail ingestion, got %v", err)
+	}
+	if store.repoMetricsInserted != 0 {
+		t.Errorf("expected 0 repo-metrics records, got %d", store.repoMetricsInserted)
+	}
+	// Entity metrics still ingested.
+	if store.insertedCount != 1 {
+		t.Errorf("expected 1 entity record, got %d", store.insertedCount)
+	}
+}
+
 func TestIngestDay_SupplementaryFailureDoesNotFailIngestion(t *testing.T) {
 	ctx := context.Background()
 	day := time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC)
@@ -637,5 +726,9 @@ func (f *callbackFetcher) FetchDailyUserTeams(_ context.Context, _ time.Time) (*
 }
 
 func (f *callbackFetcher) FetchDailyUserMetrics(_ context.Context, _ time.Time) (*FetchResult, error) {
+	return nil, ErrReportNotAvailable
+}
+
+func (f *callbackFetcher) FetchDailyRepoMetrics(_ context.Context, _ time.Time) (*FetchResult, error) {
 	return nil, ErrReportNotAvailable
 }


### PR DESCRIPTION
**Phase 1 (ingestion only)** of the repository-level Copilot usage metrics design in #387.

Fetches the new `repos-1-day` report and stores per-repo, PR-only records as raw JSON in a new dedicated **`repository_metrics`** BigQuery table (same generic schema/mechanism as `user_metrics` / `user_teams`). No new `scope` value on `usage_metrics` — separate table per the design's precedent.

## What's included
- **`github.go`** — `FetchDailyRepoMetrics` over the existing generic `fetchDailyReport(…, "repos-1-day")` (reuses enterprise-first→org fallback, `X-GitHub-Api-Version` header, and NDJSON download/parse — no new HTTP plumbing).
- **`bigquery.go`** — `repository_metrics` table via the existing `ensureMetricsTable` (5-col raw-JSON schema: `day`, `scope`, `scope_id`, `raw_record`, `loaded_at`; partitioned by `day`, clustered by `scope,scope_id`) + thin insert/exists/delete wrappers.
- **`config.go`** — `BIGQUERY_REPO_METRICS_TABLE` env (default `repository_metrics`).
- **`main.go`** — startup table creation; `ingestSupplementary` fetch+upsert; `ingestMissingSupplementary` 7-day gap-fill.
- **`interfaces.go`**, mocks, and unit tests (enterprise fetch, org fallback, ingest wiring, report-not-available tolerance, config coverage). README updated.

## Idempotency & backfill
Per-day `upsertReport` (check→delete→insert on `(day, scope_id)`, `ErrStreamingBuffer`-safe). Historical backfill flows for free through `runBackfill → ingestDay → ingestSupplementary`; pre-GA days skip on `ErrReportNotAvailable`.

## Verification
`go build` / `go vet` / `go test` all clean (only `copilot-metrics` touched).

## Follow-up phases
views (`v_repository_usage`) → copilot-api read endpoint → my-copilot dashboard → privacy hardening (PRIVATE-repo exclusion + k=5 repo-activity suppression).

## Open items for live-API verification
Exact `repos-1-day` field names/nullability, earliest fetchable `day`, and whether the enterprise report covers all `navikt` repos vs. a narrower org fallback. Ingestion is schema-agnostic (raw JSON), so these are safe to confirm before the Phase 3 view casts.

Refs #373.