### PR TITLE
fix: rett krasj i feilsokingsguiden og Linux-installasjon

### DIFF
--- a/apps/my-copilot/src/app/praksis/sections.test.ts
+++ b/apps/my-copilot/src/app/praksis/sections.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Aksel ships `"use client"` at the package root, so `@navikt/ds-react` is a
+ * client module. A server component may render such a component, but it cannot
+ * read properties off it: `Accordion.Item` resolves to `undefined` and React
+ * fails with "Element type is invalid ... but got: undefined".
+ *
+ * Only `Accordion` is exported from the package root, so the subcomponents
+ * cannot be imported by name as a workaround — the file has to be a client
+ * component. Guide sections are rendered by a server component, so this is easy
+ * to get wrong (see issue #378).
+ */
+
+const SECTIONS_DIR = join(__dirname, "sections");
+
+// Aksel components that are only reachable through dot notation.
+const COMPOUND_COMPONENTS = [
+  "Accordion",
+  "ActionMenu",
+  "Dropdown",
+  "ExpansionCard",
+  "List",
+  "Modal",
+  "Stepper",
+  "Table",
+  "Tabs",
+  "ToggleGroup",
+];
+
+const dotNotation = new RegExp(`<(${COMPOUND_COMPONENTS.join("|")})\\.`);
+
+describe("praksis-seksjoner", () => {
+  const files = readdirSync(SECTIONS_DIR).filter((f) => f.endsWith(".tsx"));
+
+  it("finner seksjonsfiler", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it.each(files)('%s bruker ikke dot-notasjon på Aksel-komponenter uten "use client"', (file) => {
+    const source = readFileSync(join(SECTIONS_DIR, file), "utf8");
+    const match = source.match(dotNotation);
+
+    if (!match) return;
+
+    const isClientComponent = /^\s*(\/\/.*|\/\*[\s\S]*?\*\/)?\s*"use client";/m.test(source);
+
+    expect(
+      isClientComponent,
+      `${file} bruker <${match[1]}.…> fra @navikt/ds-react. Legg til "use client" øverst i filen, ` +
+        `ellers blir subkomponenten undefined når seksjonen rendres fra en server-komponent.`
+    ).toBe(true);
+  });
+});

--- a/apps/my-copilot/src/app/praksis/sections/getting-started.tsx
+++ b/apps/my-copilot/src/app/praksis/sections/getting-started.tsx
@@ -9,7 +9,7 @@ export default function GettingStarted() {
         </Heading>
         <BodyShort className="text-gray-700 mb-4">
           For å bruke GitHub Copilot i Nav må du ha en tildelt lisens. Har du ikke dette ennå, kan du be om tilgang via
-          Porten eller ved å spørre i Slack-kanalen <strong>#copilot-hjelp</strong>. Når du har fått tildelt lisensen,
+          Porten eller ved å spørre i Slack-kanalen <strong>#github-copilot</strong>. Når du har fått tildelt lisensen,
           er den knyttet til din GitHub-brukerkonto (den som er medlem av navikt-organisasjonen).
         </BodyShort>
       </section>

--- a/apps/my-copilot/src/app/praksis/sections/troubleshooting.tsx
+++ b/apps/my-copilot/src/app/praksis/sections/troubleshooting.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Heading, BodyShort, Box, Accordion, VStack } from "@navikt/ds-react";
 import { WrenchIcon, InformationSquareIcon } from "@navikt/aksel-icons";
 
@@ -22,26 +24,33 @@ export default function Troubleshooting() {
           <Accordion.Item>
             <Accordion.Header>
               <Heading size="xsmall" level="4">
-                1. Sertifikat- eller Proxy-feil (Zscaler / VPN)
+                1. Nettverksproblemer og tilkobling
               </Heading>
             </Accordion.Header>
             <Accordion.Content>
               <VStack gap="space-16">
-                <BodyShort>
-                  Dette er den hyppigste årsaken til at Copilot slutter å virke i enterprise-miljøer. Strenge VPN-er og
-                  proxyer (som Zscaler) kan blokkere telemetri-endepunktene eller tukle med SSL-sertifikatene.
-                </BodyShort>
                 <div className="pl-4 border-l-2 border-gray-300">
-                  <BodyShort weight="semibold">Løsning:</BodyShort>
+                  <BodyShort weight="semibold">Sjekk:</BodyShort>
                   <ul className="list-disc pl-5 space-y-1 mt-2 text-gray-700 text-sm">
-                    <li>Koble fra og til VPN/Zscaler.</li>
-                    <li>Sørg for at du har de nyeste Nav-sertifikatene installert på maskinen.</li>
                     <li>
-                      Hvis editoren din klager på "Self-signed certificate in certificate chain", må du peke editoren
-                      til Navs sertifikat-bundle via innstillingene.
+                      Om det er en pågående hendelse hos GitHub:{" "}
+                      <a href="https://www.githubstatus.com" className="text-blue-600 hover:underline">
+                        githubstatus.com
+                      </a>
+                      .
+                    </li>
+                    <li>Nettverket du sitter på — gjestenett og enkelte hjemmerutere blokkerer utgående trafikk.</li>
+                    <li>
+                      Proxy-innstillinger du selv har satt i editoren tidligere. Står det noe under <em>http.proxy</em>{" "}
+                      i VS Code, er det som regel en rest fra et gammelt oppsett.
                     </li>
                   </ul>
                 </div>
+                <BodyShort className="text-sm text-gray-600">
+                  Endpoint-sikkerhet (CrowdStrike Falcon) kan i prinsippet påvirke nettverkstrafikk, men er per i dag
+                  ingen kjent kilde til Copilot-feil. Mistenker du likevel det, si fra i{" "}
+                  <strong>#github-copilot</strong> — da får vi kartlagt det.
+                </BodyShort>
               </VStack>
             </Accordion.Content>
           </Accordion.Item>
@@ -169,8 +178,8 @@ export default function Troubleshooting() {
           </Heading>
         </div>
         <BodyShort className="text-gray-800">
-          Hvis trinnene over ikke løser problemet ditt, spør gjerne i <strong>#copilot-hjelp</strong> på Slack. Legg ved
-          et utdrag fra Copilot Logs og nevn hvilken Editor (inkludert versjon) du sitter på.
+          Hvis trinnene over ikke løser problemet ditt, spør gjerne i <strong>#github-copilot</strong> på Slack. Legg
+          ved et utdrag fra Copilot Logs og nevn hvilken Editor (inkludert versjon) du sitter på.
         </BodyShort>
       </Box>
     </VStack>

--- a/scripts/install.bats
+++ b/scripts/install.bats
@@ -97,8 +97,10 @@ teardown() {
 @test "installs via brew on macOS if brew is available" {
   cat <<'EOF' > "${MOCK_BIN}/uname"
 #!/bin/bash
-echo "Darwin"
+if [[ "$1" == "-s" ]]; then echo "Darwin"; elif [[ "$1" == "-m" ]]; then echo "arm64"; fi
+exit 0
 EOF
+  chmod +x "${MOCK_BIN}/uname"
   
   cat <<'EOF' > "${MOCK_BIN}/brew"
 #!/bin/bash
@@ -128,6 +130,25 @@ EOF
   # Check that it fetched the latest release and correctly resolved the linux-amd64 asset
   [[ "$output" == *"Fetching latest nav-pilot release"* ]]
   [[ "$output" == *"nav-pilot nav-pilot/2026.01.01-mock (linux/amd64)"* ]]
+  [[ "$output" == *"Downloading nav-pilot-linux-amd64"* ]]
+  [[ "$output" == *"Installed nav-pilot to ${TMP_DIR}/install-dest/nav-pilot"* ]]
+}
+
+# Homebrew on Linux resolves navikt/tap/cplt, which only ships macOS bottles.
+# Taking the brew path there aborts the entire install before nav-pilot is
+# downloaded, so Linux must use the release binary even when brew is present.
+@test "does not use brew on Linux even if brew is available" {
+  cat <<'EOF' > "${MOCK_BIN}/brew"
+#!/bin/bash
+echo "mock brew $*"
+exit 0
+EOF
+  chmod +x "${MOCK_BIN}/brew"
+
+  run bash "$SCRIPT" --dir "${TMP_DIR}/install-dest"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Installing via Homebrew"* ]]
   [[ "$output" == *"Downloading nav-pilot-linux-amd64"* ]]
   [[ "$output" == *"Installed nav-pilot to ${TMP_DIR}/install-dest/nav-pilot"* ]]
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,9 +42,33 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# ─── Homebrew install (macOS) ────────────────────────────────────────────────
+# ─── Detect platform ─────────────────────────────────────────────────────────
 
-if [[ "$NO_BREW" == false && -z "$VERSION" && -z "$INSTALL_DIR" ]] && command -v brew &>/dev/null; then
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
+
+case "$OS" in
+  darwin) ;;
+  linux)  ;;
+  *)      echo "Error: Unsupported OS: $OS"; exit 1 ;;
+esac
+
+case "$ARCH" in
+  arm64|aarch64) ARCH="arm64" ;;
+  x86_64)        ARCH="amd64" ;;
+  *)             echo "Error: Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+ASSET="${BINARY}-${OS}-${ARCH}"
+
+# ─── Homebrew install (macOS) ────────────────────────────────────────────────
+#
+# Homebrew is only used on macOS. Homebrew on Linux exists, but navikt/tap/cplt
+# ships macOS-only bottles, so `brew install` aborts the whole install with
+# "formula requires at least a URL". Linux falls through to the download path
+# below, where cplt's own installer provides a Linux binary.
+
+if [[ "$OS" == "darwin" && "$NO_BREW" == false && -z "$VERSION" && -z "$INSTALL_DIR" ]] && command -v brew &>/dev/null; then
   echo "→ Installing via Homebrew..."
   brew install navikt/tap/nav-pilot navikt/tap/cplt rtk
   echo ""
@@ -73,25 +97,6 @@ fi
 #   curl -fsSL https://raw.githubusercontent.com/navikt/copilot/main/scripts/install.sh -o install.sh
 #   cat install.sh  # Inspect before running!
 #   bash install.sh
-
-# ─── Detect platform ─────────────────────────────────────────────────────────
-
-OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
-ARCH="$(uname -m)"
-
-case "$OS" in
-  darwin) ;;
-  linux)  ;;
-  *)      echo "Error: Unsupported OS: $OS"; exit 1 ;;
-esac
-
-case "$ARCH" in
-  arm64|aarch64) ARCH="arm64" ;;
-  x86_64)        ARCH="amd64" ;;
-  *)             echo "Error: Unsupported architecture: $ARCH"; exit 1 ;;
-esac
-
-ASSET="${BINARY}-${OS}-${ARCH}"
 
 # ─── Resolve version ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Samler to feilrapporter fra brukere. De henger ikke sammen teknisk, men begge er ting folk møter i første kontakt med verktøyene.

## #378 — feilsøkingsguiden krasjet

`/praksis/guide/feilsoking` traff error-boundaryen med *«Element type is invalid … but got: undefined»*. Ikke en død lenke — ruten fantes hele tiden.

`@navikt/ds-react` har `"use client"` i pakkeroten, så `Accordion` er en klientmodul. En server-komponent kan rendre den, men ikke lese felter av den: **`Accordion.Item` ble `undefined`**. Bare `Accordion` eksporteres fra pakkeroten, så subkomponentene kan ikke importeres ved navn som omvei — filen må være en klientkomponent.

`troubleshooting.tsx` var den eneste seksjonen som brukte dot-notasjon på en Aksel-komponent, og dermed den eneste som krasjet. Ny test feiler hvis en seksjon gjør det samme igjen. Verifisert ved å fjerne `"use client"` — da feiler den, med fiksen passerer den.

**Hvorfor ingen fanget det:** appen bygges med `next build --experimental-build-mode compile`, som hopper over prerendering. Feilen kunne derfor ikke stoppe bygget, og siden var nede til noen meldte fra.

### Innholdsrettelser i samme guide

Avsnittet om nettverk bygget på feil premiss — Zscaler, «strenge VPN-er» og råd om å installere Nav-sertifikater og peke editoren mot en sertifikat-bundle. Nav har ikke et slikt oppsett, så rådene sendte folk på villspor. Erstattet med det som faktisk er verdt å sjekke: githubstatus.com, nettverket man sitter på, og gamle `http.proxy`-innstillinger i editoren. Falcon EDR nevnes som mulig framtidig faktor, uten å blåse det opp.

Slack-kanalen heter `#github-copilot`, ikke `#copilot-hjelp`. Rettet to steder.

## #377 — install.sh feilet på Linux

Brew-grenen sjekket bare om `brew` fantes, ikke hvilket OS man var på. Homebrew finnes også på Linux, så Linux-brukere med brew havnet i macOS-stien:

```
Error: navikt/tap/cplt: formula requires at least a URL
```

Formelen har bare en `on_macos`-blokk. Med `set -e` stoppet hele installasjonen der, så **nav-pilot ble aldri installert**.

Kommentaren øverst i skriptet har hele tiden beskrevet riktig oppførsel («On macOS: uses Homebrew … On Linux / CI: downloads the latest release binary») — det var implementasjonen som manglet OS-sjekken. Plattformdeteksjonen er flyttet opp foran brew-grenen, som nå krever `darwin`.

Linux faller gjennom til nedlastingsstien, og det er riktig sted å havne: **cplt har egne Linux-binærer** via sin egen installer, det er kun brew-formelen som er macOS-only. Ingen grunn til å hoppe over cplt på Linux.

**Hvorfor testene ikke fanget det:** `downloads linux binary if OS is Linux` mocket ikke `brew`. På CI-maskiner uten Homebrew passerte den, mens en Linux-utvikler med brew fikk noe helt annet. Ny test mocker brew eksplisitt og krever at brew-stien ikke velges.

## Verifisering

| | |
|---|---|
| `mise check` (my-copilot) | 499 tester, eslint, tsc, prettier, knip — grønt |
| `bats scripts/install.bats` | 6/6 |
| Siden i dev | 200, alt innhold rendres |
| Regresjonsvakten | Feiler uten fiksen, passerer med |

Eneste gjenværende lint-treff er en advarsel om ubrukt `NextLink` i `tools-and-modes.tsx`, som er urørt og fra før.

## Verdt å ta videre

`navikt/homebrew-tap` kunne fått en `on_linux`-blokk for `cplt`, siden Linux-binærene finnes. Da ville brew fungert på Linux også. Utenfor dette repoet.

Fixes #378
Fixes #377
