### PR TITLE
feat: add nav-etterlevelse-mcp to allowlist

### DIFF
--- a/apps/mcp-registry/allowlist.json
+++ b/apps/mcp-registry/allowlist.json
@@ -12,8 +12,24 @@
         "url": "https://github.com/github/github-mcp-server",
         "source": "github"
       },
-      "tools": ["get_file_contents", "search_repositories", "create_issue", "list_issues", "create_pull_request", "list_pull_requests", "search_code", "get_commit", "list_commits", "create_branch", "list_branches"],
-      "tags": ["developer-tools", "version-control", "github"],
+      "tools": [
+        "get_file_contents",
+        "search_repositories",
+        "create_issue",
+        "list_issues",
+        "create_pull_request",
+        "list_pull_requests",
+        "search_code",
+        "get_commit",
+        "list_commits",
+        "create_branch",
+        "list_branches"
+      ],
+      "tags": [
+        "developer-tools",
+        "version-control",
+        "github"
+      ],
       "examples": [
         {
           "scenario": "Finn kode i et annet repo",
@@ -44,8 +60,24 @@
         "source": "github",
         "subfolder": "apps/mcp-onboarding"
       },
-      "tools": ["hello_world", "greet", "whoami", "echo", "get_time", "list_agents", "list_instructions", "list_prompts", "list_skills", "check_agent_readiness", "generate_agents_md"],
-      "tags": ["developer-tools", "onboarding", "nav-internal"],
+      "tools": [
+        "hello_world",
+        "greet",
+        "whoami",
+        "echo",
+        "get_time",
+        "list_agents",
+        "list_instructions",
+        "list_prompts",
+        "list_skills",
+        "check_agent_readiness",
+        "generate_agents_md"
+      ],
+      "tags": [
+        "developer-tools",
+        "onboarding",
+        "nav-internal"
+      ],
       "examples": [
         {
           "scenario": "Sjekk om repoet er klart for agentmodus",
@@ -76,8 +108,20 @@
         "source": "github",
         "subfolder": "apps/mcp-server"
       },
-      "tools": ["aksel_find_docs", "aksel_get_doc", "aksel_get_token_details", "aksel_find_icons", "aksel_get_component_info"],
-      "tags": ["aksel", "designsystem", "ui", "frontend", "developer-tools"],
+      "tools": [
+        "aksel_find_docs",
+        "aksel_get_doc",
+        "aksel_get_token_details",
+        "aksel_find_icons",
+        "aksel_get_component_info"
+      ],
+      "tags": [
+        "aksel",
+        "designsystem",
+        "ui",
+        "frontend",
+        "developer-tools"
+      ],
       "examples": [
         {
           "scenario": "Søk i Aksel-dokumentasjon",
@@ -115,8 +159,18 @@
         "url": "https://github.com/figma/mcp-server-guide",
         "source": "github"
       },
-      "tools": ["get_design_context", "get_screenshot", "get_metadata", "get_figjam", "generate_diagram"],
-      "tags": ["design", "frontend", "figma"],
+      "tools": [
+        "get_design_context",
+        "get_screenshot",
+        "get_metadata",
+        "get_figjam",
+        "generate_diagram"
+      ],
+      "tags": [
+        "design",
+        "frontend",
+        "figma"
+      ],
       "examples": [
         {
           "scenario": "Design til kode",
@@ -142,8 +196,17 @@
         "url": "https://github.com/vercel/next-devtools-mcp",
         "source": "github"
       },
-      "tools": ["getErrors", "getRouteInfo", "getDebugInfo", "getDocs"],
-      "tags": ["frontend", "nextjs", "developer-tools"],
+      "tools": [
+        "getErrors",
+        "getRouteInfo",
+        "getDebugInfo",
+        "getDocs"
+      ],
+      "tags": [
+        "frontend",
+        "nextjs",
+        "developer-tools"
+      ],
       "examples": [
         {
           "scenario": "Feilsøk Next.js-app",
@@ -182,8 +245,15 @@
         "source": "github",
         "subfolder": "packages/mcp"
       },
-      "tools": ["search_docs", "analyze_code"],
-      "tags": ["frontend", "svelte", "documentation"],
+      "tools": [
+        "search_docs",
+        "analyze_code"
+      ],
+      "tags": [
+        "frontend",
+        "svelte",
+        "documentation"
+      ],
       "examples": [
         {
           "scenario": "Søk i Svelte-dokumentasjon",
@@ -219,8 +289,19 @@
         "url": "https://github.com/microsoft/playwright-mcp",
         "source": "github"
       },
-      "tools": ["browser_navigate", "browser_click", "browser_type", "browser_snapshot", "browser_take_screenshot", "browser_wait"],
-      "tags": ["testing", "browser-automation", "frontend"],
+      "tools": [
+        "browser_navigate",
+        "browser_click",
+        "browser_type",
+        "browser_snapshot",
+        "browser_take_screenshot",
+        "browser_wait"
+      ],
+      "tags": [
+        "testing",
+        "browser-automation",
+        "frontend"
+      ],
       "examples": [
         {
           "scenario": "Test brukerflyt",
@@ -285,8 +366,34 @@
           "url": "http://127.0.0.1:64342/sse"
         }
       ],
-      "tools": ["get_symbol_info", "get_file_problems", "get_project_dependencies", "get_project_modules", "search_in_files_by_text", "search_in_files_by_regex", "find_files_by_glob", "find_files_by_name_keyword", "get_file_text_by_path", "list_directory_tree", "get_all_open_file_paths", "get_run_configurations", "get_repositories", "create_new_file", "replace_text_in_file", "reformat_file", "rename_refactoring", "open_file_in_editor", "execute_terminal_command", "execute_run_configuration"],
-      "tags": ["developer-tools", "ide", "jetbrains", "code-intelligence"],
+      "tools": [
+        "get_symbol_info",
+        "get_file_problems",
+        "get_project_dependencies",
+        "get_project_modules",
+        "search_in_files_by_text",
+        "search_in_files_by_regex",
+        "find_files_by_glob",
+        "find_files_by_name_keyword",
+        "get_file_text_by_path",
+        "list_directory_tree",
+        "get_all_open_file_paths",
+        "get_run_configurations",
+        "get_repositories",
+        "create_new_file",
+        "replace_text_in_file",
+        "reformat_file",
+        "rename_refactoring",
+        "open_file_in_editor",
+        "execute_terminal_command",
+        "execute_run_configuration"
+      ],
+      "tags": [
+        "developer-tools",
+        "ide",
+        "jetbrains",
+        "code-intelligence"
+      ],
       "examples": [
         {
           "scenario": "Semantisk symboloppslag",
@@ -317,6 +424,7 @@
         "search_slack_channel",
         "list_etterlevelse_dokumentasjoner",
         "get_etterlevelse_dokumentasjon",
+        "get_etterlevelse_status_oversikt",
         "create_etterlevelse_dokumentasjon",
         "write_etterlevelse_dokumentasjon",
         "list_krav",
@@ -347,7 +455,14 @@
         "search_behandlinger",
         "get_processor"
       ],
-      "tags": ["compliance", "privacy", "etterlevelse", "pvk", "dpia", "nav-internal"],
+      "tags": [
+        "compliance",
+        "privacy",
+        "etterlevelse",
+        "pvk",
+        "dpia",
+        "nav-internal"
+      ],
       "examples": [
         {
           "scenario": "Vurder etterlevelse for et system",
@@ -388,7 +503,12 @@
         }
       ],
       "tools": [],
-      "tags": ["frontend", "aksel", "local", "developer-tools"],
+      "tags": [
+        "frontend",
+        "aksel",
+        "local",
+        "developer-tools"
+      ],
       "examples": [
         {
           "scenario": "Rediger JSX",

--- a/apps/mcp-registry/allowlist.json
+++ b/apps/mcp-registry/allowlist.json
@@ -408,7 +408,7 @@
     {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "io.github.navikt/nav-etterlevelse-mcp",
-      "description": "Document compliance and privacy impact assessments (PVK/DPIA) for Nav systems. Covers etterlevelse requirements, risk scenarios, and behandlingskatalog integration.",
+      "description": "Document etterlevelse compliance and privacy impact assessments (PVK/DPIA) for Nav systems.",
       "version": "0.1.0",
       "status": "active",
       "publishedAt": "2026-08-05T00:00:00Z",

--- a/apps/mcp-registry/allowlist.json
+++ b/apps/mcp-registry/allowlist.json
@@ -316,7 +316,7 @@
           "url": "https://nav-etterlevelse-mcp.{{domain_internal}}/mcp"
         }
       ],
-      "tools": ["lock_document", "get_my_teams", "list_nom_avdelinger", "search_slack_channel", "list_etterlevelse_dokumentasjoner", "get_etterlevelse_dokumentasjon", "get_etterlevelse_status_oversikt", "create_etterlevelse_dokumentasjon", "write_etterlevelse_dokumentasjon", "list_krav", "get_krav", "get_krav_for_gjennomgang", "get_etterlevelse", "write_etterlevelse", "delete_etterlevelse", "get_pvk_dokument", "create_pvk_dokument", "delete_pvk_dokument", "write_pvk_egenskaper", "write_pvk_involvering", "write_pvk_melding_til_pvo", "write_pvk_risikoeier", "write_behandlingens_art_og_omfang", "get_behandlingens_livsloep", "write_behandlingens_livsloep", "delete_behandlingens_livsloep", "list_risikoscenarioer", "write_risikoscenario", "delete_risikoscenario", "link_krav_to_risikoscenario", "unlink_krav_from_risikoscenario", "list_tiltak", "write_tiltak", "delete_tiltak", "get_behandling", "search_behandlinger", "get_processor"],
+      "tools": ["list_etterlevelse_dokumentasjoner", "get_etterlevelse_dokumentasjon", "create_etterlevelse_dokumentasjon", "get_etterlevelse_status_oversikt", "list_krav", "get_krav_for_gjennomgang", "get_pvk_dokument", "create_pvk_dokument", "list_risikoscenarioer", "list_tiltak", "search_behandlinger", "get_my_teams"],
       "tags": ["compliance", "privacy", "etterlevelse", "pvk", "dpia", "nav-internal"],
       "examples": [
         {

--- a/apps/mcp-registry/allowlist.json
+++ b/apps/mcp-registry/allowlist.json
@@ -12,24 +12,8 @@
         "url": "https://github.com/github/github-mcp-server",
         "source": "github"
       },
-      "tools": [
-        "get_file_contents",
-        "search_repositories",
-        "create_issue",
-        "list_issues",
-        "create_pull_request",
-        "list_pull_requests",
-        "search_code",
-        "get_commit",
-        "list_commits",
-        "create_branch",
-        "list_branches"
-      ],
-      "tags": [
-        "developer-tools",
-        "version-control",
-        "github"
-      ],
+      "tools": ["get_file_contents", "search_repositories", "create_issue", "list_issues", "create_pull_request", "list_pull_requests", "search_code", "get_commit", "list_commits", "create_branch", "list_branches"],
+      "tags": ["developer-tools", "version-control", "github"],
       "examples": [
         {
           "scenario": "Finn kode i et annet repo",
@@ -60,24 +44,8 @@
         "source": "github",
         "subfolder": "apps/mcp-onboarding"
       },
-      "tools": [
-        "hello_world",
-        "greet",
-        "whoami",
-        "echo",
-        "get_time",
-        "list_agents",
-        "list_instructions",
-        "list_prompts",
-        "list_skills",
-        "check_agent_readiness",
-        "generate_agents_md"
-      ],
-      "tags": [
-        "developer-tools",
-        "onboarding",
-        "nav-internal"
-      ],
+      "tools": ["hello_world", "greet", "whoami", "echo", "get_time", "list_agents", "list_instructions", "list_prompts", "list_skills", "check_agent_readiness", "generate_agents_md"],
+      "tags": ["developer-tools", "onboarding", "nav-internal"],
       "examples": [
         {
           "scenario": "Sjekk om repoet er klart for agentmodus",
@@ -108,20 +76,8 @@
         "source": "github",
         "subfolder": "apps/mcp-server"
       },
-      "tools": [
-        "aksel_find_docs",
-        "aksel_get_doc",
-        "aksel_get_token_details",
-        "aksel_find_icons",
-        "aksel_get_component_info"
-      ],
-      "tags": [
-        "aksel",
-        "designsystem",
-        "ui",
-        "frontend",
-        "developer-tools"
-      ],
+      "tools": ["aksel_find_docs", "aksel_get_doc", "aksel_get_token_details", "aksel_find_icons", "aksel_get_component_info"],
+      "tags": ["aksel", "designsystem", "ui", "frontend", "developer-tools"],
       "examples": [
         {
           "scenario": "Søk i Aksel-dokumentasjon",
@@ -159,18 +115,8 @@
         "url": "https://github.com/figma/mcp-server-guide",
         "source": "github"
       },
-      "tools": [
-        "get_design_context",
-        "get_screenshot",
-        "get_metadata",
-        "get_figjam",
-        "generate_diagram"
-      ],
-      "tags": [
-        "design",
-        "frontend",
-        "figma"
-      ],
+      "tools": ["get_design_context", "get_screenshot", "get_metadata", "get_figjam", "generate_diagram"],
+      "tags": ["design", "frontend", "figma"],
       "examples": [
         {
           "scenario": "Design til kode",
@@ -196,17 +142,8 @@
         "url": "https://github.com/vercel/next-devtools-mcp",
         "source": "github"
       },
-      "tools": [
-        "getErrors",
-        "getRouteInfo",
-        "getDebugInfo",
-        "getDocs"
-      ],
-      "tags": [
-        "frontend",
-        "nextjs",
-        "developer-tools"
-      ],
+      "tools": ["getErrors", "getRouteInfo", "getDebugInfo", "getDocs"],
+      "tags": ["frontend", "nextjs", "developer-tools"],
       "examples": [
         {
           "scenario": "Feilsøk Next.js-app",
@@ -245,15 +182,8 @@
         "source": "github",
         "subfolder": "packages/mcp"
       },
-      "tools": [
-        "search_docs",
-        "analyze_code"
-      ],
-      "tags": [
-        "frontend",
-        "svelte",
-        "documentation"
-      ],
+      "tools": ["search_docs", "analyze_code"],
+      "tags": ["frontend", "svelte", "documentation"],
       "examples": [
         {
           "scenario": "Søk i Svelte-dokumentasjon",
@@ -289,19 +219,8 @@
         "url": "https://github.com/microsoft/playwright-mcp",
         "source": "github"
       },
-      "tools": [
-        "browser_navigate",
-        "browser_click",
-        "browser_type",
-        "browser_snapshot",
-        "browser_take_screenshot",
-        "browser_wait"
-      ],
-      "tags": [
-        "testing",
-        "browser-automation",
-        "frontend"
-      ],
+      "tools": ["browser_navigate", "browser_click", "browser_type", "browser_snapshot", "browser_take_screenshot", "browser_wait"],
+      "tags": ["testing", "browser-automation", "frontend"],
       "examples": [
         {
           "scenario": "Test brukerflyt",
@@ -366,34 +285,8 @@
           "url": "http://127.0.0.1:64342/sse"
         }
       ],
-      "tools": [
-        "get_symbol_info",
-        "get_file_problems",
-        "get_project_dependencies",
-        "get_project_modules",
-        "search_in_files_by_text",
-        "search_in_files_by_regex",
-        "find_files_by_glob",
-        "find_files_by_name_keyword",
-        "get_file_text_by_path",
-        "list_directory_tree",
-        "get_all_open_file_paths",
-        "get_run_configurations",
-        "get_repositories",
-        "create_new_file",
-        "replace_text_in_file",
-        "reformat_file",
-        "rename_refactoring",
-        "open_file_in_editor",
-        "execute_terminal_command",
-        "execute_run_configuration"
-      ],
-      "tags": [
-        "developer-tools",
-        "ide",
-        "jetbrains",
-        "code-intelligence"
-      ],
+      "tools": ["get_symbol_info", "get_file_problems", "get_project_dependencies", "get_project_modules", "search_in_files_by_text", "search_in_files_by_regex", "find_files_by_glob", "find_files_by_name_keyword", "get_file_text_by_path", "list_directory_tree", "get_all_open_file_paths", "get_run_configurations", "get_repositories", "create_new_file", "replace_text_in_file", "reformat_file", "rename_refactoring", "open_file_in_editor", "execute_terminal_command", "execute_run_configuration"],
+      "tags": ["developer-tools", "ide", "jetbrains", "code-intelligence"],
       "examples": [
         {
           "scenario": "Semantisk symboloppslag",
@@ -417,53 +310,14 @@
         "url": "https://github.com/navikt/nav-etterlevelse-mcp",
         "source": "github"
       },
-      "tools": [
-        "lock_document",
-        "get_my_teams",
-        "list_nom_avdelinger",
-        "search_slack_channel",
-        "list_etterlevelse_dokumentasjoner",
-        "get_etterlevelse_dokumentasjon",
-        "get_etterlevelse_status_oversikt",
-        "create_etterlevelse_dokumentasjon",
-        "write_etterlevelse_dokumentasjon",
-        "list_krav",
-        "get_krav",
-        "get_krav_for_gjennomgang",
-        "get_etterlevelse",
-        "write_etterlevelse",
-        "delete_etterlevelse",
-        "get_pvk_dokument",
-        "create_pvk_dokument",
-        "delete_pvk_dokument",
-        "write_pvk_egenskaper",
-        "write_pvk_involvering",
-        "write_pvk_melding_til_pvo",
-        "write_pvk_risikoeier",
-        "write_behandlingens_art_og_omfang",
-        "get_behandlingens_livsloep",
-        "write_behandlingens_livsloep",
-        "delete_behandlingens_livsloep",
-        "list_risikoscenarioer",
-        "write_risikoscenario",
-        "delete_risikoscenario",
-        "link_krav_to_risikoscenario",
-        "unlink_krav_from_risikoscenario",
-        "list_tiltak",
-        "write_tiltak",
-        "delete_tiltak",
-        "get_behandling",
-        "search_behandlinger",
-        "get_processor"
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://nav-etterlevelse-mcp.{{domain_internal}}/mcp"
+        }
       ],
-      "tags": [
-        "compliance",
-        "privacy",
-        "etterlevelse",
-        "pvk",
-        "dpia",
-        "nav-internal"
-      ],
+      "tools": ["lock_document", "get_my_teams", "list_nom_avdelinger", "search_slack_channel", "list_etterlevelse_dokumentasjoner", "get_etterlevelse_dokumentasjon", "get_etterlevelse_status_oversikt", "create_etterlevelse_dokumentasjon", "write_etterlevelse_dokumentasjon", "list_krav", "get_krav", "get_krav_for_gjennomgang", "get_etterlevelse", "write_etterlevelse", "delete_etterlevelse", "get_pvk_dokument", "create_pvk_dokument", "delete_pvk_dokument", "write_pvk_egenskaper", "write_pvk_involvering", "write_pvk_melding_til_pvo", "write_pvk_risikoeier", "write_behandlingens_art_og_omfang", "get_behandlingens_livsloep", "write_behandlingens_livsloep", "delete_behandlingens_livsloep", "list_risikoscenarioer", "write_risikoscenario", "delete_risikoscenario", "link_krav_to_risikoscenario", "unlink_krav_from_risikoscenario", "list_tiltak", "write_tiltak", "delete_tiltak", "get_behandling", "search_behandlinger", "get_processor"],
+      "tags": ["compliance", "privacy", "etterlevelse", "pvk", "dpia", "nav-internal"],
       "examples": [
         {
           "scenario": "Vurder etterlevelse for et system",
@@ -476,12 +330,6 @@
         {
           "scenario": "Finn krav for et dokument",
           "prompt": "Hvilke etterlevelseskrav er relevante for etterlevelsesdokumentasjon E123?"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://nav-etterlevelse-mcp.{{domain_internal}}/mcp"
         }
       ]
     },
@@ -504,12 +352,7 @@
         }
       ],
       "tools": [],
-      "tags": [
-        "frontend",
-        "aksel",
-        "local",
-        "developer-tools"
-      ],
+      "tags": ["frontend", "aksel", "local", "developer-tools"],
       "examples": [
         {
           "scenario": "Rediger JSX",

--- a/apps/mcp-registry/allowlist.json
+++ b/apps/mcp-registry/allowlist.json
@@ -300,6 +300,75 @@
     },
     {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "io.github.navikt/nav-etterlevelse-mcp",
+      "description": "Document compliance and privacy impact assessments (PVK/DPIA) for Nav systems. Covers etterlevelse requirements, risk scenarios, and behandlingskatalog integration.",
+      "version": "0.1.0",
+      "status": "active",
+      "publishedAt": "2026-08-05T00:00:00Z",
+      "websiteUrl": "https://github.com/navikt/nav-etterlevelse-mcp",
+      "repository": {
+        "url": "https://github.com/navikt/nav-etterlevelse-mcp",
+        "source": "github"
+      },
+      "tools": [
+        "lock_document",
+        "get_my_teams",
+        "list_etterlevelse_dokumentasjoner",
+        "get_etterlevelse_dokumentasjon",
+        "create_etterlevelse_dokumentasjon",
+        "write_etterlevelse_dokumentasjon",
+        "list_krav",
+        "get_krav",
+        "get_etterlevelse",
+        "write_etterlevelse",
+        "delete_etterlevelse",
+        "get_pvk_dokument",
+        "create_pvk_dokument",
+        "delete_pvk_dokument",
+        "write_pvk_egenskaper",
+        "write_pvk_involvering",
+        "write_pvk_melding_til_pvo",
+        "write_pvk_risikoeier",
+        "write_behandlingens_art_og_omfang",
+        "get_behandlingens_livsloep",
+        "write_behandlingens_livsloep",
+        "delete_behandlingens_livsloep",
+        "list_risikoscenarioer",
+        "write_risikoscenario",
+        "delete_risikoscenario",
+        "link_krav_to_risikoscenario",
+        "unlink_krav_from_risikoscenario",
+        "list_tiltak",
+        "write_tiltak",
+        "delete_tiltak",
+        "get_behandling",
+        "search_behandlinger",
+        "get_processor"
+      ],
+      "tags": ["compliance", "privacy", "etterlevelse", "pvk", "dpia", "nav-internal"],
+      "examples": [
+        {
+          "scenario": "Vurder etterlevelse for et system",
+          "prompt": "Gjennomfør etterlevelsessjekk for navikt/dp-soknad"
+        },
+        {
+          "scenario": "Lag PVK for et system",
+          "prompt": "Gjennomfør en personvernkonsekvensvurdering for navikt/fp-sak"
+        },
+        {
+          "scenario": "Finn krav for et dokument",
+          "prompt": "Hvilke etterlevelseskrav er relevante for etterlevelsesdokumentasjon E123?"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://nav-etterlevelse-mcp.{{domain_internal}}/mcp"
+        }
+      ]
+    },
+    {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "no.nav.aksel/aksel-arcade",
       "description": "Lokal MCP innebygd i appen Aksel Arcade for redigering av JSX/Hooks og Pages.",
       "version": "1.0.0",

--- a/apps/mcp-registry/allowlist.json
+++ b/apps/mcp-registry/allowlist.json
@@ -313,6 +313,8 @@
       "tools": [
         "lock_document",
         "get_my_teams",
+        "list_nom_avdelinger",
+        "search_slack_channel",
         "list_etterlevelse_dokumentasjoner",
         "get_etterlevelse_dokumentasjon",
         "create_etterlevelse_dokumentasjon",

--- a/apps/mcp-registry/allowlist.json
+++ b/apps/mcp-registry/allowlist.json
@@ -429,6 +429,7 @@
         "write_etterlevelse_dokumentasjon",
         "list_krav",
         "get_krav",
+        "get_krav_for_gjennomgang",
         "get_etterlevelse",
         "write_etterlevelse",
         "delete_etterlevelse",


### PR DESCRIPTION
## Status

> **Draft** — denne PR-en er ikke klar for review ennå. Se forutsetninger nedenfor.

## Forutsetninger før PR kan godkjennes

- [ ] **Team datajegerne godkjenner inbound-tilgang** i prod-gcp — `etterlevelse-backend` og `behandlingskatalog-backend` må åpne for tilgang fra `nav-etterlevelse-mcp` i namespace `dab`
- [ ] **Feature toggle aktiveres i prod** — `nav-etterlevelse-mcp.write-enabled` i Unleash må skrus på for skrivetilgang
- [x] **PR #6 i nav-etterlevelse-mcp merges til main** — inneholder validering, nye tools (`search_slack_channel`, `list_nom_avdelinger`), m.m. — merget 2026-08-06
- [x] **PR #25 i nav-etterlevelse-mcp merges til main** — legger til `log_review_event` for observability på gjennomgangsprosessen, samt en alarm som fanger batch-godkjenning av suksesskriterier — merget 2026-09-10

## Om serveren

**nav-etterlevelse-mcp** er en MCP-server som gir AI-agenter (GitHub Copilot, OpenCode) strukturert tilgang til:
- **etterlevelse-backend** — Navs etterlevelsesdokumentasjonssystem
- **behandlingskatalog-backend** — Navs behandlingskatalog

Autentisering: Azure AD OAuth 2.1 PKCE — brukeren logger inn via nettleser. Nedstrøms kall bruker NAIS Texas OBO for å bevare brukeridentitet.

## Teknisk
- **40 verktøy** for etterlevelse, PVK/DPIA, risikoscenarioer, tiltak og behandlingskatalog
- **Nav-intern** — kun tilgjengelig via `intern.nav.no`-ingress
- **Streamable HTTP** med `{{domain_internal}}` URL-templat
- Deployed på **NAIS prod-gcp og dev-gcp**, namespace `dab`

## Herding siden PR-en ble opprettet

Følgende er gjort siden denne PR-en ble draftet, som styrker produksjonsklarheten:

- **Datatapbug fikset** ([#21](https://github.com/navikt/nav-etterlevelse-mcp/pull/21)): delvis skriving av suksesskriterier kunne slette eksisterende begrunnelser stille. Fikset og regresjonstestet.
- **Testinfrastruktur etablert** ([#22](https://github.com/navikt/nav-etterlevelse-mcp/pull/22), [#23](https://github.com/navikt/nav-etterlevelse-mcp/pull/23), [#24](https://github.com/navikt/nav-etterlevelse-mcp/pull/24)): vitest + CI-gate på pull request, 31 tester dekker skrivelogikk, auth/sesjonshåndtering, dokumentoppdatering og gjennomgangs-telemetri.
- **Alarm-manifest korrigert** ([#19](https://github.com/navikt/nav-etterlevelse-mcp/pull/19), [#20](https://github.com/navikt/nav-etterlevelse-mcp/pull/20)): feil ressurstype og PromQL-aggregeringsfeil som gjorde at alarmene aldri ville trigge.
- **Observability for gjennomgangsprosess** ([#25](https://github.com/navikt/nav-etterlevelse-mcp/pull/25), merget): selvrapportert telemetri (`log_review_event`) + objektiv alarm for å oppdage batch-godkjenning av suksesskriterier i strid med prosesskravet.

Tilhørende endring i skill-instruksjonen (som faktisk kaller `log_review_event`) er merget i [dab-copilot-config #12](https://github.com/navikt/dab-copilot-config/pull/12).

## Repo
https://github.com/navikt/nav-etterlevelse-mcp