### PR TITLE
docs(skills): document nav-dekoratoren origin

### DIFF
--- a/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
+++ b/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
@@ -870,7 +870,7 @@
       "displayName": "nav-dekoratoren",
       "description": "Integrer, konfigurer og bidra til Nav Dekoratøren – felles header og footer for nav.no-applikasjoner",
       "filePath": "skills/nav-dekoratoren/SKILL.md",
-      "contentHash": "c7df0b1bfcac4b052f079dc6ce4d157fa3be91d30e1f699a1c3820b634d02149",
+      "contentHash": "28498852a2df92d9cf27f9898529b4fb1deab4df0e213ced3153d0af4b5f0cbf",
       "installUrl": "",
       "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/skills/nav-dekoratoren/SKILL.md",
       "references": [

--- a/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
+++ b/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
@@ -870,7 +870,7 @@
       "displayName": "nav-dekoratoren",
       "description": "Integrer, konfigurer og bidra til Nav Dekoratøren – felles header og footer for nav.no-applikasjoner",
       "filePath": "skills/nav-dekoratoren/SKILL.md",
-      "contentHash": "ed183555a49d4e2dfe2ec867a1e844183231f5de62e7614928477f96f08ee720",
+      "contentHash": "c7df0b1bfcac4b052f079dc6ce4d157fa3be91d30e1f699a1c3820b634d02149",
       "installUrl": "",
       "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/skills/nav-dekoratoren/SKILL.md",
       "references": [

--- a/apps/my-copilot/src/lib/copilot-manifest.json
+++ b/apps/my-copilot/src/lib/copilot-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-08-06T11:19:28.765Z",
+  "generatedAt": "2026-08-06T11:24:46.300Z",
   "items": [
     {
       "id": "accessibility-agent",
@@ -1418,7 +1418,7 @@
       "domain": "frontend",
       "filePath": "skills/nav-dekoratoren/SKILL.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/skills/nav-dekoratoren/SKILL.md",
-      "contentHash": "c7df0b1bfcac4b052f079dc6ce4d157fa3be91d30e1f699a1c3820b634d02149",
+      "contentHash": "28498852a2df92d9cf27f9898529b4fb1deab4df0e213ced3153d0af4b5f0cbf",
       "installUrl": null,
       "insidersInstallUrl": null,
       "tags": ["nav", "dekoratoren", "header", "footer", "integration", "ssr", "analytics", "consent"],

--- a/apps/my-copilot/src/lib/copilot-manifest.json
+++ b/apps/my-copilot/src/lib/copilot-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-07-30T17:53:53.263Z",
+  "generatedAt": "2026-08-06T11:19:28.765Z",
   "items": [
     {
       "id": "accessibility-agent",
@@ -1418,7 +1418,7 @@
       "domain": "frontend",
       "filePath": "skills/nav-dekoratoren/SKILL.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/skills/nav-dekoratoren/SKILL.md",
-      "contentHash": "ed183555a49d4e2dfe2ec867a1e844183231f5de62e7614928477f96f08ee720",
+      "contentHash": "c7df0b1bfcac4b052f079dc6ce4d157fa3be91d30e1f699a1c3820b634d02149",
       "installUrl": null,
       "insidersInstallUrl": null,
       "tags": ["nav", "dekoratoren", "header", "footer", "integration", "ssr", "analytics", "consent"],

--- a/skills/nav-dekoratoren/SKILL.md
+++ b/skills/nav-dekoratoren/SKILL.md
@@ -311,7 +311,7 @@ Send appens tekniske navn som `origin` i dekoratørparameterne. Verdien legges t
 ```ts
 import { getAnalyticsInstance, Events } from "@navikt/nav-dekoratoren-moduler";
 
-const logger = getAnalyticsInstance("min-app-origin");
+const logger = getAnalyticsInstance("min-app");
 
 // Taksonomi-event (strengt typet fra @navikt/analytics-types)
 logger(Events.SKJEMA_STARTET, { skjemaId: "1234", skjemanavn: "aap" });

--- a/skills/nav-dekoratoren/SKILL.md
+++ b/skills/nav-dekoratoren/SKILL.md
@@ -116,7 +116,11 @@ export default async function RootLayout({
 }) {
     const Decorator = await fetchDecoratorReact({
         env: "prod",
-        params: { context: "privatperson", language: "nb" },
+        params: {
+            context: "privatperson",
+            language: "nb",
+            origin: "min-app",
+        },
     });
 
     return (
@@ -167,7 +171,11 @@ class MyDocument extends Document<MyDocumentProps> {
         const initialProps = await Document.getInitialProps(ctx);
         const Decorator = await fetchDecoratorReact({
             env: "prod",
-            params: { context: "privatperson", language: "nb" },
+            params: {
+                context: "privatperson",
+                language: "nb",
+                origin: "min-app",
+            },
         });
 
         return { ...initialProps, Decorator };
@@ -207,7 +215,7 @@ const {
     DECORATOR_SCRIPTS,
 } = await fetchDecoratorHtml({
     env: "dev",
-    params: { context: "privatperson" },
+    params: { context: "privatperson", origin: "min-app" },
 });
 ```
 
@@ -241,6 +249,7 @@ De viktigste:
 | `redirectToApp`      | `boolean`                                             | `false`        |
 | `logoutWarning`      | `boolean`                                             | `true`         |
 | `feedback`           | `boolean`                                             | `false`        |
+| `origin`             | `string`                                              | `undefined`    |
 
 ---
 
@@ -294,6 +303,10 @@ onLanguageSelect((language) => {
 ```
 
 ### 5.3 Analytics (Umami)
+
+Send appens tekniske navn som `origin` i dekoratørparameterne. Verdien legges til automatiske
+`besøk`-hendelser, slik at sidevisninger kan filtreres per app. Når parameteren utelates, bruker
+`besøk`-hendelser verdien `nav-dekoratoren`.
 
 ```ts
 import { getAnalyticsInstance, Events } from "@navikt/nav-dekoratoren-moduler";

--- a/skills/nav-dekoratoren/references/client-functions.md
+++ b/skills/nav-dekoratoren/references/client-functions.md
@@ -69,6 +69,8 @@ onLanguageSelect((language) => {
 ## getAnalyticsInstance
 
 Henter logger-instans for analytics (Umami). Støtter taksonomi-events og custom events.
+Oppgi `origin` når logger-instansen opprettes for å identifisere appens egne hendelser. Bruk den
+samme verdien som `origin` i dekoratørparameterne for automatiske `besøk`-hendelser.
 
 ```ts
 import {

--- a/skills/nav-dekoratoren/references/client-functions.md
+++ b/skills/nav-dekoratoren/references/client-functions.md
@@ -79,7 +79,7 @@ import {
     isValidEventName,
 } from "@navikt/nav-dekoratoren-moduler";
 
-const logger = getAnalyticsInstance("min-app-origin");
+const logger = getAnalyticsInstance("min-app");
 
 // Taksonomi-event – strengt typet fra @navikt/analytics-types
 logger(Events.SKJEMA_STARTET, { skjemaId: "1234", skjemanavn: "aap" });

--- a/skills/nav-dekoratoren/references/params.md
+++ b/skills/nav-dekoratoren/references/params.md
@@ -22,6 +22,7 @@ Kan settes som query-parametre ved direkte SSR-kall, eller som `params`-objekt i
 | `logoutUrl`             | `string`                                              | `undefined`    | Deleger all utlogging til angitt URL (teamet håndterer cookie-sletting)   |
 | `logoutWarning`         | `boolean`                                             | `true`         | Vis advarsel etter 55 min (WCAG-krav – deaktiver kun med eget alternativ) |
 | `redirectOnUserChange`  | `boolean`                                             | `false`        | Redirect til nav.no hvis annen bruker logger inn i annet vindu            |
+| `origin`                | `string`                                              | `undefined`    | Appidentifikator på automatiske `besøk`-hendelser                         |
 | `pageType`              | `string`                                              | `undefined`    | Sidetype for Analytics-logging                                            |
 | `analyticsQueryParams`  | `string[]`                                            | `[]`           | Hviteliste av query-params som inkluderes i Analytics (ingen sensitive!)  |
 | `analyticsRedactFilter` | `string[]`                                            | `['uuid']`     | Opt-out av automatisk redaction (UUID fjernes som standard)               |
@@ -31,6 +32,9 @@ Kan settes som query-parametre ved direkte SSR-kall, eller som `params`-objekt i
 ```
 # Sett kontekst
 https://www.nav.no/dekoratoren/?context=arbeidsgiver
+
+# Identifiser appen i besøk-hendelser
+https://www.nav.no/dekoratoren/?origin=min-app
 
 # Språkvelger
 https://www.nav.no/dekoratoren/?availableLanguages=[{"locale":"nb","url":"https://www.nav.no/nb"},{"locale":"en","url":"https://www.nav.no/en"}]
@@ -71,6 +75,7 @@ type DecoratorParams = Partial<{
     logoutUrl: string;
     logoutWarning: boolean;
     redirectOnUserChange: boolean;
+    origin: string;
     pageType: string;
     analyticsQueryParams: string[];
     analyticsRedactFilter: string[];


### PR DESCRIPTION
## Hva

Oppdaterer `nav-dekoratoren`-skillen med støtte for `origin`-parameteren i `@navikt/nav-dekoratoren-moduler` v4.3. Parameteren identifiserer appen på automatiske `besøk`-hendelser.

## Innhold

- legger til `origin` i SSR-eksemplene og parameterreferansen
- beskriver fallback til `nav-dekoratoren` når parameteren utelates
- tydeliggjør at `getAnalyticsInstance` bruker eksplisitt `origin` for appens egne hendelser
- regenererer manifestene med oppdatert skill-hash

## Verifisering

- `bash scripts/lint-skills.sh nav-dekoratoren`
- `cd apps/my-copilot && bash hack/generate-check.sh`
- verifisert at manifest-hashen matcher `skills/nav-dekoratoren/SKILL.md`