### PR TITLE
fix(copilot-metrics): opprett v_repository_usage og backfill manglende repo-dager

### DIFF
--- a/apps/copilot-metrics/.mise.toml
+++ b/apps/copilot-metrics/.mise.toml
@@ -129,24 +129,36 @@ description = "Backfill daily model billing usage only (prod)"
 env = { LOG_LEVEL = "INFO", GCP_TEAM_PROJECT_ID = "copilot-prod-c697" }
 run = "fnox exec -- go run . --billing-model-daily-backfill --billing-model-daily-from=${BACKFILL_FROM:-2025-10-10} --force"
 
+[tasks."backfill:repo-metrics"]
+description = "Backfill per-repository usage metrics only (dev)"
+env = { LOG_LEVEL = "INFO", GCP_TEAM_PROJECT_ID = "copilot-dev-e17a" }
+run = "fnox exec -- go run . --repo-metrics-backfill --repo-metrics-from=${BACKFILL_FROM:-2026-07-17}"
+
+[tasks."backfill:repo-metrics:prod"]
+description = "Backfill per-repository usage metrics only (prod)"
+env = { LOG_LEVEL = "INFO", GCP_TEAM_PROJECT_ID = "copilot-prod-c697" }
+run = "fnox exec -- go run . --repo-metrics-backfill --repo-metrics-from=${BACKFILL_FROM:-2026-07-17}"
+
 [tasks."backfill:all"]
-description = "Backfill usage metrics + monthly billing + daily billing usage reports + daily model billing (dev)"
+description = "Backfill usage metrics + monthly billing + daily billing usage reports + daily model billing + repository metrics (dev)"
 env = { LOG_LEVEL = "INFO", GCP_TEAM_PROJECT_ID = "copilot-dev-e17a" }
 run = [
   "fnox exec -- go run . --backfill --backfill-from=${BACKFILL_FROM:-2025-10-10} --force",
   "FROM=${BACKFILL_FROM:-2026-03-01}; fnox exec -- go run . --billing-monthly-backfill --billing-monthly-from=${FROM:0:7} --force",
   "fnox exec -- go run . --billing-daily-report-backfill --billing-daily-report-from=${BACKFILL_FROM:-2025-10-10} --force",
   "fnox exec -- go run . --billing-model-daily-backfill --billing-model-daily-from=${BACKFILL_FROM:-2025-10-10} --force",
+  "fnox exec -- go run . --repo-metrics-backfill --force",
 ]
 
 [tasks."backfill:all:prod"]
-description = "Backfill usage metrics + monthly billing + daily billing usage reports + daily model billing (prod)"
+description = "Backfill usage metrics + monthly billing + daily billing usage reports + daily model billing + repository metrics (prod)"
 env = { LOG_LEVEL = "INFO", GCP_TEAM_PROJECT_ID = "copilot-prod-c697" }
 run = [
   "fnox exec -- go run . --backfill --backfill-from=${BACKFILL_FROM:-2025-10-10} --force",
   "FROM=${BACKFILL_FROM:-2026-03-01}; fnox exec -- go run . --billing-monthly-backfill --billing-monthly-from=${FROM:0:7} --force",
   "fnox exec -- go run . --billing-daily-report-backfill --billing-daily-report-from=${BACKFILL_FROM:-2025-10-10} --force",
   "fnox exec -- go run . --billing-model-daily-backfill --billing-model-daily-from=${BACKFILL_FROM:-2025-10-10} --force",
+  "fnox exec -- go run . --repo-metrics-backfill --force",
 ]
 
 [tasks."docker:build"]

--- a/apps/copilot-metrics/README.md
+++ b/apps/copilot-metrics/README.md
@@ -45,6 +45,9 @@ rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:billing-daily-report'
 # Daily model billing usage only
 rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:billing-model-daily'
 
+# Per-repository usage metrics only
+rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:repo-metrics'
+
 # Everything
 rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:all'
 ```
@@ -56,6 +59,7 @@ rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:usage:prod'
 rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:billing-monthly:prod'
 rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:billing-daily-report:prod'
 rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:billing-model-daily:prod'
+rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:repo-metrics:prod'
 rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:all:prod'
 ```
 
@@ -105,6 +109,26 @@ rtk copilot-metrics --billing-model-daily-backfill
 rtk copilot-metrics --billing-model-daily-backfill --billing-model-daily-from=2025-10-10
 rtk copilot-metrics --billing-model-daily-backfill --billing-model-daily-from=2025-10-10 --force
 ```
+
+### Repository metrics backfill
+
+One-time operation to fill gaps in the `repository_metrics` table without
+touching `usage_metrics`, `user_metrics` or `user_teams`.
+
+The nightly job only gap-fills the last 7 days, so days between the report's
+GA date (2026-07-17) and the deploy of repository ingestion fall outside that
+window permanently. This flag closes those gaps.
+
+```bash
+rtk copilot-metrics --repo-metrics-backfill
+rtk copilot-metrics --repo-metrics-backfill --repo-metrics-from=2026-07-17
+rtk copilot-metrics --repo-metrics-backfill --repo-metrics-from=2026-07-17 --force
+```
+
+Days that already have data are skipped before the API call, so the command is
+cheap to re-run. Unlike `--backfill`, it resumes per day rather than from a
+single high-water mark, so interior gaps are filled. Use `--force` to re-ingest
+days that already exist. Days before GA are reported as unavailable and skipped.
 
 ### Local development
 
@@ -156,8 +180,9 @@ Per-repository, PR-only Copilot lifecycle activity from the `repos-1-day`
 Usage Metrics report (coding-agent authored/merged PRs and Copilot code-review
 suggestions). One row per repository per day. Ingested as a supplementary report
 alongside `users-1-day` / `user-teams-1-day`, so it flows through the nightly
-gap-fill and historical backfill automatically (data available from GitHub's
-GA on 2026-07-17).
+gap-fill (last 7 days) and historical backfill automatically (data available
+from GitHub's GA on 2026-07-17). Days older than the gap-fill window are filled
+with `--repo-metrics-backfill`.
 
 | Column       | Type      | Description                    |
 | ------------ | --------- | ------------------------------ |

--- a/apps/copilot-metrics/main.go
+++ b/apps/copilot-metrics/main.go
@@ -89,7 +89,10 @@ func main() {
 	}
 
 	if err := bqClient.EnsureViewsExist(ctx); err != nil {
-		slog.Warn("Failed to ensure views exist (continuing without views)", "error", err)
+		// Non-fatal: ingestion is the job's primary purpose and must not be
+		// blocked by DDL. Logged at ERROR so a missing view surfaces in
+		// alerting instead of silently 500-ing the dashboard.
+		slog.Error("Failed to ensure views exist (continuing without them)", "error", err)
 	}
 
 	// Set up billing + budget clients (optional — require classic PAT with admin:enterprise scope)

--- a/apps/copilot-metrics/main.go
+++ b/apps/copilot-metrics/main.go
@@ -24,6 +24,8 @@ func main() {
 	billingDailyReportFrom := flag.String("billing-daily-report-from", "2025-10-10", "Start day for daily billing usage report backfill (YYYY-MM-DD)")
 	billingModelDailyBackfill := flag.Bool("billing-model-daily-backfill", false, "Backfill daily model billing data")
 	billingModelDailyFrom := flag.String("billing-model-daily-from", "2025-10-10", "Start day for daily model billing backfill (YYYY-MM-DD)")
+	repoMetricsBackfill := flag.Bool("repo-metrics-backfill", false, "Backfill per-repository usage metrics (repos-1-day) only")
+	repoMetricsFrom := flag.String("repo-metrics-from", repoMetricsGADate, "Start day for repository metrics backfill (YYYY-MM-DD)")
 	legacyBillingBackfill := flag.Bool("billing-backfill", false, "Deprecated: use --billing-monthly-backfill")
 	legacyBillingFrom := flag.String("billing-from", "", "Deprecated: use --billing-monthly-from")
 	legacyBillingUsageBackfill := flag.Bool("billing-usage-backfill", false, "Deprecated: use --billing-daily-report-backfill")
@@ -191,6 +193,19 @@ func main() {
 		}
 		if err := runBillingBackfill(ctx, billingClient, bqClient, config, startMonth, *backfillForce); err != nil {
 			slog.Error("Billing monthly backfill failed", "error", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	if *repoMetricsBackfill {
+		startDay, err := time.Parse("2006-01-02", *repoMetricsFrom)
+		if err != nil {
+			slog.Error("Invalid repo-metrics-from day", "error", err)
+			os.Exit(1)
+		}
+		if err := runRepoMetricsBackfill(ctx, ghClient, bqClient, config, startDay, *backfillForce); err != nil {
+			slog.Error("Repository metrics backfill failed", "error", err)
 			os.Exit(1)
 		}
 		return

--- a/apps/copilot-metrics/repo_metrics_backfill.go
+++ b/apps/copilot-metrics/repo_metrics_backfill.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+const (
+	// repoMetricsGADate is the first day GitHub publishes the repos-1-day
+	// report. Earlier days always return ErrReportNotAvailable, so there is
+	// no point starting a backfill before this.
+	repoMetricsGADate = "2026-07-17"
+)
+
+// repoMetricsRateLimitDelay matches the entity backfill delay — the
+// repos-1-day report goes through the same GitHub report API.
+// Declared as a var so tests can disable the delay.
+var repoMetricsRateLimitDelay = 1 * time.Second
+
+type RepoMetricsFetcher interface {
+	FetchDailyRepoMetrics(ctx context.Context, day time.Time) (*FetchResult, error)
+}
+
+type RepoMetricsStore interface {
+	RepoMetricsDayExists(ctx context.Context, day time.Time, scopeID string) (bool, error)
+	DeleteRepoMetricsDay(ctx context.Context, day time.Time, scopeID string) error
+	InsertRepoMetrics(ctx context.Context, day time.Time, scope, scopeID string, records []json.RawMessage) error
+}
+
+// runRepoMetricsBackfill fills gaps in the repository_metrics table without
+// touching usage_metrics, user_metrics or user_teams.
+//
+// The nightly job only gap-fills the last 7 days (ingestMissingSupplementary),
+// so days between the report's GA date and the deploy of repository ingestion
+// fall outside that window permanently. This backfill closes those gaps.
+//
+// Days are skipped individually when data already exists, so the command is
+// cheap to re-run and handles interior gaps — unlike the entity backfill,
+// which resumes from a single high-water mark.
+func runRepoMetricsBackfill(ctx context.Context, gh RepoMetricsFetcher, bq RepoMetricsStore, cfg *Config, startDay time.Time, force bool) error {
+	endDay := time.Now().UTC().Truncate(24*time.Hour).AddDate(0, 0, -1)
+
+	slog.Info("Starting repository metrics backfill",
+		"start", startDay.Format("2006-01-02"),
+		"end", endDay.Format("2006-01-02"),
+		"force", force,
+	)
+
+	if endDay.Before(startDay) {
+		slog.Info("No days to backfill - start day is after yesterday")
+		return nil
+	}
+
+	var ingested, skipped, unavailable int
+	var failedDays []string
+
+	for day := startDay; !day.After(endDay); day = day.AddDate(0, 0, 1) {
+		select {
+		case <-ctx.Done():
+			slog.Warn("Repository metrics backfill interrupted",
+				"ingested", ingested, "errors", len(failedDays))
+			return ctx.Err()
+		default:
+		}
+
+		dayStr := day.Format("2006-01-02")
+
+		// Cheap skip using the enterprise slug. If the report was stored under
+		// an org scope_id instead, this reports "not exists" and we fall
+		// through to upsertReport, which re-checks with the real scope.
+		if !force {
+			exists, err := bq.RepoMetricsDayExists(ctx, day, cfg.EnterpriseSlug)
+			if err != nil {
+				slog.Warn("Failed to check repo-metrics existence", "day", dayStr, "error", err)
+			} else if exists {
+				skipped++
+				continue
+			}
+		}
+
+		result, err := gh.FetchDailyRepoMetrics(ctx, day)
+		if err != nil {
+			if errors.Is(err, ErrReportNotAvailable) {
+				slog.Info("Repository report not available", "day", dayStr)
+				unavailable++
+			} else {
+				slog.Error("Failed to fetch repository metrics", "day", dayStr, "error", err)
+				failedDays = append(failedDays, dayStr)
+			}
+			time.Sleep(repoMetricsRateLimitDelay)
+			continue
+		}
+
+		// Never delete existing rows for an empty response — an upstream
+		// hiccup should not wipe a day that already has data.
+		if len(result.Records) == 0 {
+			slog.Warn("No repository records returned for day", "day", dayStr)
+			time.Sleep(repoMetricsRateLimitDelay)
+			continue
+		}
+
+		if err := upsertReport(ctx, bq.RepoMetricsDayExists, bq.DeleteRepoMetricsDay, bq.InsertRepoMetrics,
+			day, result); err != nil {
+			if errors.Is(err, ErrStreamingBuffer) {
+				slog.Info("Skipping repo-metrics re-import (streaming buffer not yet flushed, re-run in ~90 min)", "day", dayStr)
+				skipped++
+			} else {
+				// The insert is a streaming Put and is not atomic: a row-level
+				// failure can leave the day partially written. A later run
+				// would see rows present and skip it, so the day is named
+				// explicitly and needs --force to be repaired.
+				slog.Error("Failed to store repository metrics (day may be partially written, re-run with --force)", "day", dayStr, "error", err)
+				failedDays = append(failedDays, dayStr)
+			}
+			time.Sleep(repoMetricsRateLimitDelay)
+			continue
+		}
+
+		slog.Info("Ingested repository metrics",
+			"day", dayStr,
+			"scope", result.Scope,
+			"records", len(result.Records),
+		)
+		ingested++
+		time.Sleep(repoMetricsRateLimitDelay)
+	}
+
+	slog.Info("Repository metrics backfill completed",
+		"ingested", ingested,
+		"skipped", skipped,
+		"unavailable", unavailable,
+		"errors", len(failedDays),
+		"failed_days", failedDays,
+	)
+
+	if len(failedDays) > 0 {
+		return fmt.Errorf("repository metrics backfill finished with %d failed day(s): %s — re-run with --force, a failed day may have been partially written and would otherwise be skipped",
+			len(failedDays), strings.Join(failedDays, ", "))
+	}
+	return nil
+}

--- a/apps/copilot-metrics/repo_metrics_backfill.go
+++ b/apps/copilot-metrics/repo_metrics_backfill.go
@@ -43,6 +43,21 @@ type RepoMetricsStore interface {
 // cheap to re-run and handles interior gaps — unlike the entity backfill,
 // which resumes from a single high-water mark.
 func runRepoMetricsBackfill(ctx context.Context, gh RepoMetricsFetcher, bq RepoMetricsStore, cfg *Config, startDay time.Time, force bool) error {
+	// Normalise to UTC midnight so the loop steps day-by-day regardless of the
+	// caller's location or time component, and so the comparison against
+	// endDay below is on equal footing.
+	startDay = startDay.UTC().Truncate(24 * time.Hour)
+
+	// Days before GA always return ErrReportNotAvailable, so clamp to avoid
+	// spending API calls and rate-limit sleeps on days that cannot exist.
+	if gaDay, err := time.Parse("2006-01-02", repoMetricsGADate); err == nil && startDay.Before(gaDay) {
+		slog.Info("Clamping start day to repository metrics GA date",
+			"requested", startDay.Format("2006-01-02"),
+			"ga", repoMetricsGADate,
+		)
+		startDay = gaDay
+	}
+
 	endDay := time.Now().UTC().Truncate(24*time.Hour).AddDate(0, 0, -1)
 
 	slog.Info("Starting repository metrics backfill",

--- a/apps/copilot-metrics/repo_metrics_backfill_test.go
+++ b/apps/copilot-metrics/repo_metrics_backfill_test.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+// repoBackfillFetcher records which days were fetched and can return
+// per-day results or errors.
+type repoBackfillFetcher struct {
+	fetched []string
+	err     error
+	records int
+	scopeID string
+}
+
+func (f *repoBackfillFetcher) FetchDailyRepoMetrics(_ context.Context, day time.Time) (*FetchResult, error) {
+	f.fetched = append(f.fetched, day.Format("2006-01-02"))
+	if f.err != nil {
+		return nil, f.err
+	}
+	records := make([]json.RawMessage, f.records)
+	for i := range records {
+		records[i] = json.RawMessage(`{"repo_name":"navikt/copilot"}`)
+	}
+	scopeID := f.scopeID
+	if scopeID == "" {
+		scopeID = "nav"
+	}
+	return &FetchResult{Records: records, Scope: "enterprise", ScopeID: scopeID}, nil
+}
+
+// repoBackfillStore tracks upserts per day and can report pre-existing days.
+type repoBackfillStore struct {
+	existing    map[string]bool
+	inserted    map[string]int
+	deleted     []string
+	insertErr   error
+	existsErr   error
+	existsScope []string
+	insertScope []string
+}
+
+func newRepoBackfillStore(existing ...string) *repoBackfillStore {
+	s := &repoBackfillStore{existing: map[string]bool{}, inserted: map[string]int{}}
+	for _, day := range existing {
+		s.existing[day] = true
+	}
+	return s
+}
+
+func (s *repoBackfillStore) RepoMetricsDayExists(_ context.Context, day time.Time, scopeID string) (bool, error) {
+	s.existsScope = append(s.existsScope, scopeID)
+	if s.existsErr != nil {
+		return false, s.existsErr
+	}
+	return s.existing[day.Format("2006-01-02")], nil
+}
+
+func (s *repoBackfillStore) DeleteRepoMetricsDay(_ context.Context, day time.Time, _ string) error {
+	s.deleted = append(s.deleted, day.Format("2006-01-02"))
+	return nil
+}
+
+func (s *repoBackfillStore) InsertRepoMetrics(_ context.Context, day time.Time, _, scopeID string, records []json.RawMessage) error {
+	s.insertScope = append(s.insertScope, scopeID)
+	if s.insertErr != nil {
+		return s.insertErr
+	}
+	s.inserted[day.Format("2006-01-02")] = len(records)
+	return nil
+}
+
+func withoutRepoMetricsDelay(t *testing.T) {
+	t.Helper()
+	original := repoMetricsRateLimitDelay
+	repoMetricsRateLimitDelay = 0
+	t.Cleanup(func() { repoMetricsRateLimitDelay = original })
+}
+
+func repoBackfillConfig() *Config {
+	return &Config{EnterpriseSlug: "nav"}
+}
+
+// daysAgo returns the UTC day n days before today.
+func daysAgo(n int) time.Time {
+	return time.Now().UTC().Truncate(24*time.Hour).AddDate(0, 0, -n)
+}
+
+func TestRunRepoMetricsBackfill_FillsInteriorGap(t *testing.T) {
+	withoutRepoMetricsDelay(t)
+
+	// Days 3 and 2 already ingested by the nightly gap-fill; days 5 and 4
+	// fell outside its 7-day window and must be filled.
+	store := newRepoBackfillStore(daysAgo(3).Format("2006-01-02"), daysAgo(2).Format("2006-01-02"))
+	fetcher := &repoBackfillFetcher{records: 7}
+
+	if err := runRepoMetricsBackfill(context.Background(), fetcher, store, repoBackfillConfig(), daysAgo(5), false); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	for _, day := range []int{5, 4, 1} {
+		if store.inserted[daysAgo(day).Format("2006-01-02")] != 7 {
+			t.Errorf("expected day -%d to be ingested with 7 records, got %d", day, store.inserted[daysAgo(day).Format("2006-01-02")])
+		}
+	}
+	for _, day := range []int{3, 2} {
+		if _, ok := store.inserted[daysAgo(day).Format("2006-01-02")]; ok {
+			t.Errorf("expected existing day -%d to be skipped", day)
+		}
+	}
+	if len(fetcher.fetched) != 3 {
+		t.Errorf("expected 3 fetches (existing days skipped before fetch), got %d", len(fetcher.fetched))
+	}
+}
+
+func TestRunRepoMetricsBackfill_ForceReingestsExistingDays(t *testing.T) {
+	withoutRepoMetricsDelay(t)
+
+	store := newRepoBackfillStore(daysAgo(2).Format("2006-01-02"), daysAgo(1).Format("2006-01-02"))
+	fetcher := &repoBackfillFetcher{records: 3}
+
+	if err := runRepoMetricsBackfill(context.Background(), fetcher, store, repoBackfillConfig(), daysAgo(2), true); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(fetcher.fetched) != 2 {
+		t.Errorf("expected 2 fetches with force, got %d", len(fetcher.fetched))
+	}
+	if len(store.deleted) != 2 {
+		t.Errorf("expected 2 deletes before re-insert, got %d", len(store.deleted))
+	}
+}
+
+func TestRunRepoMetricsBackfill_ToleratesUnavailableReport(t *testing.T) {
+	withoutRepoMetricsDelay(t)
+
+	store := newRepoBackfillStore()
+	fetcher := &repoBackfillFetcher{err: ErrReportNotAvailable}
+
+	// Pre-GA days must not fail the run.
+	if err := runRepoMetricsBackfill(context.Background(), fetcher, store, repoBackfillConfig(), daysAgo(3), false); err != nil {
+		t.Fatalf("expected unavailable reports to be tolerated, got %v", err)
+	}
+	if len(store.inserted) != 0 {
+		t.Errorf("expected no inserts, got %d", len(store.inserted))
+	}
+}
+
+func TestRunRepoMetricsBackfill_EmptyResponseDoesNotDelete(t *testing.T) {
+	withoutRepoMetricsDelay(t)
+
+	store := newRepoBackfillStore(daysAgo(1).Format("2006-01-02"))
+	fetcher := &repoBackfillFetcher{records: 0}
+
+	if err := runRepoMetricsBackfill(context.Background(), fetcher, store, repoBackfillConfig(), daysAgo(1), true); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(store.deleted) != 0 {
+		t.Errorf("expected empty response to leave existing rows intact, got %d deletes", len(store.deleted))
+	}
+}
+
+func TestRunRepoMetricsBackfill_ExistsCheckErrorFallsThrough(t *testing.T) {
+	withoutRepoMetricsDelay(t)
+
+	// A failing existence check must not be treated as "already ingested" —
+	// the day is fetched anyway and upsertReport re-checks authoritatively.
+	store := newRepoBackfillStore()
+	store.existsErr = errors.New("bigquery unavailable")
+	fetcher := &repoBackfillFetcher{records: 4}
+
+	err := runRepoMetricsBackfill(context.Background(), fetcher, store, repoBackfillConfig(), daysAgo(1), false)
+	if err == nil {
+		t.Fatal("expected the failing existence check inside upsertReport to surface as an error")
+	}
+	if len(fetcher.fetched) != 1 {
+		t.Errorf("expected the day to be fetched despite the existence-check error, got %d fetches", len(fetcher.fetched))
+	}
+}
+
+func TestRunRepoMetricsBackfill_PreCheckUsesEnterpriseSlugAndUpsertUsesFetchedScope(t *testing.T) {
+	withoutRepoMetricsDelay(t)
+
+	// The cheap pre-check queries the configured enterprise slug, while the
+	// authoritative upsert uses whatever scope the fetch actually resolved to
+	// (enterprise-first with org fallback).
+	store := newRepoBackfillStore()
+	fetcher := &repoBackfillFetcher{records: 2, scopeID: "navikt"}
+
+	if err := runRepoMetricsBackfill(context.Background(), fetcher, store, repoBackfillConfig(), daysAgo(1), false); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(store.existsScope) == 0 || store.existsScope[0] != "nav" {
+		t.Errorf("expected pre-check to use the enterprise slug %q, got %v", "nav", store.existsScope)
+	}
+	if len(store.insertScope) != 1 || store.insertScope[0] != "navikt" {
+		t.Errorf("expected insert to use the fetched scope %q, got %v", "navikt", store.insertScope)
+	}
+}
+
+func TestRunRepoMetricsBackfill_ReportsFailedDays(t *testing.T) {
+	withoutRepoMetricsDelay(t)
+
+	store := newRepoBackfillStore()
+	fetcher := &repoBackfillFetcher{err: errors.New("upstream 500")}
+
+	err := runRepoMetricsBackfill(context.Background(), fetcher, store, repoBackfillConfig(), daysAgo(2), false)
+	if err == nil {
+		t.Fatal("expected error for failed days, got nil")
+	}
+	if !contains(err.Error(), "2 failed day(s)") {
+		t.Errorf("expected failed-day count in error, got: %v", err)
+	}
+}
+
+func TestRunRepoMetricsBackfill_StreamingBufferIsNotFatal(t *testing.T) {
+	withoutRepoMetricsDelay(t)
+
+	store := newRepoBackfillStore()
+	store.insertErr = ErrStreamingBuffer
+	fetcher := &repoBackfillFetcher{records: 2}
+
+	if err := runRepoMetricsBackfill(context.Background(), fetcher, store, repoBackfillConfig(), daysAgo(1), false); err != nil {
+		t.Fatalf("expected streaming buffer to be non-fatal, got %v", err)
+	}
+}
+
+func TestRunRepoMetricsBackfill_NothingToDo(t *testing.T) {
+	withoutRepoMetricsDelay(t)
+
+	store := newRepoBackfillStore()
+	fetcher := &repoBackfillFetcher{records: 1}
+
+	// Start date in the future relative to yesterday.
+	if err := runRepoMetricsBackfill(context.Background(), fetcher, store, repoBackfillConfig(), daysAgo(0), false); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(fetcher.fetched) != 0 {
+		t.Errorf("expected no fetches, got %d", len(fetcher.fetched))
+	}
+}
+
+func TestRunRepoMetricsBackfill_CancelledContext(t *testing.T) {
+	withoutRepoMetricsDelay(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	store := newRepoBackfillStore()
+	fetcher := &repoBackfillFetcher{records: 1}
+
+	if err := runRepoMetricsBackfill(ctx, fetcher, store, repoBackfillConfig(), daysAgo(3), false); err == nil {
+		t.Fatal("expected context error, got nil")
+	}
+}
+
+func TestRepoMetricsGADateIsParseable(t *testing.T) {
+	if _, err := time.Parse("2006-01-02", repoMetricsGADate); err != nil {
+		t.Fatalf("repoMetricsGADate must be a valid date: %v", err)
+	}
+}

--- a/apps/copilot-metrics/repo_metrics_backfill_test.go
+++ b/apps/copilot-metrics/repo_metrics_backfill_test.go
@@ -259,6 +259,56 @@ func TestRunRepoMetricsBackfill_CancelledContext(t *testing.T) {
 	}
 }
 
+func TestRunRepoMetricsBackfill_ClampsStartDayToGADate(t *testing.T) {
+	withoutRepoMetricsDelay(t)
+
+	gaDay, err := time.Parse("2006-01-02", repoMetricsGADate)
+	if err != nil {
+		t.Fatalf("parse GA date: %v", err)
+	}
+
+	store := newRepoBackfillStore()
+	fetcher := &repoBackfillFetcher{records: 1}
+
+	// A year before GA: without clamping this would burn ~365 API calls on
+	// days GitHub cannot serve.
+	if err := runRepoMetricsBackfill(context.Background(), fetcher, store, repoBackfillConfig(), gaDay.AddDate(-1, 0, 0), false); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(fetcher.fetched) == 0 {
+		t.Fatal("expected days to be fetched")
+	}
+	if got := fetcher.fetched[0]; got != repoMetricsGADate {
+		t.Errorf("expected first fetched day to be clamped to %s, got %s", repoMetricsGADate, got)
+	}
+}
+
+func TestRunRepoMetricsBackfill_NormalisesStartDayToUTCMidnight(t *testing.T) {
+	withoutRepoMetricsDelay(t)
+
+	store := newRepoBackfillStore()
+	fetcher := &repoBackfillFetcher{records: 1}
+
+	// Late-evening local time two days ago. Without normalisation the loop
+	// would step on a non-midnight offset and the boundary comparison against
+	// yesterday could drop the final day.
+	startDay := daysAgo(2).Add(23 * time.Hour)
+
+	if err := runRepoMetricsBackfill(context.Background(), fetcher, store, repoBackfillConfig(), startDay, false); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	want := []string{daysAgo(2).Format("2006-01-02"), daysAgo(1).Format("2006-01-02")}
+	if len(fetcher.fetched) != len(want) {
+		t.Fatalf("expected %d days fetched, got %d (%v)", len(want), len(fetcher.fetched), fetcher.fetched)
+	}
+	for i, day := range want {
+		if fetcher.fetched[i] != day {
+			t.Errorf("day %d: expected %s, got %s", i, day, fetcher.fetched[i])
+		}
+	}
+}
+
 func TestRepoMetricsGADateIsParseable(t *testing.T) {
 	if _, err := time.Parse("2006-01-02", repoMetricsGADate); err != nil {
 		t.Fatalf("repoMetricsGADate must be a valid date: %v", err)

--- a/apps/copilot-metrics/views.go
+++ b/apps/copilot-metrics/views.go
@@ -31,11 +31,19 @@ var views = []viewDefinition{
 	{name: "v_repository_usage", filename: "views/v_repository_usage.sql"},
 }
 
+// EnsureViewsExist creates or replaces every view. A failing view no longer
+// blocks the ones after it — views are independent, and aborting on the first
+// error means a single bad definition silently leaves later views missing.
 func (c *BigQueryClient) EnsureViewsExist(ctx context.Context) error {
+	var failed []string
 	for _, v := range views {
 		if err := c.createOrReplaceView(ctx, v); err != nil {
-			return fmt.Errorf("failed to create view %s: %w", v.name, err)
+			slog.Error("Failed to create view", "view", v.name, "error", err)
+			failed = append(failed, v.name)
 		}
+	}
+	if len(failed) > 0 {
+		return fmt.Errorf("failed to create %d view(s): %s", len(failed), strings.Join(failed, ", "))
 	}
 	return nil
 }

--- a/apps/copilot-metrics/views/v_repository_usage.sql
+++ b/apps/copilot-metrics/views/v_repository_usage.sql
@@ -28,13 +28,7 @@
 -- All pull_requests.* metrics are NULL for pre-GA (2026-07-17) days — the
 -- repos-1-day report did not exist before GA, so those days contribute nothing.
 CREATE OR REPLACE VIEW `%s.%s.v_repository_usage` AS
-WITH privacy_thresholds AS (
-  -- min_repo_activity mirrors bigquery_stats.go:minUsersForDistribution (k = 5):
-  -- below this many total PRs created over the window, a single contributor's
-  -- behaviour dominates the repo's numbers, so the repo is suppressed.
-  SELECT 5 AS min_repo_activity
-),
-daily AS (
+WITH daily AS (
   SELECT
     CAST(JSON_VALUE(raw_record, '$.repo_id') AS INT64)  AS repo_id,
     JSON_VALUE(raw_record, '$.repo_owner_name')         AS repo_owner,
@@ -85,6 +79,14 @@ SELECT
   AVG(pr_median_minutes_to_merge_copilot_reviewed) AS pr_avg_median_minutes_to_merge_copilot_reviewed
 FROM daily
 GROUP BY repo_id, repo_owner, repo_name, scope_id
--- Privacy safeguard 2: suppress low-activity repos (k = 5 on total PRs created).
-HAVING SUM(pr_total_created) >= (SELECT min_repo_activity FROM privacy_thresholds)
+-- Privacy safeguard 2: suppress low-activity repos. The threshold 5 mirrors
+-- bigquery_stats.go:minUsersForDistribution (k = 5) — below this many total PRs
+-- created over the window, a single contributor's behaviour dominates the
+-- repo's numbers, so the repo is suppressed.
+--
+-- Referenced as the SELECT alias, not SUM(pr_total_created): in HAVING the alias
+-- shadows the source column, so wrapping it in SUM() again is read as
+-- SUM(SUM(...)) and BigQuery rejects it with "Aggregations of aggregations are
+-- not allowed".
+HAVING pr_total_created >= 5
 ORDER BY pr_created_by_copilot DESC;

--- a/apps/copilot-metrics/views_test.go
+++ b/apps/copilot-metrics/views_test.go
@@ -87,7 +87,12 @@ func TestRepositoryUsageViewPlaceholders(t *testing.T) {
 	if !strings.Contains(sql, "IN ('PUBLIC', 'INTERNAL')") {
 		t.Errorf("v_repository_usage.sql must exclude private repos via visibility filter")
 	}
-	if !strings.Contains(sql, "HAVING") || !strings.Contains(sql, "min_repo_activity") {
-		t.Errorf("v_repository_usage.sql must suppress low-activity repos via a HAVING threshold")
+	if !strings.Contains(sql, "HAVING pr_total_created >= 5") {
+		t.Errorf("v_repository_usage.sql must suppress low-activity repos via a k=5 HAVING threshold")
+	}
+	// Regression guard: SUM() over the SELECT alias is read as SUM(SUM(...)) by
+	// BigQuery and fails with "Aggregations of aggregations are not allowed".
+	if strings.Contains(sql, "HAVING SUM(") {
+		t.Errorf("v_repository_usage.sql must not re-aggregate an aggregate alias in HAVING")
 	}
 }


### PR DESCRIPTION
## Hvorfor

`v_repository_usage` fantes ikke i noen av BigQuery-prosjektene. `/api/v1/copilot/usage/repositories` svarte 500, og Repositorier-fanen i my-copilot var nede i to døgn uten at noen alarm gikk.

I tillegg manglet `repository_metrics` de tre første dagene etter GA, og hullet kunne ikke fylles med eksisterende verktøy.

## Del 1 — produksjonsrettelse (`3dbfbb9`)

**View-definisjonen var ugyldig.** `pr_total_created` er både kildekolonne i CTE-en og SELECT-alias for `SUM(pr_total_created)`. I `HAVING` skygger aliaset for kildekolonnen, så

```sql
HAVING SUM(pr_total_created) >= 5
```

ble lest som `SUM(SUM(...))` → *«Aggregations of aggregations are not allowed»*. Referansen står nå naken, siden aliaset allerede **er** summen.

**Feilen var usynlig.** `EnsureViewsExist` returnerte på første feilende view, og `v_repository_usage` er sist av tolv — én ugyldig definisjon etterlot dermed alle etterfølgende views uopprettet. `main.go` logget det som `Warn` og fortsatte, så naisjobben ble grønn hver natt mens dashbordet feilet.

Løkka fortsetter nå forbi feil, samler navnene i én returfeil og logger på `ERROR`. Fortsatt ikke-fatalt — innhenting skal ikke blokkeres av DDL.

## Del 2 — dedikert backfill (`a90e4c0`)

Nattjobben gap-fyller kun sju dager bakover. `repos-1-day` ble GA 2026-07-17, innhentingen deployet 2026-07-26, så 17.–19. juli falt utenfor vinduet og gled lenger bort for hvert døgn.

`runBackfill` kunne ikke redde dem: den gjenopptar fra ett høyvannsmerke via `GetLatestDay` på `usage_metrics`, som er ajour, og kortsluttet med «already up to date». Eneste utvei var `--backfill --force`, som sletter og skriver om `usage_metrics`, `user_metrics` og `user_teams` som utilsiktet sideeffekt.

```bash
mise run backfill:repo-metrics:prod
```

Rører kun `repository_metrics`, hopper over per dag i stedet for fra ett merke, og sjekker eksisterende dager før API-kallet.

**Sikkerhetsdetaljer**

- Tomt svar sletter aldri eksisterende rader
- Dager før GA telles som utilgjengelige, ikke som feil
- Innsettingen er en streaming `Put` og ikke atomisk. Feiler den etter at noen rader har landet, ville dagen sett komplett ut for neste kjøring — feilende dager navngis derfor eksplisitt i logg og returfeil, med beskjed om at `--force` kreves

`backfill:all` er utvidet, siden den ellers ikke ville gjenopprettet `repository_metrics` etter datatap — samme klasse stille hull som denne PR-en finnes for å tette.

## Personvern

Uendret. Synlighetsfilteret er urørt og k=5-terskelen gjelder fortsatt.

Verifisert mot dev etter endringen: **359 rader**, synlighet `{PUBLIC, INTERNAL}`, laveste `pr_total_created` = **5**.

## Verifisering

| | |
|---|---|
| Alle tolv views | Opprettes rent i dev |
| Backfill prod | `ingested 3, skipped 8, errors 0` |
| Viewet dekker | 2026-07-17, 166 repoer første dag |
| `mise check` | 136 tester, vet, lint, staticcheck grønt |

Endepunktet svarer nå 200 med reelle data.

## Kjent begrensning

Faller enterprise-endepunktet ut og fetchen faller tilbake på org-scope, sletter `upsertReport` kun rader for det scopet, og samme dag kan ligge under to `scope_id`-er. Eksisterende mønster i `ingestDay`, ikke innført her, og personvernet svekkes ikke — splitting gjør k=5 strengere. Sporet i #400.
