### PR TITLE
feat(copilot-api): add repository usage endpoint

### DIFF
--- a/apps/copilot-api/bigquery.go
+++ b/apps/copilot-api/bigquery.go
@@ -386,6 +386,7 @@ type BigQueryQuerier interface {
 	GetBillingModelBreakdown(ctx context.Context, months int) ([]BillingModelBreakdown, error)
 	GetDailySummary(ctx context.Context) (*DailySummary, error)
 	GetUsageDistribution(ctx context.Context, month string, budgetCredits float64) (*UsageDistribution, error)
+	GetRepositoryUsage(ctx context.Context) ([]RepositoryUsage, error)
 }
 
 // Cache wrapper for BigQuery operations
@@ -651,6 +652,14 @@ func (c *CachedBigQueryClient) GetUsageDistribution(ctx context.Context, month s
 	cacheKey := fmt.Sprintf("usage_distribution_%s_%.2f", month, budgetCredits)
 	return getCachedValue(c, cacheKey, func() (*UsageDistribution, error) {
 		return c.client.GetUsageDistribution(ctx, month, budgetCredits)
+	})
+}
+
+func (c *CachedBigQueryClient) GetRepositoryUsage(ctx context.Context) ([]RepositoryUsage, error) {
+	ctx, cancel := withQueryTimeout(ctx)
+	defer cancel()
+	return getCachedValue(c, "repository_usage", func() ([]RepositoryUsage, error) {
+		return c.client.GetRepositoryUsage(ctx)
 	})
 }
 

--- a/apps/copilot-api/bigquery_handlers_test.go
+++ b/apps/copilot-api/bigquery_handlers_test.go
@@ -47,6 +47,8 @@ type mockBigQueryClient struct {
 	cohortsErr         error
 	usageDistribution  *UsageDistribution
 	usageDistErr       error
+	repositoryUsage    []RepositoryUsage
+	repositoryUsageErr error
 }
 
 func (m *mockBigQueryClient) GetDailyMetrics(_ context.Context, _ *int) ([]EnterpriseMetrics, error) {
@@ -131,6 +133,10 @@ func (m *mockBigQueryClient) GetDailySummary(_ context.Context) (*DailySummary, 
 
 func (m *mockBigQueryClient) GetUsageDistribution(_ context.Context, _ string, _ float64) (*UsageDistribution, error) {
 	return m.usageDistribution, m.usageDistErr
+}
+
+func (m *mockBigQueryClient) GetRepositoryUsage(_ context.Context) ([]RepositoryUsage, error) {
+	return m.repositoryUsage, m.repositoryUsageErr
 }
 
 func TestHandleDailyMetrics(t *testing.T) {
@@ -542,6 +548,20 @@ func TestHandleNewStatsEndpoints(t *testing.T) {
 			mock:       &mockBigQueryClient{cohortsErr: errors.New("bq")},
 			req:        httptest.NewRequest(http.MethodGet, "/api/v1/copilot/adoption/cohorts", nil),
 			handle:     (*BigQueryHandlers).handleAdoptionCohorts,
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:       "repository usage success",
+			mock:       &mockBigQueryClient{repositoryUsage: []RepositoryUsage{{RepoName: "repo-a", RepoVisibility: "INTERNAL", PRCreatedByCopilot: 3}}},
+			req:        httptest.NewRequest(http.MethodGet, "/api/v1/copilot/usage/repositories", nil),
+			handle:     (*BigQueryHandlers).handleRepositoryUsage,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "repository usage error",
+			mock:       &mockBigQueryClient{repositoryUsageErr: errors.New("bq")},
+			req:        httptest.NewRequest(http.MethodGet, "/api/v1/copilot/usage/repositories", nil),
+			handle:     (*BigQueryHandlers).handleRepositoryUsage,
 			wantStatus: http.StatusInternalServerError,
 		},
 	}

--- a/apps/copilot-api/bigquery_stats.go
+++ b/apps/copilot-api/bigquery_stats.go
@@ -1194,6 +1194,81 @@ func (bq *BigQueryClient) GetDailySummary(ctx context.Context) (*DailySummary, e
 	return &rows[0], nil
 }
 
+// RepositoryUsage is one per-repository rollup of GitHub Copilot pull-request
+// activity, read from the v_repository_usage view. The view aggregates across
+// all available days and bakes in privacy safeguards (private repos excluded,
+// low-activity repos suppressed), so this layer exposes its rows as-is.
+//
+// The three PRAvgMedian* fields are *float64: the view emits NULL for a repo
+// whose days never carried a merge-time median (pre-GA days / no merges), and a
+// pointer lets that serialize as JSON null instead of a misleading 0. The
+// count columns are always present, so they stay int64.
+type RepositoryUsage struct {
+	RepoID                                   int64    `bigquery:"repo_id" json:"repo_id"`
+	RepoOwner                                string   `bigquery:"repo_owner" json:"repo_owner"`
+	RepoName                                 string   `bigquery:"repo_name" json:"repo_name"`
+	RepoVisibility                           string   `bigquery:"repo_visibility" json:"repo_visibility"`
+	ScopeID                                  string   `bigquery:"scope_id" json:"scope_id"`
+	DaysWithData                             int64    `bigquery:"days_with_data" json:"days_with_data"`
+	FirstDay                                 string   `bigquery:"first_day" json:"first_day"`
+	LastDay                                  string   `bigquery:"last_day" json:"last_day"`
+	PRTotalCreated                           int64    `bigquery:"pr_total_created" json:"pr_total_created"`
+	PRTotalMerged                            int64    `bigquery:"pr_total_merged" json:"pr_total_merged"`
+	PRTotalReviewed                          int64    `bigquery:"pr_total_reviewed" json:"pr_total_reviewed"`
+	PRCreatedByCopilot                       int64    `bigquery:"pr_created_by_copilot" json:"pr_created_by_copilot"`
+	PRReviewedByCopilot                      int64    `bigquery:"pr_reviewed_by_copilot" json:"pr_reviewed_by_copilot"`
+	PRMergedCopilotAuthored                  int64    `bigquery:"pr_merged_copilot_authored" json:"pr_merged_copilot_authored"`
+	PRMergedCopilotReviewed                  int64    `bigquery:"pr_merged_copilot_reviewed" json:"pr_merged_copilot_reviewed"`
+	PRCopilotSuggestions                     int64    `bigquery:"pr_copilot_suggestions" json:"pr_copilot_suggestions"`
+	PRCopilotAppliedSuggestions              int64    `bigquery:"pr_copilot_applied_suggestions" json:"pr_copilot_applied_suggestions"`
+	PRAvgMedianMinutesToMerge                *float64 `bigquery:"pr_avg_median_minutes_to_merge" json:"pr_avg_median_minutes_to_merge"`
+	PRAvgMedianMinutesToMergeCopilot         *float64 `bigquery:"pr_avg_median_minutes_to_merge_copilot" json:"pr_avg_median_minutes_to_merge_copilot"`
+	PRAvgMedianMinutesToMergeCopilotReviewed *float64 `bigquery:"pr_avg_median_minutes_to_merge_copilot_reviewed" json:"pr_avg_median_minutes_to_merge_copilot_reviewed"`
+}
+
+// GetRepositoryUsage returns the per-repository Copilot PR activity rollups from
+// the v_repository_usage view, most Copilot-authored PRs first. The view is
+// already all-time-aggregated and privacy-suppressed (see
+// apps/copilot-metrics/views/v_repository_usage.sql), so there is no time-window
+// parameter to apply here — every surfaced row is returned as-is.
+//
+// DEPLOY ORDERING: the v_repository_usage view must be deployed by copilot-metrics
+// before this endpoint is queried, the same coupling GetDailySummary has with
+// v_daily_summary.
+func (bq *BigQueryClient) GetRepositoryUsage(ctx context.Context) ([]RepositoryUsage, error) {
+	viewRef := bq.viewRef(bq.metricsDataset, "v_repository_usage")
+	queryStr := fmt.Sprintf(`
+      SELECT
+        repo_id,
+        repo_owner,
+        repo_name,
+        repo_visibility,
+        scope_id,
+        days_with_data,
+        CAST(first_day AS STRING) AS first_day,
+        CAST(last_day AS STRING) AS last_day,
+        pr_total_created,
+        pr_total_merged,
+        pr_total_reviewed,
+        pr_created_by_copilot,
+        pr_reviewed_by_copilot,
+        pr_merged_copilot_authored,
+        pr_merged_copilot_reviewed,
+        pr_copilot_suggestions,
+        pr_copilot_applied_suggestions,
+        pr_avg_median_minutes_to_merge,
+        pr_avg_median_minutes_to_merge_copilot,
+        pr_avg_median_minutes_to_merge_copilot_reviewed
+      FROM %s
+      ORDER BY pr_created_by_copilot DESC
+    `, viewRef)
+	it, err := bq.client.Query(queryStr).Read(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("execute query: %w", err)
+	}
+	return readAllRows[RepositoryUsage](it)
+}
+
 func (bq *BigQueryClient) GetBillingModelBreakdown(ctx context.Context, months int) ([]BillingModelBreakdown, error) {
 	viewRef := bq.viewRef(bq.metricsDataset, "v_billing_model_breakdown")
 	queryStr := fmt.Sprintf(`

--- a/apps/copilot-api/bigquery_stats_handlers.go
+++ b/apps/copilot-api/bigquery_stats_handlers.go
@@ -409,3 +409,19 @@ func (h *BigQueryHandlers) handleDailySummary(w http.ResponseWriter, r *http.Req
 	cacheControl(w, 3600, false)
 	respondJSON(w, summary, http.StatusOK)
 }
+
+// handleRepositoryUsage handles GET /api/v1/copilot/usage/repositories
+// Cache: 1 hour (aggregated per-repository metrics). No query parameters: the
+// v_repository_usage view is already all-time-aggregated and privacy-suppressed,
+// so there is no trailing window to bound here.
+func (h *BigQueryHandlers) handleRepositoryUsage(w http.ResponseWriter, r *http.Request) {
+	repositories, err := h.bqClient.GetRepositoryUsage(r.Context())
+	if err != nil {
+		slog.Error("Failed to fetch repository usage", "error", err)
+		respondError(w, "internal_error", "Failed to fetch repository usage", http.StatusInternalServerError)
+		return
+	}
+
+	cacheControl(w, 3600, false)
+	respondJSON(w, repositories, http.StatusOK)
+}

--- a/apps/copilot-api/handlers.go
+++ b/apps/copilot-api/handlers.go
@@ -92,6 +92,7 @@ func makeAPIRouter(config *Config, bqHandlers *BigQueryHandlers, ghHandlers *Git
 	mux.HandleFunc("GET /api/v1/copilot/adoption/cohorts", bq(nilSafe(bqHandlers, func(h *BigQueryHandlers) http.HandlerFunc { return h.handleAdoptionCohorts })))
 	mux.HandleFunc("GET /api/v1/copilot/usage/daily-summary", bq(nilSafe(bqHandlers, func(h *BigQueryHandlers) http.HandlerFunc { return h.handleDailySummary })))
 	mux.HandleFunc("GET /api/v1/copilot/usage/distribution", bq(nilSafe(bqHandlers, func(h *BigQueryHandlers) http.HandlerFunc { return h.handleUsageDistribution })))
+	mux.HandleFunc("GET /api/v1/copilot/usage/repositories", bq(nilSafe(bqHandlers, func(h *BigQueryHandlers) http.HandlerFunc { return h.handleRepositoryUsage })))
 
 	// GitHub API endpoints
 	mux.HandleFunc("GET /api/v1/copilot/billing", gh(nilSafe(ghHandlers, func(h *GitHubHandlers) http.HandlerFunc { return h.handleBilling })))


### PR DESCRIPTION
**Phase 3** of the repository-level Copilot usage metrics design (#387). Exposes the `v_repository_usage` view (#389, merged) via a read endpoint for the dashboard.

## What's included
- **`bigquery_stats.go`** — `RepositoryUsage` struct (columns match the view exactly) + `GetRepositoryUsage(ctx)` querying `v_repository_usage`, ordered `pr_created_by_copilot DESC`. Mirrors `GetDailySummary`/`GetBillingMonthlyTrend` style. The three `pr_avg_median_minutes_to_merge*` fields are `*float64` so NULL (pre-GA / no-merge) serializes as JSON `null` (via the #386 pointer-scalar decoder).
- **`bigquery.go`** — `GetRepositoryUsage` added to `BigQueryQuerier` + a `CachedBigQueryClient` passthrough (cache key `repository_usage`).
- **`bigquery_stats_handlers.go`** — `handleRepositoryUsage` (GET, 1 h cache, standard error/JSON helpers).
- **`handlers.go`** — `GET /api/v1/copilot/usage/repositories`, same `bq(nilSafe(...))` auth wrapper as sibling `/usage/*` routes.
- **`bigquery_handlers_test.go`** — mock + success/error tests.

## Notes
- **No `days` param** (deliberate): the merged `v_repository_usage` view is pre-aggregated across all days (no per-day column to filter), so the endpoint returns all privacy-suppressed per-repo rollups. The design's earlier `days` sketch predates the final view shape.
- **Deploy ordering:** the view (#389) must be deployed before this endpoint is queried — same coupling as `GetDailySummary`↔`v_daily_summary`. #389 is already on `main`.
- `repo_id` is `int64` (view emits `INT64`).

## Verification
`go build` / `go vet` / `go test` all clean (new repository-usage success/error subtests pass).

## Follow-up
Phase 4 — my-copilot dashboard tab consuming this endpoint.

Refs #373.