### PR TITLE
feat(my-copilot): add repository usage dashboard tab

### DIFF
--- a/apps/my-copilot/src/app/statistikk/page.tsx
+++ b/apps/my-copilot/src/app/statistikk/page.tsx
@@ -13,10 +13,12 @@ import {
   getBillingMonthlyTrend,
   getBillingModelBreakdown,
   getDailySummary,
+  getRepositoryUsage,
 } from "@/lib/cached-bigquery";
 import type { EnterpriseMetrics } from "@/lib/types";
 import Tabs from "@/components/tabs";
 import TeamUsageTable from "@/components/team-usage-table";
+import RepositoryUsageTable from "@/components/repository-usage-table";
 import TrendChart from "@/components/charts/TrendChart";
 import ModelUsageChart from "@/components/charts/ModelUsageChart";
 
@@ -45,25 +47,9 @@ import {
 } from "@/lib/data-utils";
 import { currentMonthUTC, previousMonth, selectCompleteMonths } from "@/lib/month-utils";
 import type { LanguageData, EditorData, ModelData } from "@/lib/types";
-import { formatNumber } from "@/lib/format";
+import { formatNumber, formatMinutes } from "@/lib/format";
 import { getUser, getUserToken } from "@/lib/auth";
 import { backendRequest } from "@/lib/backend-api";
-
-// formatMinutes converts a duration to human-readable Norwegian format.
-// IMPORTANT: Rounds total minutes FIRST, then splits into hours/minutes.
-// The previous approach (Math.round on the remainder) caused "1t 60m" when
-// minutes % 60 was between 59.5 and 60 (e.g. 119.7 → floor(1.99)=1h, round(59.7)=60m).
-function formatMinutes(minutes: number | null): string {
-  if (minutes == null || minutes <= 0) return "–";
-  if (minutes < 60) return `${Math.round(minutes)} min`;
-  const totalMinutes = Math.round(minutes);
-  const hours = Math.floor(totalMinutes / 60);
-  const mins = totalMinutes % 60;
-  if (hours < 24) return mins > 0 ? `${hours}t ${mins}m` : `${hours}t`;
-  const days = Math.floor(hours / 24);
-  const remainingHours = hours % 24;
-  return remainingHours > 0 ? `${days}d ${remainingHours}t` : `${days}d`;
-}
 
 // Static header component (automatically prerendered)
 function UsageHeader() {
@@ -131,6 +117,52 @@ async function TeamUsageContent({ token }: { token: string }) {
   return <TeamUsageTable teams={visibleTeams} userTeams={userTeams} allowAllTeams={ALLOW_ALL_TEAMS} />;
 }
 
+// Cached repository usage data component — per-repo Copilot PR activity.
+// The backend view is already all-time aggregated and privacy-suppressed
+// (private repos excluded, repos with < 5 total PRs hidden), so this component
+// just fetches and renders. Wrapped in its own Suspense boundary on the page so
+// a slow query here doesn't block the other tabs.
+async function RepositoryUsageContent({ token }: { token: string }) {
+  const { repositories, error } = await getRepositoryUsage(token);
+
+  if (error) return <ErrorState message={`Feil ved henting av repositoriedata: ${error}`} />;
+  if (!repositories || repositories.length === 0)
+    return <ErrorState message="Ingen repositoriedata tilgjengelig ennå." />;
+
+  // Roll up headline totals across all surfaced repos for the metric cards.
+  const totalCopilotAuthored = repositories.reduce((sum, r) => sum + r.pr_created_by_copilot, 0);
+  const totalCopilotReviewed = repositories.reduce((sum, r) => sum + r.pr_reviewed_by_copilot, 0);
+  const totalSuggestions = repositories.reduce((sum, r) => sum + r.pr_copilot_suggestions, 0);
+  const totalAppliedSuggestions = repositories.reduce((sum, r) => sum + r.pr_copilot_applied_suggestions, 0);
+  const appliedRate = totalSuggestions > 0 ? Math.round((totalAppliedSuggestions / totalSuggestions) * 100) : 0;
+
+  return (
+    <VStack gap="space-24">
+      <HGrid columns={{ xs: 1, sm: 3 }} gap="space-16">
+        <MetricCard
+          value={formatNumber(totalCopilotAuthored)}
+          label="Copilot-forfattede PR-er"
+          helpTitle="Copilot-forfattede PR-er"
+          helpText="Antall pull requests opprettet av Copilot coding agent, summert over alle synlige repositorier og hele perioden med data."
+        />
+        <MetricCard
+          value={formatNumber(totalCopilotReviewed)}
+          label="Copilot-reviewede PR-er"
+          helpTitle="Copilot-reviewede PR-er"
+          helpText="Antall pull requests gjennomgått av Copilot code review, summert over alle synlige repositorier og hele perioden med data."
+        />
+        <MetricCard
+          value={`${appliedRate} %`}
+          label="Forslag tatt i bruk"
+          helpTitle="Forslag tatt i bruk"
+          helpText="Andel av Copilots review-forslag som ble tatt i bruk, på tvers av alle synlige repositorier."
+        />
+      </HGrid>
+      <RepositoryUsageTable repositories={repositories} />
+    </VStack>
+  );
+}
+
 // Main content component that takes usage data as props.
 // Individual data fetches are NOT cached at the BFF layer — caching is owned
 // by copilot-api (1 h in-memory cache). Each request fetches fresh data from
@@ -187,6 +219,18 @@ function UsageTabs({ usage, token }: { usage: EnterpriseMetrics[]; token: string
         </div>
       ),
       hashIds: ["team"],
+    },
+    {
+      id: "repositories",
+      label: "Repositorier",
+      content: (
+        <div id="repositories">
+          <Suspense fallback={<Skeleton variant="rectangle" height={200} />}>
+            <RepositoryUsageContent token={token} />
+          </Suspense>
+        </div>
+      ),
+      hashIds: ["repositories", "repositorier"],
     },
     {
       id: "details",

--- a/apps/my-copilot/src/components/repository-usage-table.test.tsx
+++ b/apps/my-copilot/src/components/repository-usage-table.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, within } from "@testing-library/react";
+import RepositoryUsageTable from "./repository-usage-table";
+import type { RepositoryUsage } from "@/lib/types";
+
+function makeRepo(overrides: Partial<RepositoryUsage>): RepositoryUsage {
+  return {
+    repo_id: 1,
+    repo_owner: "navikt",
+    repo_name: "foo",
+    repo_visibility: "PUBLIC",
+    scope_id: "scope",
+    days_with_data: 10,
+    first_day: "2026-01-01",
+    last_day: "2026-01-10",
+    pr_total_created: 20,
+    pr_total_merged: 15,
+    pr_total_reviewed: 12,
+    pr_created_by_copilot: 5,
+    pr_reviewed_by_copilot: 4,
+    pr_merged_copilot_authored: 3,
+    pr_merged_copilot_reviewed: 2,
+    pr_copilot_suggestions: 30,
+    pr_copilot_applied_suggestions: 18,
+    pr_avg_median_minutes_to_merge: 192,
+    pr_avg_median_minutes_to_merge_copilot: 100,
+    pr_avg_median_minutes_to_merge_copilot_reviewed: 80,
+    ...overrides,
+  };
+}
+
+describe("RepositoryUsageTable", () => {
+  it("renders repository owner/name and a GitHub link", () => {
+    render(<RepositoryUsageTable repositories={[makeRepo({ repo_id: 1 })]} />);
+    const link = screen.getByRole("link", { name: "navikt/foo" });
+    expect(link).toHaveAttribute("href", "https://github.com/navikt/foo");
+  });
+
+  it("formats the nullable median as an en-dash when null", () => {
+    render(
+      <RepositoryUsageTable
+        repositories={[makeRepo({ repo_id: 1, repo_name: "nomedian", pr_avg_median_minutes_to_merge: null })]}
+      />
+    );
+    const row = screen.getByRole("link", { name: "navikt/nomedian" }).closest("tr")!;
+    expect(within(row).getByText("–")).toBeInTheDocument();
+  });
+
+  it("formats a non-null median duration", () => {
+    render(<RepositoryUsageTable repositories={[makeRepo({ pr_avg_median_minutes_to_merge: 192 })]} />);
+    expect(screen.getByText("3t 12m")).toBeInTheDocument();
+  });
+
+  it("defaults to sorting by Copilot-authored PRs descending", () => {
+    render(
+      <RepositoryUsageTable
+        repositories={[
+          makeRepo({ repo_id: 1, repo_name: "low", pr_created_by_copilot: 2 }),
+          makeRepo({ repo_id: 2, repo_name: "high", pr_created_by_copilot: 99 }),
+        ]}
+      />
+    );
+    const links = screen.getAllByRole("link").map((a) => a.textContent);
+    expect(links).toEqual(["navikt/high", "navikt/low"]);
+  });
+
+  it("shows an empty state when there are no repositories", () => {
+    render(<RepositoryUsageTable repositories={[]} />);
+    expect(screen.getByText("Ingen repositoriedata tilgjengelig ennå.")).toBeInTheDocument();
+  });
+});

--- a/apps/my-copilot/src/components/repository-usage-table.tsx
+++ b/apps/my-copilot/src/components/repository-usage-table.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useState, useMemo, useCallback } from "react";
+import { HStack, Pagination, Table, Search, Alert, VStack, BodyShort, Button, Tag } from "@navikt/ds-react";
+import { TableBody, TableDataCell, TableHeader, TableRow } from "@navikt/ds-react/Table";
+import type { RepositoryUsage } from "@/lib/types";
+import { formatNumber, formatMinutes } from "@/lib/format";
+
+function CopyJsonButton({ data, label = "Kopier JSON" }: { data: unknown; label?: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(JSON.stringify(data, null, 2)).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [data]);
+  return (
+    <Button variant="tertiary-neutral" size="xsmall" onClick={handleCopy}>
+      {copied ? "✓ Kopiert" : label}
+    </Button>
+  );
+}
+
+const PAGE_SIZE = 15;
+
+type SortKey =
+  | "repo_name"
+  | "repo_visibility"
+  | "pr_created_by_copilot"
+  | "pr_reviewed_by_copilot"
+  | "pr_total_merged"
+  | "pr_avg_median_minutes_to_merge";
+
+interface RepositoryUsageTableProps {
+  repositories: RepositoryUsage[];
+}
+
+// nb-NO label for the GitHub visibility enum (PUBLIC | INTERNAL).
+// Private repos are excluded server-side, so PRIVATE should never reach here.
+function visibilityLabel(visibility: string): string {
+  switch (visibility.toUpperCase()) {
+    case "PUBLIC":
+      return "Offentlig";
+    case "INTERNAL":
+      return "Intern";
+    case "PRIVATE":
+      return "Privat";
+    default:
+      return visibility;
+  }
+}
+
+export default function RepositoryUsageTable({ repositories }: RepositoryUsageTableProps) {
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  // Default sort mirrors the API's ordering: most Copilot-authored PRs first.
+  const [sortKey, setSortKey] = useState<SortKey>("pr_created_by_copilot");
+  const [sortDirection, setSortDirection] = useState<"ascending" | "descending">("descending");
+
+  const filteredRepos = useMemo(() => {
+    if (!search.trim()) return repositories;
+    const query = search.toLowerCase();
+    return repositories.filter((r) => `${r.repo_owner}/${r.repo_name}`.toLowerCase().includes(query));
+  }, [repositories, search]);
+
+  const sortedRepos = useMemo(() => {
+    return [...filteredRepos].sort((a, b) => {
+      if (sortKey === "repo_name") {
+        const aName = `${a.repo_owner}/${a.repo_name}`;
+        const bName = `${b.repo_owner}/${b.repo_name}`;
+        return sortDirection === "ascending" ? aName.localeCompare(bName) : bName.localeCompare(aName);
+      }
+      if (sortKey === "repo_visibility") {
+        return sortDirection === "ascending"
+          ? a.repo_visibility.localeCompare(b.repo_visibility)
+          : b.repo_visibility.localeCompare(a.repo_visibility);
+      }
+      // Numeric keys, including the nullable median — nulls sort to the bottom
+      // regardless of direction so "no data" rows never top the list.
+      const aVal = a[sortKey];
+      const bVal = b[sortKey];
+      if (aVal == null && bVal == null) return 0;
+      if (aVal == null) return 1;
+      if (bVal == null) return -1;
+      const diff = aVal - bVal;
+      return sortDirection === "ascending" ? diff : -diff;
+    });
+  }, [filteredRepos, sortKey, sortDirection]);
+
+  const totalPages = Math.ceil(sortedRepos.length / PAGE_SIZE);
+  const pageRepos = sortedRepos.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  function handleSort(key: string) {
+    if (sortKey === key) {
+      setSortDirection((d) => (d === "ascending" ? "descending" : "ascending"));
+    } else {
+      setSortKey(key as SortKey);
+      setSortDirection("descending");
+    }
+    setPage(1);
+  }
+
+  function handleSearch(value: string) {
+    setSearch(value);
+    setPage(1);
+  }
+
+  return (
+    <VStack gap="space-16">
+      <Alert variant="info" size="small">
+        Tallene er summert over hele perioden med data. Private repositorier er utelatt, og repositorier med færre enn 5
+        pull requests totalt vises ikke (personvern).
+      </Alert>
+
+      <HStack gap="space-8" align="end" wrap>
+        <Search label="Søk" size="small" variant="simple" value={search} onChange={handleSearch} className="max-w-xs" />
+        <CopyJsonButton data={sortedRepos} label="📋 JSON" />
+      </HStack>
+
+      <div className="overflow-x-auto">
+        <Table size="small" sort={{ orderBy: sortKey, direction: sortDirection }} onSortChange={handleSort}>
+          <TableHeader>
+            <TableRow>
+              <Table.ColumnHeader scope="col" sortKey="repo_name" sortable>
+                Repositorium
+              </Table.ColumnHeader>
+              <Table.ColumnHeader scope="col" sortKey="repo_visibility" sortable>
+                Synlighet
+              </Table.ColumnHeader>
+              <Table.ColumnHeader scope="col" sortKey="pr_created_by_copilot" sortable align="right">
+                Copilot-forfattet
+              </Table.ColumnHeader>
+              <Table.ColumnHeader scope="col" sortKey="pr_reviewed_by_copilot" sortable align="right">
+                Copilot-reviewet
+              </Table.ColumnHeader>
+              <Table.ColumnHeader scope="col" sortKey="pr_total_merged" sortable align="right">
+                Merget totalt
+              </Table.ColumnHeader>
+              <Table.ColumnHeader scope="col" sortKey="pr_avg_median_minutes_to_merge" sortable align="right">
+                Median tid til merge
+              </Table.ColumnHeader>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {pageRepos.map((repo) => (
+              <TableRow key={repo.repo_id}>
+                <TableDataCell>
+                  <a
+                    href={`https://github.com/${repo.repo_owner}/${repo.repo_name}`}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    className="text-blue-600 hover:underline"
+                  >
+                    {repo.repo_owner}/{repo.repo_name}
+                  </a>
+                </TableDataCell>
+                <TableDataCell>
+                  <Tag variant={repo.repo_visibility.toUpperCase() === "PUBLIC" ? "success" : "neutral"} size="xsmall">
+                    {visibilityLabel(repo.repo_visibility)}
+                  </Tag>
+                </TableDataCell>
+                <TableDataCell align="right">{formatNumber(repo.pr_created_by_copilot)}</TableDataCell>
+                <TableDataCell align="right">{formatNumber(repo.pr_reviewed_by_copilot)}</TableDataCell>
+                <TableDataCell align="right">{formatNumber(repo.pr_total_merged)}</TableDataCell>
+                <TableDataCell align="right">{formatMinutes(repo.pr_avg_median_minutes_to_merge)}</TableDataCell>
+              </TableRow>
+            ))}
+            {pageRepos.length === 0 && (
+              <TableRow>
+                <TableDataCell colSpan={6}>
+                  <BodyShort className="text-gray-500 text-center">
+                    {search ? "Ingen repositorier funnet for søket ditt." : "Ingen repositoriedata tilgjengelig ennå."}
+                  </BodyShort>
+                </TableDataCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {totalPages > 1 && (
+        <HStack justify="center">
+          <Pagination page={page} onPageChange={setPage} count={totalPages} size="small" />
+        </HStack>
+      )}
+    </VStack>
+  );
+}

--- a/apps/my-copilot/src/lib/cached-bigquery.ts
+++ b/apps/my-copilot/src/lib/cached-bigquery.ts
@@ -28,6 +28,7 @@ import type {
   DailySummary,
   DailyCredits,
   UsageDistribution,
+  RepositoryUsage,
 } from "./types";
 
 function getErrorMessage(label: string, err: unknown): string {
@@ -114,6 +115,16 @@ export async function getTeamUsage(token: string): Promise<{
     backendRequest<TeamUsageSummary[]>("/api/v1/copilot/usage/team-summary", token)
   );
   return { teams: result.data, error: result.error };
+}
+
+export async function getRepositoryUsage(token: string): Promise<{
+  repositories: RepositoryUsage[];
+  error: string | null;
+}> {
+  const result = await fetchWithFallback("getRepositoryUsage", [] as RepositoryUsage[], () =>
+    backendRequest<RepositoryUsage[]>("/api/v1/copilot/usage/repositories", token)
+  );
+  return { repositories: result.data, error: result.error };
 }
 
 export async function getUserMetrics(

--- a/apps/my-copilot/src/lib/format.test.ts
+++ b/apps/my-copilot/src/lib/format.test.ts
@@ -1,4 +1,4 @@
-import { formatNumber, formatPercentage, isoWeekLabel } from "./format";
+import { formatNumber, formatPercentage, isoWeekLabel, formatMinutes } from "./format";
 
 describe("formatNumber", () => {
   it("should format numbers with Norwegian locale (space as thousands separator)", () => {
@@ -32,6 +32,35 @@ describe("formatPercentage", () => {
   it("should handle decimal percentages", () => {
     expect(formatPercentage(25.5)).toBe("25.5%");
     expect(formatPercentage(99.9)).toBe("99.9%");
+  });
+});
+
+describe("formatMinutes", () => {
+  it("returns an en-dash for null, zero and negative durations", () => {
+    expect(formatMinutes(null)).toBe("–");
+    expect(formatMinutes(0)).toBe("–");
+    expect(formatMinutes(-5)).toBe("–");
+  });
+
+  it("formats sub-hour durations as minutes", () => {
+    expect(formatMinutes(1)).toBe("1 min");
+    expect(formatMinutes(45)).toBe("45 min");
+    expect(formatMinutes(59.4)).toBe("59 min");
+  });
+
+  it("formats hour+minute durations", () => {
+    expect(formatMinutes(60)).toBe("1t");
+    expect(formatMinutes(192)).toBe("3t 12m");
+  });
+
+  it("rounds total minutes before splitting to avoid a 60-minute remainder", () => {
+    // 119.7 rounds to 120 total minutes → "2t", never "1t 60m"
+    expect(formatMinutes(119.7)).toBe("2t");
+  });
+
+  it("formats multi-day durations", () => {
+    expect(formatMinutes(24 * 60)).toBe("1d");
+    expect(formatMinutes(2 * 24 * 60 + 4 * 60)).toBe("2d 4t");
   });
 });
 

--- a/apps/my-copilot/src/lib/format.ts
+++ b/apps/my-copilot/src/lib/format.ts
@@ -17,6 +17,29 @@ export function formatPercentage(value: number): string {
   return `${value}%`;
 }
 
+/**
+ * Format a duration in minutes to a human-readable Norwegian string.
+ * Returns "–" for null, zero or negative durations (e.g. a nullable median
+ * with no qualifying pull requests).
+ *
+ * IMPORTANT: Rounds total minutes FIRST, then splits into hours/minutes.
+ * The naive approach (Math.round on the remainder) caused "1t 60m" when
+ * minutes % 60 was between 59.5 and 60 (e.g. 119.7 → floor(1.99)=1h, round(59.7)=60m).
+ * @param minutes - Duration in minutes, or null
+ * @returns Formatted string, e.g. "3t 12m", "45 min", "2d 4t" or "–"
+ */
+export function formatMinutes(minutes: number | null): string {
+  if (minutes == null || minutes <= 0) return "–";
+  if (minutes < 60) return `${Math.round(minutes)} min`;
+  const totalMinutes = Math.round(minutes);
+  const hours = Math.floor(totalMinutes / 60);
+  const mins = totalMinutes % 60;
+  if (hours < 24) return mins > 0 ? `${hours}t ${mins}m` : `${hours}t`;
+  const days = Math.floor(hours / 24);
+  const remainingHours = hours % 24;
+  return remainingHours > 0 ? `${days}d ${remainingHours}t` : `${days}d`;
+}
+
 export function formatDate(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString("nb-NO", {
     day: "numeric",

--- a/apps/my-copilot/src/lib/types.ts
+++ b/apps/my-copilot/src/lib/types.ts
@@ -342,6 +342,36 @@ export interface TeamUsageSummary {
   top_models?: Array<{ model: string; interactions: number }>;
 }
 
+// Per-repository Copilot PR activity, from the v_repository_usage BigQuery view
+// via copilot-api's GET /api/v1/copilot/usage/repositories. Privacy-preserving:
+// the view is all-time aggregated (never per-day per-repo), excludes private
+// repos (repo_visibility IN ('PUBLIC','INTERNAL')) and suppresses low-activity
+// repos (fewer than 5 total PRs) — see the k=5 guard mirrored from
+// minUsersForDistribution. The three median fields are nullable when no
+// qualifying PRs exist for that slice.
+export interface RepositoryUsage {
+  repo_id: number;
+  repo_owner: string;
+  repo_name: string;
+  repo_visibility: string;
+  scope_id: string;
+  days_with_data: number;
+  first_day: string;
+  last_day: string;
+  pr_total_created: number;
+  pr_total_merged: number;
+  pr_total_reviewed: number;
+  pr_created_by_copilot: number;
+  pr_reviewed_by_copilot: number;
+  pr_merged_copilot_authored: number;
+  pr_merged_copilot_reviewed: number;
+  pr_copilot_suggestions: number;
+  pr_copilot_applied_suggestions: number;
+  pr_avg_median_minutes_to_merge: number | null;
+  pr_avg_median_minutes_to_merge_copilot: number | null;
+  pr_avg_median_minutes_to_merge_copilot_reviewed: number | null;
+}
+
 export interface DailyCredits {
   day: string;
   credits: number;


### PR DESCRIPTION
**Phase 4 (final)** of the repository-level Copilot usage metrics design (#387). Adds the dashboard surface consuming the `/api/v1/copilot/usage/repositories` endpoint (#390).

## What's included
- **`components/repository-usage-table.tsx`** (new) — sortable, paginated, searchable table mirroring `team-usage-table.tsx`. Columns: Repositorium (owner/name → GitHub link), Synlighet (visibility Tag), Copilot-forfattet, Copilot-reviewet, Merget totalt, Median tid til merge. Default sort `pr_created_by_copilot` desc; null medians sink to the bottom and render "–". Includes a privacy `Alert`.
- **`statistikk/page.tsx`** — new Suspense-wrapped "Repositorier" tab (between "Team i Nav" and "Utforsking") with 3 headline MetricCards + the table.
- **`types.ts`** — `RepositoryUsage` interface (three median fields `number | null`, matching the Go `*float64`).
- **`cached-bigquery.ts`** — `getRepositoryUsage(token)` (clone of `getTeamUsage`).
- **`lib/format.ts`** — extracted the shared `formatMinutes` helper (previously inline in the page) + tests.

## Privacy note (shown in the UI)
"Tallene er summert over hele perioden med data. Private repositorier er utelatt, og repositorier med færre enn 5 pull requests totalt vises ikke (personvern)." — all-days aggregation, PRIVATE excluded, k=5 suppression.

## Verification
`tsc` ✅, eslint ✅, prettier ✅, vitest **484 tests** (10 new) ✅.

## Notes
- **Deploy/merge ordering:** merge **after #390** (this calls that endpoint). Fetch errors degrade to the page's error state, but ordering avoids a transient 404.
- No running-app visual check was available; layout follows existing table/tab patterns.

Completes the repo-level metrics vertical. Refs #373.