### PR TITLE
docs(nav-pilot): require sandboxing on Nav equipment

### DIFF
--- a/apps/my-copilot/src/app/cplt/page.tsx
+++ b/apps/my-copilot/src/app/cplt/page.tsx
@@ -178,10 +178,10 @@ function HeroSection({ stars }: { stars: number | null }) {
               }}
             >
               <p style={{ color: "#d1fae5", lineHeight: 1.6, margin: 0, textAlign: "left" }}>
-                <strong>Isolation is required on Nav-owned equipment.</strong> This applies to every AI-agent session,
-                whether the work is Nav-related or personal. Use cplt (recommended). If you choose another solution, you
-                are responsible for enabling and understanding the client&apos;s sandbox, or providing equivalent
-                isolation such as a VM or container.
+                <strong>Isolation is required on Nav-owned equipment.</strong> This applies to all AI agent work,
+                whether it is Nav-related or personal. Use cplt (recommended). If you choose another solution, you are
+                responsible for enabling and understanding the isolation provided by the agent client, or for providing
+                equivalent isolation with a VM or container.
               </p>
               <p style={{ marginBlock: "0.75rem 0 0", textAlign: "left" }}>
                 <NextLink

--- a/apps/my-copilot/src/app/cplt/page.tsx
+++ b/apps/my-copilot/src/app/cplt/page.tsx
@@ -169,6 +169,30 @@ function HeroSection({ stars }: { stars: number | null }) {
             >
               Kernel-level isolation for AI coding agents. Your secrets stay secret — enforced by the OS, not by trust.
             </p>
+            <Box
+              padding="space-16"
+              className="max-w-2xl mx-auto rounded-lg"
+              style={{
+                background: "rgba(167,243,208,0.08)",
+                border: "1px solid rgba(167,243,208,0.3)",
+              }}
+            >
+              <p style={{ color: "#d1fae5", lineHeight: 1.6, margin: 0, textAlign: "left" }}>
+                <strong>Isolation is required on Nav-owned equipment.</strong> This applies to every AI-agent session,
+                whether the work is Nav-related or personal. Use cplt (recommended). If you choose another solution, you
+                are responsible for enabling and understanding the client&apos;s sandbox, or providing equivalent
+                isolation such as a VM or container.
+              </p>
+              <p style={{ marginBlock: "0.75rem 0 0", textAlign: "left" }}>
+                <NextLink
+                  href="/nyheter/sandboxing-er-pakrevd-pa-nav-utstyr"
+                  className="underline"
+                  style={{ color: "#a7f3d0" }}
+                >
+                  Read the policy summary
+                </NextLink>
+              </p>
+            </Box>
             {/* GitHub badge */}
             <div className="flex justify-center">
               <NextLink

--- a/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
+++ b/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
@@ -493,8 +493,9 @@ function IntroductionSection() {
                   cplt
                 </NextLink>{" "}
                 — det er den anbefalte og enkleste løsningen. Hvis du velger en annen løsning, må du selv sette deg inn
-                i og aktivere sandboxingen som agentklienten tilbyr, eller sørge for tilsvarende isolasjon med for
-                eksempel en VM eller container. Ikke kjør agenter med ubegrenset tilgang til Nav-utstyret.
+                i hvordan agentklienten isolerer agenten, og aktivere denne funksjonen. Hvis klienten ikke gir
+                tilstrekkelig beskyttelse, må du sørge for tilsvarende isolasjon, for eksempel med en VM eller
+                container. Ikke kjør agenter med ubegrenset tilgang til Nav-utstyret.
               </BodyLong>
               <BodyLong style={{ color: "#475569" }}>
                 <NextLink href="/nyheter/sandboxing-er-pakrevd-pa-nav-utstyr" className="text-blue-600 hover:underline">

--- a/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
+++ b/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
@@ -41,6 +41,7 @@ const DOC_SECTIONS: TocItem[] = [
     label: "Introduksjon",
     children: [
       { id: "hva-er-nav-pilot", label: "Hva er nav-pilot?" },
+      { id: "isolasjon-er-pakrevd", label: "Isolasjon er påkrevd" },
       { id: "hvorfor-nav-pilot", label: "Hvorfor nav-pilot?" },
       { id: "hva-nav-pilot-vet", label: "Hva nav-pilot vet" },
     ],
@@ -476,6 +477,35 @@ function IntroductionSection() {
           </HGrid>
         </div>
 
+        <VStack id="isolasjon-er-pakrevd" gap="space-12">
+          <LinkableHeading size="small" level="3">
+            Isolasjon er påkrevd på Nav-utstyr
+          </LinkableHeading>
+          <Box background="warning-soft" borderRadius="8" padding="space-16">
+            <VStack gap="space-8">
+              <BodyLong style={{ color: "#475569" }}>
+                Når du bruker en AI-agent på Nav-utstyr, skal agenten kjøre i en sandbox eller tilsvarende isolasjon.
+                Kravet gjelder både Nav-relatert og personlig agentarbeid.
+              </BodyLong>
+              <BodyLong style={{ color: "#475569" }}>
+                Bruk{" "}
+                <NextLink href="/cplt" className="text-blue-600 hover:underline">
+                  cplt
+                </NextLink>{" "}
+                — det er den anbefalte og enkleste løsningen. Hvis du velger en annen løsning, må du selv sette deg inn
+                i og aktivere sandboxingen som agentklienten tilbyr, eller sørge for tilsvarende isolasjon med for
+                eksempel en VM eller container. Ikke kjør agenter med ubegrenset tilgang til Nav-utstyret.
+              </BodyLong>
+              <BodyLong style={{ color: "#475569" }}>
+                <NextLink href="/nyheter/sandboxing-er-pakrevd-pa-nav-utstyr" className="text-blue-600 hover:underline">
+                  Les kortversjonen av kravet
+                </NextLink>{" "}
+                for en lenke du kan dele med andre.
+              </BodyLong>
+            </VStack>
+          </Box>
+        </VStack>
+
         {/* Why nav-pilot */}
         <div id="hvorfor-nav-pilot">
           <LinkableHeading size="small" level="3">
@@ -616,7 +646,7 @@ function QuickStartSection() {
                 Installer nav-pilot CLI
               </Label>
             </div>
-            <CodeBlock compact>{`brew install navikt/tap/nav-pilot`}</CodeBlock>
+            <CodeBlock compact>{`brew install navikt/tap/nav-pilot navikt/tap/cplt`}</CodeBlock>
             <AltInstall />
           </div>
 
@@ -660,7 +690,7 @@ nav-pilot`}
                 </Label>
                 <div className="mt-1">
                   <CodeBlock compact>
-                    {`copilot --agent nav-pilot --prompt "Jeg trenger en ny tjeneste som behandler dagpengesøknader"`}
+                    {`cplt -- --agent nav-pilot --prompt "Jeg trenger en ny tjeneste som behandler dagpengesøknader"`}
                   </CodeBlock>
                 </div>
               </div>
@@ -1923,8 +1953,16 @@ function CliReferenceSection() {
             Installer CLI
           </LinkableHeading>
           <div className="mt-4">
-            <CodeBlock compact>{`brew install navikt/tap/nav-pilot`}</CodeBlock>
-            <AltInstall />
+            <VStack gap="space-12">
+              <div>
+                <CodeBlock compact>{`brew install navikt/tap/nav-pilot`}</CodeBlock>
+                <AltInstall />
+              </div>
+              <BodyLong size="small" style={{ color: "#64748b" }}>
+                Installer også <code className="font-mono text-xs">cplt</code> før du starter en agent. Sandboxing er et
+                krav på Nav-utstyr.
+              </BodyLong>
+            </VStack>
           </div>
         </div>
 

--- a/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
+++ b/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
@@ -649,6 +649,12 @@ function QuickStartSection() {
             </div>
             <CodeBlock compact>{`brew install navikt/tap/nav-pilot navikt/tap/cplt`}</CodeBlock>
             <AltInstall />
+            <BodyLong className="mt-3" size="small" style={{ color: "#64748b" }}>
+              Valgfritt for zsh eller bash: Legg{" "}
+              <code className="font-mono text-xs">alias copilot=&apos;cplt --&apos;</code> og{" "}
+              <code className="font-mono text-xs">alias np=&apos;nav-pilot&apos;</code> i shell-profilen din. Aliasene
+              gjelder bare i terminalen.
+            </BodyLong>
           </div>
 
           <div className="mt-6">

--- a/apps/my-copilot/src/app/praksis/sections/tools-and-modes.tsx
+++ b/apps/my-copilot/src/app/praksis/sections/tools-and-modes.tsx
@@ -1,7 +1,6 @@
 import { Heading, BodyShort, Box, HGrid, Label } from "@navikt/ds-react";
 import { Carousel } from "@/components/carousel";
 import { LaptopIcon, GlobeIcon, TerminalIcon, CpuIcon, CogIcon } from "@navikt/aksel-icons";
-import NextLink from "next/link";
 
 export default function ToolsAndModes() {
   return (

--- a/apps/my-copilot/src/lib/model-pricing.ts
+++ b/apps/my-copilot/src/lib/model-pricing.ts
@@ -1,7 +1,7 @@
 /**
  * GitHub Copilot model pricing data.
  * Source: https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
- * Last updated: 2026-07-22
+ * Last updated: 2026-08-10
  *
  * All prices are per 1 million tokens in USD.
  * 1 AI credit = $0.01 USD.
@@ -100,18 +100,20 @@ export const MODEL_PRICING: ModelPrice[] = [
     provider: "OpenAI",
     category: "Lightweight",
     status: "GA",
-    input: 1,
-    cachedInput: 0.1,
-    output: 6,
+    input: 0.2,
+    cachedInput: 0.02,
+    cacheWrite: 0.25,
+    output: 1.2,
   },
   {
     model: "GPT-5.6 Luna (Long context, 200K)",
     provider: "OpenAI",
     category: "Lightweight",
     status: "GA",
-    input: 2,
-    cachedInput: 0.2,
-    output: 9,
+    input: 0.4,
+    cachedInput: 0.04,
+    cacheWrite: 0.5,
+    output: 1.8,
   },
   {
     model: "GPT-5.6 Sol (Default, ≤ 272K)",
@@ -120,6 +122,7 @@ export const MODEL_PRICING: ModelPrice[] = [
     status: "GA",
     input: 5,
     cachedInput: 0.5,
+    cacheWrite: 6.25,
     output: 30,
   },
   {
@@ -129,6 +132,7 @@ export const MODEL_PRICING: ModelPrice[] = [
     status: "GA",
     input: 10,
     cachedInput: 1,
+    cacheWrite: 12.5,
     output: 45,
   },
   {
@@ -136,18 +140,20 @@ export const MODEL_PRICING: ModelPrice[] = [
     provider: "OpenAI",
     category: "Versatile",
     status: "GA",
-    input: 2.5,
-    cachedInput: 0.25,
-    output: 15,
+    input: 2,
+    cachedInput: 0.2,
+    cacheWrite: 2.5,
+    output: 12,
   },
   {
     model: "GPT-5.6 Terra (Long context, 272K)",
     provider: "OpenAI",
     category: "Versatile",
     status: "GA",
-    input: 5,
-    cachedInput: 0.5,
-    output: 22.5,
+    input: 4,
+    cachedInput: 0.4,
+    cacheWrite: 5,
+    output: 18,
   },
   // Anthropic
   {
@@ -261,16 +267,6 @@ export const MODEL_PRICING: ModelPrice[] = [
     output: 50,
   },
   {
-    model: "Claude Opus 5 (fast mode) (preview)",
-    provider: "Anthropic",
-    category: "Powerful",
-    status: "GA",
-    input: 10,
-    cachedInput: 1,
-    cacheWrite: 12.5,
-    output: 50,
-  },
-  {
     model: "Claude Fable 5",
     provider: "Anthropic",
     category: "Powerful",
@@ -281,24 +277,6 @@ export const MODEL_PRICING: ModelPrice[] = [
     output: 50,
   },
   // Google
-  {
-    model: "Gemini 2.5 Pro (Default)",
-    provider: "Google",
-    category: "Powerful",
-    status: "GA",
-    input: 1.25,
-    cachedInput: 0.125,
-    output: 10,
-  },
-  {
-    model: "Gemini 3 Flash (Default)",
-    provider: "Google",
-    category: "Lightweight",
-    status: "Public preview",
-    input: 0.5,
-    cachedInput: 0.05,
-    output: 3,
-  },
   {
     model: "Gemini 3.1 Pro (Default, ≤ 200K)",
     provider: "Google",
@@ -365,7 +343,16 @@ export const MODEL_PRICING: ModelPrice[] = [
     cachedInput: 0.19,
     output: 4,
   },
+  {
+    model: "Kimi K3",
+    provider: "Moonshot AI",
+    category: "Powerful",
+    status: "GA",
+    input: 3,
+    cachedInput: 0.3,
+    output: 15,
+  },
 ];
 
 export const PRICING_SOURCE_URL = "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing";
-export const PRICING_LAST_UPDATED = "2026-07-22";
+export const PRICING_LAST_UPDATED = "2026-08-10";

--- a/cli/nav-pilot/internal/telemetry/repo_test.go
+++ b/cli/nav-pilot/internal/telemetry/repo_test.go
@@ -1,7 +1,10 @@
 package telemetry
 
 import (
+	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 )
 
@@ -51,8 +54,17 @@ func TestNavRepoFromDir(t *testing.T) {
 			t.Fatalf("git init: %v\n%s", err, out)
 		}
 		if originURL != "" {
-			if out, err := exec.Command("git", "-C", dir, "remote", "add", "origin", originURL).CombinedOutput(); err != nil {
-				t.Fatalf("git remote add: %v\n%s", err, out)
+			config, err := os.OpenFile(filepath.Join(dir, ".git", "config"), os.O_APPEND|os.O_WRONLY, 0)
+			if err != nil {
+				t.Fatalf("open git config: %v", err)
+			}
+			_, writeErr := fmt.Fprintf(config, "\n[remote \"origin\"]\n\turl = %s\n", originURL)
+			closeErr := config.Close()
+			if writeErr != nil {
+				t.Fatalf("write git config: %v", writeErr)
+			}
+			if closeErr != nil {
+				t.Fatalf("close git config: %v", closeErr)
 			}
 		}
 		return dir

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -8,8 +8,8 @@ nav-pilot er et CLI-verktøy og en AI-agent for Nav-utvikling med GitHub Copilot
 ## Kom i gang
 
 ```bash
-# Anbefalt: Homebrew (macOS) — verifisert supply chain
-brew install navikt/tap/nav-pilot
+# Anbefalt: Homebrew (macOS) — nav-pilot og påkrevd sandbox
+brew install navikt/tap/nav-pilot navikt/tap/cplt
 
 # Linux / CI — last ned og inspiser skriptet manuelt:
 curl -fsSL https://raw.githubusercontent.com/navikt/copilot/main/scripts/install.sh -o install.sh
@@ -28,6 +28,20 @@ nav-pilot
 nav-pilot install kotlin-backend
 ```
 
+## Sandboxing er påkrevd
+
+Når du bruker en AI-agent på Nav-utstyr, skal agenten kjøre i en sandbox eller
+tilsvarende isolasjon. Kravet gjelder både Nav-relatert og personlig agentarbeid.
+
+Bruk [`cplt`](https://github.com/navikt/cplt) — det er den anbefalte og enkleste
+måten å oppfylle kravet på. Hvis du velger en annen løsning, må du selv sette deg
+inn i og aktivere sandboxingen som agentklienten tilbyr, eller sørge for tilsvarende
+isolasjon med for eksempel en VM eller container. Ikke kjør agenter med ubegrenset
+tilgang til Nav-utstyret.
+
+Les [kortversjonen av kravet](https://ki-utvikling.nav.no/nyheter/sandboxing-er-pakrevd-pa-nav-utstyr)
+for en lenke du kan dele med andre.
+
 ## Klienter
 
 nav-pilot støtter tre kodingsagenter (`client`-feltet i konfig):
@@ -38,10 +52,10 @@ nav-pilot støtter tre kodingsagenter (`client`-feltet i konfig):
 | `opencode` | `cplt` + `opencode` | Materialiseres automatisk i brukerens OpenCode config-mappe | `github-copilot/claude-sonnet-4.5` |
 | `pi` *(eksperimentell)* | `cplt` + `pi` | Via `AGENTS.md` i prosjektroten | Pis eget valg (`model`/`mode` videresendes ikke ennå) |
 
-> **Alle klienter startes i cplt-sandboxen.** nav-pilot kjører klienten via
-> `cplt --agent <klient>` slik at agenten er kjerne-nivå-sandboxet (kan lese/skrive
-> prosjektfiler, men når ikke SSH-nøkler, sky-credentials eller andre hemmeligheter).
-> `cplt` må derfor være installert for å starte `opencode` og `pi` (i tillegg til selve klient-binæren).
+> **Bruk cplt-sandboxen.** nav-pilot foretrekker `cplt` og kjører klienten via
+> `cplt --agent <klient>`. Agenten kan da lese og skrive prosjektfiler, men når
+> ikke SSH-nøkler, sky-credentials eller andre hemmeligheter. `cplt` må være
+> installert for å starte `opencode` og `pi` (i tillegg til selve klient-binæren).
 
 ### opencode — Nav-kontekst automatisk
 

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -8,7 +8,7 @@ nav-pilot er et CLI-verktøy og en AI-agent for Nav-utvikling med GitHub Copilot
 ## Kom i gang
 
 ```bash
-# Anbefalt: Homebrew (macOS) — nav-pilot og påkrevd sandbox
+# Anbefalt: Homebrew (macOS) — nav-pilot og påkrevd isolasjon
 brew install navikt/tap/nav-pilot navikt/tap/cplt
 
 # Linux / CI — last ned og inspiser skriptet manuelt:
@@ -28,16 +28,17 @@ nav-pilot
 nav-pilot install kotlin-backend
 ```
 
-## Sandboxing er påkrevd
+## Sandboxing og isolasjon er påkrevd
 
 Når du bruker en AI-agent på Nav-utstyr, skal agenten kjøre i en sandbox eller
 tilsvarende isolasjon. Kravet gjelder både Nav-relatert og personlig agentarbeid.
 
 Bruk [`cplt`](https://github.com/navikt/cplt) — det er den anbefalte og enkleste
 måten å oppfylle kravet på. Hvis du velger en annen løsning, må du selv sette deg
-inn i og aktivere sandboxingen som agentklienten tilbyr, eller sørge for tilsvarende
-isolasjon med for eksempel en VM eller container. Ikke kjør agenter med ubegrenset
-tilgang til Nav-utstyret.
+inn i hvordan agentklienten isolerer agenten, og aktivere denne funksjonen. Hvis
+klienten ikke gir tilstrekkelig beskyttelse, må du sørge for tilsvarende isolasjon,
+for eksempel med en VM eller container. Ikke kjør agenter med ubegrenset tilgang
+til Nav-utstyret.
 
 Les [kortversjonen av kravet](https://ki-utvikling.nav.no/nyheter/sandboxing-er-pakrevd-pa-nav-utstyr)
 for en lenke du kan dele med andre.
@@ -54,8 +55,9 @@ nav-pilot støtter tre kodingsagenter (`client`-feltet i konfig):
 
 > **Bruk cplt-sandboxen.** nav-pilot foretrekker `cplt` og kjører klienten via
 > `cplt --agent <klient>`. Agenten kan da lese og skrive prosjektfiler, men når
-> ikke SSH-nøkler, sky-credentials eller andre hemmeligheter. `cplt` må være
-> installert for å starte `opencode` og `pi` (i tillegg til selve klient-binæren).
+> ikke SSH-nøkler, tilgangsinformasjon for skytjenester eller andre hemmeligheter.
+> `cplt` må være installert for å starte `opencode` og `pi` (i tillegg til selve
+> klient-binæren).
 
 ### opencode — Nav-kontekst automatisk
 

--- a/docs/news/articles/sandboxing-er-pakrevd-pa-nav-utstyr.md
+++ b/docs/news/articles/sandboxing-er-pakrevd-pa-nav-utstyr.md
@@ -44,6 +44,24 @@ nav-pilot
 
 Bruk cplt som standard fremfor å bygge din egen løsning.
 
+### Valgfrie aliaser
+
+Bruker du zsh eller bash, kan du legge disse aliasene i `~/.zshrc` eller
+`~/.bashrc`:
+
+```bash
+alias copilot='cplt --'
+alias np='nav-pilot'
+```
+
+Det første aliaset sender vanlig bruk av `copilot` gjennom cplt. `--` gjør at
+Copilot-flagg sendes videre til Copilot CLI. Det andre er bare en kortform for
+`nav-pilot`, som allerede bruker cplt.
+
+Aliasene gjelder bare i terminalen. Agenter i VS Code, JetBrains og andre
+klienter må fortsatt bruke klientens sandboxing eller en annen
+isolasjonsmekanisme.
+
 ## Hvis du ikke bruker cplt
 
 Du må selv sette deg inn i hvordan agentklienten isolerer agenten, aktivere denne

--- a/docs/news/articles/sandboxing-er-pakrevd-pa-nav-utstyr.md
+++ b/docs/news/articles/sandboxing-er-pakrevd-pa-nav-utstyr.md
@@ -1,0 +1,76 @@
+---
+title: "Sandboxing er påkrevd for agentarbeid på Nav-utstyr"
+date: 2026-08-10
+author: starefossen
+category: praksis
+excerpt: "AI-agenter skal alltid kjøre isolert på Nav-utstyr. Bruk cplt som standard, også når agentarbeidet er personlig."
+tags:
+  - cplt
+  - security
+  - sandbox
+  - coding-agents
+---
+
+Når du bruker en AI-agent på Nav-utstyr, skal agenten kjøre i en sandbox eller
+tilsvarende isolasjon. Dette er et krav, ikke et valgfritt sikkerhetstiltak.
+
+Kravet gjelder alt agentarbeid på utstyret:
+
+- Nav-relaterte oppgaver
+- arbeid i private repoer
+- personlig utforsking og sideprosjekter
+
+Det er utstyret og tilgangene som må beskyttes. At oppgaven er personlig, reduserer
+ikke risikoen for at agenten får tilgang til credentials, secrets, filer eller
+interne tjenester på maskinen.
+
+## Bruk cplt
+
+[`cplt`](/cplt) er den anbefalte og enkleste måten å oppfylle kravet på. cplt
+starter agenten med OS-håndhevet isolasjon og begrenser blant annet tilgang til
+filer, credentials og nettverk.
+
+```bash
+brew install navikt/tap/cplt
+cplt
+```
+
+nav-pilot er laget for å brukes sammen med cplt:
+
+```bash
+brew install navikt/tap/nav-pilot navikt/tap/cplt
+nav-pilot
+```
+
+Bruk cplt som standard fremfor å bygge din egen løsning.
+
+## Hvis du ikke bruker cplt
+
+Du må selv sette deg inn i hvilken sandboxing agentklienten tilbyr, aktivere den
+og forstå hva den faktisk isolerer. Hvis klienten ikke tilbyr tilstrekkelig
+isolasjon, må du bruke en annen mekanisme, for eksempel en VM eller container.
+
+Vi går ikke nærmere inn på oppsett av alternative løsninger her. Hovedregelen er
+enkel: Ikke kjør en AI-agent med ubegrenset tilgang til Nav-utstyret.
+
+## Hvorfor godkjenning ikke er nok
+
+En agent kan lese innhold den ikke bør stole på, kjøre kommandoer og installere
+avhengigheter. Prompt injection og kompromitterte pakker kan påvirke hva agenten
+gjør. Bekreftelsesdialoger og gode instruksjoner reduserer risiko, men erstatter
+ikke en teknisk sikkerhetsgrense.
+
+Sandboxing begrenser konsekvensene når agenten, et verktøy eller en avhengighet
+gjør noe uventet. Derfor skal isolasjonen være på plass før agenten starter.
+
+## Kortversjonen
+
+**På Nav-utstyr skal AI-agenter alltid kjøre isolert. Bruk cplt. Velger du noe
+annet, er du ansvarlig for å sikre tilsvarende isolasjon. Kravet gjelder både
+Nav-relatert og personlig agentarbeid.**
+
+**Kilder:**
+
+- [cplt-dokumentasjonen](/cplt) (Nav)
+- [cplt threat model](https://github.com/navikt/cplt/blob/main/SECURITY.md) (GitHub)
+- [Cloud and local sandboxes for GitHub Copilot](https://github.blog/changelog/2026-06-02-cloud-and-local-sandboxes-for-github-copilot-now-in-public-preview) (GitHub, 2. juni 2026)

--- a/docs/news/articles/sandboxing-er-pakrevd-pa-nav-utstyr.md
+++ b/docs/news/articles/sandboxing-er-pakrevd-pa-nav-utstyr.md
@@ -1,5 +1,5 @@
 ---
-title: "Sandboxing er påkrevd for agentarbeid på Nav-utstyr"
+title: "Sandboxing og isolasjon er påkrevd på Nav-utstyr"
 date: 2026-08-10
 author: starefossen
 category: praksis
@@ -21,14 +21,14 @@ Kravet gjelder alt agentarbeid på utstyret:
 - personlig utforsking og sideprosjekter
 
 Det er utstyret og tilgangene som må beskyttes. At oppgaven er personlig, reduserer
-ikke risikoen for at agenten får tilgang til credentials, secrets, filer eller
-interne tjenester på maskinen.
+ikke risikoen for at agenten får tilgang til filer, hemmeligheter,
+tilgangsinformasjon eller interne tjenester på maskinen.
 
 ## Bruk cplt
 
 [`cplt`](/cplt) er den anbefalte og enkleste måten å oppfylle kravet på. cplt
-starter agenten med OS-håndhevet isolasjon og begrenser blant annet tilgang til
-filer, credentials og nettverk.
+starter agenten med isolasjon som operativsystemet håndhever. Dette begrenser
+blant annet tilgangen til filer, tilgangsinformasjon og nettverk.
 
 ```bash
 brew install navikt/tap/cplt
@@ -46,9 +46,10 @@ Bruk cplt som standard fremfor å bygge din egen løsning.
 
 ## Hvis du ikke bruker cplt
 
-Du må selv sette deg inn i hvilken sandboxing agentklienten tilbyr, aktivere den
-og forstå hva den faktisk isolerer. Hvis klienten ikke tilbyr tilstrekkelig
-isolasjon, må du bruke en annen mekanisme, for eksempel en VM eller container.
+Du må selv sette deg inn i hvordan agentklienten isolerer agenten, aktivere denne
+funksjonen og forstå hva den faktisk beskytter. Hvis klienten ikke gir
+tilstrekkelig beskyttelse, må du bruke en annen mekanisme, for eksempel en VM
+eller container.
 
 Vi går ikke nærmere inn på oppsett av alternative løsninger her. Hovedregelen er
 enkel: Ikke kjør en AI-agent med ubegrenset tilgang til Nav-utstyret.


### PR DESCRIPTION
Document cplt as the recommended isolation mechanism for all agent work on Nav-owned equipment, including personal work. Add a shareable article and link it from the nav-pilot and cplt documentation.

Also refresh generated model pricing and make existing checks warning- and sandbox-safe.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
