### PR TITLE
feat(copilot-metrics): add v_repository_usage view with privacy suppression

### DIFF
--- a/apps/copilot-metrics/views.go
+++ b/apps/copilot-metrics/views.go
@@ -28,6 +28,7 @@ var views = []viewDefinition{
 	{name: "v_billing_monthly_trend", filename: "views/v_billing_monthly_trend.sql"},
 	{name: "v_billing_model_breakdown", filename: "views/v_billing_model_breakdown.sql"},
 	{name: "v_user_budget_trend", filename: "views/v_user_budget_trend.sql"},
+	{name: "v_repository_usage", filename: "views/v_repository_usage.sql"},
 }
 
 func (c *BigQueryClient) EnsureViewsExist(ctx context.Context) error {
@@ -68,8 +69,10 @@ func (c *BigQueryClient) createOrReplaceView(ctx context.Context, v viewDefiniti
 	billingUsageRef := fmt.Sprintf("`%s.%s.%s`", c.projectID, c.dataset, billingUsageTable)
 	billingUsageDailyModelRef := fmt.Sprintf("`%s.%s.%s`", c.projectID, c.dataset, billingUsageDailyModelTable)
 	userBudgetSnapshotsRef := fmt.Sprintf("`%s.%s.%s`", c.projectID, c.dataset, userBudgetSnapshotsTable)
+	repoMetricsRef := fmt.Sprintf("`%s.%s.%s`", c.projectID, c.dataset, c.repoMetricsTable)
 	sql = strings.ReplaceAll(sql, "{{user_teams}}", userTeamsRef)
 	sql = strings.ReplaceAll(sql, "{{user_metrics}}", userMetricsRef)
+	sql = strings.ReplaceAll(sql, "{{repository_metrics}}", repoMetricsRef)
 	sql = strings.ReplaceAll(sql, "{{billing_usage_daily_model}}", billingUsageDailyModelRef)
 	sql = strings.ReplaceAll(sql, "{{billing_usage}}", billingUsageRef)
 	sql = strings.ReplaceAll(sql, "{{user_budget_snapshots}}", userBudgetSnapshotsRef)

--- a/apps/copilot-metrics/views/v_repository_usage.sql
+++ b/apps/copilot-metrics/views/v_repository_usage.sql
@@ -1,0 +1,90 @@
+-- v_repository_usage — per-repository GitHub Copilot pull-request activity,
+-- aggregated across all available days, with privacy safeguards baked in.
+--
+-- The repos-1-day report is PR-only (coding agent + code review); the
+-- pull_requests.* sub-object is the same shape already extracted per entity in
+-- v_daily_summary.sql, so the field mapping is a known quantity — but here it is
+-- read per repository from the repository_metrics raw-JSON table.
+--
+-- WHY AGGREGATED (never raw per-day per-repo):
+-- Repo-level data creates a re-identification risk the user-level k-anonymity
+-- guard (bigquery_stats.go:minUsersForDistribution = 5) does not cover: a repo
+-- with only one or two contributors makes Copilot PR counts effectively
+-- attributable to a named individual, and a single active day could be singled
+-- out. This view therefore exposes ONLY per-repo rollups, never raw per-day
+-- per-repo rows.
+--
+-- PRIVACY SAFEGUARDS (see docs/repository-level-metrics-integration.md §7):
+--   1. Private repos are excluded — only repo_visibility IN ('PUBLIC','INTERNAL').
+--   2. Low-activity repos are suppressed: a repo is surfaced only when its total
+--      PRs created (all authors, over the window) is >= min_repo_activity (5),
+--      matching the k = 5 used for user distributions so the two guards stay
+--      visibly related.
+--   3. Aggregation is per-repo across ALL available days; the API/query layer
+--      bounds the trailing window. This mirrors the existing views
+--      (v_daily_summary / v_team_daily_summary) which leave time windowing to the
+--      query layer rather than hard-coding a window in the view.
+--
+-- All pull_requests.* metrics are NULL for pre-GA (2026-07-17) days — the
+-- repos-1-day report did not exist before GA, so those days contribute nothing.
+CREATE OR REPLACE VIEW `%s.%s.v_repository_usage` AS
+WITH privacy_thresholds AS (
+  -- min_repo_activity mirrors bigquery_stats.go:minUsersForDistribution (k = 5):
+  -- below this many total PRs created over the window, a single contributor's
+  -- behaviour dominates the repo's numbers, so the repo is suppressed.
+  SELECT 5 AS min_repo_activity
+),
+daily AS (
+  SELECT
+    CAST(JSON_VALUE(raw_record, '$.repo_id') AS INT64)  AS repo_id,
+    JSON_VALUE(raw_record, '$.repo_owner_name')         AS repo_owner,
+    JSON_VALUE(raw_record, '$.repo_name')               AS repo_name,
+    JSON_VALUE(raw_record, '$.repo_visibility')         AS repo_visibility,
+    scope,
+    scope_id,
+    day,
+    CAST(JSON_VALUE(raw_record, '$.pull_requests.total_created') AS INT64) AS pr_total_created,
+    CAST(JSON_VALUE(raw_record, '$.pull_requests.total_merged') AS INT64) AS pr_total_merged,
+    CAST(JSON_VALUE(raw_record, '$.pull_requests.total_reviewed') AS INT64) AS pr_total_reviewed,
+    CAST(JSON_VALUE(raw_record, '$.pull_requests.total_created_by_copilot') AS INT64) AS pr_created_by_copilot,
+    CAST(JSON_VALUE(raw_record, '$.pull_requests.total_reviewed_by_copilot') AS INT64) AS pr_reviewed_by_copilot,
+    CAST(JSON_VALUE(raw_record, '$.pull_requests.total_merged_created_by_copilot') AS INT64) AS pr_merged_copilot_authored,
+    CAST(JSON_VALUE(raw_record, '$.pull_requests.total_merged_reviewed_by_copilot') AS INT64) AS pr_merged_copilot_reviewed,
+    CAST(JSON_VALUE(raw_record, '$.pull_requests.median_minutes_to_merge') AS FLOAT64) AS pr_median_minutes_to_merge,
+    CAST(JSON_VALUE(raw_record, '$.pull_requests.median_minutes_to_merge_copilot_authored') AS FLOAT64) AS pr_median_minutes_to_merge_copilot,
+    CAST(JSON_VALUE(raw_record, '$.pull_requests.median_minutes_to_merge_copilot_reviewed') AS FLOAT64) AS pr_median_minutes_to_merge_copilot_reviewed,
+    CAST(JSON_VALUE(raw_record, '$.pull_requests.total_copilot_suggestions') AS INT64) AS pr_copilot_suggestions,
+    CAST(JSON_VALUE(raw_record, '$.pull_requests.total_copilot_applied_suggestions') AS INT64) AS pr_copilot_applied_suggestions
+  FROM {{repository_metrics}}
+  -- Privacy safeguard 1: never surface private repositories.
+  WHERE JSON_VALUE(raw_record, '$.repo_visibility') IN ('PUBLIC', 'INTERNAL')
+)
+SELECT
+  repo_id,
+  repo_owner,
+  repo_name,
+  ANY_VALUE(repo_visibility) AS repo_visibility,
+  scope_id,
+  COUNT(DISTINCT day) AS days_with_data,
+  MIN(day) AS first_day,
+  MAX(day) AS last_day,
+  SUM(pr_total_created) AS pr_total_created,
+  SUM(pr_total_merged) AS pr_total_merged,
+  SUM(pr_total_reviewed) AS pr_total_reviewed,
+  SUM(pr_created_by_copilot) AS pr_created_by_copilot,
+  SUM(pr_reviewed_by_copilot) AS pr_reviewed_by_copilot,
+  SUM(pr_merged_copilot_authored) AS pr_merged_copilot_authored,
+  SUM(pr_merged_copilot_reviewed) AS pr_merged_copilot_reviewed,
+  SUM(pr_copilot_suggestions) AS pr_copilot_suggestions,
+  SUM(pr_copilot_applied_suggestions) AS pr_copilot_applied_suggestions,
+  -- Medians cannot be summed across days; expose the simple average of the daily
+  -- median values (over days where the median is present) as an approximation of
+  -- the window's typical time-to-merge. NULL when no day had a median.
+  AVG(pr_median_minutes_to_merge) AS pr_avg_median_minutes_to_merge,
+  AVG(pr_median_minutes_to_merge_copilot) AS pr_avg_median_minutes_to_merge_copilot,
+  AVG(pr_median_minutes_to_merge_copilot_reviewed) AS pr_avg_median_minutes_to_merge_copilot_reviewed
+FROM daily
+GROUP BY repo_id, repo_owner, repo_name, scope_id
+-- Privacy safeguard 2: suppress low-activity repos (k = 5 on total PRs created).
+HAVING SUM(pr_total_created) >= (SELECT min_repo_activity FROM privacy_thresholds)
+ORDER BY pr_created_by_copilot DESC;

--- a/apps/copilot-metrics/views_test.go
+++ b/apps/copilot-metrics/views_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -45,6 +46,7 @@ func TestViewDefinitions(t *testing.T) {
 		"v_billing_monthly_trend",
 		"v_billing_model_breakdown",
 		"v_user_budget_trend",
+		"v_repository_usage",
 	}
 
 	if len(views) != len(expectedViews) {
@@ -65,5 +67,27 @@ func TestViewDefinitions(t *testing.T) {
 		if len(data) == 0 {
 			t.Errorf("embedded SQL for %s is empty", want)
 		}
+	}
+}
+
+// TestRepositoryUsageViewPlaceholders asserts the repository usage view is wired
+// to the {{repository_metrics}} placeholder that createOrReplaceView substitutes,
+// and that its privacy safeguards (private-repo exclusion + k=5 suppression) are
+// present in the SQL.
+func TestRepositoryUsageViewPlaceholders(t *testing.T) {
+	data, err := viewsFS.ReadFile("views/v_repository_usage.sql")
+	if err != nil {
+		t.Fatalf("could not read v_repository_usage.sql: %v", err)
+	}
+	sql := string(data)
+
+	if !strings.Contains(sql, "{{repository_metrics}}") {
+		t.Errorf("v_repository_usage.sql must reference the {{repository_metrics}} placeholder")
+	}
+	if !strings.Contains(sql, "IN ('PUBLIC', 'INTERNAL')") {
+		t.Errorf("v_repository_usage.sql must exclude private repos via visibility filter")
+	}
+	if !strings.Contains(sql, "HAVING") || !strings.Contains(sql, "min_repo_activity") {
+		t.Errorf("v_repository_usage.sql must suppress low-activity repos via a HAVING threshold")
 	}
 }


### PR DESCRIPTION
**Phase 2** of the repository-level Copilot usage metrics design (#387, doc on `main`). Builds the BigQuery view over the `repository_metrics` table from Phase 1 (#388), with the design's privacy safeguards baked in.

## What's included
- **`views/v_repository_usage.sql`** (new) — per-repository aggregate over `repository_metrics.raw_record`, extracting the `pull_requests.*` fields (created/merged/reviewed, Copilot-authored/reviewed, suggestion counts, median-time-to-merge) using the same `JSON_VALUE`/`CAST` idiom as `v_daily_summary.sql`.
- **`views.go`** — registers the view and wires a new `{{repository_metrics}}` placeholder (mirrors the `{{user_metrics}}`/`{{user_teams}}` substitution).
- **`views_test.go`** — updated view-list assertion + `TestRepositoryUsageViewPlaceholders`.

## Privacy safeguards (design §7)
1. **Visibility filter** — `daily` CTE keeps only `repo_visibility IN ('PUBLIC','INTERNAL')` (excludes PRIVATE).
2. **k=5 suppression** — `privacy_thresholds` CTE (`min_repo_activity = 5`, mirroring `minUsersForDistribution`), enforced via `HAVING SUM(pr_total_created) >= 5` so low-activity repos (where Copilot-authored PRs could be individually attributable) are dropped.
3. **Aggregate-only** — groups per repo across available days; never exposes raw per-day per-repo rows. Time-window bounding is left to the API layer, matching `v_daily_summary`/`v_team_daily_summary`.

## Verification
`go build` / `go vet` / `go test` all clean (includes updated view tests). SQL reviewed manually — no live BigQuery available to execute it.

## Notes / open items
- Medians can't be summed, so daily medians are surfaced as an `AVG` approximation (documented in-SQL).
- Exact `repos-1-day` field names/nullability still pending live-API verification (design §9); fields are NULL for pre-GA (2026-07-17) days.

## Follow-up phases
copilot-api read endpoint (`/api/v1/copilot/usage/repositories`) → my-copilot dashboard tab.

Refs #373.