### PR TITLE
fix(nav-pilot): honor user model selection and refresh model lists

### DIFF
--- a/agents/nav-pilot.agent.md
+++ b/agents/nav-pilot.agent.md
@@ -1,7 +1,6 @@
 ---
 name: nav-pilot
 description: Planlegg, arkitekturer og bygg Nav-applikasjoner med innebygd kjennskap til Nais, auth, Kafka, sikkerhet og Nav-mønstre
-model: Claude Sonnet 4.6
 tools:
   - execute
   - read

--- a/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
+++ b/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
@@ -198,7 +198,7 @@
         "infrastructure"
       ],
       "filePath": "agents/nav-pilot.agent.md",
-      "contentHash": "09c7351bf3ceb03b2e43978ca95cee75be010c50fbaf796bf360b903bb978ecd",
+      "contentHash": "8ce02d89fd7a818a4a5ff9baa9def68d71dbb06d503faea9901f0e0133e7336e",
       "useCases": [
         "Adding PostgreSQL/Kafka",
         "Troubleshooting deployments",

--- a/apps/my-copilot/src/lib/copilot-manifest.json
+++ b/apps/my-copilot/src/lib/copilot-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-08-06T11:24:46.300Z",
+  "generatedAt": "2026-08-14T11:29:18.686Z",
   "items": [
     {
       "id": "accessibility-agent",
@@ -398,7 +398,7 @@
       "domain": "general",
       "filePath": ".github/agents/nav-pilot.agent.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/agents/nav-pilot.agent.md",
-      "contentHash": "09c7351bf3ceb03b2e43978ca95cee75be010c50fbaf796bf360b903bb978ecd",
+      "contentHash": "8ce02d89fd7a818a4a5ff9baa9def68d71dbb06d503faea9901f0e0133e7336e",
       "installUrl": "/install/agent?url=vscode%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fagents%2Fnav-pilot.agent.md",
       "insidersInstallUrl": "/install/agent?url=vscode-insiders%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fagents%2Fnav-pilot.agent.md",
       "tools": [
@@ -421,7 +421,6 @@
         "io.github.navikt/github-mcp/get_latest_release",
         "io.github.navikt/github-mcp/list_releases"
       ],
-      "model": ["Claude Sonnet 4.6"],
       "agentReferences": [
         "accessibility-agent",
         "aksel-agent",

--- a/cli/nav-pilot/internal/cli/config_cmd.go
+++ b/cli/nav-pilot/internal/cli/config_cmd.go
@@ -176,9 +176,11 @@ version = 1
 # Allowed: copilot, opencode, pi — Default: copilot
 # client = "copilot"
 
-# Model id. Common Copilot models: auto, claude-sonnet-4.6, claude-haiku-4.5,
-# claude-opus-4.8, claude-opus-4.6, gpt-5.5, gpt-5.4, gpt-5.3-codex,
-# gpt-5.4-mini, gpt-5-mini, gemini-3.1-pro-preview, gemini-3.5-flash.
+# Model id. Common Copilot models: auto, claude-opus-5, claude-sonnet-5,
+# claude-sonnet-4.6, claude-haiku-4.5, claude-opus-4.8, gpt-5.6-sol,
+# gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5.4, gpt-5.3-codex, gpt-5.4-mini,
+# gpt-5-mini, gemini-3.6-flash, gemini-3.1-pro-preview, gemini-3.5-flash,
+# kimi-k2.7-code, kimi-k3.
 # For opencode (launched via cplt → GitHub Copilot provider): a bare Copilot id
 # is mapped to github-copilot/<id>, or set a full provider/model id directly.
 # Format-validated locally; the model catalog is checked by the downstream CLI.

--- a/cli/nav-pilot/internal/provider/provider.go
+++ b/cli/nav-pilot/internal/provider/provider.go
@@ -91,17 +91,19 @@ var knownCopilotModels = []domain.ModelChoice{
 	{ID: "kimi-k3", Label: "Kimi K3"},
 }
 
-var knownOpenCodeModels = []domain.ModelChoice{
-	{ID: OpenCodeDefaultModel, Label: "Claude Sonnet 4.5 (Nav default)"},
-	{ID: "github-copilot/claude-opus-5", Label: "Claude Opus 5"},
-	{ID: "github-copilot/claude-sonnet-5", Label: "Claude Sonnet 5"},
-	{ID: "github-copilot/claude-sonnet-4.6", Label: "Claude Sonnet 4.6"},
-	{ID: "github-copilot/claude-opus-4.8", Label: "Claude Opus 4.8"},
-	{ID: "github-copilot/claude-haiku-4.5", Label: "Claude Haiku 4.5"},
-	{ID: "github-copilot/gpt-5.6-terra", Label: "GPT-5.6 Terra"},
-	{ID: "github-copilot/gpt-5.5", Label: "GPT-5.5"},
-	{ID: "github-copilot/gpt-5.4", Label: "GPT-5.4"},
-}
+// knownOpenCodeModels mirrors knownCopilotModels under the github-copilot
+// provider prefix, so a bare Copilot id never triggers the opencode advisory
+// after ToOpenCodeModel mapping.
+var knownOpenCodeModels = func() []domain.ModelChoice {
+	models := []domain.ModelChoice{{ID: OpenCodeDefaultModel, Label: "Claude Sonnet 4.5 (Nav default)"}}
+	for _, m := range knownCopilotModels {
+		if m.ID == "auto" {
+			continue
+		}
+		models = append(models, domain.ModelChoice{ID: openCodeProviderPrefix + m.ID, Label: m.Label})
+	}
+	return models
+}()
 
 // ToOpenCodeModel maps a configured model id to an opencode model id for the
 // github-copilot provider that cplt connects opencode to. Empty or "auto" use

--- a/cli/nav-pilot/internal/provider/provider.go
+++ b/cli/nav-pilot/internal/provider/provider.go
@@ -64,28 +64,41 @@ const OpenCodeAgentPersona = "nav-pilot"
 // opencode against. Bare Copilot-style model ids are mapped under it.
 const openCodeProviderPrefix = "github-copilot/"
 
+// Curated model lists. Source of truth for ids: models.dev github-copilot
+// provider. Keep pinned (no dynamic fetch) — update when Copilot ships new
+// models.
 var knownCopilotModels = []domain.ModelChoice{
 	{ID: "auto", Label: "Auto (let Copilot pick)"},
+	{ID: "claude-opus-5", Label: "Claude Opus 5"},
+	{ID: "claude-fable-5", Label: "Claude Fable 5"},
 	{ID: "claude-sonnet-5", Label: "Claude Sonnet 5"},
-	{ID: "claude-sonnet-4.6", Label: "Claude Sonnet 4.6 (default)"},
+	{ID: "claude-sonnet-4.6", Label: "Claude Sonnet 4.6"},
 	{ID: "claude-haiku-4.5", Label: "Claude Haiku 4.5"},
 	{ID: "claude-opus-4.8", Label: "Claude Opus 4.8"},
 	{ID: "claude-opus-4.6", Label: "Claude Opus 4.6"},
+	{ID: "gpt-5.6-sol", Label: "GPT-5.6 Sol"},
+	{ID: "gpt-5.6-terra", Label: "GPT-5.6 Terra"},
+	{ID: "gpt-5.6-luna", Label: "GPT-5.6 Luna"},
 	{ID: "gpt-5.5", Label: "GPT-5.5"},
 	{ID: "gpt-5.4", Label: "GPT-5.4"},
 	{ID: "gpt-5.3-codex", Label: "GPT-5.3-Codex"},
 	{ID: "gpt-5.4-mini", Label: "GPT-5.4 mini"},
 	{ID: "gpt-5-mini", Label: "GPT-5 mini"},
+	{ID: "gemini-3.6-flash", Label: "Gemini 3.6 Flash"},
 	{ID: "gemini-3.1-pro-preview", Label: "Gemini 3.1 Pro (Preview)"},
 	{ID: "gemini-3.5-flash", Label: "Gemini 3.5 Flash"},
+	{ID: "kimi-k2.7-code", Label: "Kimi K2.7 Code"},
+	{ID: "kimi-k3", Label: "Kimi K3"},
 }
 
 var knownOpenCodeModels = []domain.ModelChoice{
 	{ID: OpenCodeDefaultModel, Label: "Claude Sonnet 4.5 (Nav default)"},
+	{ID: "github-copilot/claude-opus-5", Label: "Claude Opus 5"},
 	{ID: "github-copilot/claude-sonnet-5", Label: "Claude Sonnet 5"},
 	{ID: "github-copilot/claude-sonnet-4.6", Label: "Claude Sonnet 4.6"},
 	{ID: "github-copilot/claude-opus-4.8", Label: "Claude Opus 4.8"},
 	{ID: "github-copilot/claude-haiku-4.5", Label: "Claude Haiku 4.5"},
+	{ID: "github-copilot/gpt-5.6-terra", Label: "GPT-5.6 Terra"},
 	{ID: "github-copilot/gpt-5.5", Label: "GPT-5.5"},
 	{ID: "github-copilot/gpt-5.4", Label: "GPT-5.4"},
 }

--- a/cli/nav-pilot/internal/provider/provider_test.go
+++ b/cli/nav-pilot/internal/provider/provider_test.go
@@ -114,6 +114,10 @@ func TestCopilotProvider_ModelAdvisory(t *testing.T) {
 	if msg := p.ModelAdvisory("claude-sonnet-4.6"); msg != "" {
 		t.Errorf("ModelAdvisory(known) = %q, want empty", msg)
 	}
+	// Regression: claude-opus-5 is GA in Copilot and must not warn (#425).
+	if msg := p.ModelAdvisory("claude-opus-5"); msg != "" {
+		t.Errorf("ModelAdvisory(claude-opus-5) = %q, want empty", msg)
+	}
 	if msg := p.ModelAdvisory("sonnet"); msg == "" {
 		t.Error("ModelAdvisory(unknown) = empty, want advisory")
 	}

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -169,10 +169,11 @@ globale flagg som `--client`, `--model`, `--mode`, `--effort`, `--context`,
 > cplt/copilot/opencode automatisk uten «Launch X now?»-bekreftelsen.
 
 **Modell per klient:**
-- Copilot: `auto`, `claude-opus-5`, `claude-sonnet-5`, `claude-sonnet-4.6`,
-  `claude-haiku-4.5`, `claude-opus-4.8`, `gpt-5.6-sol`, `gpt-5.6-terra`,
-  `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.4-mini`, `gemini-3.6-flash`,
-  `gemini-3.1-pro-preview`, `kimi-k2.7-code`, `kimi-k3`
+- Copilot: `auto`, `claude-opus-5`, `claude-fable-5`, `claude-sonnet-5`,
+  `claude-sonnet-4.6`, `claude-haiku-4.5`, `claude-opus-4.8`, `claude-opus-4.6`,
+  `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`,
+  `gpt-5.3-codex`, `gpt-5.4-mini`, `gpt-5-mini`, `gemini-3.6-flash`,
+  `gemini-3.1-pro-preview`, `gemini-3.5-flash`, `kimi-k2.7-code`, `kimi-k3`
 - opencode (startes via cplt → GitHub Copilot-provider): bruk `github-copilot/<id>`,
   f.eks. `github-copilot/claude-sonnet-4.5` (Nav-standard), `github-copilot/claude-opus-4.8`,
   `github-copilot/gpt-5.5`. Modellen må være på `provider/model`-format (med `/`);

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -169,8 +169,10 @@ globale flagg som `--client`, `--model`, `--mode`, `--effort`, `--context`,
 > cplt/copilot/opencode automatisk uten «Launch X now?»-bekreftelsen.
 
 **Modell per klient:**
-- Copilot: `auto`, `claude-sonnet-4.6`, `claude-haiku-4.5`, `claude-opus-4.8`,
-  `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.4-mini`, `gemini-3.1-pro-preview`
+- Copilot: `auto`, `claude-opus-5`, `claude-sonnet-5`, `claude-sonnet-4.6`,
+  `claude-haiku-4.5`, `claude-opus-4.8`, `gpt-5.6-sol`, `gpt-5.6-terra`,
+  `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.4-mini`, `gemini-3.6-flash`,
+  `gemini-3.1-pro-preview`, `kimi-k2.7-code`, `kimi-k3`
 - opencode (startes via cplt → GitHub Copilot-provider): bruk `github-copilot/<id>`,
   f.eks. `github-copilot/claude-sonnet-4.5` (Nav-standard), `github-copilot/claude-opus-4.8`,
   `github-copilot/gpt-5.5`. Modellen må være på `provider/model`-format (med `/`);


### PR DESCRIPTION
Remove the model pin from the nav-pilot agent frontmatter — it overrode the user's --model/config choice a few hundred ms after launch (the agent's model strategy guidance remains in the body). Specialist sub-agent pins are unchanged.

Refresh the curated Copilot and OpenCode model lists from models.dev (github-copilot provider): adds claude-opus-5, claude-fable-5, gpt-5.6-sol/terra/luna, gemini-3.6-flash, kimi-k2.7-code and kimi-k3 so GA models no longer trigger the 'not a recognized model' advisory. Lists stay pinned by design; ids documented in config template and README.

Adds a regression test for claude-opus-5. Fixes #425.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
