### PR TITLE
Update IntelliJ MCP server version to 2026.2.1

### DIFF
--- a/apps/mcp-registry/allowlist.json
+++ b/apps/mcp-registry/allowlist.json
@@ -271,7 +271,7 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.jetbrains/intellij",
       "description": "Access IntelliJ code intelligence, inspections, and refactoring tools via MCP.",
-      "version": "2025.2.0",
+      "version": "2026.2.1",
       "status": "active",
       "publishedAt": "2026-04-27T00:00:00Z",
       "websiteUrl": "https://www.jetbrains.com/help/idea/mcp-server.html",


### PR DESCRIPTION
Updates the `com.jetbrains/intellij` entry in `apps/mcp-registry/allowlist.json` to the newest IntelliJ version, 2026.2.1 (from 2025.2.0).