### PR TITLE
chore(nav-pilot): default opencode to github-copilot/auto

### DIFF
--- a/agents/nav-pilot.agent.md
+++ b/agents/nav-pilot.agent.md
@@ -102,9 +102,9 @@ If a task has both a discovery part and a decision part, split it: research firs
 
 ### Cost guardrails (mandatory)
 
-- **Model gate before Opus**: Escalate to `@nav-pilot-opus` only when all are true: (1) irreversible/high-stakes decision, (2) meaningful tradeoff remains after Sonnet + specialist pass, (3) escalation scope is one explicit subproblem.
-- **Ask-before-Agent gate**: Use standard Ask/chat for factual clarifications, syntax help, and tiny local edits. Use Agent Mode only when tool use, multi-step planning, or cross-file execution is needed.
-- **Context hygiene**: Keep one objective per thread. When objective changes, start a new thread. Use `/compact` before long handoffs and `/clear` when prior context is irrelevant.
+- **Model gate before Opus**: Standard is non-Opus. Escalate to `@nav-pilot-opus` only when all are true: (1) the decision is irreversible or high-stakes, (2) Sonnet + relevant specialist has not resolved the central tradeoff, and (3) the escalation can be scoped to one explicit subproblem. Never use Opus for routine tasks, repo exploration, boilerplate, simple wiring, lint/test interpretation, or small refactors.
+- **Ask-before-Agent gate**: Default to standard Ask/chat. Use Agent Mode only when the task requires (1) tool use, (2) cross-file work, or (3) multi-step execution with dependencies or verification. Do not use Agent Mode for factual clarifications, syntax help, short explanations, simple error interpretation, tiny local edits, or one-file advice that can be answered without tools.
+- **Context hygiene**: One objective per thread. New objective = new thread. Use `/compact` only when prior context is still needed for the same objective; use `/clear` when the old history is no longer relevant. Do not mix exploration, planning, implementation, and debugging for different problems in the same session.
 - **Cache hygiene**: Avoid changing active instruction files, tool sets, or environment toggles mid-thread. Start a new thread after such changes to prevent cache churn.
 - **Tool-first workflow**: Prefer deterministic commands and targeted file reads before broad reasoning over large logs or diffs.
 - **MCP/tool pruning**: Use only needed MCP servers/tools for the task. Avoid loading broad tool catalogs when a narrow subset is sufficient.

--- a/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
+++ b/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
@@ -198,7 +198,7 @@
         "infrastructure"
       ],
       "filePath": "agents/nav-pilot.agent.md",
-      "contentHash": "8ce02d89fd7a818a4a5ff9baa9def68d71dbb06d503faea9901f0e0133e7336e",
+      "contentHash": "c026ac85182629e4c3fc68de4922cc540e14d49dbeca228c73ee9db57a54dc7f",
       "useCases": [
         "Adding PostgreSQL/Kafka",
         "Troubleshooting deployments",

--- a/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
+++ b/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
@@ -1766,8 +1766,7 @@ function KlienterOgKonfigurasjonSection() {
                 desc: (
                   <>
                     Når ingen modell er konfigurert, settes{" "}
-							<code className="font-mono text-xs">github-copilot/auto</code> som Nav-standard for
-                    opencode.
+                    <code className="font-mono text-xs">github-copilot/auto</code> som Nav-standard for opencode.
                   </>
                 ),
                 color: "#3b82f6",

--- a/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
+++ b/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
@@ -1585,7 +1585,7 @@ const CONFIG_KEYS = [
   {
     key: "model",
     flag: "--model",
-    values: "f.eks. claude-opus-4.8, gpt-5.5 (Copilot); anthropic/claude-sonnet-4-5 (opencode)",
+    values: "f.eks. claude-opus-4.8, gpt-5.5 (Copilot); github-copilot/auto (opencode)",
     desc: "Modell å bruke. Format avhenger av klient.",
   },
   {
@@ -1766,7 +1766,7 @@ function KlienterOgKonfigurasjonSection() {
                 desc: (
                   <>
                     Når ingen modell er konfigurert, settes{" "}
-                    <code className="font-mono text-xs">anthropic/claude-sonnet-4-5</code> som Nav-standard for
+							<code className="font-mono text-xs">github-copilot/auto</code> som Nav-standard for
                     opencode.
                   </>
                 ),
@@ -1870,7 +1870,7 @@ function KlienterOgKonfigurasjonSection() {
 client = "opencode"
 
 # Modell (format avhenger av klient)
-model = "anthropic/claude-sonnet-4-5"
+model = "github-copilot/auto"
 
 # Modus (default | plan | autopilot) — kun Copilot
 # mode = "default"

--- a/apps/my-copilot/src/components/nav-pilot/command-builder.test.ts
+++ b/apps/my-copilot/src/components/nav-pilot/command-builder.test.ts
@@ -8,8 +8,18 @@ describe("buildCommands", () => {
       surface: "terminal",
       collection: "kotlin-backend",
     });
-    expect(cmd.launch).toBe("nav-pilot --client copilot --model github-copilot/claude-sonnet-4.5");
+    expect(cmd.launch).toBe("nav-pilot --client copilot --model auto");
     expect(cmd.clientLabel).toBe("GitHub Copilot CLI");
+  });
+
+  it("prefixes opencode models with the GitHub Copilot provider", () => {
+    const cmd = buildCommands({
+      client: "opencode",
+      surface: "terminal",
+      collection: "kotlin-backend",
+    });
+    expect(cmd.launch).toContain("--client opencode");
+    expect(cmd.launch).toContain("github-copilot/auto");
   });
 
   it("uses opus for the fullstack collection", () => {

--- a/apps/my-copilot/src/components/nav-pilot/command-builder.ts
+++ b/apps/my-copilot/src/components/nav-pilot/command-builder.ts
@@ -26,10 +26,17 @@ const CLIENT_LABEL: Record<ClientId, string> = {
 };
 
 const COLLECTION_MODEL: Record<CollectionId, string> = {
-  "kotlin-backend": "github-copilot/claude-sonnet-4.5",
-  "nextjs-frontend": "github-copilot/claude-sonnet-4.5",
-  fullstack: "github-copilot/claude-opus-4.6",
+  "kotlin-backend": "auto",
+  "nextjs-frontend": "auto",
+  fullstack: "claude-opus-4.6",
 };
+
+function launchModelForClient(client: ClientId, model: string): string {
+  if (client === "opencode") {
+    return model.includes("/") ? model : `github-copilot/${model}`;
+  }
+  return model;
+}
 
 const COLLECTION_LABEL: Record<CollectionId, string> = {
   "kotlin-backend": "Kotlin-backend",
@@ -43,7 +50,7 @@ const COLLECTION_LABEL: Record<CollectionId, string> = {
  */
 export function buildCommands(sel: BuilderSelection): BuiltCommands {
   const clientLabel = CLIENT_LABEL[sel.client];
-  const model = COLLECTION_MODEL[sel.collection];
+  const model = launchModelForClient(sel.client, COLLECTION_MODEL[sel.collection]);
 
   if (sel.surface === "editor") {
     return {

--- a/apps/my-copilot/src/lib/copilot-manifest.json
+++ b/apps/my-copilot/src/lib/copilot-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-08-14T11:29:18.686Z",
+  "generatedAt": "2026-08-17T08:22:20.388Z",
   "items": [
     {
       "id": "accessibility-agent",
@@ -398,7 +398,7 @@
       "domain": "general",
       "filePath": ".github/agents/nav-pilot.agent.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/agents/nav-pilot.agent.md",
-      "contentHash": "8ce02d89fd7a818a4a5ff9baa9def68d71dbb06d503faea9901f0e0133e7336e",
+      "contentHash": "c026ac85182629e4c3fc68de4922cc540e14d49dbeca228c73ee9db57a54dc7f",
       "installUrl": "/install/agent?url=vscode%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fagents%2Fnav-pilot.agent.md",
       "insidersInstallUrl": "/install/agent?url=vscode-insiders%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fagents%2Fnav-pilot.agent.md",
       "tools": [

--- a/cli/nav-pilot/DESIGN.md
+++ b/cli/nav-pilot/DESIGN.md
@@ -89,6 +89,10 @@ Veiviseren viser en **velger** med Nav-kurerte modeller per provider
 - Copilot: `knownCopilotModels` — inkluderer `auto`, Claude Sonnet/Haiku/Opus, GPT-5.x, Gemini
 - opencode: `knownOpenCodeModels` — Nav-anbefalt `github-copilot/auto` som standard
 
+Ved oppstart med `--client opencode` normaliseres modellverdien med `ToOpenCodeModel`:
+tom verdi eller `auto` blir `github-copilot/auto`, og bare Copilot-id-er (som
+`claude-sonnet-4.6`) prefikses til `github-copilot/<id>`.
+
 En "Custom…"-mulighet i velgeren lar brukeren skrive inn valgfri id med validering.
 `nav-pilot config explain model` lister opp de kjente id-ene per provider.
 

--- a/cli/nav-pilot/DESIGN.md
+++ b/cli/nav-pilot/DESIGN.md
@@ -87,7 +87,7 @@ Copilot-id som `claude-opus-4.8` gir hard feil for opencode-provideren.
 Veiviseren viser en **velger** med Nav-kurerte modeller per provider
 (`KnownModels()` fra `Provider`-grensesnittet):
 - Copilot: `knownCopilotModels` — inkluderer `auto`, Claude Sonnet/Haiku/Opus, GPT-5.x, Gemini
-- opencode: `knownOpenCodeModels` — Nav-anbefalt `anthropic/claude-sonnet-4-5` som standard
+- opencode: `knownOpenCodeModels` — Nav-anbefalt `github-copilot/auto` som standard
 
 En "Custom…"-mulighet i velgeren lar brukeren skrive inn valgfri id med validering.
 `nav-pilot config explain model` lister opp de kjente id-ene per provider.
@@ -158,7 +158,7 @@ flagg-grensesnitt er annerledes enn Copilots, så flere felt oversettes eller dr
 
 | nav-pilot konfig | opencode-flagg | Merknad |
 |---|---|---|
-| `model` | `--model` | Krever `provider/model` (f.eks. `anthropic/claude-sonnet-4-5`); Nav-standard er `anthropic/claude-sonnet-4-5` når unset |
+| `model` | `--model` | Krever `provider/model` (f.eks. `github-copilot/claude-sonnet-4.6`); Nav-standard er `github-copilot/auto` når unset |
 | `mode = plan` | `--agent plan` | opencode har ingen `--mode`; `autopilot` har ingen opencode-ekvivalent — advarsel ved oppstart |
 | `reasoning_effort` | `--variant` | Leverandørspesifikk resonering (f.eks. `high`, `max`) |
 | `allow_all_tools` | `--dangerously-skip-permissions` | |

--- a/cli/nav-pilot/DESIGN.md
+++ b/cli/nav-pilot/DESIGN.md
@@ -89,9 +89,10 @@ Veiviseren viser en **velger** med Nav-kurerte modeller per provider
 - Copilot: `knownCopilotModels` — inkluderer `auto`, Claude Sonnet/Haiku/Opus, GPT-5.x, Gemini
 - opencode: `knownOpenCodeModels` — Nav-anbefalt `github-copilot/auto` som standard
 
-Ved oppstart med `--client opencode` normaliseres modellverdien med `ToOpenCodeModel`:
-tom verdi eller `auto` blir `github-copilot/auto`, og bare Copilot-id-er (som
-`claude-sonnet-4.6`) prefikses til `github-copilot/<id>`.
+Ved oppstart med `--client opencode` normaliseres **CLI-overstyringen** `--model`
+med `ToOpenCodeModel`: tom verdi eller `auto` blir `github-copilot/auto`, og bare
+Copilot-id-er (som `claude-sonnet-4.6`) prefikses til `github-copilot/<id>`.
+Konfigverdi for opencode må fortsatt være på `provider/model`-format.
 
 En "Custom…"-mulighet i velgeren lar brukeren skrive inn valgfri id med validering.
 `nav-pilot config explain model` lister opp de kjente id-ene per provider.

--- a/cli/nav-pilot/TELEMETRY.md
+++ b/cli/nav-pilot/TELEMETRY.md
@@ -19,7 +19,7 @@ nav-pilot sender **pseudonymiserte bruks- og ytelsesmetrikker** via OpenTelemetr
 | `nav_pilot_info` | Gauge | Prosess-start informasjon (alltid verdi 1) | `version=0.12.3`, `device_id=nav-pilot-abc123`, `execution_context=ci_github_actions`, `os=linux`, `arch=amd64` |
 | `nav_pilot_install_present` | Gauge | Om scope har installert state (1/0) | `scope=user`, `collection=all` |
 | `nav_pilot_installed_items` | Gauge | Antall installerte items per type/status | `scope=repo`, `type=skill`, `status=active` |
-| `nav_pilot_config_info` | Gauge | Resolvert konfigurasjon per oppstart (alltid verdi 1) | `client=opencode`, `config_mode=autopilot`, `model=github-copilot/claude-sonnet-4.5`, `reasoning_effort=high`, `context_tier=unset`, `otel_log_level=none`, `allow_all_tools=false`, `ask_user=true`, `device_id=nav-pilot-abc123` |
+| `nav_pilot_config_info` | Gauge | Resolvert konfigurasjon per oppstart (alltid verdi 1) | `client=opencode`, `config_mode=autopilot`, `model=github-copilot/auto`, `reasoning_effort=high`, `context_tier=unset`, `otel_log_level=none`, `allow_all_tools=false`, `ask_user=true`, `device_id=nav-pilot-abc123` |
 | `nav_pilot_client_available` | Gauge | Om en coding-agent-klient finnes på PATH (1/0) | `client=copilot` / `client=opencode` / `client=pi` |
 | `nav_pilot_staleness_check_total` | Counter | Antall ferskhetssjekker per resultat | `component=collection`, `scope=user`, `result=stale` |
 | `nav_pilot_up_to_date` | Gauge | Om komponent er tilstrekkelig oppdatert (1/0) | `component=cli`, `scope=none` |
@@ -33,7 +33,7 @@ nav-pilot sender **pseudonymiserte bruks- og ytelsesmetrikker** via OpenTelemetr
 - `config_mode` er konfig-modus (`default`/`plan`/`autopilot`) — ikke å forveksle
   med `mode` på `nav_pilot_command_total` som er kjøremodus (`interactive`/`non_interactive`).
 - `model` kollapses til kjent klient-modell-id (Copilot-modeller som `claude-sonnet-4.6`,
-  eller opencode-modeller som `github-copilot/claude-sonnet-4.5`), `custom` (ukjent/egendefinert)
+  eller opencode-modeller som `github-copilot/auto`), `custom` (ukjent/egendefinert)
   eller `unset` for å holde kardinaliteten lav.
 - Tomme valg (`reasoning_effort`, `context_tier`, `model`) rapporteres som `unset`.
 - `nav_pilot_client_available` PATH-sjekker `copilot` (cplt/copilot), `opencode` og `pi`

--- a/cli/nav-pilot/TELEMETRY.md
+++ b/cli/nav-pilot/TELEMETRY.md
@@ -19,7 +19,7 @@ nav-pilot sender **pseudonymiserte bruks- og ytelsesmetrikker** via OpenTelemetr
 | `nav_pilot_info` | Gauge | Prosess-start informasjon (alltid verdi 1) | `version=0.12.3`, `device_id=nav-pilot-abc123`, `execution_context=ci_github_actions`, `os=linux`, `arch=amd64` |
 | `nav_pilot_install_present` | Gauge | Om scope har installert state (1/0) | `scope=user`, `collection=all` |
 | `nav_pilot_installed_items` | Gauge | Antall installerte items per type/status | `scope=repo`, `type=skill`, `status=active` |
-| `nav_pilot_config_info` | Gauge | Resolvert konfigurasjon per oppstart (alltid verdi 1) | `client=opencode`, `config_mode=autopilot`, `model=github-copilot/auto`, `reasoning_effort=high`, `context_tier=unset`, `otel_log_level=none`, `allow_all_tools=false`, `ask_user=true`, `device_id=nav-pilot-abc123` |
+| `nav_pilot_config_info` | Gauge | Konfigurasjonssnapshot per oppstart (alltid verdi 1) | `client=opencode`, `config_mode=autopilot`, `model=auto`, `reasoning_effort=high`, `context_tier=unset`, `otel_log_level=none`, `allow_all_tools=false`, `ask_user=true`, `device_id=nav-pilot-abc123` |
 | `nav_pilot_client_available` | Gauge | Om en coding-agent-klient finnes på PATH (1/0) | `client=copilot` / `client=opencode` / `client=pi` |
 | `nav_pilot_staleness_check_total` | Counter | Antall ferskhetssjekker per resultat | `component=collection`, `scope=user`, `result=stale` |
 | `nav_pilot_up_to_date` | Gauge | Om komponent er tilstrekkelig oppdatert (1/0) | `component=cli`, `scope=none` |

--- a/cli/nav-pilot/TELEMETRY.md
+++ b/cli/nav-pilot/TELEMETRY.md
@@ -32,9 +32,11 @@ nav-pilot sender **pseudonymiserte bruks- og ytelsesmetrikker** via OpenTelemetr
 **Merk om `nav_pilot_config_info`:**
 - `config_mode` er konfig-modus (`default`/`plan`/`autopilot`) — ikke å forveksle
   med `mode` på `nav_pilot_command_total` som er kjøremodus (`interactive`/`non_interactive`).
-- `model` kollapses til kjent klient-modell-id (Copilot-modeller som `claude-sonnet-4.6`,
-  eller opencode-modeller som `github-copilot/auto`), `custom` (ukjent/egendefinert)
-  eller `unset` for å holde kardinaliteten lav.
+- `model` baseres på konfigurert/CLI modell-id (ikke launch-normalisert med
+  `ToOpenCodeModel`) og kollapses til kjent klient-modell-id, `custom`
+  (ukjent/egendefinert) eller `unset` for å holde kardinaliteten lav. For
+  opencode betyr dette at `--model auto` kan rapporteres som `auto`, mens tom
+  modellverdi rapporteres som `unset`.
 - Tomme valg (`reasoning_effort`, `context_tier`, `model`) rapporteres som `unset`.
 - `nav_pilot_client_available` PATH-sjekker `copilot` (cplt/copilot), `opencode` og `pi`
   ved oppstart, så vi ser hvilke klienter brukere faktisk har installert.

--- a/cli/nav-pilot/internal/cli/config_test.go
+++ b/cli/nav-pilot/internal/cli/config_test.go
@@ -1135,7 +1135,7 @@ func TestConfigAdvisories_KnownCopilotModel_NoWarning(t *testing.T) {
 
 func TestConfigAdvisories_NonCopilotModel_NoWarning(t *testing.T) {
 	// Known Nav-curated opencode model must not generate any warning.
-	cfg, meta := decodeConfigForTest(t, "version = 1\nclient = \"opencode\"\nmodel = \"github-copilot/claude-sonnet-4.5\"\n")
+	cfg, meta := decodeConfigForTest(t, "version = 1\nclient = \"opencode\"\nmodel = \"github-copilot/auto\"\n")
 	if w := configAdvisories(cfg, meta); len(w) != 0 {
 		t.Errorf("configAdvisories() = %v, want no warnings for known opencode model", w)
 	}

--- a/cli/nav-pilot/internal/cli/config_test.go
+++ b/cli/nav-pilot/internal/cli/config_test.go
@@ -1141,6 +1141,13 @@ func TestConfigAdvisories_NonCopilotModel_NoWarning(t *testing.T) {
 	}
 }
 
+func TestConfigAdvisories_KnownOpenCodeModel_NoWarning(t *testing.T) {
+	cfg, meta := decodeConfigForTest(t, "version = 1\nclient = \"opencode\"\nmodel = \"github-copilot/claude-opus-4.6\"\n")
+	if w := configAdvisories(cfg, meta); len(w) != 0 {
+		t.Errorf("configAdvisories() = %v, want no warnings for known opencode model", w)
+	}
+}
+
 func TestConfigAdvisories_UnrecognizedOpenCodeModel(t *testing.T) {
 	// Valid shape but not in the Nav-curated list → soft advisory.
 	cfg, meta := decodeConfigForTest(t, "version = 1\nclient = \"opencode\"\nmodel = \"anthropic/claude-3-5-sonnet\"\n")

--- a/cli/nav-pilot/internal/provider/opencode_launch_test.go
+++ b/cli/nav-pilot/internal/provider/opencode_launch_test.go
@@ -22,6 +22,7 @@ func TestToOpenCodeModel(t *testing.T) {
 		{"  ", OpenCodeDefaultModel},
 		{"claude-sonnet-4.6", "github-copilot/claude-sonnet-4.6"},
 		{"gpt-5.5", "github-copilot/gpt-5.5"},
+		{"github-copilot/auto", "github-copilot/auto"},
 		{"github-copilot/claude-opus-4.8", "github-copilot/claude-opus-4.8"},
 		{"anthropic/claude-3-5-sonnet", "anthropic/claude-3-5-sonnet"},
 		{"  claude-haiku-4.5 ", "github-copilot/claude-haiku-4.5"},

--- a/cli/nav-pilot/internal/provider/provider.go
+++ b/cli/nav-pilot/internal/provider/provider.go
@@ -51,10 +51,12 @@ type Provider interface {
 	PrintSystemDiagnostics()
 }
 
-// OpenCodeDefaultModel is the Nav-curated default model for opencode. opencode
-// is always launched inside cplt, which connects it to the GitHub Copilot
-// provider, so the model id uses the github-copilot/<id> form (see models.dev).
-const OpenCodeDefaultModel = "github-copilot/claude-sonnet-4.5"
+// OpenCodeDefaultModel is the Nav-curated default model selector for opencode.
+// opencode is always launched inside cplt, which connects it to the GitHub
+// Copilot provider, so the model id uses the github-copilot/<id> form.
+// Prefer Copilot Auto so default routing can follow the current
+// cost/quality frontier instead of a historically pinned model.
+const OpenCodeDefaultModel = "github-copilot/auto"
 
 // OpenCodeAgentPersona is the materialized opencode primary agent that loads
 // Nav's context and persona. Mirrors CopilotAgentPersona for the copilot client.
@@ -95,7 +97,7 @@ var knownCopilotModels = []domain.ModelChoice{
 // provider prefix, so a bare Copilot id never triggers the opencode advisory
 // after ToOpenCodeModel mapping.
 var knownOpenCodeModels = func() []domain.ModelChoice {
-	models := []domain.ModelChoice{{ID: OpenCodeDefaultModel, Label: "Claude Sonnet 4.5 (Nav default)"}}
+	models := []domain.ModelChoice{{ID: OpenCodeDefaultModel, Label: "Auto (Nav default)"}}
 	for _, m := range knownCopilotModels {
 		if m.ID == "auto" {
 			continue

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -176,8 +176,9 @@ globale flagg som `--client`, `--model`, `--mode`, `--effort`, `--context`,
   `gemini-3.1-pro-preview`, `gemini-3.5-flash`, `kimi-k2.7-code`, `kimi-k3`
 - opencode (startes via cplt → GitHub Copilot-provider): bruk `github-copilot/<id>`,
   f.eks. `github-copilot/auto` (Nav-standard), `github-copilot/claude-opus-4.8`,
-  `github-copilot/gpt-5.5`. Modellen må være på `provider/model`-format (med `/`);
-  `auto` eller tom verdi faller tilbake til Nav-standarden `github-copilot/auto`.
+  `github-copilot/gpt-5.5`. Modellen i config må være på `provider/model`-format
+  (med `/`). `--model auto` på CLI (eller tom CLI-verdi) normaliseres til
+  Nav-standarden `github-copilot/auto`.
 
 Veiviseren (`nav-pilot config setup`) viser en modellvelger tilpasset valgt klient.
 `nav-pilot config explain model` lister opp de kurerte id-ene.

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -50,7 +50,7 @@ nav-pilot støtter tre kodingsagenter (`client`-feltet i konfig):
 | Klient | Binær | Nav-kontekst | Standard modell |
 |---|---|---|---|
 | `copilot` (standard) | `cplt` / `copilot` | Installeres i `.github/` | Agentens eget valg |
-| `opencode` | `cplt` + `opencode` | Materialiseres automatisk i brukerens OpenCode config-mappe | `github-copilot/claude-sonnet-4.5` |
+| `opencode` | `cplt` + `opencode` | Materialiseres automatisk i brukerens OpenCode config-mappe | `github-copilot/auto` |
 | `pi` *(eksperimentell)* | `cplt` + `pi` | Via `AGENTS.md` i prosjektroten | Pis eget valg (`model`/`mode` videresendes ikke ennå) |
 
 > **Bruk cplt-sandboxen.** nav-pilot foretrekker `cplt` og kjører klienten via
@@ -175,9 +175,9 @@ globale flagg som `--client`, `--model`, `--mode`, `--effort`, `--context`,
   `gpt-5.3-codex`, `gpt-5.4-mini`, `gpt-5-mini`, `gemini-3.6-flash`,
   `gemini-3.1-pro-preview`, `gemini-3.5-flash`, `kimi-k2.7-code`, `kimi-k3`
 - opencode (startes via cplt → GitHub Copilot-provider): bruk `github-copilot/<id>`,
-  f.eks. `github-copilot/claude-sonnet-4.5` (Nav-standard), `github-copilot/claude-opus-4.8`,
+  f.eks. `github-copilot/auto` (Nav-standard), `github-copilot/claude-opus-4.8`,
   `github-copilot/gpt-5.5`. Modellen må være på `provider/model`-format (med `/`);
-  `auto` eller tom verdi faller tilbake til Nav-standarden `github-copilot/claude-sonnet-4.5`.
+  `auto` eller tom verdi faller tilbake til Nav-standarden `github-copilot/auto`.
 
 Veiviseren (`nav-pilot config setup`) viser en modellvelger tilpasset valgt klient.
 `nav-pilot config explain model` lister opp de kurerte id-ene.


### PR DESCRIPTION
## What
- set nav-pilot opencode default model to github-copilot/auto
- normalize command-builder output so opencode uses provider-prefixed model IDs
- update docs, tests, and telemetry examples for the same default

## Why
- keep model selection flexible and cost-aware instead of pinning one historical model
- keep UI, CLI, and docs behavior consistent for opencode mapping

## Notes
- this keeps Nav mapping to Copilot auto; it does not add an opencode-native auto model concept