### PR TITLE
feat(nav-pilot): agentpakke contract, source selection, and validate (M1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Gå til **[min-copilot.ansatt.nav.no/verktoy](https://min-copilot.ansatt.nav.no/
 - **[Skills →](docs/README.skills.md)** — VS Code (`security-owasp` dekker OWASP Top 10:2025 for Kotlin, Go, Java og Node.js)
 - **[MCP-servere →](docs/README.mcp.md)** — Alle editorer
 - **[Samlinger →](docs/README.collections.md)** — Installer alt på én gang
+- **[Agentpakke →](docs/README.agentpakke.md)** — Lag og distribuer teamets egen agentpakke
 - **[nav-pilot →](docs/README.nav-pilot.md)** — CLI-verktøy og AI-agent for Nav-tilpasninger
 - **[Testing →](docs/README.testing.md)** — Strukturelle og E2E-tester for nav-pilot
 - **[Hold tilpasninger oppdatert →](docs/README.sync.md)** — Automatisk sync-workflow (som Dependabot)
@@ -84,6 +85,7 @@ Bruk **MCP Onboarding**-serveren for å utforske tilpasninger, sjekke agent-read
 | 🔌 **MCP-servere**   | Nav-godkjente servere fra [MCP-registeret](https://mcp-registry.nav.no)                 | **[MCP-servere →](docs/README.mcp.md)**            |
 | 🔄 **Sync**          | Hold tilpasninger oppdatert automatisk (som Dependabot)                                 | **[Sync →](docs/README.sync.md)**                  |
 | 📦 **Samlinger**     | Installer en hel pakke med agenter, skills og instruksjoner på én gang                  | **[Samlinger →](docs/README.collections.md)**      |
+| 🧳 **Agentpakke**    | Teamets eget innholdsrepo med manifest — installeres med `nav-pilot install --source`   | **[Agentpakke →](docs/README.agentpakke.md)**      |
 | 🧭 **nav-pilot**     | CLI-verktøy og AI-agent som installerer og bruker Nav-tilpasninger i Copilot Chat       | **[nav-pilot →](docs/README.nav-pilot.md)**        |
 
 ---

--- a/cli/nav-pilot/DESIGN.md
+++ b/cli/nav-pilot/DESIGN.md
@@ -448,11 +448,18 @@ Konsekvenser:
   Innholdet hentes fra `layout`-stiene, og `StateFile.Collection` får manifestets
   `name`. Uten manifest er alt uendret, byte for byte.
 - **Per scope (B4):** hvert scope husker `source_repo` i state. `guardScopeSource`
-  (install) og `guardScopeSyncSource` (sync) nekter å blande innhold fra to
-  agentpakker i samme scope; eksplisitt `--source` er overstyringen.
+  (install, inkludert alle interaktive stier) og `guardScopeSyncSource` (sync)
+  nekter å blande innhold fra to agentpakker i samme scope; eksplisitt
+  `--source` er overstyringen. Sync bruker scopets registrerte kilde og sier fra
+  når den avviker fra den konfigurerte. Ferskhetssjekken i rot-TUI-en hopper over
+  scope som ikke kommer fra `navikt/copilot`: release-feeden beskriver bare den.
+- **Tier 2 ennå ikke støttet:** en agentpakke uten `layout`, med klienter som har
+  `payloads`, avvises med sin egen begrunnelse i stedet for en misvisende
+  «mangler agenter»-feil.
 - **Sømmen stopper her:** persona, modell og launch (`internal/provider`,
   `internal/source/frontmatter.go`) leser fortsatt Nav-defaults. De flyttes til
-  manifestet i M2.
+  manifestet i M2. `export` leser fortsatt de kanoniske katalogene og nekter
+  derfor kilder med et manifest som legger innholdet et annet sted.
 
 `nav-pilot validate [--source <repo>|<sti>] [--ref <ref>]` kjører hele
 konformanssjekken og avslutter med kode 1 ved brudd — ment for agentpakke-repoets
@@ -474,6 +481,12 @@ writeStateAt(path, boundary, state) // sjekker state-sti
 `checkSymlink()` stopper ved boundary for å unngå falske positiver fra system-symlinker (f.eks. `/var → /private/var` på macOS).
 
 `copyDirSimple()` i export.go sjekker kilde-symlinker i stedet (avviser dem).
+
+Lesesiden er også innelukket: `SourceResolver.checkSafePath()` og
+`agentpakke.ValidateSource()` bruker `domain.PathWithinRoot()`, som løser opp
+symlinker i hele stikjeden. En agentpakke der `layout.agents` peker ut av
+checkouten blir dermed avvist både av install og av `nav-pilot validate` — ikke
+bare når siste ledd er en symlink.
 
 ### Stivalidering
 

--- a/cli/nav-pilot/DESIGN.md
+++ b/cli/nav-pilot/DESIGN.md
@@ -48,6 +48,7 @@ Files:
 |---|---|---|---|
 | `version` | int | (required) | — |
 | `client` | string | `copilot` | `--client` |
+| `source` | string | `navikt/copilot` | `--source` |
 | `model` | string | unset | `--model` |
 | `mode` | string | `default` | `--mode` |
 | `reasoning_effort` | string | unset | `--effort` |
@@ -242,6 +243,7 @@ func cmdExport(format string, scope *InstallScope, ref, sourceRepo string, dryRu
 func cmdInstallAuto(name, itemType string, scope *InstallScope, ref, sourceRepo string, dryRun, force bool, jsonOutput bool) error
 func cmdInstall(collection string, scope *InstallScope, ref, sourceRepo string, dryRun, force bool, jsonOutput bool) error
 func cmdSync(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bool) error
+func cmdValidate(ref, sourceRepo string, jsonOutput bool) error
 func cmdAdd(itemType, name string, scope *InstallScope, ref, sourceRepo string, dryRun, force bool, jsonOutput bool) error  // deprecated alias
 func cmdInit(targetDir string, dryRun, force bool) error
 ```
@@ -370,7 +372,19 @@ installArtifact(resolver, scope, kind, name, dryRun, force, result)  // replaces
 
 ## Source
 
-`Source` løser opp kildekodemappa. Prioritet:
+Hvilket *innholdsrepo* som brukes, avgjøres av kilde-presedensen (B1):
+
+1. Eksplisitt `--source <owner/name>` eller absolutt sti
+2. `source`-nøkkelen i `~/.nav-pilot/config.toml` (settes av
+   `nav-pilot install --source <repo>` etter vellykket install, tømmes med
+   `nav-pilot config set source ""`)
+3. Standard: `navikt/copilot` (`source.DefaultRepo`)
+
+Presedensen ligger i `sourceRepoFor()` (config.go) og brukes fra trakta i
+`aliases.go` — `resolveSource`/`resolveSourceForSync` — slik at hver kommando
+arver den uten å gjenta den.
+
+`Source` løser deretter opp kildekodemappa. Prioritet:
 
 1. Eksplisitt `--ref` → `git clone --depth 1 --branch <ref>`
 2. Lokal repo (CWD er inne i navikt/copilot) → dev-modus, ingen clone
@@ -398,8 +412,8 @@ Alle flagg parses manuelt i `run()`. Ingen flag-bibliotek.
 | `--dry-run` | `-n` | nei | install, add, export, uninstall |
 | `--force` | `-f` | nei | install, add, export |
 | `--target` | `-t` | dir | install, add, export, sync |
-| `--ref` | `-r` | ref | install, add, export, sync, list |
-| `--source` | `-s` | repo | install, add, export, sync, list |
+| `--ref` | `-r` | ref | install, add, export, sync, list, validate |
+| `--source` | `-s` | repo/sti | install, add, export, sync, list, validate |
 | `--user` | `-u` | nei | install, add, sync, status, uninstall, export |
 | `--apply` | | nei | sync |
 | `--json` | | nei | sync, install, add, status, export, list |
@@ -409,6 +423,41 @@ Alle flagg parses manuelt i `run()`. Ingen flag-bibliotek.
 Nye flagg: legg til i for-løkka i `run()`, med `--long` og `-short` form. Gjenbruk eksisterende flagg der det gir mening.
 
 `--user` og `--target` er gjensidig utelukkende — `run()` sjekker dette.
+
+## Agentpakke (agentpakke.json)
+
+Et kilderepo kan levere en **agentpakke-manifest** på
+`.nav-pilot/agentpakke.json` (`internal/agentpakke`, JSON Schema i
+`cli/nav-pilot/schemas/`). Manifestet er den eneste interne valutaen:
+
+```
+resolveSource (aliases.go)
+  └─ attachPakke  → src.Pakke  (nil hvis repoet ikke har manifest)
+       └─ pakkeFor(src, collection)  → *agentpakke.Manifest
+            │   nil ⇒ agentpakke.SynthesizeLegacy(collection) — legacy-adapteren
+            └─ resolverFor(dir, pakke) → SourceResolver med layout-stiene
+                 └─ install / sync
+```
+
+Konsekvenser:
+
+- **Fail-closed (A3):** et repo som *har* manifest må ha et gyldig et. Feil
+  manifest stopper resolve før noe skrives; innholdssjekken
+  (`agentpakke.ValidateSource`) kjører før første filoperasjon i install.
+- **Supersede:** et repo med manifest erstatter `collections/<navn>/manifest.json`.
+  Innholdet hentes fra `layout`-stiene, og `StateFile.Collection` får manifestets
+  `name`. Uten manifest er alt uendret, byte for byte.
+- **Per scope (B4):** hvert scope husker `source_repo` i state. `guardScopeSource`
+  (install) og `guardScopeSyncSource` (sync) nekter å blande innhold fra to
+  agentpakker i samme scope; eksplisitt `--source` er overstyringen.
+- **Sømmen stopper her:** persona, modell og launch (`internal/provider`,
+  `internal/source/frontmatter.go`) leser fortsatt Nav-defaults. De flyttes til
+  manifestet i M2.
+
+`nav-pilot validate [--source <repo>|<sti>] [--ref <ref>]` kjører hele
+konformanssjekken og avslutter med kode 1 ved brudd — ment for agentpakke-repoets
+egen CI. Ikke å forveksle med `nav-pilot config validate`, som sjekker
+brukerens egen config.
 
 ## Sikkerhetsregler
 

--- a/cli/nav-pilot/DESIGN.md
+++ b/cli/nav-pilot/DESIGN.md
@@ -472,6 +472,39 @@ konformanssjekken og avslutter med kode 1 ved brudd — ment for agentpakke-repo
 egen CI. Ikke å forveksle med `nav-pilot config validate`, som sjekker
 brukerens egen config.
 
+Feltreferansen for manifestet, kompatibilitetsreglene og CI-bruken for
+agentpakke-forfattere står i [docs/README.agentpakke.md](../../docs/README.agentpakke.md).
+Kontrakten selv er JSON Schema-filen `schemas/agentpakke-v1.json`, som er både
+publisert i repoet og embedded i binæren.
+
+### Migrasjon: én valuta, tre faser
+
+Prinsippet bak sømmen er at **manifestet er den eneste interne valutaen**. Hver
+konsument nedstrøms leser persona, allowlist, modell-defaults og innholdslayout
+fra en `agentpakke.Manifest` — aldri fra hardkodede konstanter, og aldri fra en
+`legacy eller manifest`-forgrening. Kilder uten manifest adapteres opp i toppen
+av pipelinen (`agentpakke.SynthesizeLegacy`), som uttrykker dagens
+navikt/copilot-konvensjoner i manifestform. Etter load trenger ingenting å vite
+hvor manifestet kom fra. Legacy-adapteren finnes nettopp for at det skal være
+én installasjonsmodell, ikke to.
+
+Overgangen går i tre faser:
+
+1. **Fase 1 (levert, M1):** manifestet er valgfritt. En kilde uten
+   `.nav-pilot/agentpakke.json` gir `ErrNoManifest`, og kalleren setter inn
+   `SynthesizeLegacy` — eksisterende installasjoner oppfører seg byte for byte
+   som før.
+2. **Fase 2:** `navikt/copilot` leverer sitt eget `.nav-pilot/agentpakke.json` og
+   blir en ordinær agentpakke — standardpakka. Syntesen sluttes å bli brukt for
+   standardkilden.
+3. **Fase 3:** `SynthesizeLegacy` og samlingsmekanismen fjernes, innenfor
+   deprekeringsvinduet kontraktens kompatibilitetsregler (A4) krever.
+
+Ingenting her skal vokse en andre, parallell installasjonsmodell for å betjene
+overgangen. Fasene er også dokumentert i pakkedokumentasjonen til
+`internal/agentpakke` (`go doc ./internal/agentpakke`), som er referansen på
+kodenivå; denne seksjonen er den kanoniske beskrivelsen for designet.
+
 ## Sikkerhetsregler
 
 ### Symlinkbeskyttelse

--- a/cli/nav-pilot/DESIGN.md
+++ b/cli/nav-pilot/DESIGN.md
@@ -448,10 +448,16 @@ Konsekvenser:
   Innholdet hentes fra `layout`-stiene, og `StateFile.Collection` får manifestets
   `name`. Uten manifest er alt uendret, byte for byte.
 - **Per scope (B4):** hvert scope husker `source_repo` i state. `guardScopeSource`
-  (install, inkludert alle interaktive stier) og `guardScopeSyncSource` (sync)
-  nekter å blande innhold fra to agentpakker i samme scope; eksplisitt
-  `--source` er overstyringen. Sync bruker scopets registrerte kilde og sier fra
-  når den avviker fra den konfigurerte. Ferskhetssjekken i rot-TUI-en hopper over
+  (install, inkludert alle interaktive stier) nekter å blande innhold fra to
+  agentpakker i samme scope; eksplisitt `--source` er overstyringen. Sync bruker
+  scopets registrerte kilde og sier fra når den avviker fra den konfigurerte.
+  Et scope fra før kildesporingen har ingen registrert kilde å beskytte:
+  `adoptSyncSource` lar synken gå fra den gjeldende kilden, skriver én
+  informasjonslinje om det (ikke i `--json`), og `recordAdoptedSource` fester
+  kilden i state *etter* en vellykket sync — en sync som feiler registrerer
+  ingenting. Fra neste kjøring gjelder den vanlige B3-vakten. Stiformede kilder
+  sammenlignes symlink-oppløst (`resolvedSourcePath`), så en symlink og
+  checkouten bak den er én kilde. Ferskhetssjekken i rot-TUI-en hopper over
   scope som ikke kommer fra `navikt/copilot`: release-feeden beskriver bare den.
 - **Tier 2 ennå ikke støttet:** en agentpakke uten `layout`, med klienter som har
   `payloads`, avvises med sin egen begrunnelse i stedet for en misvisende

--- a/cli/nav-pilot/go.mod
+++ b/cli/nav-pilot/go.mod
@@ -7,11 +7,13 @@ require (
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/go-logr/logr v1.4.4
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.45.0
 	go.opentelemetry.io/otel/metric v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
 	go.opentelemetry.io/otel/sdk/metric v1.45.0
+	golang.org/x/text v0.40.0
 )
 
 require (
@@ -49,7 +51,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.11.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
-	golang.org/x/text v0.40.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260803160001-6ac0973c030d // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260803160001-6ac0973c030d // indirect
 	google.golang.org/grpc v1.83.0 // indirect

--- a/cli/nav-pilot/go.sum
+++ b/cli/nav-pilot/go.sum
@@ -50,6 +50,8 @@ github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
@@ -87,6 +89,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 h1:1EYB5IzjZawrrnELUi78f9fPu57HuXjmddZPjrls/28=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=

--- a/cli/nav-pilot/internal/agentpakke/agentpakke.go
+++ b/cli/nav-pilot/internal/agentpakke/agentpakke.go
@@ -1,0 +1,367 @@
+// Package agentpakke implements the agentpakke contract: the versioned,
+// self-describing manifest an agentpakke repo ships so the nav-pilot binary can
+// install, sync, and launch its content without a fork.
+//
+// The manifest lives at [ManifestPath] inside the agentpakke repo and is
+// validated against the published JSON Schema in cli/nav-pilot/schemas (embedded
+// here via go:embed, so the schema file is the single source of truth for both
+// nav-pilot and an agentpakke repo's own CI lint).
+//
+// # Manifest is the single internal currency
+//
+// Every downstream consumer reads its persona, allowlist, model defaults, and
+// content layout from a [Manifest] — never from hardcoded constants and never
+// from a legacy-vs-manifest branch. Sources that do not ship a manifest are
+// adapted up-front by [SynthesizeLegacy] / [Default], which express today's
+// navikt/copilot conventions in manifest form. Past the point of load, nothing
+// in this package (or in its callers) needs to know whether a Manifest came
+// from disk or from synthesis.
+//
+// # Migration path
+//
+// The legacy adapter is transitional, and the collection model it represents is
+// on its way out:
+//
+//   - Phase 1 (now): the manifest is optional. A source without
+//     [ManifestPath] yields [ErrNoManifest] and the caller substitutes
+//     [SynthesizeLegacy], so existing installs behave byte-for-byte as before.
+//   - Phase 2: navikt/copilot ships its own .nav-pilot/agentpakke.json and
+//     becomes an ordinary agentpakke — the default one. Synthesis stops being
+//     exercised for the default source.
+//   - Phase 3: [SynthesizeLegacy] and the collection mechanism are removed,
+//     under the deprecation window the contract's compatibility rules (A4)
+//     require.
+//
+// Nothing here should grow a second, parallel installation model to serve that
+// transition: the adapter exists so there is exactly one.
+//
+// # Tiers
+//
+// A client's conformance tier is derived from the shape of its manifest entry,
+// never declared separately (so it cannot drift out of sync with the content):
+// an entry with payloads is Tier 2 (pre-built, digest-bound trees that nav-pilot
+// verifies and stages), an entry without is Tier 1 (markdown content at the
+// manifest's layout paths, which nav-pilot materializes). See [Manifest.Tier].
+//
+// # Ignore-unknown
+//
+// Client keys, context keys, and additional fields that this binary does not
+// recognize are ignored rather than rejected: an agentpakke that adds a client
+// or a context stays valid on older binaries, which simply do not offer what
+// they cannot name. Fail-closed applies to malformed declarations of *known*
+// constructs.
+package agentpakke
+
+import (
+	"path"
+	"sort"
+	"strings"
+)
+
+const (
+	// ManifestDir is the agentpakke-repo directory holding nav-pilot metadata.
+	ManifestDir = ".nav-pilot"
+
+	// ManifestFile is the manifest's file name inside [ManifestDir].
+	ManifestFile = "agentpakke.json"
+
+	// ManifestPath is the repo-relative path to an agentpakke manifest.
+	ManifestPath = ManifestDir + "/" + ManifestFile
+
+	// PayloadManifestFile is the payload manifest name resolved by convention
+	// inside a Tier 2 payload directory (A7). A payload's `manifest` field
+	// overrides this.
+	PayloadManifestFile = "manifest.json"
+
+	// DefaultContext is the payload context launched when a client entry
+	// declares no defaultContext (G3).
+	DefaultContext = "full"
+
+	// InheritModel is the literal defaultModel value meaning "do not pin a
+	// model; inherit the provider's or session's choice" (F3).
+	InheritModel = "inherit"
+)
+
+// SupportedContractMajors lists the manifest contract major versions this
+// binary understands. A manifest outside this set is rejected with an error
+// naming the supported versions (A3/A4).
+var SupportedContractMajors = []string{"1"}
+
+// KnownClients are the client ids this binary can actually launch. It mirrors
+// internal/provider's registry; the list lives here rather than being imported
+// because provider will consume this package once the manifest drives its
+// personas. Client keys outside this list are ignored, not rejected: that
+// client is simply unavailable (A3/A4).
+var KnownClients = []string{"copilot", "opencode", "pi"}
+
+// IsKnownClient reports whether this binary can launch a client id.
+func IsKnownClient(client string) bool {
+	for _, known := range KnownClients {
+		if known == client {
+			return true
+		}
+	}
+	return false
+}
+
+// Manifest is a parsed agentpakke manifest. Unknown JSON fields are tolerated
+// (encoding/json ignores them), matching the contract's ignore-unknown rule.
+type Manifest struct {
+	// ContractVersion is the manifest schema-and-semantics version ("1" or "1.x").
+	ContractVersion string `json:"contractVersion"`
+
+	// Name is the agentpakke identity. It is also what an agentpakke install
+	// records as its collection: a manifest-bearing source supersedes the
+	// legacy collections/<name>/manifest.json model rather than declaring
+	// entries in it.
+	Name string `json:"name"`
+
+	Description string `json:"description"`
+
+	// Owner is attribution only; the install source is wherever the manifest
+	// was cloned from.
+	Owner *Owner `json:"owner,omitempty"`
+
+	// Clients holds one entry per supported client, keyed by client id
+	// ("copilot", "opencode", "pi", …). Unrecognized keys are ignored, not
+	// rejected.
+	Clients map[string]ClientEntry `json:"clients"`
+
+	// Layout declares repo-relative content directories. Required whenever any
+	// client is Tier 1 (D1).
+	Layout *Layout `json:"layout,omitempty"`
+
+	// Provenance records what composed content is made of (H2).
+	Provenance *Provenance `json:"provenance,omitempty"`
+
+	// Policies points at optional policy artifacts materialized for Tier 1
+	// clients (E1).
+	Policies *Policies `json:"policies,omitempty"`
+
+	// Profiles points at optional launch profiles (E2).
+	Profiles *Profiles `json:"profiles,omitempty"`
+
+	// MinNavPilotVersion is the minimum running nav-pilot version, in the
+	// YYYY.MM.DD-HHMMSS-sha7 release format.
+	MinNavPilotVersion string `json:"minNavPilotVersion,omitempty"`
+}
+
+// Owner is attribution metadata for an agentpakke.
+type Owner struct {
+	Repo string `json:"repo,omitempty"`
+	Team string `json:"team,omitempty"`
+}
+
+// ClientEntry is a manifest's declaration for one client. Its tier is derived
+// from shape: a non-empty Payloads makes it Tier 2, otherwise Tier 1.
+type ClientEntry struct {
+	// PrimaryAgents are the agents selectable/launchable directly in the
+	// client (C1, C2). Every other agent materializes as a subagent.
+	PrimaryAgents []string `json:"primaryAgents"`
+
+	// Compatibility is a client version range (e.g. ">=1.18.20,<2"). Exact
+	// pins belong to the local/security-profile tier, not here.
+	Compatibility string `json:"compatibility,omitempty"`
+
+	// DefaultModel is a model id, or [InheritModel].
+	DefaultModel string `json:"defaultModel,omitempty"`
+
+	// DefaultContext names the payload context launched by default; empty
+	// means [DefaultContext].
+	DefaultContext string `json:"defaultContext,omitempty"`
+
+	// Payloads maps context id ("full", "focused", …) to a pre-built payload.
+	// Its presence is what makes this entry Tier 2.
+	Payloads map[string]Payload `json:"payloads,omitempty"`
+}
+
+// Payload locates one Tier 2 payload tree for a single client×context.
+type Payload struct {
+	// Path is the repo-relative directory holding the payload tree.
+	Path string `json:"path"`
+
+	// Manifest optionally overrides the payload manifest location, which
+	// otherwise resolves by convention to <Path>/manifest.json.
+	Manifest string `json:"manifest,omitempty"`
+}
+
+// Layout declares repo-relative content directories for Tier 1 clients.
+type Layout struct {
+	Agents       string `json:"agents"`
+	Skills       string `json:"skills"`
+	Instructions string `json:"instructions,omitempty"`
+	Prompts      string `json:"prompts,omitempty"`
+}
+
+// Provenance records the base and overlays a composed agentpakke was built from.
+type Provenance struct {
+	Base     *ProvenanceBase     `json:"base,omitempty"`
+	Overlays []ProvenanceOverlay `json:"overlays,omitempty"`
+}
+
+// ProvenanceBase is the pinned base an agentpakke composed against.
+type ProvenanceBase struct {
+	Repo   string `json:"repo"`
+	Digest string `json:"digest"`
+}
+
+// ProvenanceOverlay is one composed-in component and its version.
+type ProvenanceOverlay struct {
+	Component string `json:"component"`
+	Version   string `json:"version"`
+}
+
+// Policies points at optional policy artifacts.
+type Policies struct {
+	OpenCodePermissions string `json:"opencodePermissions,omitempty"`
+}
+
+// Profiles points at optional launch profiles and names the default one.
+type Profiles struct {
+	Dir     string `json:"dir,omitempty"`
+	Default string `json:"default,omitempty"`
+}
+
+// Tier constants returned by [Manifest.Tier].
+const (
+	// TierUnknown means the manifest declares no entry for that client, so the
+	// client is unavailable for this agentpakke.
+	TierUnknown = 0
+
+	// TierLayout (Tier 1) means nav-pilot materializes client config from the
+	// manifest's layout paths.
+	TierLayout = 1
+
+	// TierPayload (Tier 2) means nav-pilot verifies and stages pre-built
+	// payloads declared by the client entry.
+	TierPayload = 2
+)
+
+// Tier returns the conformance tier for a client, derived from the shape of its
+// entry. Unknown clients return [TierUnknown].
+func (m *Manifest) Tier(client string) int {
+	entry, ok := m.Client(client)
+	if !ok {
+		return TierUnknown
+	}
+	if len(entry.Payloads) > 0 {
+		return TierPayload
+	}
+	return TierLayout
+}
+
+// Client returns the entry for a client id.
+func (m *Manifest) Client(client string) (ClientEntry, bool) {
+	if m == nil || m.Clients == nil {
+		return ClientEntry{}, false
+	}
+	entry, ok := m.Clients[client]
+	return entry, ok
+}
+
+// ClientIDs returns the declared client ids in sorted order.
+func (m *Manifest) ClientIDs() []string {
+	if m == nil {
+		return nil
+	}
+	ids := make([]string, 0, len(m.Clients))
+	for id := range m.Clients {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// AvailableClients returns the declared clients this binary can launch, in
+// sorted order — the manifest's clients minus the keys it does not recognize.
+func (m *Manifest) AvailableClients() []string {
+	var ids []string
+	for _, id := range m.ClientIDs() {
+		if IsKnownClient(id) {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// PrimaryAgents returns the client's primary agents, or nil for an unknown
+// client.
+func (m *Manifest) PrimaryAgents(client string) []string {
+	entry, ok := m.Client(client)
+	if !ok {
+		return nil
+	}
+	return entry.PrimaryAgents
+}
+
+// IsPrimaryAgent reports whether an agent is primary for a client. Everything
+// else materializes as a subagent (C2).
+func (m *Manifest) IsPrimaryAgent(client, agent string) bool {
+	for _, name := range m.PrimaryAgents(client) {
+		if name == agent {
+			return true
+		}
+	}
+	return false
+}
+
+// DefaultModel returns the client's default model id, or the empty string when
+// the client is unknown or pins nothing. The literal [InheritModel] is returned
+// as-is: it is a meaningful value, not an absent one.
+func (m *Manifest) DefaultModel(client string) string {
+	entry, ok := m.Client(client)
+	if !ok {
+		return ""
+	}
+	return entry.DefaultModel
+}
+
+// DefaultContext returns the payload context a client launches by default,
+// falling back to [DefaultContext] when unset (G3).
+func (m *Manifest) DefaultContext(client string) string {
+	entry, ok := m.Client(client)
+	if !ok || strings.TrimSpace(entry.DefaultContext) == "" {
+		return DefaultContext
+	}
+	return entry.DefaultContext
+}
+
+// Payload returns the payload declared for a client×context.
+func (m *Manifest) Payload(client, context string) (Payload, bool) {
+	entry, ok := m.Client(client)
+	if !ok || entry.Payloads == nil {
+		return Payload{}, false
+	}
+	p, ok := entry.Payloads[context]
+	return p, ok
+}
+
+// PayloadManifestPath returns the repo-relative payload manifest path for a
+// client×context: the payload's `manifest` override when set, otherwise
+// <path>/manifest.json by convention (A7).
+func (m *Manifest) PayloadManifestPath(client, context string) (string, bool) {
+	p, ok := m.Payload(client, context)
+	if !ok {
+		return "", false
+	}
+	return p.ManifestPath(), true
+}
+
+// ManifestPath returns the payload manifest location for a payload: its
+// override when set, otherwise <Path>/manifest.json.
+func (p Payload) ManifestPath() string {
+	if override := strings.TrimSpace(p.Manifest); override != "" {
+		return override
+	}
+	return path.Join(p.Path, PayloadManifestFile)
+}
+
+// HasTier reports whether any declared client is at the given tier.
+func (m *Manifest) HasTier(tier int) bool {
+	for _, id := range m.ClientIDs() {
+		if m.Tier(id) == tier {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/nav-pilot/internal/agentpakke/agentpakke_test.go
+++ b/cli/nav-pilot/internal/agentpakke/agentpakke_test.go
@@ -1,0 +1,232 @@
+package agentpakke
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestTier(t *testing.T) {
+	m := &Manifest{Clients: map[string]ClientEntry{
+		"copilot": {
+			PrimaryAgents: []string{"grillmester"},
+			Payloads:      map[string]Payload{"full": {Path: "plugin"}},
+		},
+		"opencode": {PrimaryAgents: []string{"nav-pilot"}},
+		"pi":       {PrimaryAgents: []string{"nav-pilot"}, Payloads: map[string]Payload{}},
+	}}
+
+	tests := []struct {
+		client string
+		want   int
+	}{
+		{"copilot", TierPayload},
+		{"opencode", TierLayout},
+		{"pi", TierLayout}, // an empty payloads map declares no payload, so it is not Tier 2
+		{"claude-code", TierUnknown},
+		{"", TierUnknown},
+	}
+	for _, tt := range tests {
+		if got := m.Tier(tt.client); got != tt.want {
+			t.Errorf("Tier(%q) = %d, want %d", tt.client, got, tt.want)
+		}
+	}
+
+	if !m.HasTier(TierPayload) || !m.HasTier(TierLayout) {
+		t.Error("HasTier should see both tiers in a mixed manifest")
+	}
+	if m.HasTier(TierUnknown) {
+		t.Error("HasTier(TierUnknown) = true, want false")
+	}
+}
+
+func TestPayloadManifestPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload Payload
+		want    string
+	}{
+		{"by convention", Payload{Path: "targets/opencode-v1"}, "targets/opencode-v1/manifest.json"},
+		{"override wins", Payload{Path: "plugin", Manifest: "policy/plugin-manifest.json"}, "policy/plugin-manifest.json"},
+		{"blank override falls back", Payload{Path: "plugin", Manifest: "  "}, "plugin/manifest.json"},
+	}
+	for _, tt := range tests {
+		if got := tt.payload.ManifestPath(); got != tt.want {
+			t.Errorf("%s: ManifestPath() = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestDefaultContextFallback(t *testing.T) {
+	m := &Manifest{Clients: map[string]ClientEntry{
+		"copilot":  {DefaultContext: "focused"},
+		"opencode": {},
+	}}
+	tests := []struct{ client, want string }{
+		{"copilot", "focused"},
+		{"opencode", DefaultContext},
+		{"claude-code", DefaultContext},
+	}
+	for _, tt := range tests {
+		if got := m.DefaultContext(tt.client); got != tt.want {
+			t.Errorf("DefaultContext(%q) = %q, want %q", tt.client, got, tt.want)
+		}
+	}
+}
+
+func TestAvailableClients(t *testing.T) {
+	m := &Manifest{Clients: map[string]ClientEntry{
+		"opencode":    {},
+		"claude-code": {},
+		"copilot":     {},
+	}}
+	want := []string{"copilot", "opencode"}
+	if got := m.AvailableClients(); !reflect.DeepEqual(got, want) {
+		t.Errorf("AvailableClients() = %v, want %v (unknown keys are ignored, not offered)", got, want)
+	}
+	if got := len(m.ClientIDs()); got != 3 {
+		t.Errorf("ClientIDs() dropped an unknown client key: got %d entries, want 3", got)
+	}
+}
+
+func TestNilManifestHelpers(t *testing.T) {
+	var m *Manifest
+	if _, ok := m.Client("copilot"); ok {
+		t.Error("Client on a nil manifest reported a hit")
+	}
+	if m.Tier("copilot") != TierUnknown {
+		t.Error("Tier on a nil manifest is not TierUnknown")
+	}
+	if m.ClientIDs() != nil || m.PrimaryAgents("copilot") != nil {
+		t.Error("nil manifest should yield nil slices")
+	}
+	if m.DefaultContext("copilot") != DefaultContext {
+		t.Error("nil manifest should still yield the default context")
+	}
+}
+
+// --- legacy synthesis ---
+
+func TestDefaultIsAValidManifest(t *testing.T) {
+	// The legacy adapter is not a special case: it must survive the same
+	// validation a manifest read off disk does, or consumers would need to know
+	// where their Manifest came from.
+	data, err := json.Marshal(Default())
+	if err != nil {
+		t.Fatalf("marshalling Default(): %v", err)
+	}
+	if _, err := parse(data, devVersion); err != nil {
+		t.Fatalf("Default() does not satisfy the published schema: %v\n%s", err, data)
+	}
+}
+
+func TestDefaultMirrorsCurrentBehavior(t *testing.T) {
+	m := Default()
+
+	// Values duplicated from their current call sites. When those move to the
+	// manifest in stage 2, this test is what catches a silent drift in between:
+	//   internal/provider/copilot_launch.go  CopilotAgentPersona
+	//   internal/provider/provider.go        OpenCodeAgentPersona, OpenCodeDefaultModel
+	//   internal/source/frontmatter.go       openCodePrimaryAgents
+	if got := m.PrimaryAgents("copilot"); !reflect.DeepEqual(got, []string{"nav-pilot"}) {
+		t.Errorf("copilot primaryAgents = %v, want [nav-pilot] (CopilotAgentPersona)", got)
+	}
+	if got := m.PrimaryAgents("opencode"); !reflect.DeepEqual(got, []string{"nav-pilot", "nav-pilot-opus"}) {
+		t.Errorf("opencode primaryAgents = %v, want [nav-pilot nav-pilot-opus] (openCodePrimaryAgents)", got)
+	}
+	if got := m.PrimaryAgents("opencode")[0]; got != "nav-pilot" {
+		t.Errorf("opencode launch persona = %q, want nav-pilot (OpenCodeAgentPersona)", got)
+	}
+	if got := m.DefaultModel("opencode"); got != "github-copilot/auto" {
+		t.Errorf("opencode defaultModel = %q, want github-copilot/auto (OpenCodeDefaultModel)", got)
+	}
+	if got := m.DefaultModel("copilot"); got != "" {
+		t.Errorf("copilot defaultModel = %q, want empty — copilot pins no default today", got)
+	}
+	if m.IsPrimaryAgent("opencode", "kafka") {
+		t.Error("kafka is a subagent in opencode today, not a primary agent")
+	}
+	if m.Layout == nil || m.Layout.Agents != "agents" || m.Layout.Skills != "skills" {
+		t.Errorf("layout = %+v, want the agents//skills/ content layout", m.Layout)
+	}
+	for _, client := range KnownClients {
+		if m.Tier(client) != TierLayout {
+			t.Errorf("Tier(%q) = %d, want TierLayout — Nav's default content is markdown, not payloads", client, m.Tier(client))
+		}
+	}
+}
+
+func TestSynthesizeLegacyCarriesTheCollection(t *testing.T) {
+	tests := []struct {
+		name       string
+		collection string
+		wantName   string
+	}{
+		{"named collection", "utvikler", "utvikler"},
+		{"hyphenated collection", "nav-pilot", "nav-pilot"},
+		{"no collection", "", DefaultName},
+		{"synthetic all-collection is not an identifier", "(all)", DefaultName},
+		{"uppercase is not an identifier", "Utvikler", DefaultName},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := SynthesizeLegacy(tt.collection)
+			if m.Name != tt.wantName {
+				t.Errorf("SynthesizeLegacy(%q).Name = %q, want %q", tt.collection, m.Name, tt.wantName)
+			}
+			data, err := json.Marshal(m)
+			if err != nil {
+				t.Fatalf("marshalling: %v", err)
+			}
+			if _, err := parse(data, devVersion); err != nil {
+				t.Fatalf("synthesized manifest fails validation: %v", err)
+			}
+		})
+	}
+}
+
+// --- published schema ---
+
+func TestEmbeddedSchemaMatchesPublishedFile(t *testing.T) {
+	// The file in cli/nav-pilot/schemas is what agentpakke repos lint against;
+	// the binary must validate with those exact bytes.
+	published := filepath.Join("..", "..", "schemas", "agentpakke-v1.json")
+	onDisk, err := os.ReadFile(published)
+	if err != nil {
+		t.Fatalf("reading %s: %v", published, err)
+	}
+	if !bytes.Equal(onDisk, SchemaJSON()) {
+		t.Fatalf("the embedded schema differs from %s", published)
+	}
+}
+
+func TestPublishedSchemaCompiles(t *testing.T) {
+	var doc map[string]any
+	if err := json.Unmarshal(SchemaJSON(), &doc); err != nil {
+		t.Fatalf("the published schema is not valid JSON: %v", err)
+	}
+	if got := doc["$id"]; got != SchemaID {
+		t.Errorf("schema $id = %v, want %s", got, SchemaID)
+	}
+	sch, err := schema()
+	if err != nil {
+		t.Fatalf("compiling the published schema: %v", err)
+	}
+	if sch == nil {
+		t.Fatal("compiled schema is nil")
+	}
+}
+
+func TestSchemaJSONIsACopy(t *testing.T) {
+	first := SchemaJSON()
+	if len(first) == 0 {
+		t.Fatal("SchemaJSON() is empty")
+	}
+	first[0] = 'X'
+	if SchemaJSON()[0] == 'X' {
+		t.Error("SchemaJSON() handed out the embedded bytes; callers could corrupt the schema")
+	}
+}

--- a/cli/nav-pilot/internal/agentpakke/legacy.go
+++ b/cli/nav-pilot/internal/agentpakke/legacy.go
@@ -1,0 +1,82 @@
+package agentpakke
+
+import "regexp"
+
+// DefaultName is the identity of the synthesized manifest that represents
+// navikt/copilot's own content.
+const DefaultName = "nav-pilot"
+
+// identifierPattern mirrors the schema's identifier definition. Synthesis has
+// to honor it: a synthesized manifest must be indistinguishable from a loaded
+// one, including passing validation.
+var identifierPattern = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+
+// Default returns the manifest for a source that ships no
+// .nav-pilot/agentpakke.json.
+//
+// It is the transitional legacy adapter, not a hardcoded alternative to the
+// manifest mechanism: it expresses today's navikt/copilot conventions —
+// personas, opencode primary-agent allowlist, model defaults, and the
+// agents//skills/ content layout — in manifest form, so every consumer reads
+// one type and no code path branches on "legacy or manifest". It disappears
+// once navikt/copilot ships its own manifest and the collection mechanism is
+// retired (see the package doc's migration path).
+//
+// The literals below mirror the values still hardcoded at their call sites
+// (internal/provider's CopilotAgentPersona / OpenCodeAgentPersona /
+// OpenCodeDefaultModel, and internal/source's openCodePrimaryAgents). Stage 2
+// replaces those call sites with reads from the active manifest; until then the
+// two must be kept in step, which the package's tests assert.
+func Default() *Manifest {
+	return SynthesizeLegacy("")
+}
+
+// SynthesizeLegacy returns the legacy adapter manifest for a source installed
+// under the collection model, naming the manifest after the collection being
+// installed. The legacy install flow is collection-parameterized, so the
+// synthesized identity has to carry the collection for state to round-trip
+// (StateFile.Collection records a manifest's name for agentpakke installs).
+//
+// An empty collection, or one whose name is not a contract identifier — the
+// synthetic "(all)" collection, for instance — falls back to [DefaultName].
+func SynthesizeLegacy(collection string) *Manifest {
+	name := DefaultName
+	if identifierPattern.MatchString(collection) {
+		name = collection
+	}
+	return &Manifest{
+		ContractVersion: "1",
+		Name:            name,
+		Description:     "Nav's default agents, skills, instructions, and prompts",
+		Owner: &Owner{
+			Repo: "navikt/copilot",
+			Team: "nav-pilot maintainers",
+		},
+		Clients: map[string]ClientEntry{
+			// Copilot CLI loads a single Nav persona; every other agent is
+			// reachable through it rather than selectable directly.
+			"copilot": {
+				PrimaryAgents: []string{"nav-pilot"},
+			},
+			// opencode's picker offers both Nav personas; everything else
+			// materializes as a subagent. The first entry is the persona
+			// launched by default.
+			"opencode": {
+				PrimaryAgents: []string{"nav-pilot", "nav-pilot-opus"},
+				DefaultModel:  "github-copilot/auto",
+			},
+			// pi consumes no persona today; the entry exists so client
+			// availability is expressible in one place instead of a special
+			// case at every call site.
+			"pi": {
+				PrimaryAgents: []string{"nav-pilot"},
+			},
+		},
+		Layout: &Layout{
+			Agents:       "agents",
+			Skills:       "skills",
+			Instructions: "instructions",
+			Prompts:      "prompts",
+		},
+	}
+}

--- a/cli/nav-pilot/internal/agentpakke/load.go
+++ b/cli/nav-pilot/internal/agentpakke/load.go
@@ -1,0 +1,397 @@
+package agentpakke
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ErrNoManifest reports that a source checkout ships no agentpakke manifest.
+// It is not a failure: callers substitute [SynthesizeLegacy] and install the
+// source under the legacy collection conventions (see the package doc's
+// migration path).
+var ErrNoManifest = errors.New("no agentpakke manifest")
+
+// Load reads and validates the agentpakke manifest of a resolved source
+// checkout. sourceRoot is the checkout's root directory; the manifest is read
+// from <sourceRoot>/.nav-pilot/agentpakke.json.
+//
+// A missing manifest returns an error matching [ErrNoManifest] via errors.Is.
+// Every other failure is fail-closed and actionable: the manifest exists but
+// does not conform, so nothing should be installed, synced, or launched from it.
+func Load(sourceRoot string) (*Manifest, error) {
+	file := filepath.Join(sourceRoot, ManifestDir, ManifestFile)
+	data, err := os.ReadFile(file)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("%s: %w", file, ErrNoManifest)
+		}
+		return nil, fmt.Errorf("reading %s: %w", file, err)
+	}
+	m, err := Parse(data)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", file, err)
+	}
+	return m, nil
+}
+
+// Parse validates raw manifest bytes and returns the manifest. Validation runs
+// schema-first (the published contract), then the semantic rules the schema
+// cannot express.
+func Parse(data []byte) (*Manifest, error) {
+	return parse(data, cliVersion)
+}
+
+// Validate checks raw manifest bytes without returning the manifest — the entry
+// point for `nav-pilot validate` and for agentpakke CI that only wants a verdict.
+func Validate(data []byte) error {
+	_, err := Parse(data)
+	return err
+}
+
+// parse is Parse with the running version injected, so version gating is
+// testable without mutating package state.
+func parse(data []byte, runningVersion string) (*Manifest, error) {
+	if err := validateSchema(data); err != nil {
+		return nil, err
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		// Unreachable in practice: the schema pass already parsed the JSON, so
+		// only a type the schema permits but Go cannot decode lands here.
+		return nil, fmt.Errorf("decoding manifest: %w", err)
+	}
+	if err := m.checkSemantics(runningVersion); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+// checkSemantics runs the fail-closed rules that JSON Schema cannot express:
+// contract-version support, minimum binary version, Tier 1's dependence on
+// layout, and path containment for every repo-relative path in the manifest.
+func (m *Manifest) checkSemantics(runningVersion string) error {
+	if err := m.checkContractVersion(); err != nil {
+		return err
+	}
+	if err := m.checkMinVersion(runningVersion); err != nil {
+		return err
+	}
+	if err := m.checkTiers(); err != nil {
+		return err
+	}
+	return m.checkPaths()
+}
+
+// checkContractVersion rejects a contract major this binary does not implement,
+// naming what it does support and how to proceed (A3/A4).
+func (m *Manifest) checkContractVersion() error {
+	major, _, _ := strings.Cut(m.ContractVersion, ".")
+	for _, supported := range SupportedContractMajors {
+		if major == supported {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"contractVersion %q is not supported by this nav-pilot; supported contract versions: %s. "+
+			"Upgrade nav-pilot (nav-pilot update) or ask the agentpakke to publish a manifest on a supported contract version",
+		m.ContractVersion, strings.Join(SupportedContractMajors, ", "))
+}
+
+// checkMinVersion enforces minNavPilotVersion against the running binary.
+// Development and unset builds are exempt: they carry no comparable version,
+// and gating them would block local work on an agentpakke.
+func (m *Manifest) checkMinVersion(runningVersion string) error {
+	required := strings.TrimSpace(m.MinNavPilotVersion)
+	if required == "" || !isReleaseVersion(required) {
+		return nil
+	}
+	if !isReleaseVersion(runningVersion) {
+		return nil
+	}
+	if versionOlder(runningVersion, required) {
+		return fmt.Errorf(
+			"agentpakke %q requires nav-pilot %s or newer, but this binary is %s. "+
+				"Run `nav-pilot update` (or reinstall via Homebrew) and try again",
+			m.Name, required, runningVersion)
+	}
+	return nil
+}
+
+// checkTiers verifies that every Tier 1 client has content to materialize:
+// tier is derived from shape, so a client entry without payloads is a promise
+// that the manifest's layout exists (D1).
+//
+// Only clients this binary knows are checked. A future client key is ignored
+// per A3/A4 — it is unavailable here, and rejecting the manifest over content
+// this binary would never materialize is exactly the breakage ignore-unknown
+// exists to prevent.
+func (m *Manifest) checkTiers() error {
+	if m.Layout != nil {
+		return nil
+	}
+	var tier1 []string
+	for _, id := range m.AvailableClients() {
+		if m.Tier(id) == TierLayout {
+			tier1 = append(tier1, id)
+		}
+	}
+	if len(tier1) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"client(s) %s declare no payloads, which makes them Tier 1, but the manifest has no \"layout\". "+
+			"Add a layout with agents and skills paths, or declare payloads to make them Tier 2",
+		strings.Join(tier1, ", "))
+}
+
+// checkPaths rejects any repo-relative path that is absolute or escapes the
+// agentpakke checkout. Applied to every path the manifest can point at, not
+// only payloads: all of them are resolved against a cloned repo at install and
+// launch time.
+func (m *Manifest) checkPaths() error {
+	type ref struct{ field, value string }
+	var refs []ref
+
+	for _, client := range m.ClientIDs() {
+		entry := m.Clients[client]
+		contexts := make([]string, 0, len(entry.Payloads))
+		for ctx := range entry.Payloads {
+			contexts = append(contexts, ctx)
+		}
+		sort.Strings(contexts)
+		for _, ctx := range contexts {
+			p := entry.Payloads[ctx]
+			base := fmt.Sprintf("clients.%s.payloads.%s", client, ctx)
+			refs = append(refs, ref{base + ".path", p.Path})
+			if p.Manifest != "" {
+				refs = append(refs, ref{base + ".manifest", p.Manifest})
+			}
+		}
+	}
+	if m.Layout != nil {
+		refs = append(refs,
+			ref{"layout.agents", m.Layout.Agents},
+			ref{"layout.skills", m.Layout.Skills},
+			ref{"layout.instructions", m.Layout.Instructions},
+			ref{"layout.prompts", m.Layout.Prompts},
+		)
+	}
+	if m.Policies != nil {
+		refs = append(refs, ref{"policies.opencodePermissions", m.Policies.OpenCodePermissions})
+	}
+	if m.Profiles != nil {
+		refs = append(refs, ref{"profiles.dir", m.Profiles.Dir})
+	}
+
+	for _, r := range refs {
+		if r.value == "" {
+			continue
+		}
+		if err := checkRelPath(r.value); err != nil {
+			return fmt.Errorf("%s: %w", r.field, err)
+		}
+	}
+	return nil
+}
+
+// checkRelPath validates a manifest path as repo-relative and contained.
+// Manifest paths always use forward slashes, so this reasons in slash space and
+// additionally rejects backslashes, which would otherwise pass on Linux and
+// resolve as separators on Windows.
+func checkRelPath(p string) error {
+	if strings.TrimSpace(p) != p || p == "" {
+		return fmt.Errorf("path %q must not be empty or padded with whitespace", p)
+	}
+	if strings.ContainsAny(p, `\`) {
+		return fmt.Errorf("path %q must use forward slashes and be relative to the agentpakke repo root", p)
+	}
+	if path.IsAbs(p) || filepath.IsAbs(p) || strings.HasPrefix(p, "~") {
+		return fmt.Errorf("path %q is absolute; agentpakke paths must be relative to the repo root", p)
+	}
+	clean := path.Clean(p)
+	if clean == ".." || strings.HasPrefix(clean, "../") {
+		return fmt.Errorf("path %q escapes the agentpakke repo root; use a path inside the repo", p)
+	}
+	return nil
+}
+
+// ValidateSource runs the deeper conformance checks that need the agentpakke
+// checkout on disk, and returns every violation it finds rather than the first
+// — an agentpakke author fixing CI wants the whole list.
+//
+// It is the check `nav-pilot validate` performs on top of [Load]: referenced
+// layout directories exist, payload trees exist, and every Tier 2 payload
+// carries a payload manifest (A7).
+//
+// A nil/empty result means the checkout conforms. A missing manifest is
+// reported as a single error matching [ErrNoManifest].
+func ValidateSource(sourceRoot string) []error {
+	m, err := Load(sourceRoot)
+	if err != nil {
+		return []error{err}
+	}
+	return m.validateContent(sourceRoot)
+}
+
+// validateContent checks a validated manifest against the files on disk.
+func (m *Manifest) validateContent(sourceRoot string) []error {
+	var errs []error
+
+	if m.Layout != nil && m.HasTier(TierLayout) {
+		for _, d := range []struct{ field, value string }{
+			{"layout.agents", m.Layout.Agents},
+			{"layout.skills", m.Layout.Skills},
+			{"layout.instructions", m.Layout.Instructions},
+			{"layout.prompts", m.Layout.Prompts},
+		} {
+			if d.value == "" {
+				continue
+			}
+			if err := requireDir(sourceRoot, d.field, d.value); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			if d.field == "layout.agents" {
+				errs = append(errs, checkAgentFiles(filepath.Join(sourceRoot, filepath.FromSlash(d.value)), d.field)...)
+			}
+		}
+	}
+
+	for _, client := range m.ClientIDs() {
+		entry := m.Clients[client]
+		contexts := make([]string, 0, len(entry.Payloads))
+		for ctx := range entry.Payloads {
+			contexts = append(contexts, ctx)
+		}
+		sort.Strings(contexts)
+		for _, ctx := range contexts {
+			p := entry.Payloads[ctx]
+			field := fmt.Sprintf("clients.%s.payloads.%s", client, ctx)
+			if err := requireDir(sourceRoot, field+".path", p.Path); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			manifestRel := p.ManifestPath()
+			if err := requireFile(sourceRoot, field, manifestRel); err != nil {
+				errs = append(errs, fmt.Errorf(
+					"%w; every Tier 2 payload must ship a payload manifest (A7) — nav-pilot refuses to stage an unmanifested payload",
+					err))
+			}
+		}
+	}
+
+	if m.Policies != nil && m.Policies.OpenCodePermissions != "" {
+		if err := requireFile(sourceRoot, "policies.opencodePermissions", m.Policies.OpenCodePermissions); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if m.Profiles != nil && m.Profiles.Dir != "" {
+		if err := requireDir(sourceRoot, "profiles.dir", m.Profiles.Dir); err != nil {
+			errs = append(errs, err)
+		} else if m.Profiles.Default != "" {
+			if err := requireFile(sourceRoot, "profiles.default",
+				path.Join(m.Profiles.Dir, m.Profiles.Default+".json")); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	return errs
+}
+
+// requireDir reports a manifest-referenced directory that is missing or is not
+// a directory.
+func requireDir(sourceRoot, field, rel string) error {
+	abs := filepath.Join(sourceRoot, filepath.FromSlash(rel))
+	info, err := os.Stat(abs)
+	if err != nil {
+		return fmt.Errorf("%s references %q, which does not exist in the agentpakke repo", field, rel)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s references %q, which is not a directory", field, rel)
+	}
+	return nil
+}
+
+// requireFile reports a manifest-referenced file that is missing or is not a
+// regular file.
+func requireFile(sourceRoot, field, rel string) error {
+	abs := filepath.Join(sourceRoot, filepath.FromSlash(rel))
+	info, err := os.Stat(abs)
+	if err != nil {
+		return fmt.Errorf("%s expects the file %q, which does not exist in the agentpakke repo", field, rel)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("%s expects the file %q, but it is a directory", field, rel)
+	}
+	return nil
+}
+
+// checkAgentFiles verifies that the Tier 1 agents directory holds agent files
+// and that each opens with YAML frontmatter, which the sync layer needs to read
+// name/description/model from.
+//
+// The check stays shallow on purpose: the frontmatter parser lives in
+// internal/source, which will itself consume this package's Manifest for the
+// Tier 1 layout resolver — importing it here would close that cycle. Deep
+// frontmatter conformance therefore belongs in the sync layer, where the parser
+// already runs.
+func checkAgentFiles(agentsDir, field string) []error {
+	entries, err := os.ReadDir(agentsDir)
+	if err != nil {
+		return []error{fmt.Errorf("%s: reading %q: %v", field, agentsDir, err)}
+	}
+	var errs []error
+	var found int
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), agentFileSuffix) {
+			continue
+		}
+		found++
+		data, err := os.ReadFile(filepath.Join(agentsDir, e.Name()))
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: reading %q: %v", field, e.Name(), err))
+			continue
+		}
+		if !hasFrontmatter(data) {
+			errs = append(errs, fmt.Errorf(
+				"%s: %q has no YAML frontmatter; agent files must open with a --- delimited block declaring at least name and description",
+				field, e.Name()))
+		}
+	}
+	if found == 0 {
+		errs = append(errs, fmt.Errorf("%s: %q contains no *%s files", field, agentsDir, agentFileSuffix))
+	}
+	return errs
+}
+
+// agentFileSuffix is the agent file extension in nav-pilot's content layout.
+const agentFileSuffix = ".agent.md"
+
+// hasFrontmatter reports whether a markdown file opens with a --- delimited
+// block. It mirrors the opening condition of internal/source.SplitFrontmatter
+// without importing it (see checkAgentFiles).
+func hasFrontmatter(data []byte) bool {
+	text := strings.ReplaceAll(string(data), "\r\n", "\n")
+	text = strings.TrimLeft(text, " \t\n")
+	if !strings.HasPrefix(text, "---") {
+		return false
+	}
+	rest := text[len("---"):]
+	nl := strings.IndexByte(rest, '\n')
+	if nl < 0 {
+		return false
+	}
+	for _, line := range strings.Split(rest[nl+1:], "\n") {
+		if strings.TrimRight(line, " \t") == "---" {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/nav-pilot/internal/agentpakke/load.go
+++ b/cli/nav-pilot/internal/agentpakke/load.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/domain"
 )
 
 // ErrNoManifest reports that a source checkout ships no agentpakke manifest.
@@ -107,9 +109,18 @@ func (m *Manifest) checkContractVersion() error {
 // Development and unset builds are exempt: they carry no comparable version,
 // and gating them would block local work on an agentpakke.
 func (m *Manifest) checkMinVersion(runningVersion string) error {
-	required := strings.TrimSpace(m.MinNavPilotVersion)
-	if required == "" || !isReleaseVersion(required) {
+	// The raw value is checked, not a trimmed copy: padding is a malformed
+	// declaration of a known field, and checkRelPath rejects it for paths too.
+	required := m.MinNavPilotVersion
+	if strings.TrimSpace(required) == "" {
 		return nil
+	}
+	if !isReleaseVersionFormat(required) {
+		return fmt.Errorf(
+			"minNavPilotVersion %q is not a nav-pilot release version. "+
+				"Use the YYYY.MM.DD-HHMMSS-sha7 format (for example 2026.09.01-120000-a1b2c3d); "+
+				"a value nav-pilot cannot compare would silently disable the minimum-version gate instead of enforcing it",
+			m.MinNavPilotVersion)
 	}
 	if !isReleaseVersion(runningVersion) {
 		return nil
@@ -305,10 +316,13 @@ func (m *Manifest) validateContent(sourceRoot string) []error {
 	return errs
 }
 
-// requireDir reports a manifest-referenced directory that is missing or is not
-// a directory.
+// requireDir reports a manifest-referenced directory that is missing, is not a
+// directory, or is not really inside the repo.
 func requireDir(sourceRoot, field, rel string) error {
 	abs := filepath.Join(sourceRoot, filepath.FromSlash(rel))
+	if err := requireContained(sourceRoot, field, rel); err != nil {
+		return err
+	}
 	info, err := os.Stat(abs)
 	if err != nil {
 		return fmt.Errorf("%s references %q, which does not exist in the agentpakke repo", field, rel)
@@ -319,16 +333,40 @@ func requireDir(sourceRoot, field, rel string) error {
 	return nil
 }
 
-// requireFile reports a manifest-referenced file that is missing or is not a
-// regular file.
+// requireFile reports a manifest-referenced file that is missing, is not a
+// regular file, or is not really inside the repo.
 func requireFile(sourceRoot, field, rel string) error {
 	abs := filepath.Join(sourceRoot, filepath.FromSlash(rel))
+	if err := requireContained(sourceRoot, field, rel); err != nil {
+		return err
+	}
 	info, err := os.Stat(abs)
 	if err != nil {
 		return fmt.Errorf("%s expects the file %q, which does not exist in the agentpakke repo", field, rel)
 	}
 	if info.IsDir() {
 		return fmt.Errorf("%s expects the file %q, but it is a directory", field, rel)
+	}
+	return nil
+}
+
+// requireContained is checkRelPath's on-disk counterpart. checkRelPath rules out
+// paths that are textually outside the repo; this rules out paths that are
+// textually inside it and physically elsewhere — a symlinked layout directory,
+// or a link somewhere along the way to one. nav-pilot reads and copies from
+// these paths, so what they resolve to is what matters, and os.Stat alone would
+// follow the link and call it conforming.
+func requireContained(sourceRoot, field, rel string) error {
+	abs := filepath.Join(sourceRoot, filepath.FromSlash(rel))
+	if info, err := os.Lstat(abs); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf(
+			"%s references %q, which is a symlink; agentpakke content must be real files and directories inside the repo",
+			field, rel)
+	}
+	if !domain.PathWithinRoot(sourceRoot, abs) {
+		return fmt.Errorf(
+			"%s references %q, which resolves outside the agentpakke repo through a symlinked parent directory",
+			field, rel)
 	}
 	return nil
 }
@@ -354,6 +392,13 @@ func checkAgentFiles(agentsDir, field string) []error {
 			continue
 		}
 		found++
+		// A symlinked agent file reads whatever it points at — including files
+		// outside the checkout — so it is refused rather than parsed.
+		if e.Type()&os.ModeSymlink != 0 {
+			errs = append(errs, fmt.Errorf(
+				"%s: %q is a symlink; agent files must be real files inside the agentpakke repo", field, e.Name()))
+			continue
+		}
 		data, err := os.ReadFile(filepath.Join(agentsDir, e.Name()))
 		if err != nil {
 			errs = append(errs, fmt.Errorf("%s: reading %q: %v", field, e.Name(), err))

--- a/cli/nav-pilot/internal/agentpakke/load_test.go
+++ b/cli/nav-pilot/internal/agentpakke/load_test.go
@@ -1,0 +1,574 @@
+package agentpakke
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// grillmesterManifest is the reference agentpakke manifest from the PRD's
+// worked example, adjusted to the decided design (no `collections` field; the
+// manifest supersedes the collection model).
+const grillmesterManifest = `{
+  "contractVersion": "1",
+  "name": "grillmester",
+  "description": "A Copilot agent team for clarified software delivery, design, and product work with portable progressive skills.",
+  "owner": { "repo": "navikt/grillmester", "team": "Team eSyfo" },
+  "clients": {
+    "copilot": {
+      "primaryAgents": ["grillmester", "barista", "designer", "doctor-who"],
+      "compatibility": ">=1.0.79,<2",
+      "defaultModel": "gpt-5.6-sol",
+      "defaultContext": "full",
+      "payloads": {
+        "full": { "path": "plugin" },
+        "focused": { "path": "targets/copilot-cli-focused-v1" }
+      }
+    },
+    "opencode": {
+      "primaryAgents": ["grillmester", "barista", "designer", "doctor-who"],
+      "compatibility": ">=1.18.20,<2",
+      "defaultModel": "inherit",
+      "payloads": {
+        "full": { "path": "targets/opencode-v1" },
+        "focused": { "path": "targets/opencode-v1-focused" }
+      }
+    }
+  },
+  "provenance": {
+    "base": { "repo": "navikt/copilot", "digest": "sha256:abc" },
+    "overlays": [ { "component": "grillmester", "version": "0.3.0-rc.8" } ]
+  },
+  "profiles": { "dir": "profiles/opencode", "default": "hybrid" },
+  "minNavPilotVersion": "2026.09.01-000000-0000000"
+}`
+
+// devVersion stands in for a development build, which is exempt from the
+// minNavPilotVersion gate.
+const devVersion = "dev"
+
+func TestParseValidManifest(t *testing.T) {
+	m, err := parse([]byte(grillmesterManifest), devVersion)
+	if err != nil {
+		t.Fatalf("parse(grillmester) = %v, want nil", err)
+	}
+	if m.Name != "grillmester" {
+		t.Errorf("Name = %q, want %q", m.Name, "grillmester")
+	}
+	if got := m.ClientIDs(); len(got) != 2 || got[0] != "copilot" || got[1] != "opencode" {
+		t.Errorf("ClientIDs() = %v, want [copilot opencode]", got)
+	}
+	if got := m.Tier("copilot"); got != TierPayload {
+		t.Errorf("Tier(copilot) = %d, want %d", got, TierPayload)
+	}
+	if !m.IsPrimaryAgent("opencode", "barista") {
+		t.Error("IsPrimaryAgent(opencode, barista) = false, want true")
+	}
+	if m.IsPrimaryAgent("opencode", "kokk") {
+		t.Error("IsPrimaryAgent(opencode, kokk) = true, want false")
+	}
+	if got := m.DefaultModel("opencode"); got != InheritModel {
+		t.Errorf("DefaultModel(opencode) = %q, want %q", got, InheritModel)
+	}
+	// opencode declares no defaultContext, so it falls back to "full".
+	if got := m.DefaultContext("opencode"); got != DefaultContext {
+		t.Errorf("DefaultContext(opencode) = %q, want %q", got, DefaultContext)
+	}
+	if got, ok := m.PayloadManifestPath("opencode", "focused"); !ok || got != "targets/opencode-v1-focused/manifest.json" {
+		t.Errorf("PayloadManifestPath(opencode, focused) = %q, %v; want conventional <path>/manifest.json", got, ok)
+	}
+	if m.Provenance == nil || m.Provenance.Base == nil || m.Provenance.Base.Repo != "navikt/copilot" {
+		t.Errorf("Provenance.Base = %+v, want navikt/copilot", m.Provenance)
+	}
+	if m.Profiles == nil || m.Profiles.Default != "hybrid" {
+		t.Errorf("Profiles = %+v, want default hybrid", m.Profiles)
+	}
+}
+
+func TestParseIgnoresUnknownConstructs(t *testing.T) {
+	tests := []struct {
+		name  string
+		patch func(map[string]any)
+		check func(t *testing.T, m *Manifest)
+	}{
+		{
+			name: "unknown client key",
+			patch: func(doc map[string]any) {
+				clients := doc["clients"].(map[string]any)
+				clients["claude-code"] = map[string]any{"primaryAgents": []any{"grillmester"}}
+			},
+			check: func(t *testing.T, m *Manifest) {
+				if _, ok := m.Client("claude-code"); !ok {
+					t.Error("unknown client key was dropped, want it retained for forward compatibility")
+				}
+			},
+		},
+		{
+			name: "unknown context key",
+			patch: func(doc map[string]any) {
+				clients := doc["clients"].(map[string]any)
+				oc := clients["opencode"].(map[string]any)
+				oc["payloads"].(map[string]any)["tiny"] = map[string]any{"path": "targets/tiny"}
+			},
+			check: func(t *testing.T, m *Manifest) {
+				if _, ok := m.Payload("opencode", "tiny"); !ok {
+					t.Error("unknown context key was dropped, want it retained")
+				}
+			},
+		},
+		{
+			name: "unknown top-level field",
+			patch: func(doc map[string]any) {
+				doc["experimentalThing"] = map[string]any{"enabled": true}
+			},
+			check: func(t *testing.T, m *Manifest) {
+				if m.Name != "grillmester" {
+					t.Errorf("Name = %q after unknown field, want grillmester", m.Name)
+				}
+			},
+		},
+		{
+			name: "unknown field inside a client entry",
+			patch: func(doc map[string]any) {
+				clients := doc["clients"].(map[string]any)
+				clients["opencode"].(map[string]any)["minCpltVersion"] = "1.2.3"
+			},
+			check: func(t *testing.T, m *Manifest) {
+				if m.Tier("opencode") != TierPayload {
+					t.Error("unknown client field changed the derived tier")
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := parse(patchManifest(t, grillmesterManifest, tt.patch), devVersion)
+			if err != nil {
+				t.Fatalf("parse = %v, want nil (unknown constructs must be ignored, not rejected)", err)
+			}
+			tt.check(t, m)
+		})
+	}
+}
+
+func TestParseRejectsMalformedKnownConstructs(t *testing.T) {
+	tests := []struct {
+		name     string
+		patch    func(map[string]any)
+		wantErrs []string
+	}{
+		{
+			name: "unsupported contractVersion",
+			patch: func(doc map[string]any) {
+				doc["contractVersion"] = "2"
+			},
+			wantErrs: []string{"contractVersion", "supported"},
+		},
+		{
+			name: "contractVersion of the wrong type",
+			patch: func(doc map[string]any) {
+				doc["contractVersion"] = 1
+			},
+			wantErrs: []string{"contractVersion"},
+		},
+		{
+			name: "missing primaryAgents",
+			patch: func(doc map[string]any) {
+				delete(doc["clients"].(map[string]any)["opencode"].(map[string]any), "primaryAgents")
+			},
+			wantErrs: []string{"clients.opencode", "primaryAgents"},
+		},
+		{
+			name: "empty primaryAgents",
+			patch: func(doc map[string]any) {
+				doc["clients"].(map[string]any)["opencode"].(map[string]any)["primaryAgents"] = []any{}
+			},
+			wantErrs: []string{"primaryAgents"},
+		},
+		{
+			name: "no clients at all",
+			patch: func(doc map[string]any) {
+				doc["clients"] = map[string]any{}
+			},
+			wantErrs: []string{"clients"},
+		},
+		{
+			name: "missing name",
+			patch: func(doc map[string]any) {
+				delete(doc, "name")
+			},
+			wantErrs: []string{"name"},
+		},
+		{
+			name: "name is not an identifier",
+			patch: func(doc map[string]any) {
+				doc["name"] = "Grill Mester"
+			},
+			wantErrs: []string{"name", "^[a-z]"},
+		},
+		{
+			name: "payload without path",
+			patch: func(doc map[string]any) {
+				oc := doc["clients"].(map[string]any)["opencode"].(map[string]any)
+				oc["payloads"].(map[string]any)["full"] = map[string]any{}
+			},
+			wantErrs: []string{"payloads", "path"},
+		},
+		{
+			name: "absolute payload path",
+			patch: func(doc map[string]any) {
+				oc := doc["clients"].(map[string]any)["opencode"].(map[string]any)
+				oc["payloads"].(map[string]any)["full"] = map[string]any{"path": "/etc/passwd"}
+			},
+			wantErrs: []string{"clients.opencode.payloads.full.path", "absolute", "relative"},
+		},
+		{
+			name: "escaping payload path",
+			patch: func(doc map[string]any) {
+				oc := doc["clients"].(map[string]any)["opencode"].(map[string]any)
+				oc["payloads"].(map[string]any)["full"] = map[string]any{"path": "../../elsewhere"}
+			},
+			wantErrs: []string{"clients.opencode.payloads.full.path", "escapes"},
+		},
+		{
+			name: "escaping payload manifest override",
+			patch: func(doc map[string]any) {
+				oc := doc["clients"].(map[string]any)["opencode"].(map[string]any)
+				oc["payloads"].(map[string]any)["full"] = map[string]any{
+					"path":     "targets/opencode-v1",
+					"manifest": "../secrets/manifest.json",
+				}
+			},
+			wantErrs: []string{"clients.opencode.payloads.full.manifest", "escapes"},
+		},
+		{
+			name: "tier 1 client without layout",
+			patch: func(doc map[string]any) {
+				clients := doc["clients"].(map[string]any)
+				clients["copilot"] = map[string]any{"primaryAgents": []any{"grillmester"}}
+			},
+			wantErrs: []string{"copilot", "Tier 1", "layout"},
+		},
+		{
+			name: "layout without skills",
+			patch: func(doc map[string]any) {
+				doc["layout"] = map[string]any{"agents": "plugin/agents"}
+			},
+			wantErrs: []string{"layout", "skills"},
+		},
+		{
+			name: "absolute layout path",
+			patch: func(doc map[string]any) {
+				doc["layout"] = map[string]any{"agents": "/srv/agents", "skills": "plugin/skills"}
+			},
+			wantErrs: []string{"layout.agents", "absolute"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parse(patchManifest(t, grillmesterManifest, tt.patch), devVersion)
+			if err == nil {
+				t.Fatal("parse = nil, want an error (malformed known constructs must fail closed)")
+			}
+			for _, want := range tt.wantErrs {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q does not mention %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+func TestParseRejectsInvalidJSON(t *testing.T) {
+	_, err := parse([]byte("{not json"), devVersion)
+	if err == nil {
+		t.Fatal("parse(invalid json) = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "not valid JSON") {
+		t.Errorf("error %q should say the manifest is not valid JSON", err)
+	}
+}
+
+func TestMinNavPilotVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		running  string
+		required string
+		wantErr  bool
+	}{
+		{"running binary is newer", "2026.10.01-120000-abc1234", "2026.09.01-000000-0000000", false},
+		{"running binary is exactly the minimum", "2026.09.01-000000-0000000", "2026.09.01-000000-0000000", false},
+		{"running binary is older", "2026.08.01-120000-abc1234", "2026.09.01-000000-0000000", true},
+		{"same day, older build time", "2026.09.01-000000-abc1234", "2026.09.01-120000-0000000", true},
+		{"dev build is exempt", "dev", "2099.01.01-000000-0000000", false},
+		{"unset version is exempt", "", "2099.01.01-000000-0000000", false},
+		{"no minimum declared", "2020.01.01-000000-abc1234", "", false},
+		{"unparseable minimum is not enforced", "2020.01.01-000000-abc1234", "whenever", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := patchManifest(t, grillmesterManifest, func(doc map[string]any) {
+				if tt.required == "" {
+					delete(doc, "minNavPilotVersion")
+					return
+				}
+				doc["minNavPilotVersion"] = tt.required
+			})
+			_, err := parse(data, tt.running)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("parse = nil, want a version error")
+				}
+				for _, want := range []string{tt.required, tt.running, "nav-pilot update"} {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("error %q does not mention %q", err, want)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parse = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestSetVersion(t *testing.T) {
+	original := cliVersion
+	t.Cleanup(func() { cliVersion = original })
+
+	SetVersion("2020.01.01-000000-abc1234")
+	if err := Validate([]byte(grillmesterManifest)); err == nil {
+		t.Fatal("Validate = nil with an old running version, want a minNavPilotVersion error")
+	}
+	SetVersion("2099.01.01-000000-abc1234")
+	if err := Validate([]byte(grillmesterManifest)); err != nil {
+		t.Fatalf("Validate = %v with a new running version, want nil", err)
+	}
+}
+
+func TestLoad(t *testing.T) {
+	root := t.TempDir()
+	writeManifest(t, root, grillmesterManifest)
+
+	m, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load = %v, want nil", err)
+	}
+	if m.Name != "grillmester" {
+		t.Errorf("Name = %q, want grillmester", m.Name)
+	}
+}
+
+func TestLoadNoManifestFallback(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T) string
+	}{
+		{
+			name:  "empty source checkout",
+			setup: func(t *testing.T) string { return t.TempDir() },
+		},
+		{
+			name: "legacy layout without .nav-pilot",
+			setup: func(t *testing.T) string {
+				root := t.TempDir()
+				mkdirAll(t, filepath.Join(root, "agents"))
+				mkdirAll(t, filepath.Join(root, "skills"))
+				return root
+			},
+		},
+		{
+			name: ".nav-pilot dir without a manifest",
+			setup: func(t *testing.T) string {
+				root := t.TempDir()
+				mkdirAll(t, filepath.Join(root, ManifestDir))
+				return root
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Load(tt.setup(t))
+			if !errors.Is(err, ErrNoManifest) {
+				t.Fatalf("Load = %v, want an error matching ErrNoManifest so callers fall back to the legacy adapter", err)
+			}
+		})
+	}
+}
+
+func TestLoadInvalidManifestFailsClosed(t *testing.T) {
+	root := t.TempDir()
+	writeManifest(t, root, `{"contractVersion": "9", "name": "x", "description": "d", "clients": {"opencode": {"primaryAgents": ["x"]}}, "layout": {"agents": "a", "skills": "s"}}`)
+
+	_, err := Load(root)
+	if err == nil {
+		t.Fatal("Load = nil, want an error")
+	}
+	if errors.Is(err, ErrNoManifest) {
+		t.Fatal("an existing but invalid manifest must not fall back to the legacy adapter")
+	}
+	if !strings.Contains(err.Error(), ManifestFile) {
+		t.Errorf("error %q should name the offending file", err)
+	}
+}
+
+// --- ValidateSource ---
+
+func TestValidateSourceTier2(t *testing.T) {
+	root := t.TempDir()
+	writeManifest(t, root, grillmesterManifest)
+	for _, dir := range []string{
+		"plugin", "targets/copilot-cli-focused-v1",
+		"targets/opencode-v1", "targets/opencode-v1-focused",
+	} {
+		mkdirAll(t, filepath.Join(root, filepath.FromSlash(dir)))
+		writeFile(t, filepath.Join(root, filepath.FromSlash(dir), PayloadManifestFile), `{"schemaVersion":1}`)
+	}
+	mkdirAll(t, filepath.Join(root, "profiles", "opencode"))
+	writeFile(t, filepath.Join(root, "profiles", "opencode", "hybrid.json"), `{}`)
+
+	if errs := ValidateSource(root); len(errs) != 0 {
+		t.Fatalf("ValidateSource = %v, want no violations", errs)
+	}
+}
+
+func TestValidateSourceReportsEveryViolation(t *testing.T) {
+	root := t.TempDir()
+	writeManifest(t, root, grillmesterManifest)
+	// plugin/ exists but ships no payload manifest — grillmester's known A7 gap.
+	mkdirAll(t, filepath.Join(root, "plugin"))
+	// The other payload trees are missing entirely.
+
+	errs := ValidateSource(root)
+	if len(errs) < 2 {
+		t.Fatalf("ValidateSource returned %d errors, want every violation reported: %v", len(errs), errs)
+	}
+	joined := joinErrs(errs)
+	for _, want := range []string{
+		"clients.copilot.payloads.full",
+		"payload manifest",
+		"targets/opencode-v1",
+		"profiles.dir",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("violations %q do not mention %q", joined, want)
+		}
+	}
+}
+
+func TestValidateSourceTier1(t *testing.T) {
+	manifest := `{
+  "contractVersion": "1",
+  "name": "eksempel",
+  "description": "Tier 1 agentpakke",
+  "clients": { "opencode": { "primaryAgents": ["eksempel"] } },
+  "layout": { "agents": "agents", "skills": "skills" }
+}`
+
+	t.Run("conforming", func(t *testing.T) {
+		root := t.TempDir()
+		writeManifest(t, root, manifest)
+		mkdirAll(t, filepath.Join(root, "agents"))
+		mkdirAll(t, filepath.Join(root, "skills"))
+		writeFile(t, filepath.Join(root, "agents", "eksempel.agent.md"),
+			"---\nname: eksempel\ndescription: Et eksempel\n---\n\nBody\n")
+
+		if errs := ValidateSource(root); len(errs) != 0 {
+			t.Fatalf("ValidateSource = %v, want no violations", errs)
+		}
+	})
+
+	t.Run("missing layout dir", func(t *testing.T) {
+		root := t.TempDir()
+		writeManifest(t, root, manifest)
+		mkdirAll(t, filepath.Join(root, "agents"))
+		writeFile(t, filepath.Join(root, "agents", "eksempel.agent.md"), "---\nname: eksempel\n---\n")
+
+		errs := ValidateSource(root)
+		if joined := joinErrs(errs); !strings.Contains(joined, "layout.skills") {
+			t.Fatalf("violations %q should name the missing layout.skills directory", joined)
+		}
+	})
+
+	t.Run("agent without frontmatter", func(t *testing.T) {
+		root := t.TempDir()
+		writeManifest(t, root, manifest)
+		mkdirAll(t, filepath.Join(root, "agents"))
+		mkdirAll(t, filepath.Join(root, "skills"))
+		writeFile(t, filepath.Join(root, "agents", "eksempel.agent.md"), "# No frontmatter here\n")
+
+		errs := ValidateSource(root)
+		if joined := joinErrs(errs); !strings.Contains(joined, "frontmatter") {
+			t.Fatalf("violations %q should flag the missing frontmatter", joined)
+		}
+	})
+
+	t.Run("agents dir with no agent files", func(t *testing.T) {
+		root := t.TempDir()
+		writeManifest(t, root, manifest)
+		mkdirAll(t, filepath.Join(root, "agents"))
+		mkdirAll(t, filepath.Join(root, "skills"))
+
+		errs := ValidateSource(root)
+		if joined := joinErrs(errs); !strings.Contains(joined, agentFileSuffix) {
+			t.Fatalf("violations %q should flag the empty agents directory", joined)
+		}
+	})
+}
+
+func TestValidateSourceNoManifest(t *testing.T) {
+	errs := ValidateSource(t.TempDir())
+	if len(errs) != 1 || !errors.Is(errs[0], ErrNoManifest) {
+		t.Fatalf("ValidateSource = %v, want a single ErrNoManifest", errs)
+	}
+}
+
+// --- helpers ---
+
+// patchManifest decodes a manifest, applies a mutation, and re-encodes it, so
+// each test case states only what it changes.
+func patchManifest(t *testing.T, base string, patch func(map[string]any)) []byte {
+	t.Helper()
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(base), &doc); err != nil {
+		t.Fatalf("decoding base manifest: %v", err)
+	}
+	patch(doc)
+	data, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("encoding patched manifest: %v", err)
+	}
+	return data
+}
+
+func writeManifest(t *testing.T, root, content string) {
+	t.Helper()
+	mkdirAll(t, filepath.Join(root, ManifestDir))
+	writeFile(t, filepath.Join(root, ManifestDir, ManifestFile), content)
+}
+
+func mkdirAll(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func joinErrs(errs []error) string {
+	msgs := make([]string, 0, len(errs))
+	for _, err := range errs {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "\n")
+}

--- a/cli/nav-pilot/internal/agentpakke/load_test.go
+++ b/cli/nav-pilot/internal/agentpakke/load_test.go
@@ -306,7 +306,7 @@ func TestMinNavPilotVersion(t *testing.T) {
 		{"dev build is exempt", "dev", "2099.01.01-000000-0000000", false},
 		{"unset version is exempt", "", "2099.01.01-000000-0000000", false},
 		{"no minimum declared", "2020.01.01-000000-abc1234", "", false},
-		{"unparseable minimum is not enforced", "2020.01.01-000000-abc1234", "whenever", false},
+		{"minimum without a build sha still compares", "2026.10.01-120000-abc1234", "2026.09.01-000000", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -333,6 +333,64 @@ func TestMinNavPilotVersion(t *testing.T) {
 				t.Fatalf("parse = %v, want nil", err)
 			}
 		})
+	}
+}
+
+// TestMinNavPilotVersionMustBeAReleaseVersion covers the fail-closed half of
+// the gate: a minimum nav-pilot cannot compare (a bare date, a word) must be an
+// error, not a silently disabled check. Both layers enforce it — the published
+// schema, so an agentpakke's own CI lint catches it, and the semantic pass, so
+// a manifest reaching this binary another way still fails.
+func TestMinNavPilotVersionMustBeAReleaseVersion(t *testing.T) {
+	malformed := []string{
+		"2026.09.01",              // date only: compares older than every release
+		"2026.09.01-",             // truncated
+		"whenever",                // not a version at all
+		"v2026.09.01-120000-abc1", // tagged form
+		" 2026.09.01-120000",      // padded
+	}
+
+	for _, required := range malformed {
+		t.Run("schema/"+required, func(t *testing.T) {
+			data := patchManifest(t, grillmesterManifest, func(doc map[string]any) {
+				doc["minNavPilotVersion"] = required
+			})
+			err := Validate(data)
+			if err == nil {
+				t.Fatalf("Validate with minNavPilotVersion %q = nil, want a schema violation", required)
+			}
+			if !strings.Contains(err.Error(), "minNavPilotVersion") {
+				t.Errorf("error %q does not name the offending field", err)
+			}
+		})
+
+		t.Run("semantics/"+required, func(t *testing.T) {
+			// Bypass the schema pass: the semantic rule must stand on its own.
+			m := &Manifest{Name: "grillmester", MinNavPilotVersion: required}
+			err := m.checkMinVersion("2099.01.01-000000-abc1234")
+			if err == nil {
+				t.Fatalf("checkMinVersion with %q = nil, want a fail-closed error", required)
+			}
+			if !strings.Contains(err.Error(), "YYYY.MM.DD-HHMMSS") {
+				t.Errorf("error %q does not say what the format is", err)
+			}
+		})
+
+		t.Run("dev-build/"+required, func(t *testing.T) {
+			// The dev-build exemption applies to the *running* version, never to
+			// a malformed declaration.
+			m := &Manifest{Name: "grillmester", MinNavPilotVersion: required}
+			if err := m.checkMinVersion(devVersion); err == nil {
+				t.Errorf("checkMinVersion(%q) on a dev build = nil, want the format error", required)
+			}
+		})
+	}
+
+	for _, required := range []string{"2026.09.01-120000", "2026.09.01-120000-a1b2c3d", "2026.09.01-120000-a1b2c3d4e5f6"} {
+		m := &Manifest{Name: "grillmester", MinNavPilotVersion: required}
+		if err := m.checkMinVersion("2099.01.01-000000-abc1234"); err != nil {
+			t.Errorf("checkMinVersion with the well-formed %q = %v, want nil", required, err)
+		}
 	}
 }
 

--- a/cli/nav-pilot/internal/agentpakke/schema.go
+++ b/cli/nav-pilot/internal/agentpakke/schema.go
@@ -164,6 +164,8 @@ func hintFor(loc []string, msg string) string {
 		}
 	case "layout":
 		return "layout requires agents and skills as repo-relative paths"
+	case "minNavPilotVersion":
+		return "expected a nav-pilot release version, e.g. 2026.09.01-120000-a1b2c3d"
 	}
 	return ""
 }

--- a/cli/nav-pilot/internal/agentpakke/schema.go
+++ b/cli/nav-pilot/internal/agentpakke/schema.go
@@ -1,0 +1,169 @@
+package agentpakke
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/navikt/copilot/cli/nav-pilot/schemas"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
+)
+
+// SchemaID is the published identity of the agentpakke manifest schema — the
+// $id an agentpakke repo references when linting its manifest in CI.
+const SchemaID = "https://github.com/navikt/copilot/cli/nav-pilot/schemas/agentpakke-v1.json"
+
+// SchemaJSON returns the published JSON Schema bytes. They come from the file
+// that ships in the repo (cli/nav-pilot/schemas/agentpakke-v1.json), so the
+// binary and an agentpakke repo's CI validate against identical bytes.
+func SchemaJSON() []byte {
+	out := make([]byte, len(schemas.AgentpakkeV1))
+	copy(out, schemas.AgentpakkeV1)
+	return out
+}
+
+var (
+	compileOnce sync.Once
+	compiled    *jsonschema.Schema
+	compileErr  error
+
+	// errPrinter renders the library's localized error kinds. The library keeps
+	// its own printer unexported, so validation messages need one here.
+	errPrinter = message.NewPrinter(language.English)
+)
+
+// schema compiles the embedded schema once. A compile failure is a defect in
+// this repo (the schema ships with the binary), not something a manifest author
+// can fix.
+func schema() (*jsonschema.Schema, error) {
+	compileOnce.Do(func() {
+		doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(schemas.AgentpakkeV1))
+		if err != nil {
+			compileErr = fmt.Errorf("parsing embedded agentpakke schema: %w", err)
+			return
+		}
+		c := jsonschema.NewCompiler()
+		if err := c.AddResource(SchemaID, doc); err != nil {
+			compileErr = fmt.Errorf("loading embedded agentpakke schema: %w", err)
+			return
+		}
+		compiled, err = c.Compile(SchemaID)
+		if err != nil {
+			compileErr = fmt.Errorf("compiling embedded agentpakke schema: %w", err)
+		}
+	})
+	return compiled, compileErr
+}
+
+// validateSchema checks raw manifest bytes against the published JSON Schema
+// and rewrites library errors into actionable ones (A3: what is wrong, where,
+// and what the contract expects).
+func validateSchema(data []byte) error {
+	sch, err := schema()
+	if err != nil {
+		return err
+	}
+	inst, err := jsonschema.UnmarshalJSON(bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("%s is not valid JSON: %w", ManifestPath, err)
+	}
+	if err := sch.Validate(inst); err != nil {
+		var verr *jsonschema.ValidationError
+		if !errors.As(err, &verr) {
+			return fmt.Errorf("%s failed schema validation: %w", ManifestPath, err)
+		}
+		return schemaError(verr)
+	}
+	return nil
+}
+
+// schemaError turns a jsonschema ValidationError tree into a single actionable
+// message: one line per concrete violation, each naming the manifest field by
+// path plus a hint drawn from the contract.
+func schemaError(verr *jsonschema.ValidationError) error {
+	causes := leafCauses(verr, nil)
+	lines := make([]string, 0, len(causes))
+	seen := make(map[string]bool, len(causes))
+	for _, c := range causes {
+		line := "  - " + describeCause(c)
+		if seen[line] {
+			continue
+		}
+		seen[line] = true
+		lines = append(lines, line)
+	}
+	sort.Strings(lines)
+	return fmt.Errorf(
+		"%s does not conform to the agentpakke contract (schema %s):\n%s\n"+
+			"fix the manifest, or lint it against the published schema in your own CI before pushing",
+		ManifestPath, SchemaID, strings.Join(lines, "\n"))
+}
+
+// leafCauses flattens a ValidationError tree to its most specific failures;
+// intermediate nodes only restate that some subschema failed.
+func leafCauses(verr *jsonschema.ValidationError, acc []*jsonschema.ValidationError) []*jsonschema.ValidationError {
+	if len(verr.Causes) == 0 {
+		return append(acc, verr)
+	}
+	for _, c := range verr.Causes {
+		acc = leafCauses(c, acc)
+	}
+	return acc
+}
+
+// describeCause renders one violation as "<field>: <what failed> (<how to fix>)".
+func describeCause(c *jsonschema.ValidationError) string {
+	loc := instanceLocation(c.InstanceLocation)
+	msg := strings.TrimSpace(c.ErrorKind.LocalizedString(errPrinter))
+	if hint := hintFor(c.InstanceLocation, msg); hint != "" {
+		return fmt.Sprintf("%s: %s (%s)", loc, msg, hint)
+	}
+	return fmt.Sprintf("%s: %s", loc, msg)
+}
+
+// instanceLocation renders a JSON pointer path as a readable field reference.
+func instanceLocation(parts []string) string {
+	if len(parts) == 0 {
+		return "manifest root"
+	}
+	return strings.Join(parts, ".")
+}
+
+// hintFor adds contract guidance for the violations manifest authors hit most,
+// so an error says how to fix it and not only what failed.
+func hintFor(loc []string, msg string) string {
+	if len(loc) == 0 {
+		switch {
+		case strings.Contains(msg, "contractVersion"):
+			return "supported contract versions: " + strings.Join(SupportedContractMajors, ", ")
+		case strings.Contains(msg, "clients"):
+			return `declare at least one client, e.g. "clients": {"opencode": {"primaryAgents": ["nav-pilot"]}}`
+		}
+		return ""
+	}
+	switch loc[0] {
+	case "contractVersion":
+		return `expected "1" or "1.<minor>"; supported: ` + strings.Join(SupportedContractMajors, ", ")
+	case "name":
+		return "lowercase identifier: ^[a-z][a-z0-9-]*$"
+	case "clients":
+		switch {
+		case len(loc) == 1:
+			return "declare at least one client entry"
+		case len(loc) == 2:
+			return "a client entry needs primaryAgents; add payloads for Tier 2, or rely on the top-level layout for Tier 1"
+		case loc[2] == "primaryAgents":
+			return "list at least one agent name selectable in this client"
+		case loc[2] == "payloads":
+			return `each context maps to {"path": "<dir>"}; its payload manifest resolves to <path>/manifest.json`
+		}
+	case "layout":
+		return "layout requires agents and skills as repo-relative paths"
+	}
+	return ""
+}

--- a/cli/nav-pilot/internal/agentpakke/version.go
+++ b/cli/nav-pilot/internal/agentpakke/version.go
@@ -1,0 +1,45 @@
+package agentpakke
+
+import "strings"
+
+// cliVersion is the running binary version, injected by package main at startup
+// (mirrors internal/provider's SetVersion seam). Development builds leave it at
+// "dev", which disables the minNavPilotVersion gate.
+var cliVersion = "dev"
+
+// SetVersion sets the running CLI version used for minNavPilotVersion checks.
+// Called once from main().
+func SetVersion(v string) { cliVersion = v }
+
+// versionTimestamp extracts the sortable date-time prefix of a nav-pilot
+// release version: "2026.04.14-202800-a25f6c3" → "2026.04.14-202800".
+//
+// Deliberately duplicated from internal/artifacts rather than imported: this
+// package is a dependency of the install/sync layers that artifacts belongs to,
+// and importing upward would close a cycle once stage 2 wires the manifest into
+// them.
+func versionTimestamp(v string) string {
+	parts := strings.SplitN(v, "-", 3)
+	if len(parts) >= 2 {
+		return parts[0] + "-" + parts[1]
+	}
+	return v
+}
+
+// isReleaseVersion reports whether a version string carries the comparable
+// YYYY.MM.DD-HHMMSS release shape. Development and unset builds ("dev", "",
+// "v0.0.0-…") do not, and are exempt from version gating.
+func isReleaseVersion(v string) bool {
+	ts := versionTimestamp(strings.TrimSpace(v))
+	if len(ts) == 0 || ts[0] < '0' || ts[0] > '9' {
+		return false
+	}
+	return strings.Contains(ts, "-")
+}
+
+// versionOlder reports whether running is strictly older than required.
+// The release format is zero-padded and fixed-width, so lexicographic
+// comparison of the date-time prefix is a correct ordering.
+func versionOlder(running, required string) bool {
+	return versionTimestamp(running) < versionTimestamp(required)
+}

--- a/cli/nav-pilot/internal/agentpakke/version.go
+++ b/cli/nav-pilot/internal/agentpakke/version.go
@@ -1,6 +1,25 @@
 package agentpakke
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
+
+// releaseVersionPattern is nav-pilot's release version format: the date-time
+// core that makes versions comparable, plus the build sha the release tooling
+// appends. It mirrors the "minNavPilotVersion" pattern in the published schema
+// (schemas/agentpakke-v1.json) — keep the two in sync, since a manifest is
+// checked by both this binary and an agentpakke repo's own schema lint.
+var releaseVersionPattern = regexp.MustCompile(`^\d{4}\.\d{2}\.\d{2}-\d{6}(-[0-9a-zA-Z][0-9a-zA-Z.-]*)?$`)
+
+// isReleaseVersionFormat reports whether v is a well-formed nav-pilot release
+// version. It is the check applied to a manifest-declared minimum, which is a
+// known construct and therefore fails closed when malformed — a value like a
+// bare date compares as older than every real release and would silently
+// disable the gate.
+func isReleaseVersionFormat(v string) bool {
+	return releaseVersionPattern.MatchString(v)
+}
 
 // cliVersion is the running binary version, injected by package main at startup
 // (mirrors internal/provider's SetVersion seam). Development builds leave it at

--- a/cli/nav-pilot/internal/artifacts/export.go
+++ b/cli/nav-pilot/internal/artifacts/export.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
 	"github.com/navikt/copilot/cli/nav-pilot/internal/domain"
 	"github.com/navikt/copilot/cli/nav-pilot/internal/source"
 )
@@ -22,6 +24,62 @@ func CmdExport(format string, scope *domain.InstallScope, ref, sourceRepo, cliVe
 	}
 }
 
+// refuseNonCanonicalPakke stops an export that would otherwise produce wrong or
+// empty output.
+//
+// export reads a source's canonical agents//skills/instructions/prompts
+// directories directly; it does not go through the agentpakke layout resolver
+// that install and sync use. A source whose manifest puts its content anywhere
+// else would therefore export whatever happens to sit at the canonical paths —
+// in practice nothing at all, silently. Until export is migrated onto the
+// manifest (M2), that is a hard error. A manifest declaring the canonical
+// layout, and a manifest-less source, export exactly as before.
+func refuseNonCanonicalPakke(src *source.Source) error {
+	m, err := agentpakke.Load(src.Dir)
+	if err != nil {
+		// No manifest is the legacy case. A manifest that fails to load is
+		// install and sync's fail-closed error to report, in the words those
+		// commands use; export does not second-guess it here.
+		return nil //nolint:nilerr // deliberate: only a usable manifest changes export's behaviour
+	}
+	if isCanonicalLayout(m.Layout) {
+		return nil
+	}
+	label := src.Repo
+	if label == "" {
+		label = source.DefaultRepo
+	}
+	return fmt.Errorf(
+		"export does not support agentpakke sources yet: %s ships an agentpakke (%q) whose content is not at the canonical agents/, skills/, instructions/, prompts/ paths.\n"+
+			"Exporting it would silently produce an empty or wrong opencode tree, so nothing was written.\n\n"+
+			"  Install the agentpakke instead:    %s\n"+
+			"  Or export from a canonical source: %s",
+		label, m.Name,
+		domain.Bold("nav-pilot install --source "+label+" "+m.Name),
+		domain.Bold("nav-pilot export opencode --source "+source.DefaultRepo))
+}
+
+// isCanonicalLayout reports whether a manifest's layout is the one export
+// already reads: the canonical directory names. A Tier 2-only manifest declares
+// no layout at all, which is equally not something export can read.
+func isCanonicalLayout(l *agentpakke.Layout) bool {
+	if l == nil {
+		return false
+	}
+	for _, d := range []struct{ declared, canonical string }{
+		{l.Agents, "agents"},
+		{l.Skills, "skills"},
+		{l.Instructions, "instructions"},
+		{l.Prompts, "prompts"},
+	} {
+		declared := strings.TrimSpace(d.declared)
+		if declared != "" && path.Clean(declared) != d.canonical {
+			return false
+		}
+	}
+	return true
+}
+
 // ExportOpenCode transforms Nav's .github/ artifacts into OpenCode-compatible .opencode/ format.
 func ExportOpenCode(scope *domain.InstallScope, ref, sourceRepo, cliVersion string, dryRun, force, jsonOutput bool) error {
 	src, err := source.ResolveSource(ref, sourceRepo, cliVersion)
@@ -29,6 +87,10 @@ func ExportOpenCode(scope *domain.InstallScope, ref, sourceRepo, cliVersion stri
 		return err
 	}
 	defer src.Cleanup()
+
+	if err := refuseNonCanonicalPakke(src); err != nil {
+		return err
+	}
 
 	outputDir := OpenCodeOutputDir(scope)
 

--- a/cli/nav-pilot/internal/artifacts/export_test.go
+++ b/cli/nav-pilot/internal/artifacts/export_test.go
@@ -656,3 +656,63 @@ func TestMaterializeOpenCodeEmpty(t *testing.T) {
 		t.Errorf("expected all zeros on empty source, got %d/%d/%d/%d", skills, commands, agents, instructions)
 	}
 }
+
+// ─── agentpakke sources ─────────────────────────────────────────────────────
+
+// TestExportRefusesNonCanonicalAgentpakke covers the seam export has not
+// crossed yet: it reads canonical directories, so a source that puts its
+// content elsewhere must be refused loudly instead of exporting nothing.
+func TestExportRefusesNonCanonicalAgentpakke(t *testing.T) {
+	srcDir := t.TempDir()
+	mustWrite(t, filepath.Join(srcDir, ".nav-pilot", "agentpakke.json"), `{
+	  "contractVersion": "1",
+	  "name": "grillmester",
+	  "description": "Grillmester agentpakke",
+	  "clients": {"copilot": {"primaryAgents": ["grillmester"]}},
+	  "layout": {"agents": "plugin/agents", "skills": "plugin/skills"}
+	}`)
+	mustWrite(t, filepath.Join(srcDir, "plugin", "agents", "grillmester.agent.md"),
+		"---\nname: grillmester\ndescription: Chef\n---\nBody\n")
+	mustWrite(t, filepath.Join(srcDir, "plugin", "skills", "grilling", "SKILL.md"), "# Grilling\n")
+
+	outputDir := t.TempDir()
+	scope := domain.ScopeRepo(outputDir)
+
+	err := ExportOpenCode(scope, "", srcDir, "dev", false, false, false)
+	if err == nil {
+		t.Fatal("export from a non-canonical agentpakke succeeded, want a refusal")
+	}
+	if !strings.Contains(err.Error(), "export does not support agentpakke sources yet") {
+		t.Errorf("error %q is not the documented refusal", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outputDir, ".opencode")); statErr == nil {
+		t.Error("refused export still wrote an .opencode tree")
+	}
+}
+
+// TestExportAllowsCanonicalAgentpakke keeps the refusal narrow: a manifest that
+// declares the canonical layout is exactly what export already reads.
+func TestExportAllowsCanonicalAgentpakke(t *testing.T) {
+	srcDir := t.TempDir()
+	mustWrite(t, filepath.Join(srcDir, ".nav-pilot", "agentpakke.json"), `{
+	  "contractVersion": "1",
+	  "name": "grillmester",
+	  "description": "Grillmester agentpakke",
+	  "clients": {"copilot": {"primaryAgents": ["grillmester"]}},
+	  "layout": {"agents": "agents", "skills": "skills"}
+	}`)
+	mustWrite(t, filepath.Join(srcDir, "agents", "grillmester.agent.md"),
+		"---\nname: grillmester\ndescription: Chef\n---\nBody\n")
+
+	outputDir := t.TempDir()
+	scope := domain.ScopeRepo(outputDir)
+
+	if err := ExportOpenCode(scope, "", srcDir, "dev", false, false, false); err != nil {
+		t.Fatalf("export from a canonical-layout agentpakke: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, ".opencode", "agent", "grillmester.md")); err != nil {
+		if _, err2 := os.Stat(filepath.Join(outputDir, ".opencode")); err2 != nil {
+			t.Errorf("canonical agentpakke export wrote nothing: %v", err)
+		}
+	}
+}

--- a/cli/nav-pilot/internal/cli/add.go
+++ b/cli/nav-pilot/internal/cli/add.go
@@ -31,6 +31,10 @@ func cmdAdd(itemType, name string, scope *InstallScope, ref, sourceRepo string, 
 		}
 	}
 
+	if err := guardScopeSource(scope, sourceRepo); err != nil {
+		return err
+	}
+
 	if !jsonOutput {
 		fmt.Println(dim("Resolving source..."))
 	}
@@ -40,10 +44,12 @@ func cmdAdd(itemType, name string, scope *InstallScope, ref, sourceRepo string, 
 	}
 	defer src.Cleanup()
 
-	sourceLabel := "navikt/copilot"
-	if sourceRepo != "" {
-		sourceLabel = sourceRepo
+	// Fail closed before touching the filesystem (A3).
+	if err := validatePakkeSource(src); err != nil {
+		return err
 	}
+
+	sourceLabel := sourceLabelFor(src)
 
 	result := &installResult{}
 
@@ -61,7 +67,7 @@ func cmdAdd(itemType, name string, scope *InstallScope, ref, sourceRepo string, 
 
 	// Dispatch to the appropriate installer
 	kind := kindByName[itemType]
-	resolver := NewSourceResolver(src.Dir)
+	resolver := resolverFor(src.Dir, pakkeFor(src, name))
 	installErr := installArtifact(resolver, scope, kind, name, dryRun, force, result)
 	if installErr != nil {
 		return installErr

--- a/cli/nav-pilot/internal/cli/add_test.go
+++ b/cli/nav-pilot/internal/cli/add_test.go
@@ -328,7 +328,7 @@ func TestListAvailableItems(t *testing.T) {
 	os.WriteFile(filepath.Join(ghDir, "prompts", "test.prompt.md"), []byte("# Prompt"), 0o644)
 
 	// Should not panic/error
-	err := listAvailableItems(source)
+	err := listAvailableItems(NewSourceResolver(source))
 	if err != nil {
 		t.Fatalf("listAvailableItems: %v", err)
 	}
@@ -401,7 +401,7 @@ func TestCmdInstall_FullFlow(t *testing.T) {
 		t.Fatalf("loadManifest: %v", err)
 	}
 
-	result, err := installItems(source, ScopeRepo(target), manifest, false, false)
+	result, err := installItems(NewSourceResolver(source), ScopeRepo(target), manifest, false, false)
 	if err != nil {
 		t.Fatalf("installItems: %v", err)
 	}
@@ -433,7 +433,7 @@ func TestCmdInstall_DryRunNoSideEffects(t *testing.T) {
 		t.Fatalf("loadManifest: %v", err)
 	}
 
-	result, err := installItems(source, ScopeRepo(target), manifest, true, false)
+	result, err := installItems(NewSourceResolver(source), ScopeRepo(target), manifest, true, false)
 	if err != nil {
 		t.Fatalf("installItems dry-run: %v", err)
 	}
@@ -461,7 +461,7 @@ func TestInstallArtifact_ConflictStillTracked(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadManifest: %v", err)
 	}
-	result, err := installItems(source, ScopeRepo(target), manifest, false, false)
+	result, err := installItems(NewSourceResolver(source), ScopeRepo(target), manifest, false, false)
 	if err != nil {
 		t.Fatalf("first install: %v", err)
 	}
@@ -474,7 +474,7 @@ func TestInstallArtifact_ConflictStillTracked(t *testing.T) {
 	os.WriteFile(agentPath, []byte("# Modified locally"), 0o644)
 
 	// Second install WITHOUT force — should report conflict but still track it
-	result2, err := installItems(source, ScopeRepo(target), manifest, false, false)
+	result2, err := installItems(NewSourceResolver(source), ScopeRepo(target), manifest, false, false)
 	if err != nil {
 		t.Fatalf("second install: %v", err)
 	}
@@ -513,7 +513,7 @@ func TestCmdStatus_Integrity(t *testing.T) {
 	os.MkdirAll(filepath.Join(target, ".git"), 0o755)
 
 	manifest, _ := loadManifest(source, "test-collection")
-	result, _ := installItems(source, ScopeRepo(target), manifest, false, false)
+	result, _ := installItems(NewSourceResolver(source), ScopeRepo(target), manifest, false, false)
 
 	state := &StateFile{
 		Collection: "test-collection",
@@ -537,7 +537,7 @@ func TestCmdUninstall_RemovesFiles(t *testing.T) {
 	os.MkdirAll(filepath.Join(target, ".git"), 0o755)
 
 	manifest, _ := loadManifest(source, "test-collection")
-	result, _ := installItems(source, ScopeRepo(target), manifest, false, false)
+	result, _ := installItems(NewSourceResolver(source), ScopeRepo(target), manifest, false, false)
 
 	state := &StateFile{
 		Collection: "test-collection",
@@ -662,7 +662,7 @@ func TestCmdAdd_ClearsIgnoredStatus(t *testing.T) {
 	}
 
 	// Verify resolveSyncFiles includes the file again
-	files, _, err := resolveSyncFiles(scope, "", false)
+	files, _, err := resolveSyncFiles(scope, NewSourceResolver(""), false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/nav-pilot/internal/cli/agentpakke.go
+++ b/cli/nav-pilot/internal/cli/agentpakke.go
@@ -1,0 +1,233 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
+)
+
+// This file is the CLI's agentpakke seam. Source resolution funnels through
+// attachPakke, and everything downstream of it reads content through a
+// [Manifest]-derived resolver — the single-currency rule from the agentpakke
+// package doc. A source that ships no manifest gets one from
+// agentpakke.SynthesizeLegacy at the top of the pipeline (pakkeFor), so no
+// install or sync code below this point branches on "legacy or agentpakke".
+//
+// The seam stops at the CLI's install/sync source resolution: persona, model,
+// and launch call sites (internal/provider, internal/source/frontmatter.go)
+// still read their hardcoded Nav defaults and are migrated in M2.
+
+// attachPakke loads the agentpakke manifest of a resolved checkout onto the
+// source, fail-closed (A3): a source that ships a manifest must have a
+// conforming one before nav-pilot installs, syncs, or launches anything from
+// it. A source with no manifest is not an error — it is the legacy case, and
+// src.Pakke stays nil for pakkeFor to adapt.
+func attachPakke(src *Source) error {
+	m, err := agentpakke.Load(src.Dir)
+	if err != nil {
+		if errors.Is(err, agentpakke.ErrNoManifest) {
+			src.Pakke = nil
+			return nil
+		}
+		return fmt.Errorf("%s ships an agentpakke manifest (%s) that this nav-pilot cannot use:\n  %v\n\nNothing was installed. Fix the manifest in the source repo, or run %s to list every finding",
+			sourceLabelFor(src), agentpakke.ManifestPath, err,
+			bold("nav-pilot validate --source "+sourceLabelFor(src)))
+	}
+	src.Pakke = m
+	return nil
+}
+
+// pakkeFor returns the manifest that governs an install from this source: the
+// one the source ships, or the legacy adapter naming the collection being
+// installed. Past this call nothing needs to know which of the two it got.
+func pakkeFor(src *Source, collection string) *agentpakke.Manifest {
+	if src != nil && src.Pakke != nil {
+		return src.Pakke
+	}
+	return agentpakke.SynthesizeLegacy(collection)
+}
+
+// resolverFor builds the content resolver for a manifest. The legacy adapter
+// declares the canonical agents//skills/ layout, so manifest-less sources
+// resolve exactly as they did before this seam existed.
+func resolverFor(sourceDir string, pakke *agentpakke.Manifest) *SourceResolver {
+	if pakke == nil {
+		return NewSourceResolver(sourceDir)
+	}
+	return NewSourceResolverForLayout(sourceDir, pakke.Layout)
+}
+
+// resolverForState builds the resolver used by sync for an existing install.
+// The source may or may not ship a manifest; the collection recorded in state
+// names the legacy adapter when it does not.
+func resolverForState(src *Source, state *StateFile) *SourceResolver {
+	collection := ""
+	if state != nil {
+		collection = state.Collection
+	}
+	return resolverFor(src.Dir, pakkeFor(src, collection))
+}
+
+// stateCollection returns what an install records in StateFile.Collection.
+//
+// A manifest-bearing source supersedes the collection model, so its identity is
+// the agentpakke name (A1/Q2). A manifest-less source keeps recording the legacy
+// collection label verbatim — including the synthetic "(all)" and "(à la carte)"
+// labels, which are not contract identifiers and must round-trip unchanged for
+// existing installs.
+func stateCollection(src *Source, collection string) string {
+	if src != nil && src.Pakke != nil {
+		return src.Pakke.Name
+	}
+	return collection
+}
+
+// validatePakkeSource runs the on-disk conformance checks before any file is
+// written (A3: no partial installs). It is a no-op for manifest-less sources,
+// which have no contract to violate.
+func validatePakkeSource(src *Source) error {
+	if src == nil || src.Pakke == nil {
+		return nil
+	}
+	errs := agentpakke.ValidateSource(src.Dir)
+	if len(errs) == 0 {
+		return nil
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "agentpakke %q in %s does not conform to its manifest:", src.Pakke.Name, sourceLabelFor(src))
+	for _, e := range errs {
+		fmt.Fprintf(&b, "\n  - %v", e)
+	}
+	fmt.Fprintf(&b, "\n\nNothing was installed. Ask the agentpakke to fix its content, or run %s to re-check",
+		bold("nav-pilot validate --source "+sourceLabelFor(src)))
+	return errors.New(b.String())
+}
+
+// sourceLabelFor names a resolved source in user-facing messages.
+func sourceLabelFor(src *Source) string {
+	if src == nil || src.Repo == "" {
+		return defaultSourceRepo
+	}
+	return src.Repo
+}
+
+// pakkeInstallName is the single installable name a manifest-bearing source
+// offers: its agentpakke identity, which supersedes collections/<name>.
+func pakkeInstallName(src *Source) string {
+	if src == nil || src.Pakke == nil {
+		return ""
+	}
+	return src.Pakke.Name
+}
+
+// ─── B3: cross-source guard ──────────────────────────────────────────────────
+
+// guardScopeSource refuses to install content from a source other than the one
+// a scope was installed from (B3). The guard is per scope, so different scopes
+// may track different agentpakker (B4).
+//
+// It only fires for a source that came from the persisted config key: an
+// explicit --source is the user saying "yes, this source, into this scope", and
+// a scope with no install yet is free to pick any source.
+func guardScopeSource(scope *InstallScope, flagSource string) error {
+	configured, state, err := crossSourceCheck(scope, flagSource)
+	if err != nil || state == nil || state.SourceRepo == "" {
+		return err
+	}
+	if sameSourceRepo(configured, state.SourceRepo) {
+		return nil
+	}
+	return fmt.Errorf(
+		"the %s scope was installed from %s, but your configured source is %s.\n"+
+			"nav-pilot will not silently mix content from two agentpakker into one install.\n\n"+
+			"  Keep this scope on its current source:  %s\n"+
+			"  Switch this scope to the new source:    %s\n"+
+			"  Or clear the persisted source:          %s",
+		scope.Name, bold(state.SourceRepo), bold(configured),
+		bold("nav-pilot install --source "+state.SourceRepo+" <name>"),
+		bold("nav-pilot install --source "+configured+" <name>"),
+		bold(`nav-pilot config set source ""`))
+}
+
+// guardScopeSyncSource is the sync-side half of B3. Sync already prefers the
+// source recorded in the scope's state over the configured one, so a scope that
+// knows where it came from can never be cross-synced. What it cannot decide is
+// an install whose state predates source tracking: syncing that against a
+// configured agentpakke would overwrite files from an unknown origin, so it
+// refuses and asks for an explicit answer.
+func guardScopeSyncSource(scope *InstallScope, flagSource string) error {
+	configured, state, err := crossSourceCheck(scope, flagSource)
+	if err != nil || state == nil || state.SourceRepo != "" {
+		return err
+	}
+	return fmt.Errorf(
+		"the %s scope records no source (it was installed before nav-pilot tracked one), "+
+			"and your configured source is %s.\n"+
+			"Syncing would pull content from an agentpakke this install may not come from.\n\n"+
+			"  Sync from a named source:  %s\n"+
+			"  Or reinstall the scope:    %s",
+		scope.Name, bold(configured),
+		bold("nav-pilot sync --source "+defaultSourceRepo),
+		bold("nav-pilot install --source "+configured+" <name>"))
+}
+
+// crossSourceCheck returns the configured source and the scope's state for the
+// B3 guards, or a nil state when there is nothing to guard: an explicit
+// --source, no persisted source, or no install in this scope.
+func crossSourceCheck(scope *InstallScope, flagSource string) (string, *StateFile, error) {
+	if flagSource != "" {
+		return "", nil, nil
+	}
+	configured, err := configuredSourceRepo()
+	if err != nil || configured == "" {
+		return "", nil, err
+	}
+	state, err := readScopedState(scope)
+	if err != nil {
+		// A broken state file is the command's error to report, not the guard's.
+		return "", nil, nil //nolint:nilerr // deliberate: guard stays silent
+	}
+	return configured, state, nil
+}
+
+// sameSourceRepo compares two source values. Repo ids are case-insensitive on
+// GitHub; local paths are compared as cleaned paths.
+func sameSourceRepo(a, b string) bool {
+	if a == b {
+		return true
+	}
+	if filepath.IsAbs(a) || filepath.IsAbs(b) {
+		return filepath.Clean(a) == filepath.Clean(b)
+	}
+	return strings.EqualFold(a, b)
+}
+
+// ─── B2: persisting the selected source ──────────────────────────────────────
+
+// persistInstalledSource stores an explicitly selected source in the user
+// config after a successful install, so later invocations do not need --source
+// (B2). It is a no-op without an explicit --source and for dry runs, and it
+// never fails the install: the content is already on disk.
+func persistInstalledSource(flagSource string, dryRun bool) {
+	if flagSource == "" || dryRun {
+		return
+	}
+	if err := validateSourceValue(flagSource); err != nil {
+		return
+	}
+	current, err := configuredSourceRepo()
+	if err == nil && sameSourceRepo(current, flagSource) {
+		return
+	}
+	if _, err := writeConfigKey("source", flagSource); err != nil {
+		fmt.Fprintf(os.Stderr, "%s Could not save source to %s: %v\n", yellow("⚠"), configPath(), err)
+		return
+	}
+	fmt.Printf("\n%s Saved %s as your source in %s.\n", green("✓"), bold(flagSource), configPath())
+	fmt.Printf("  %s runs use it without %s; clear it with %s.\n",
+		dim("Future"), bold("--source"), bold(`nav-pilot config set source ""`))
+}

--- a/cli/nav-pilot/internal/cli/agentpakke.go
+++ b/cli/nav-pilot/internal/cli/agentpakke.go
@@ -86,6 +86,31 @@ func stateCollection(src *Source, collection string) string {
 	return collection
 }
 
+// guardTier2Only refuses an install from an agentpakke that ships only
+// pre-built payloads.
+//
+// Tier is derived from shape: a manifest with no layout and payload-bearing
+// clients has no Tier 1 content for this binary to materialize. Installing it
+// would resolve the canonical agents//skills/ directories in a repo that ships
+// neither, and report "declares a layout but ships no agents" about a manifest
+// that declares no layout at all. Tier 2 staging arrives in a later milestone;
+// until then this says so.
+func guardTier2Only(src *Source) error {
+	if src == nil || src.Pakke == nil || src.Pakke.Layout != nil {
+		return nil
+	}
+	if !src.Pakke.HasTier(agentpakke.TierPayload) {
+		return nil
+	}
+	return fmt.Errorf(
+		"agentpakke %q in %s ships pre-built payloads (Tier 2), which this nav-pilot version cannot install yet.\n"+
+			"Nothing was installed — Tier 2 payload staging arrives in a later nav-pilot release.\n\n"+
+			"  Inspect what it declares:  %s\n"+
+			"  Or ask the agentpakke for a Tier 1 layout (agents/skills content nav-pilot materializes itself)",
+		src.Pakke.Name, sourceLabelFor(src),
+		bold("nav-pilot validate --source "+sourceLabelFor(src)))
+}
+
 // validatePakkeSource runs the on-disk conformance checks before any file is
 // written (A3: no partial installs). It is a no-op for manifest-less sources,
 // which have no contract to violate.
@@ -204,6 +229,38 @@ func sameSourceRepo(a, b string) bool {
 		return filepath.Clean(a) == filepath.Clean(b)
 	}
 	return strings.EqualFold(a, b)
+}
+
+// noteRecordedSourceWins says which source a sync actually reads from when the
+// user has configured a different one.
+//
+// The precedence is deliberate — selection is per scope (B4), and the scope's
+// recorded source is the only one that can be synced into it without mixing
+// agentpakker — but applying it silently is how someone ends up wondering why
+// `nav-pilot sync` never picks up the agentpakke they configured. It stays
+// quiet when nothing is configured: the config key is what the user asked for,
+// and an absent key asks for nothing.
+func noteRecordedSourceWins(stateRepo string) {
+	configured, err := configuredSourceRepo()
+	if err != nil || configured == "" || sameSourceRepo(configured, stateRepo) {
+		return
+	}
+	fmt.Printf("%s Syncing from %s (recorded for this scope); configured source %s is not used here — reinstall with %s to switch.\n\n",
+		dim("ℹ"), bold(stateRepo), bold(configured),
+		bold("nav-pilot install --source "+configured+" <name>"))
+}
+
+// tracksDefaultSource reports whether a scope's install came from the default
+// source, which is the only source nav-pilot's own release feed describes.
+//
+// An install that predates source tracking records nothing; it is treated as
+// coming from the default, which is where it must have come from — so
+// manifest-less default-source users see no behaviour change.
+func tracksDefaultSource(state *StateFile) bool {
+	if state == nil || state.SourceRepo == "" {
+		return true
+	}
+	return sameSourceRepo(state.SourceRepo, defaultSourceRepo)
 }
 
 // ─── B2: persisting the selected source ──────────────────────────────────────

--- a/cli/nav-pilot/internal/cli/agentpakke.go
+++ b/cli/nav-pilot/internal/cli/agentpakke.go
@@ -178,26 +178,49 @@ func guardScopeSource(scope *InstallScope, flagSource string) error {
 		bold(`nav-pilot config set source ""`))
 }
 
-// guardScopeSyncSource is the sync-side half of B3. Sync already prefers the
-// source recorded in the scope's state over the configured one, so a scope that
-// knows where it came from can never be cross-synced. What it cannot decide is
-// an install whose state predates source tracking: syncing that against a
-// configured agentpakke would overwrite files from an unknown origin, so it
-// refuses and asks for an explicit answer.
-func guardScopeSyncSource(scope *InstallScope, flagSource string) error {
+// adoptSyncSource is the sync-side half of B3. Sync already prefers the source
+// recorded in the scope's state over the configured one, so a scope that knows
+// where it came from can never be cross-synced — [guardScopeSource] covers the
+// install side and this returns nothing for it.
+//
+// The case it answers is an install whose state predates source tracking. That
+// scope has no recorded origin to guard against, and refusing to sync it would
+// strand every pre-tracking install behind a flag. Instead sync proceeds from
+// the effective source and adopts it: the returned value is what the caller
+// records in state after a successful sync, so from the next run on the scope
+// has an origin and the normal guard applies. An empty return means there is
+// nothing to adopt (explicit --source, no configured source, no install, or a
+// scope that already records one).
+func adoptSyncSource(scope *InstallScope, flagSource string) (string, error) {
 	configured, state, err := crossSourceCheck(scope, flagSource)
 	if err != nil || state == nil || state.SourceRepo != "" {
-		return err
+		return "", err
 	}
-	return fmt.Errorf(
-		"the %s scope records no source (it was installed before nav-pilot tracked one), "+
-			"and your configured source is %s.\n"+
-			"Syncing would pull content from an agentpakke this install may not come from.\n\n"+
-			"  Sync from a named source:  %s\n"+
-			"  Or reinstall the scope:    %s",
-		scope.Name, bold(configured),
-		bold("nav-pilot sync --source "+defaultSourceRepo),
-		bold("nav-pilot install --source "+configured+" <name>"))
+	return configured, nil
+}
+
+// noteAdoptedSource says which source a pre-tracking scope is being synced
+// from, and that nav-pilot is about to remember it. Adopting silently is how
+// someone ends up with a scope pinned to a source they never chose.
+func noteAdoptedSource(scope *InstallScope, sourceRepo string) {
+	fmt.Printf("%s The %s scope predates source tracking; syncing from %s and recording it as this scope's source.\n\n",
+		dim("ℹ"), scope.Name, bold(sourceRepo))
+}
+
+// recordAdoptedSource writes the adopted source into the scope's state, after
+// the sync it describes actually succeeded. It never fails the sync: the files
+// are already correct, and a scope that stays sourceless just gets asked again
+// next time.
+func recordAdoptedSource(scope *InstallScope, sourceRepo string) {
+	state, err := readScopedState(scope)
+	if err != nil || state == nil || state.SourceRepo != "" {
+		return
+	}
+	state.SourceRepo = sourceRepo
+	if err := writeScopedState(scope, state); err != nil {
+		fmt.Fprintf(os.Stderr, "%s Could not record %s as the %s scope's source: %v\n",
+			yellow("⚠"), sourceRepo, scope.Name, err)
+	}
 }
 
 // crossSourceCheck returns the configured source and the scope's state for the
@@ -220,15 +243,33 @@ func crossSourceCheck(scope *InstallScope, flagSource string) (string, *StateFil
 }
 
 // sameSourceRepo compares two source values. Repo ids are case-insensitive on
-// GitHub; local paths are compared as cleaned paths.
+// GitHub; local paths are compared as the checkout they resolve to.
 func sameSourceRepo(a, b string) bool {
 	if a == b {
 		return true
 	}
 	if filepath.IsAbs(a) || filepath.IsAbs(b) {
-		return filepath.Clean(a) == filepath.Clean(b)
+		return resolvedSourcePath(a) == resolvedSourcePath(b)
 	}
 	return strings.EqualFold(a, b)
+}
+
+// resolvedSourcePath reduces a path-form source to the directory it actually
+// names, so a symlink and the checkout behind it are one source rather than two
+// — otherwise the B3 guard refuses a sync over what is the same content.
+//
+// A path that cannot be resolved (it no longer exists, or is not a path at all)
+// falls back to the cleaned string, which is the comparison this had before and
+// the only one still available.
+func resolvedSourcePath(p string) string {
+	if !filepath.IsAbs(p) {
+		return filepath.Clean(p)
+	}
+	resolved, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		return filepath.Clean(p)
+	}
+	return resolved
 }
 
 // noteRecordedSourceWins says which source a sync actually reads from when the

--- a/cli/nav-pilot/internal/cli/agentpakke_test.go
+++ b/cli/nav-pilot/internal/cli/agentpakke_test.go
@@ -408,6 +408,125 @@ func TestSyncNotesRecordedSourceWins(t *testing.T) {
 	}
 }
 
+// TestSyncAdoptsSourceForPreTrackingScope covers the pre-source-tracking
+// policy: a scope installed before nav-pilot recorded sources is synced from
+// the effective source, told so once, and has that source recorded afterwards
+// so the normal B3 guard applies from the next run on.
+func TestSyncAdoptsSourceForPreTrackingScope(t *testing.T) {
+	tests := []struct {
+		name          string
+		configuredSrc string
+		jsonOutput    bool
+		syncErr       error
+		wantSource    string // recorded in state after the sync
+		wantNote      bool
+	}{
+		{
+			name:          "sourceless scope adopts the configured source",
+			configuredSrc: "navikt/grillmester",
+			wantSource:    "navikt/grillmester",
+			wantNote:      true,
+		},
+		{
+			name:          "json output stays machine-readable",
+			configuredSrc: "navikt/grillmester",
+			jsonOutput:    true,
+			wantSource:    "navikt/grillmester",
+		},
+		{
+			name:          "a failed sync records nothing",
+			configuredSrc: "navikt/grillmester",
+			syncErr:       errors.New("could not clone"),
+			wantNote:      true,
+		},
+		{
+			name: "nothing configured, nothing adopted",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := isolatedConfig(t)
+			content := "version = 1\n"
+			if tt.configuredSrc != "" {
+				content += "source = \"" + tt.configuredSrc + "\"\n"
+			}
+			mustWrite(t, path, content)
+
+			scope := ScopeRepo(repoTarget(t))
+			writeGuardState(t, scope, "")
+
+			srcDir := legacySourceTree(t)
+			orig := resolveSourceForSync
+			t.Cleanup(func() { resolveSourceForSync = orig })
+			resolveSourceForSync = func(ref, sourceRepo string) (*Source, error) {
+				if tt.syncErr != nil {
+					return nil, tt.syncErr
+				}
+				return &Source{Dir: srcDir, SHA: "abc1234", Version: "dev", Repo: sourceRepo}, nil
+			}
+
+			out := captureStdoutFor(t, func() {
+				err := cmdSync(scope, "", "", false, tt.jsonOutput)
+				if tt.syncErr == nil && err != nil {
+					t.Errorf("cmdSync = %v, want nil", err)
+				}
+				if tt.syncErr != nil && err == nil {
+					t.Error("cmdSync succeeded, want the resolve failure")
+				}
+			})
+
+			gotNote := strings.Contains(out, "predates source tracking")
+			if gotNote != tt.wantNote {
+				t.Errorf("informational line present = %v, want %v. Output:\n%s", gotNote, tt.wantNote, out)
+			}
+			if tt.wantNote && !strings.Contains(out, tt.configuredSrc) {
+				t.Errorf("informational line does not name the source being adopted:\n%s", out)
+			}
+
+			state, err := readScopedState(scope)
+			if err != nil {
+				t.Fatalf("readScopedState: %v", err)
+			}
+			if state.SourceRepo != tt.wantSource {
+				t.Errorf("state.SourceRepo = %q, want %q", state.SourceRepo, tt.wantSource)
+			}
+		})
+	}
+}
+
+// TestSyncAdoptedSourceIsGuardedAfterwards covers the point of adopting: the
+// healed scope is an ordinary recorded-source scope, so a later configured
+// source change is refused on install instead of silently mixed in.
+func TestSyncAdoptedSourceIsGuardedAfterwards(t *testing.T) {
+	path := isolatedConfig(t)
+	mustWrite(t, path, "version = 1\nsource = \""+defaultSourceRepo+"\"\n")
+
+	scope := ScopeRepo(repoTarget(t))
+	writeGuardState(t, scope, "")
+
+	srcDir := legacySourceTree(t)
+	orig := resolveSourceForSync
+	t.Cleanup(func() { resolveSourceForSync = orig })
+	resolveSourceForSync = func(ref, sourceRepo string) (*Source, error) {
+		return &Source{Dir: srcDir, SHA: "abc1234", Version: "dev", Repo: sourceRepo}, nil
+	}
+	captureStdoutFor(t, func() {
+		if err := cmdSync(scope, "", "", false, false); err != nil {
+			t.Fatalf("cmdSync: %v", err)
+		}
+	})
+
+	// The user now points the config at another agentpakke.
+	mustWrite(t, path, "version = 1\nsource = \"navikt/grillmester\"\n")
+	if err := guardScopeSource(scope, ""); err == nil {
+		t.Error("install into the healed scope was not guarded against the new source")
+	}
+	adopted, err := adoptSyncSource(scope, "")
+	if err != nil || adopted != "" {
+		t.Errorf("adoptSyncSource on the healed scope = (%q, %v), want (\"\", nil)", adopted, err)
+	}
+}
+
 // ─── root TUI staleness is a default-source question ─────────────────────────
 
 // TestScopeStalenessOnlyForDefaultSource covers MINOR-4: nav-pilot's release
@@ -811,18 +930,18 @@ func TestGuardScopeSource(t *testing.T) {
 	}
 }
 
-func TestGuardScopeSyncSource(t *testing.T) {
+func TestAdoptSyncSource(t *testing.T) {
 	tests := []struct {
 		name            string
 		configuredSrc   string
 		flagSource      string
 		stateSourceRepo string
-		wantErr         bool
+		wantAdopt       string
 	}{
-		{name: "recorded source wins, no error", configuredSrc: "navikt/grillmester", stateSourceRepo: defaultSourceRepo},
+		{name: "recorded source wins, nothing to adopt", configuredSrc: "navikt/grillmester", stateSourceRepo: defaultSourceRepo},
 		{name: "same source", configuredSrc: defaultSourceRepo, stateSourceRepo: defaultSourceRepo},
 		{name: "no configured source", stateSourceRepo: ""},
-		{name: "unknown recorded source is refused", configuredSrc: "navikt/grillmester", stateSourceRepo: "", wantErr: true},
+		{name: "sourceless scope adopts the configured source", configuredSrc: "navikt/grillmester", stateSourceRepo: "", wantAdopt: "navikt/grillmester"},
 		{name: "explicit flag overrides", configuredSrc: "navikt/grillmester", flagSource: defaultSourceRepo, stateSourceRepo: ""},
 	}
 	for _, tt := range tests {
@@ -837,9 +956,12 @@ func TestGuardScopeSyncSource(t *testing.T) {
 			scope := ScopeRepo(repoTarget(t))
 			writeGuardState(t, scope, tt.stateSourceRepo)
 
-			err := guardScopeSyncSource(scope, tt.flagSource)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("guardScopeSyncSource = %v, wantErr = %v", err, tt.wantErr)
+			got, err := adoptSyncSource(scope, tt.flagSource)
+			if err != nil {
+				t.Fatalf("adoptSyncSource = %v, want no error", err)
+			}
+			if got != tt.wantAdopt {
+				t.Fatalf("adoptSyncSource = %q, want %q", got, tt.wantAdopt)
 			}
 		})
 	}
@@ -861,9 +983,10 @@ func TestGuardIsPerScope(t *testing.T) {
 	if err := guardScopeSource(navScope, ""); err == nil {
 		t.Error("scope on a different source was not guarded")
 	}
-	// Sync leaves both alone: each scope syncs from its own recorded source.
-	if err := guardScopeSyncSource(navScope, ""); err != nil {
-		t.Errorf("sync guard fired for a scope with a recorded source: %v", err)
+	// Sync leaves both alone: each scope syncs from its own recorded source,
+	// so neither has anything to adopt.
+	if adopted, err := adoptSyncSource(navScope, ""); err != nil || adopted != "" {
+		t.Errorf("adoptSyncSource on a scope with a recorded source = (%q, %v), want (\"\", nil)", adopted, err)
 	}
 }
 
@@ -1066,6 +1189,43 @@ func TestSameSourceRepo(t *testing.T) {
 		if got := sameSourceRepo(tt.a, tt.b); got != tt.want {
 			t.Errorf("sameSourceRepo(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
 		}
+	}
+}
+
+// TestSameSourceRepoResolvesSymlinks covers the false cross-source refusal: a
+// configured path and a recorded symlink to the same checkout are one source.
+func TestSameSourceRepoResolvesSymlinks(t *testing.T) {
+	root := t.TempDir()
+	real := filepath.Join(root, "checkout")
+	other := filepath.Join(root, "other")
+	for _, d := range []string{real, other} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{name: "symlink and its target are the same source", a: link, b: real, want: true},
+		{name: "symlink and its target, other way round", a: real, b: link, want: true},
+		{name: "symlink into a subpath of the target", a: filepath.Join(link, "."), b: real, want: true},
+		{name: "different directories still differ", a: link, b: other},
+		{name: "nonexistent paths fall back to the cleaned path", a: filepath.Join(root, "gone"), b: filepath.Join(root, "gone") + "/", want: true},
+		{name: "nonexistent paths that differ still differ", a: filepath.Join(root, "gone"), b: filepath.Join(root, "elsewhere")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sameSourceRepo(tt.a, tt.b); got != tt.want {
+				t.Errorf("sameSourceRepo(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/cli/nav-pilot/internal/cli/agentpakke_test.go
+++ b/cli/nav-pilot/internal/cli/agentpakke_test.go
@@ -1,0 +1,707 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
+)
+
+// ─── source-tree fixtures ────────────────────────────────────────────────────
+
+// legacySourceTree builds a manifest-less source in the canonical layout: the
+// shape every source has today.
+func legacySourceTree(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "collections", "fullstack", "manifest.json"),
+		`{"name":"fullstack","description":"Full stack","agents":["test-a"],"skills":["test-s"]}`)
+	mustWrite(t, filepath.Join(dir, "agents", "test-a.agent.md"), "---\nname: test-a\ndescription: A\n---\nBody A\n")
+	mustWrite(t, filepath.Join(dir, "skills", "test-s", "SKILL.md"), "# Skill S\n")
+	return dir
+}
+
+// pakkeSourceTree builds a manifest-bearing source whose content lives at
+// non-canonical layout paths, so a resolver that ignored the manifest would
+// find nothing.
+func pakkeSourceTree(t *testing.T, manifestJSON string) string {
+	t.Helper()
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, agentpakke.ManifestDir, agentpakke.ManifestFile), manifestJSON)
+	mustWrite(t, filepath.Join(dir, "plugin", "agents", "grillmester.agent.md"),
+		"---\nname: grillmester\ndescription: Chef\n---\nBody G\n")
+	mustWrite(t, filepath.Join(dir, "plugin", "skills", "grilling", "SKILL.md"), "# Grilling\n")
+	return dir
+}
+
+const tier1ManifestJSON = `{
+  "contractVersion": "1",
+  "name": "grillmester",
+  "description": "Grillmester agentpakke",
+  "clients": {"copilot": {"primaryAgents": ["grillmester"]}},
+  "layout": {"agents": "plugin/agents", "skills": "plugin/skills"}
+}`
+
+// repoTarget makes a git-looking target dir for repo-scope installs.
+func repoTarget(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// isolatedConfig points NAV_PILOT_CONFIG at a temp file so tests never read or
+// write the developer's own config.
+func isolatedConfig(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.toml")
+	t.Setenv("NAV_PILOT_CONFIG", path)
+	return path
+}
+
+// ─── C3: the legacy path must not change ─────────────────────────────────────
+
+func TestLegacyInstallUnchanged(t *testing.T) {
+	isolatedConfig(t)
+	srcDir := legacySourceTree(t)
+	target := repoTarget(t)
+
+	src := &Source{Dir: srcDir, SHA: "abc1234", Version: "dev", Repo: defaultSourceRepo}
+	if err := attachPakke(src); err != nil {
+		t.Fatalf("attachPakke on a manifest-less source: %v", err)
+	}
+	if src.Pakke != nil {
+		t.Fatalf("attachPakke attached %+v, want nil for a source without a manifest", src.Pakke)
+	}
+
+	scope := ScopeRepo(target)
+	if err := cmdInstallFromSource("fullstack", src, scope, false, false, false); err != nil {
+		t.Fatalf("cmdInstallFromSource: %v", err)
+	}
+
+	state, err := readScopedState(scope)
+	if err != nil {
+		t.Fatalf("readScopedState: %v", err)
+	}
+	if state.Collection != "fullstack" {
+		t.Errorf("state.Collection = %q, want %q (legacy label must round-trip verbatim)", state.Collection, "fullstack")
+	}
+	if state.SourceRepo != defaultSourceRepo {
+		t.Errorf("state.SourceRepo = %q, want %q", state.SourceRepo, defaultSourceRepo)
+	}
+	if state.Scope != "repo" {
+		t.Errorf("state.Scope = %q, want repo", state.Scope)
+	}
+	wantFiles := []string{".github/agents/test-a.agent.md", ".github/skills/test-s/"}
+	var gotFiles []string
+	for _, f := range state.Files {
+		gotFiles = append(gotFiles, f.Path)
+	}
+	if strings.Join(gotFiles, ",") != strings.Join(wantFiles, ",") {
+		t.Errorf("state files = %v, want %v", gotFiles, wantFiles)
+	}
+
+	// Installed bytes must be the source bytes, unchanged.
+	got, err := os.ReadFile(filepath.Join(target, ".github", "agents", "test-a.agent.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := os.ReadFile(filepath.Join(srcDir, "agents", "test-a.agent.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("installed agent bytes = %q, want %q", got, want)
+	}
+}
+
+func TestLegacyAdapterKeepsCanonicalLayout(t *testing.T) {
+	srcDir := legacySourceTree(t)
+	resolver := resolverFor(srcDir, pakkeFor(&Source{Dir: srcDir}, "fullstack"))
+	art, ok := resolver.Get(KindAgent, "test-a")
+	if !ok {
+		t.Fatal("legacy adapter resolver did not find agents/test-a.agent.md")
+	}
+	if art.RelPath != filepath.Join("agents", "test-a.agent.md") {
+		t.Errorf("RelPath = %q, want agents/test-a.agent.md", art.RelPath)
+	}
+}
+
+func TestStateCollection(t *testing.T) {
+	pakkeSrc := &Source{Pakke: agentpakke.SynthesizeLegacy("grillmester")}
+	tests := []struct {
+		name       string
+		src        *Source
+		collection string
+		want       string
+	}{
+		{"legacy collection", &Source{}, "fullstack", "fullstack"},
+		{"legacy all", &Source{}, CollectionAll, CollectionAll},
+		{"agentpakke supersedes", pakkeSrc, "fullstack", "grillmester"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stateCollection(tt.src, tt.collection); got != tt.want {
+				t.Errorf("stateCollection = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// ─── supersede install path ──────────────────────────────────────────────────
+
+func TestPakkeInstallUsesLayoutAndRecordsName(t *testing.T) {
+	isolatedConfig(t)
+	srcDir := pakkeSourceTree(t, tier1ManifestJSON)
+	target := repoTarget(t)
+
+	src := &Source{Dir: srcDir, SHA: "def5678", Version: "dev", Repo: "navikt/grillmester"}
+	if err := attachPakke(src); err != nil {
+		t.Fatalf("attachPakke: %v", err)
+	}
+	if src.Pakke == nil || src.Pakke.Name != "grillmester" {
+		t.Fatalf("attachPakke did not load the manifest: %+v", src.Pakke)
+	}
+
+	scope := ScopeRepo(target)
+	if err := cmdInstallFromSource("grillmester", src, scope, false, false, false); err != nil {
+		t.Fatalf("cmdInstallFromSource: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(target, ".github", "agents", "grillmester.agent.md")); err != nil {
+		t.Errorf("agent from layout path plugin/agents was not installed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(target, ".github", "skills", "grilling", "SKILL.md")); err != nil {
+		t.Errorf("skill from layout path plugin/skills was not installed: %v", err)
+	}
+
+	state, err := readScopedState(scope)
+	if err != nil {
+		t.Fatalf("readScopedState: %v", err)
+	}
+	if state.Collection != "grillmester" {
+		t.Errorf("state.Collection = %q, want the manifest name %q", state.Collection, "grillmester")
+	}
+	if state.SourceRepo != "navikt/grillmester" {
+		t.Errorf("state.SourceRepo = %q, want navikt/grillmester", state.SourceRepo)
+	}
+}
+
+func TestAttachPakkeFailsClosed(t *testing.T) {
+	tests := []struct {
+		name         string
+		manifestJSON string
+		wantContains string
+	}{
+		{
+			name:         "unsupported contract version",
+			manifestJSON: `{"contractVersion":"99","name":"x","description":"d","clients":{"copilot":{"primaryAgents":["a"]}},"layout":{"agents":"a","skills":"s"}}`,
+			wantContains: "contractVersion",
+		},
+		{
+			name:         "tier 1 without layout",
+			manifestJSON: `{"contractVersion":"1","name":"x","description":"d","clients":{"copilot":{"primaryAgents":["a"]}}}`,
+			wantContains: "layout",
+		},
+		{
+			name:         "malformed json",
+			manifestJSON: `{"contractVersion":`,
+			wantContains: "agentpakke manifest",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			mustWrite(t, filepath.Join(dir, agentpakke.ManifestDir, agentpakke.ManifestFile), tt.manifestJSON)
+			src := &Source{Dir: dir, Repo: "navikt/broken"}
+			err := attachPakke(src)
+			if err == nil {
+				t.Fatal("attachPakke = nil, want a fail-closed error")
+			}
+			if !strings.Contains(err.Error(), tt.wantContains) {
+				t.Errorf("error %q does not mention %q", err, tt.wantContains)
+			}
+			if !strings.Contains(err.Error(), "Nothing was installed") {
+				t.Errorf("error %q is not actionable about what happened", err)
+			}
+		})
+	}
+}
+
+func TestValidatePakkeSourceLeavesNothingInstalled(t *testing.T) {
+	// A manifest whose layout points at a directory the repo does not ship.
+	manifest := `{
+	  "contractVersion": "1",
+	  "name": "broken",
+	  "description": "d",
+	  "clients": {"copilot": {"primaryAgents": ["a"]}},
+	  "layout": {"agents": "missing/agents", "skills": "missing/skills"}
+	}`
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, agentpakke.ManifestDir, agentpakke.ManifestFile), manifest)
+	target := repoTarget(t)
+
+	src := &Source{Dir: dir, SHA: "aaa", Version: "dev", Repo: "navikt/broken"}
+	if err := attachPakke(src); err != nil {
+		t.Fatalf("attachPakke: %v", err)
+	}
+	scope := ScopeRepo(target)
+	err := cmdInstallFromSource("broken", src, scope, false, false, false)
+	if err == nil {
+		t.Fatal("install from a non-conforming agentpakke succeeded, want fail-closed")
+	}
+	if !strings.Contains(err.Error(), "does not conform") {
+		t.Errorf("error %q does not name the conformance failure", err)
+	}
+	if entries, _ := os.ReadDir(filepath.Join(target, ".github")); len(entries) > 0 {
+		t.Errorf("fail-closed install left %d entries under .github/", len(entries))
+	}
+	if state, _ := readScopedState(scope); state != nil {
+		t.Error("fail-closed install wrote a state file")
+	}
+}
+
+// ─── B1: source precedence ───────────────────────────────────────────────────
+
+func TestSourceRepoFor(t *testing.T) {
+	tests := []struct {
+		name       string
+		configLine string
+		flag       string
+		want       string
+		wantErr    bool
+	}{
+		{name: "no config, no flag → default", want: ""},
+		{name: "flag only", flag: "navikt/grillmester", want: "navikt/grillmester"},
+		{name: "config only", configLine: `source = "navikt/grillmester"`, want: "navikt/grillmester"},
+		{name: "flag wins over config", configLine: `source = "navikt/a"`, flag: "navikt/b", want: "navikt/b"},
+		{name: "cleared config → default", configLine: `source = ""`, want: ""},
+		{name: "invalid config value", configLine: `source = "not a repo"`, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := isolatedConfig(t)
+			content := "version = 1\n"
+			if tt.configLine != "" {
+				content += tt.configLine + "\n"
+			}
+			mustWrite(t, path, content)
+
+			got, err := sourceRepoFor(tt.flag)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("sourceRepoFor(%q) = %q, want error", tt.flag, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("sourceRepoFor(%q) = %v", tt.flag, err)
+			}
+			if got != tt.want {
+				t.Errorf("sourceRepoFor(%q) = %q, want %q", tt.flag, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateSourceValue(t *testing.T) {
+	tests := []struct {
+		value   string
+		wantErr bool
+	}{
+		{"navikt/copilot", false},
+		{"navikt/grillmester", false},
+		{"/abs/path/to/checkout", false},
+		{"", true},
+		{"navikt", true},
+		{"navikt/copilot/extra", true},
+		{"./relative", true},
+		{"~/home", true},
+		{" navikt/copilot", true},
+	}
+	for _, tt := range tests {
+		err := validateSourceValue(tt.value)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("validateSourceValue(%q) = %v, wantErr = %v", tt.value, err, tt.wantErr)
+		}
+	}
+}
+
+// ─── B2: persistence ─────────────────────────────────────────────────────────
+
+func TestPersistInstalledSource(t *testing.T) {
+	path := isolatedConfig(t)
+	mustWrite(t, path, "version = 1\n")
+
+	persistInstalledSource("navikt/grillmester", true) // dry run: never persists
+	if got, _ := configuredSourceRepo(); got != "" {
+		t.Errorf("dry-run install persisted source = %q, want none", got)
+	}
+
+	persistInstalledSource("", false) // no explicit --source: nothing to persist
+	if got, _ := configuredSourceRepo(); got != "" {
+		t.Errorf("install without --source persisted source = %q, want none", got)
+	}
+
+	persistInstalledSource("navikt/grillmester", false)
+	got, err := configuredSourceRepo()
+	if err != nil {
+		t.Fatalf("configuredSourceRepo: %v", err)
+	}
+	if got != "navikt/grillmester" {
+		t.Errorf("persisted source = %q, want navikt/grillmester", got)
+	}
+
+	// Clearing goes back to the default.
+	if err := cmdConfigSet("source", ""); err != nil {
+		t.Fatalf("config set source \"\": %v", err)
+	}
+	if got, _ := configuredSourceRepo(); got != "" {
+		t.Errorf("cleared source = %q, want empty (default %s)", got, defaultSourceRepo)
+	}
+	if effective, _ := sourceRepoFor(""); effective != "" {
+		t.Errorf("after clearing, effective source = %q, want the default", effective)
+	}
+}
+
+func TestConfigSetSourceValidates(t *testing.T) {
+	path := isolatedConfig(t)
+	mustWrite(t, path, "version = 1\n")
+
+	if err := cmdConfigSet("source", "not a repo"); err == nil {
+		t.Error("config set source with a malformed value succeeded, want error")
+	}
+	if err := cmdConfigSet("source", "navikt/grillmester"); err != nil {
+		t.Errorf("config set source = %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `source = "navikt/grillmester"`) {
+		t.Errorf("config file does not contain the source key:\n%s", data)
+	}
+}
+
+func TestConfigShowIncludesSource(t *testing.T) {
+	path := isolatedConfig(t)
+	mustWrite(t, path, "version = 1\nsource = \"navikt/grillmester\"\n")
+
+	out := captureStdoutFor(t, func() {
+		if err := cmdConfigShow(true); err != nil {
+			t.Fatalf("cmdConfigShow: %v", err)
+		}
+	})
+	var got map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parsing config show --json output %q: %v", out, err)
+	}
+	if got["source"] != "navikt/grillmester" {
+		t.Errorf("config show source = %v, want navikt/grillmester", got["source"])
+	}
+}
+
+func TestConfigShowSourceDefaults(t *testing.T) {
+	path := isolatedConfig(t)
+	mustWrite(t, path, "version = 1\n")
+
+	out := captureStdoutFor(t, func() {
+		if err := cmdConfigShow(true); err != nil {
+			t.Fatalf("cmdConfigShow: %v", err)
+		}
+	})
+	var got map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parsing config show --json output %q: %v", out, err)
+	}
+	if got["source"] != defaultSourceRepo {
+		t.Errorf("config show source = %v, want %s", got["source"], defaultSourceRepo)
+	}
+}
+
+// ─── B3/B4: cross-source guard ───────────────────────────────────────────────
+
+func TestGuardScopeSource(t *testing.T) {
+	tests := []struct {
+		name            string
+		configuredSrc   string
+		flagSource      string
+		stateSourceRepo string // "-" means: write no state file at all
+		wantErr         bool
+	}{
+		{name: "no configured source", stateSourceRepo: defaultSourceRepo},
+		{name: "no install yet", configuredSrc: "navikt/grillmester", stateSourceRepo: "-"},
+		{name: "same source", configuredSrc: defaultSourceRepo, stateSourceRepo: defaultSourceRepo},
+		{name: "case-insensitive repo match", configuredSrc: "Navikt/Copilot", stateSourceRepo: defaultSourceRepo},
+		{name: "explicit flag overrides", configuredSrc: "navikt/grillmester", flagSource: "navikt/grillmester", stateSourceRepo: defaultSourceRepo},
+		{name: "cross-source refused", configuredSrc: "navikt/grillmester", stateSourceRepo: defaultSourceRepo, wantErr: true},
+		{name: "unknown recorded source is not guarded on install", configuredSrc: "navikt/grillmester", stateSourceRepo: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := isolatedConfig(t)
+			content := "version = 1\n"
+			if tt.configuredSrc != "" {
+				content += "source = \"" + tt.configuredSrc + "\"\n"
+			}
+			mustWrite(t, path, content)
+
+			scope := ScopeRepo(repoTarget(t))
+			if tt.stateSourceRepo != "-" {
+				writeGuardState(t, scope, tt.stateSourceRepo)
+			}
+
+			err := guardScopeSource(scope, tt.flagSource)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("guardScopeSource = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if tt.wantErr && !strings.Contains(err.Error(), "--source") {
+				t.Errorf("guard error %q does not tell the user how to proceed", err)
+			}
+		})
+	}
+}
+
+func TestGuardScopeSyncSource(t *testing.T) {
+	tests := []struct {
+		name            string
+		configuredSrc   string
+		flagSource      string
+		stateSourceRepo string
+		wantErr         bool
+	}{
+		{name: "recorded source wins, no error", configuredSrc: "navikt/grillmester", stateSourceRepo: defaultSourceRepo},
+		{name: "same source", configuredSrc: defaultSourceRepo, stateSourceRepo: defaultSourceRepo},
+		{name: "no configured source", stateSourceRepo: ""},
+		{name: "unknown recorded source is refused", configuredSrc: "navikt/grillmester", stateSourceRepo: "", wantErr: true},
+		{name: "explicit flag overrides", configuredSrc: "navikt/grillmester", flagSource: defaultSourceRepo, stateSourceRepo: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := isolatedConfig(t)
+			content := "version = 1\n"
+			if tt.configuredSrc != "" {
+				content += "source = \"" + tt.configuredSrc + "\"\n"
+			}
+			mustWrite(t, path, content)
+
+			scope := ScopeRepo(repoTarget(t))
+			writeGuardState(t, scope, tt.stateSourceRepo)
+
+			err := guardScopeSyncSource(scope, tt.flagSource)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("guardScopeSyncSource = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestGuardIsPerScope covers B4: two scopes may track different agentpakker.
+func TestGuardIsPerScope(t *testing.T) {
+	path := isolatedConfig(t)
+	mustWrite(t, path, "version = 1\nsource = \"navikt/grillmester\"\n")
+
+	pakkeScope := ScopeRepo(repoTarget(t))
+	writeGuardState(t, pakkeScope, "navikt/grillmester")
+	navScope := ScopeRepo(repoTarget(t))
+	writeGuardState(t, navScope, defaultSourceRepo)
+
+	if err := guardScopeSource(pakkeScope, ""); err != nil {
+		t.Errorf("scope on the configured source was guarded: %v", err)
+	}
+	if err := guardScopeSource(navScope, ""); err == nil {
+		t.Error("scope on a different source was not guarded")
+	}
+	// Sync leaves both alone: each scope syncs from its own recorded source.
+	if err := guardScopeSyncSource(navScope, ""); err != nil {
+		t.Errorf("sync guard fired for a scope with a recorded source: %v", err)
+	}
+}
+
+func writeGuardState(t *testing.T, scope *InstallScope, sourceRepo string) {
+	t.Helper()
+	state := &StateFile{
+		Collection: "fullstack",
+		Version:    "dev",
+		Scope:      scope.Name,
+		SourceRepo: sourceRepo,
+		SourceSHA:  "abc1234",
+	}
+	if err := writeScopedState(scope, state); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSameSourceRepo(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want bool
+	}{
+		{"navikt/copilot", "navikt/copilot", true},
+		{"navikt/copilot", "Navikt/Copilot", true},
+		{"navikt/copilot", "navikt/grillmester", false},
+		{"/tmp/checkout", "/tmp/checkout/", true},
+		{"/tmp/checkout", "/tmp/other", false},
+	}
+	for _, tt := range tests {
+		if got := sameSourceRepo(tt.a, tt.b); got != tt.want {
+			t.Errorf("sameSourceRepo(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+// ─── A5: nav-pilot validate ──────────────────────────────────────────────────
+
+func TestValidateSourceTree(t *testing.T) {
+	brokenLayout := `{
+	  "contractVersion": "1",
+	  "name": "grillmester",
+	  "description": "d",
+	  "clients": {"copilot": {"primaryAgents": ["grillmester"]}},
+	  "layout": {"agents": "nope/agents", "skills": "nope/skills"}
+	}`
+
+	tests := []struct {
+		name         string
+		tree         func(t *testing.T) string
+		wantKind     string
+		wantFindings bool
+		wantNote     string
+	}{
+		{
+			name:     "legacy collection source validates as legacy",
+			tree:     legacySourceTree,
+			wantKind: "legacy",
+			wantNote: "no manifest (legacy collection source)",
+		},
+		{
+			name: "empty source has nothing to install",
+			tree: func(t *testing.T) string { return t.TempDir() },
+
+			wantKind:     "legacy",
+			wantFindings: true,
+			wantNote:     "no manifest (legacy collection source)",
+		},
+		{
+			name:     "conforming agentpakke",
+			tree:     func(t *testing.T) string { return pakkeSourceTree(t, tier1ManifestJSON) },
+			wantKind: "agentpakke",
+			wantNote: "agentpakke: grillmester",
+		},
+		{
+			name:         "agentpakke with missing layout dirs",
+			tree:         func(t *testing.T) string { return pakkeSourceTree(t, brokenLayout) },
+			wantKind:     "agentpakke",
+			wantFindings: true,
+		},
+		{
+			name: "collection listing a missing agent",
+			tree: func(t *testing.T) string {
+				dir := t.TempDir()
+				mustWrite(t, filepath.Join(dir, "collections", "x", "manifest.json"),
+					`{"name":"x","description":"d","agents":["ghost"]}`)
+				return dir
+			},
+			wantKind:     "legacy",
+			wantFindings: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := &Source{Dir: tt.tree(t), SHA: "abc", Repo: "navikt/test"}
+			kind, notes, findings := validateSourceTree(src)
+			if kind != tt.wantKind {
+				t.Errorf("kind = %q, want %q", kind, tt.wantKind)
+			}
+			if (len(findings) > 0) != tt.wantFindings {
+				t.Errorf("findings = %v, wantFindings = %v", findings, tt.wantFindings)
+			}
+			if tt.wantNote != "" && !strings.Contains(strings.Join(notes, "\n"), tt.wantNote) {
+				t.Errorf("notes %v do not mention %q", notes, tt.wantNote)
+			}
+		})
+	}
+}
+
+func TestCmdValidateExitsNonZeroOnViolation(t *testing.T) {
+	isolatedConfig(t)
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, agentpakke.ManifestDir, agentpakke.ManifestFile),
+		`{"contractVersion":"1","name":"x","description":"d","clients":{"copilot":{"primaryAgents":["a"]}},"layout":{"agents":"gone","skills":"gone"}}`)
+
+	orig := resolveSourceRaw
+	t.Cleanup(func() { resolveSourceRaw = orig })
+	resolveSourceRaw = func(ref, sourceRepo string) (*Source, error) {
+		return &Source{Dir: dir, SHA: "abc", Repo: "navikt/x"}, nil
+	}
+
+	out := captureStdoutFor(t, func() {
+		if err := cmdValidate("", "", false); err == nil {
+			t.Error("cmdValidate on a non-conforming source = nil, want an error (non-zero exit)")
+		}
+	})
+	if !strings.Contains(out, "problem") {
+		t.Errorf("validate output does not list problems:\n%s", out)
+	}
+}
+
+func TestCmdValidateLegacySourcePasses(t *testing.T) {
+	isolatedConfig(t)
+	dir := legacySourceTree(t)
+
+	orig := resolveSourceRaw
+	t.Cleanup(func() { resolveSourceRaw = orig })
+	resolveSourceRaw = func(ref, sourceRepo string) (*Source, error) {
+		return &Source{Dir: dir, SHA: "abc", Repo: defaultSourceRepo}, nil
+	}
+
+	out := captureStdoutFor(t, func() {
+		if err := cmdValidate("", "", false); err != nil {
+			t.Errorf("cmdValidate on a legacy source = %v, want nil", err)
+		}
+	})
+	if !strings.Contains(out, "legacy collection source") {
+		t.Errorf("validate output does not report the legacy case:\n%s", out)
+	}
+}
+
+// captureStdoutFor runs fn with stdout redirected to a pipe and returns what it
+// printed.
+func captureStdoutFor(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	done := make(chan string, 1)
+	go func() {
+		var sb strings.Builder
+		buf := make([]byte, 4096)
+		for {
+			n, err := r.Read(buf)
+			if n > 0 {
+				sb.Write(buf[:n])
+			}
+			if err != nil {
+				break
+			}
+		}
+		done <- sb.String()
+	}()
+
+	fn()
+	w.Close()
+	os.Stdout = orig
+	out := <-done
+	r.Close()
+	return out
+}

--- a/cli/nav-pilot/internal/cli/agentpakke_test.go
+++ b/cli/nav-pilot/internal/cli/agentpakke_test.go
@@ -2,12 +2,14 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
+	"github.com/navikt/copilot/cli/nav-pilot/internal/artifacts"
 )
 
 // ─── source-tree fixtures ────────────────────────────────────────────────────
@@ -266,6 +268,348 @@ func TestValidatePakkeSourceLeavesNothingInstalled(t *testing.T) {
 	}
 }
 
+// ─── Tier 2-only agentpakker ─────────────────────────────────────────────────
+
+const tier2ManifestJSON = `{
+  "contractVersion": "1",
+  "name": "grillmester",
+  "description": "Grillmester agentpakke, pre-built",
+  "clients": {"copilot": {"primaryAgents": ["grillmester"], "payloads": {"full": {"path": "dist/copilot/full"}}}}
+}`
+
+// tier2SourceTree builds a conforming Tier 2 agentpakke: payload tree present,
+// payload manifest present, no layout — so the only thing wrong with installing
+// it is that this binary cannot stage payloads yet.
+func tier2SourceTree(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, agentpakke.ManifestDir, agentpakke.ManifestFile), tier2ManifestJSON)
+	mustWrite(t, filepath.Join(dir, "dist", "copilot", "full", "manifest.json"), `{"files":[]}`)
+	return dir
+}
+
+func TestTier2OnlyPakkeIsRefusedWithItsOwnReason(t *testing.T) {
+	isolatedConfig(t)
+	src := &Source{Dir: tier2SourceTree(t), SHA: "abc1234", Version: "dev", Repo: "navikt/grillmester"}
+	if err := attachPakke(src); err != nil {
+		t.Fatalf("attachPakke on a conforming Tier 2 manifest: %v", err)
+	}
+	if src.Pakke == nil || src.Pakke.Layout != nil {
+		t.Fatalf("fixture is not Tier 2-only: %+v", src.Pakke)
+	}
+
+	target := repoTarget(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	userScope, err := ScopeUser()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	forceNonInteractive = true
+	t.Cleanup(func() { forceNonInteractive = false })
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{"collection install", func() error { return cmdInstallFromSource("grillmester", src, ScopeRepo(target), false, false, false) }},
+		{"install all", func() error { return installAllFromSource(userScope, src, nil, false, false, false) }},
+		{"interactive user install", func() error { return interactiveUserInstallFromSource(userScope, src, "") }},
+		{"list", func() error { return cmdList("", "", false, true) }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "list" {
+				stubResolveSource(t, src)
+			}
+			err := tt.run()
+			if err == nil {
+				t.Fatal("Tier 2-only agentpakke was accepted, want a refusal")
+			}
+			if !strings.Contains(err.Error(), "pre-built payloads (Tier 2), which this nav-pilot version cannot install yet") {
+				t.Errorf("error %q does not name the Tier 2 case", err)
+			}
+			if strings.Contains(err.Error(), "declares a layout") || strings.Contains(err.Error(), "no agents, skills, or instructions found") {
+				t.Errorf("error %q is still the misleading layout/empty-source message", err)
+			}
+		})
+	}
+
+	if entries, _ := os.ReadDir(filepath.Join(target, ".github")); len(entries) > 0 {
+		t.Errorf("refused Tier 2 install left %d entries under .github/", len(entries))
+	}
+}
+
+// ─── B4: sync says which source it actually used ─────────────────────────────
+
+// TestSyncNotesRecordedSourceWins covers MINOR-5: the recorded source keeps
+// winning, but the user is told when that means their configured source is not
+// the one being read.
+func TestSyncNotesRecordedSourceWins(t *testing.T) {
+	tests := []struct {
+		name          string
+		configuredSrc string
+		stateSource   string
+		wantNote      bool
+	}{
+		{name: "configured source differs", configuredSrc: "navikt/grillmester", stateSource: defaultSourceRepo, wantNote: true},
+		{name: "configured source matches", configuredSrc: defaultSourceRepo, stateSource: defaultSourceRepo},
+		{name: "configured source matches case-insensitively", configuredSrc: "Navikt/Copilot", stateSource: defaultSourceRepo},
+		{name: "nothing configured", stateSource: "navikt/grillmester"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := isolatedConfig(t)
+			content := "version = 1\n"
+			if tt.configuredSrc != "" {
+				content += "source = \"" + tt.configuredSrc + "\"\n"
+			}
+			mustWrite(t, path, content)
+
+			target := repoTarget(t)
+			scope := ScopeRepo(target)
+			if err := writeScopedState(scope, &StateFile{
+				Collection: "fullstack",
+				Version:    "dev",
+				Scope:      scope.Name,
+				SourceRepo: tt.stateSource,
+				SourceSHA:  "abc1234",
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			srcDir := legacySourceTree(t)
+			orig := resolveSourceForSync
+			t.Cleanup(func() { resolveSourceForSync = orig })
+			var gotSourceRepo string
+			resolveSourceForSync = func(ref, sourceRepo string) (*Source, error) {
+				gotSourceRepo = sourceRepo
+				return &Source{Dir: srcDir, SHA: "abc1234", Version: "dev", Repo: sourceRepo}, nil
+			}
+
+			out := captureStdoutFor(t, func() {
+				if err := cmdSync(scope, "", "", false, false); err != nil {
+					t.Fatalf("cmdSync: %v", err)
+				}
+			})
+
+			if gotSourceRepo != tt.stateSource {
+				t.Errorf("sync resolved source %q, want the recorded %q", gotSourceRepo, tt.stateSource)
+			}
+			gotNote := strings.Contains(out, "is not used here")
+			if gotNote != tt.wantNote {
+				t.Errorf("informational line present = %v, want %v. Output:\n%s", gotNote, tt.wantNote, out)
+			}
+			if tt.wantNote && !strings.Contains(out, tt.stateSource) {
+				t.Errorf("informational line does not name the source actually used:\n%s", out)
+			}
+		})
+	}
+}
+
+// ─── root TUI staleness is a default-source question ─────────────────────────
+
+// TestScopeStalenessOnlyForDefaultSource covers MINOR-4: nav-pilot's release
+// feed describes navikt/copilot, so a scope installed from another agentpakke
+// is neither assessed against it nor offered a sync to nav-pilot/<latest>.
+func TestScopeStalenessOnlyForDefaultSource(t *testing.T) {
+	orig := assessStaleness
+	t.Cleanup(func() { assessStaleness = orig })
+	assessed := 0
+	assessStaleness = func(installedVersion string) artifacts.StalenessAssessment {
+		assessed++
+		return artifacts.StalenessAssessment{LatestVersion: "2099.01.01-000000-abc1234"}
+	}
+
+	tests := []struct {
+		name        string
+		sourceRepo  string
+		wantLatest  string
+		wantAssess  int
+		description string
+	}{
+		{name: "default source is assessed", sourceRepo: defaultSourceRepo, wantLatest: "2099.01.01-000000-abc1234", wantAssess: 1},
+		{name: "untracked source is assessed as the default", sourceRepo: "", wantLatest: "2099.01.01-000000-abc1234", wantAssess: 1},
+		{name: "other agentpakke is left alone", sourceRepo: "navikt/grillmester", wantLatest: "", wantAssess: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assessed = 0
+			scope := ScopeRepo(repoTarget(t))
+			state := &StateFile{Collection: "grillmester", Version: "2026.01.01-000000-abc1234", SourceRepo: tt.sourceRepo}
+
+			got := scopeStaleness(scope, state)
+			if got != tt.wantLatest {
+				t.Errorf("scopeStaleness = %q, want %q", got, tt.wantLatest)
+			}
+			if assessed != tt.wantAssess {
+				t.Errorf("assessStaleness called %d time(s), want %d — a non-default source must not be checked against nav-pilot releases", assessed, tt.wantAssess)
+			}
+		})
+	}
+}
+
+// ─── new-item reminders for agentpakke scopes ────────────────────────────────
+
+// TestDetectNewItemsForPakkeScope covers MINOR-8: a pakke is installed whole, so
+// content it grows is new content for that scope — the reminder is not limited
+// to the legacy "(all)" user-scope install.
+func TestDetectNewItemsForPakkeScope(t *testing.T) {
+	isolatedConfig(t)
+	srcDir := pakkeSourceTree(t, tier1ManifestJSON)
+	target := repoTarget(t)
+	scope := ScopeRepo(target)
+
+	src := &Source{Dir: srcDir, SHA: "def5678", Version: "dev", Repo: "navikt/grillmester"}
+	if err := attachPakke(src); err != nil {
+		t.Fatalf("attachPakke: %v", err)
+	}
+	if err := cmdInstallFromSource("grillmester", src, scope, false, false, false); err != nil {
+		t.Fatalf("cmdInstallFromSource: %v", err)
+	}
+
+	resolver := resolverFor(srcDir, src.Pakke)
+	if items := detectNewItems(scope, resolver, src); len(items) != 0 {
+		t.Errorf("freshly installed pakke reported new items: %v", items)
+	}
+
+	// The agentpakke grows an agent.
+	mustWrite(t, filepath.Join(srcDir, "plugin", "agents", "sausage.agent.md"),
+		"---\nname: sausage\ndescription: S\n---\nBody\n")
+
+	items := detectNewItems(scope, resolver, src)
+	if len(items) != 1 || !strings.Contains(items[0], "sausage") {
+		t.Errorf("detectNewItems = %v, want the new agent from the pakke layout", items)
+	}
+	if got := installCommandFor(scope, src); got != "nav-pilot install grillmester" {
+		t.Errorf("installCommandFor = %q, want the pakke install command", got)
+	}
+
+	// A user's deselected item stays out of the reminder.
+	state, err := readScopedState(scope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state.Files = append(state.Files, InstalledFile{
+		Path:   KindAgent.RelPathForName(scope, "sausage"),
+		Status: fileStatusIgnored,
+	})
+	if err := writeScopedState(scope, state); err != nil {
+		t.Fatal(err)
+	}
+	if items := detectNewItems(scope, resolver, src); len(items) != 0 {
+		t.Errorf("detectNewItems reported an ignored item: %v", items)
+	}
+}
+
+// TestDetectNewItemsLegacyUnchanged pins the pre-existing rule: without an
+// agentpakke, only the "(all)" user-scope install gets reminders.
+func TestDetectNewItemsLegacyUnchanged(t *testing.T) {
+	srcDir := legacySourceTree(t)
+	resolver := resolverFor(srcDir, pakkeFor(nil, CollectionAll))
+
+	tests := []struct {
+		name       string
+		collection string
+		userScope  bool
+		want       int
+	}{
+		{name: "single collection in repo scope", collection: "fullstack", want: 0},
+		{name: "single collection in user scope", collection: "fullstack", userScope: true, want: 0},
+		{name: "(all) in repo scope", collection: CollectionAll, want: 0},
+		{name: "(all) in user scope", collection: CollectionAll, userScope: true, want: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			scope := ScopeRepo(repoTarget(t))
+			if tt.userScope {
+				var err error
+				if scope, err = ScopeUser(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := writeScopedState(scope, &StateFile{
+				Collection: tt.collection,
+				Scope:      scope.Name,
+				SourceRepo: defaultSourceRepo,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if got := detectNewItems(scope, resolver, nil); len(got) != tt.want {
+				t.Errorf("detectNewItems = %v (%d), want %d item(s)", got, len(got), tt.want)
+			}
+		})
+	}
+}
+
+// ─── containment: symlinked layout directories ───────────────────────────────
+
+// symlinkedLayoutTree builds an agentpakke whose layout.agents directory is a
+// symlink to content outside the checkout — the escape an Lstat of the final
+// path component alone does not catch.
+func symlinkedLayoutTree(t *testing.T) string {
+	t.Helper()
+	outside := t.TempDir()
+	mustWrite(t, filepath.Join(outside, "secret.agent.md"), "---\nname: secret\ndescription: S\n---\nBody\n")
+
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, agentpakke.ManifestDir, agentpakke.ManifestFile), tier1ManifestJSON)
+	if err := os.MkdirAll(filepath.Join(dir, "plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dir, "plugin", "agents")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	mustWrite(t, filepath.Join(dir, "plugin", "skills", "grilling", "SKILL.md"), "# Grilling\n")
+	return dir
+}
+
+func TestSymlinkedLayoutDirIsRefused(t *testing.T) {
+	isolatedConfig(t)
+	srcDir := symlinkedLayoutTree(t)
+	target := repoTarget(t)
+
+	src := &Source{Dir: srcDir, SHA: "abc1234", Version: "dev", Repo: "navikt/grillmester"}
+	if err := attachPakke(src); err != nil {
+		t.Fatalf("attachPakke: %v", err)
+	}
+
+	// validate reports it...
+	_, _, findings := validateSourceTree(src)
+	if len(findings) == 0 {
+		t.Error("validate accepted a layout directory symlinked outside the repo")
+	}
+	var joined string
+	for _, f := range findings {
+		joined += f.Error() + "\n"
+	}
+	if !strings.Contains(joined, "symlink") {
+		t.Errorf("findings do not name the symlink:\n%s", joined)
+	}
+
+	// ...and install refuses before writing anything.
+	err := cmdInstallFromSource("grillmester", src, ScopeRepo(target), false, false, false)
+	if err == nil {
+		t.Fatal("install from a source with a symlinked layout directory succeeded, want a refusal")
+	}
+	if entries, _ := os.ReadDir(filepath.Join(target, ".github")); len(entries) > 0 {
+		t.Errorf("refused install left %d entries under .github/", len(entries))
+	}
+
+	// The resolver behind reads and copies must not see the escaped content
+	// either, whichever way it is asked.
+	resolver := resolverFor(srcDir, src.Pakke)
+	if art, ok := resolver.Get(KindAgent, "secret"); ok {
+		t.Errorf("resolver resolved %q through a symlinked layout directory", art.AbsPath)
+	}
+	if items := resolver.List(KindAgent); len(items) != 0 {
+		t.Errorf("resolver listed %d agent(s) from outside the checkout", len(items))
+	}
+}
+
 // ─── B1: source precedence ───────────────────────────────────────────────────
 
 func TestSourceRepoFor(t *testing.T) {
@@ -520,6 +864,176 @@ func TestGuardIsPerScope(t *testing.T) {
 	// Sync leaves both alone: each scope syncs from its own recorded source.
 	if err := guardScopeSyncSource(navScope, ""); err != nil {
 		t.Errorf("sync guard fired for a scope with a recorded source: %v", err)
+	}
+}
+
+// ─── B3 in the interactive paths ─────────────────────────────────────────────
+
+// stubResolveSource points the CLI's source funnel at an already-prepared
+// checkout, so interactive flows can be driven without cloning anything.
+func stubResolveSource(t *testing.T, src *Source) {
+	t.Helper()
+	orig := resolveSource
+	t.Cleanup(func() { resolveSource = orig })
+	resolveSource = func(ref, sourceRepo string) (*Source, error) { return src, nil }
+}
+
+// pakkeSource builds a resolved, manifest-bearing source over a fixture tree.
+func pakkeSource(t *testing.T, repo string) *Source {
+	t.Helper()
+	src := &Source{Dir: pakkeSourceTree(t, tier1ManifestJSON), SHA: "def5678", Version: "dev", Repo: repo}
+	if err := attachPakke(src); err != nil {
+		t.Fatalf("attachPakke: %v", err)
+	}
+	return src
+}
+
+// TestInteractiveInstallGuardsCrossSource covers B3 in the prompt-driven install
+// paths: picking a scope in a TUI is not a way around the cross-source guard.
+func TestInteractiveInstallGuardsCrossSource(t *testing.T) {
+	tests := []struct {
+		name string
+		// run installs into a scope whose state records defaultSourceRepo while
+		// the configured source is navikt/grillmester.
+		run func(t *testing.T, src *Source, home, target string) error
+	}{
+		{
+			name: "repo collection picker",
+			run: func(t *testing.T, src *Source, home, target string) error {
+				return interactiveRepoInstall(src, ScopeRepo(target), "")
+			},
+		},
+		{
+			name: "user item picker",
+			run: func(t *testing.T, src *Source, home, target string) error {
+				scope, err := ScopeUser()
+				if err != nil {
+					t.Fatal(err)
+				}
+				return interactiveUserInstallFromSource(scope, src, "")
+			},
+		},
+		{
+			name: "bare install in a repo",
+			run: func(t *testing.T, src *Source, home, target string) error {
+				stubResolveSource(t, src)
+				return cmdInstallInteractive(target, "", "")
+			},
+		},
+		{
+			name: "bare install outside a repo",
+			run: func(t *testing.T, src *Source, home, target string) error {
+				stubResolveSource(t, src)
+				return cmdInstallInteractive("", "", "")
+			},
+		},
+		{
+			name: "install --user",
+			run: func(t *testing.T, src *Source, home, target string) error {
+				stubResolveSource(t, src)
+				scope, err := ScopeUser()
+				if err != nil {
+					t.Fatal(err)
+				}
+				return cmdInstallAll(scope, "", "", false, false, false)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			forceNonInteractive = true
+			t.Cleanup(func() { forceNonInteractive = false })
+
+			path := isolatedConfig(t)
+			mustWrite(t, path, "version = 1\nsource = \"navikt/grillmester\"\n")
+
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			target := repoTarget(t)
+
+			userScope, err := ScopeUser()
+			if err != nil {
+				t.Fatal(err)
+			}
+			writeGuardState(t, userScope, defaultSourceRepo)
+			writeGuardState(t, ScopeRepo(target), defaultSourceRepo)
+
+			err = tt.run(t, pakkeSource(t, "navikt/grillmester"), home, target)
+			if err == nil {
+				t.Fatal("interactive install from a different source succeeded, want the B3 refusal")
+			}
+			if !strings.Contains(err.Error(), "will not silently mix") {
+				t.Errorf("error %q is not the cross-source refusal", err)
+			}
+		})
+	}
+}
+
+// TestInteractiveInstallAllowsExplicitSource is the other half: an explicit
+// --source is the user answering the guard's question, so the interactive path
+// installs.
+func TestInteractiveInstallAllowsExplicitSource(t *testing.T) {
+	forceNonInteractive = true
+	t.Cleanup(func() { forceNonInteractive = false })
+
+	path := isolatedConfig(t)
+	mustWrite(t, path, "version = 1\nsource = \"navikt/grillmester\"\n")
+
+	target := repoTarget(t)
+	scope := ScopeRepo(target)
+	writeGuardState(t, scope, defaultSourceRepo)
+
+	src := pakkeSource(t, "navikt/grillmester")
+	if err := interactiveRepoInstall(src, scope, "navikt/grillmester"); err != nil {
+		t.Fatalf("interactiveRepoInstall with an explicit --source: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(target, ".github", "agents", "grillmester.agent.md")); err != nil {
+		t.Errorf("explicit --source install did not write the agent: %v", err)
+	}
+}
+
+// ─── B2: a cancelled install persists nothing ────────────────────────────────
+
+// TestCancelledInteractiveInstallDoesNotPersistSource covers MAJOR-2: cancelling
+// a prompt must be distinguishable from a successful install, or --source gets
+// saved for an install that never happened.
+func TestCancelledInteractiveInstallDoesNotPersistSource(t *testing.T) {
+	forceNonInteractive = true
+	t.Cleanup(func() { forceNonInteractive = false })
+
+	path := isolatedConfig(t)
+	mustWrite(t, path, "version = 1\n")
+
+	target := repoTarget(t)
+	src := pakkeSource(t, "navikt/grillmester")
+	stubResolveSource(t, src)
+
+	// promptInstallScope cancelling is the cheapest cancel to simulate: it is
+	// the same nil-scope path a user takes by pressing Esc.
+	origPrompt := promptInstallScopeFn
+	t.Cleanup(func() { promptInstallScopeFn = origPrompt })
+	promptInstallScopeFn = func(string) (*InstallScope, error) { return nil, nil }
+
+	err := cmdInstallInteractive(target, "", "navikt/grillmester")
+	if !errors.Is(err, errInstallCancelled) {
+		t.Fatalf("cancelled install returned %v, want errInstallCancelled", err)
+	}
+
+	// finishInstall is what run() wraps every install in: it must turn the
+	// sentinel into a clean exit and persist nothing.
+	if err := finishInstall(err, "navikt/grillmester", false); err != nil {
+		t.Errorf("finishInstall(cancelled) = %v, want nil (clean exit)", err)
+	}
+	if got, _ := configuredSourceRepo(); got != "" {
+		t.Errorf("cancelled install persisted source = %q, want none", got)
+	}
+	data, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if strings.Contains(string(data), "source =") {
+		t.Errorf("cancelled install wrote a source key:\n%s", data)
 	}
 }
 

--- a/cli/nav-pilot/internal/cli/aliases.go
+++ b/cli/nav-pilot/internal/cli/aliases.go
@@ -234,7 +234,9 @@ var (
 // cmdExport funnels the source precedence into the artifacts package, which
 // resolves its own source. The agentpakke manifest is not threaded here: export
 // materializes another tool's format from canonical content and is migrated
-// with the rest of the provider layer in M2.
+// with the rest of the provider layer in M2. Until then, artifacts refuses a
+// source whose manifest declares a non-canonical layout rather than exporting
+// an empty tree from paths that source does not use.
 var cmdExport = func(format string, scope *InstallScope, ref, sourceRepo string, dryRun, force bool, jsonOutput bool) error {
 	effective, err := sourceRepoFor(sourceRepo)
 	if err != nil {

--- a/cli/nav-pilot/internal/cli/aliases.go
+++ b/cli/nav-pilot/internal/cli/aliases.go
@@ -98,19 +98,58 @@ var (
 	kindByName      = source.KindByName
 )
 
-// Const alias
-const CollectionAll = source.CollectionAll
+// Const aliases
+const (
+	CollectionAll = source.CollectionAll
 
-// Function aliases — closures capture the package-level `Version` var at call time
+	// defaultSourceRepo is the content source used when neither --source nor
+	// the config file's source key names one.
+	defaultSourceRepo = source.DefaultRepo
+)
+
+// Function aliases — closures capture the package-level `Version` var at call time.
+//
+// resolveSource and resolveSourceForSync are the CLI's source funnel: they
+// apply the source precedence (--source > config `source` > navikt/copilot) and
+// attach the agentpakke manifest, so every command that reads content gets the
+// selected agentpakke and its fail-closed validation without repeating either.
 var (
 	resolveSource = func(ref, sourceRepo string) (*source.Source, error) {
-		return source.ResolveSource(ref, sourceRepo, Version)
+		effective, err := sourceRepoFor(sourceRepo)
+		if err != nil {
+			return nil, err
+		}
+		src, err := source.ResolveSource(ref, effective, Version)
+		if err != nil {
+			return nil, err
+		}
+		return src, attachPakkeOrCleanup(src)
 	}
 	resolveSourceForSync = func(ref, sourceRepo string) (*source.Source, error) {
-		return source.ResolveSourceForSync(ref, sourceRepo, Version)
+		effective, err := sourceRepoFor(sourceRepo)
+		if err != nil {
+			return nil, err
+		}
+		src, err := source.ResolveSourceForSync(ref, effective, Version)
+		if err != nil {
+			return nil, err
+		}
+		return src, attachPakkeOrCleanup(src)
 	}
-	findGitRoot       = source.FindGitRoot
-	NewSourceResolver = source.NewSourceResolver
+	// resolveSourceRaw skips the manifest attach, so `nav-pilot validate` can
+	// report a non-conforming manifest as findings instead of failing to
+	// resolve the source at all.
+	resolveSourceRaw = func(ref, sourceRepo string) (*source.Source, error) {
+		effective, err := sourceRepoFor(sourceRepo)
+		if err != nil {
+			return nil, err
+		}
+		return source.ResolveSource(ref, effective, Version)
+	}
+	findGitRoot                = source.FindGitRoot
+	NewSourceResolver          = source.NewSourceResolver
+	NewSourceResolverForLayout = source.NewSourceResolverForLayout
+	validateSourceValue        = source.ValidateSourceValue
 
 	// files.go
 	fileHash               = source.FileHash
@@ -125,12 +164,24 @@ var (
 	checkConflict          = source.CheckConflict
 
 	// manifest.go
-	validateName       = source.ValidateName
-	validateManifest   = source.ValidateManifest
-	loadManifest       = source.LoadManifest
-	listCollectionDirs = source.ListCollectionDirs
-	collectAllItems    = source.CollectAllItems
+	validateName        = source.ValidateName
+	validateManifest    = source.ValidateManifest
+	loadManifest        = source.LoadManifest
+	listCollectionDirs  = source.ListCollectionDirs
+	collectAllItems     = source.CollectAllItems
+	collectAllItemsWith = source.CollectAllItemsWith
 )
+
+// attachPakkeOrCleanup attaches the agentpakke manifest and removes a cloned
+// checkout when the manifest is unusable, so a fail-closed resolve does not
+// leak a temp dir the caller never got to defer Cleanup on.
+func attachPakkeOrCleanup(src *source.Source) error {
+	if err := attachPakke(src); err != nil {
+		src.Cleanup()
+		return err
+	}
+	return nil
+}
 
 // ─── artifacts aliases ───────────────────────────────────────────────────────
 
@@ -180,8 +231,16 @@ var (
 	overrideSet    = artifacts.OverrideSet
 )
 
+// cmdExport funnels the source precedence into the artifacts package, which
+// resolves its own source. The agentpakke manifest is not threaded here: export
+// materializes another tool's format from canonical content and is migrated
+// with the rest of the provider layer in M2.
 var cmdExport = func(format string, scope *InstallScope, ref, sourceRepo string, dryRun, force bool, jsonOutput bool) error {
-	return artifacts.CmdExport(format, scope, ref, sourceRepo, Version, dryRun, force, jsonOutput)
+	effective, err := sourceRepoFor(sourceRepo)
+	if err != nil {
+		return err
+	}
+	return artifacts.CmdExport(format, scope, ref, effective, Version, dryRun, force, jsonOutput)
 }
 
 var writeOpenCodeState = artifacts.WriteOpenCodeState

--- a/cli/nav-pilot/internal/cli/cli.go
+++ b/cli/nav-pilot/internal/cli/cli.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/charmbracelet/huh"
 
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
 	providerpkg "github.com/navikt/copilot/cli/nav-pilot/internal/provider"
 )
 
@@ -58,8 +59,8 @@ func isKnownCommand(arg string) bool {
 	}
 	switch arg {
 	case "install", "init", "export", "add", "ignore", "sync", "list", "doctor",
-		"uninstall", "upgrade", "update", "config", "env", "feedback", "models",
-		"version", "--version", "-v", "-h", "--help", "help":
+		"uninstall", "upgrade", "update", "config", "validate", "env", "feedback",
+		"models", "version", "--version", "-v", "-h", "--help", "help":
 		return true
 	default:
 		return false
@@ -88,6 +89,7 @@ Commands:
   uninstall (rm)          Remove installed collection files
   export <format>         Export Nav customizations to another tool's format
   config <subcommand>     Manage user-specific nav-pilot configuration (init, setup, show, get, set, validate)
+  validate                Check that a source repo conforms to the agentpakke contract
   env                     Print shell exports for Copilot CLI integration
   ignore <type> <name>    Suppress new-item reminders for a specific item (--user)
   feedback                Report a bug or request a feature
@@ -98,7 +100,7 @@ Flags:
   -f, --force             Overwrite files that differ from source
   -t, --target <dir>      Target repository (default: current directory)
   -r, --ref <ref>         Git branch or tag to install from
-  -s, --source <repo>     Source repository (default: navikt/copilot)
+  -s, --source <repo>     Source repository or absolute path (default: the config's source key, else navikt/copilot)
   -u, --user              Install to ~/.copilot — works across all repos (agents, skills & instructions only)
   --type <type>           Artifact type for install (agent, skill, instruction, prompt)
   --all                   Install everything (use with --user)
@@ -120,6 +122,8 @@ Get started:
   nav-pilot install security-champion    # Install a single agent
   nav-pilot sync                         # Check for updates
   nav-pilot export opencode              # Export for OpenCode/oh-my-openagent
+  nav-pilot install --source navikt/x    # Install another team's agentpakke (and remember it)
+  nav-pilot validate --source navikt/x   # Check an agentpakke repo against the contract
 
 After installing, use @nav-pilot in GitHub Copilot Chat.
 `)
@@ -411,6 +415,12 @@ func run(args []string) error {
 		return fmt.Errorf("--user and --target are mutually exclusive")
 	}
 
+	// --source participates in the config precedence too, so a launch triggered
+	// from a subcommand resolves the same source the command installed from.
+	if sourceRepo != "" {
+		cliOverrides.Source = sourceRepo
+	}
+
 	if abs, err := filepath.Abs(targetDir); err == nil {
 		targetDir = abs
 	}
@@ -452,20 +462,29 @@ func run(args []string) error {
 	switch command {
 	case "install":
 		return runWithCommandTelemetry("install", telemetryMode(), scope.Name, func() error {
+			// B2: an explicit --source is persisted only after the install it
+			// was given to succeeded (and validated, which resolveSource does).
+			install := func(err error) error {
+				if err != nil {
+					return err
+				}
+				persistInstalledSource(sourceRepo, dryRun)
+				return nil
+			}
 			if userScope && (len(positional) == 0 || installAll) {
-				return cmdInstallAll(scope, ref, sourceRepo, dryRun, force, jsonOutput)
+				return install(cmdInstallAll(scope, ref, sourceRepo, dryRun, force, jsonOutput))
 			}
 			if len(positional) == 0 {
 				// No args: launch interactive flow if in a terminal
 				if isInteractive() && !jsonOutput {
-					return cmdInstallInteractive(targetDir, ref, sourceRepo)
+					return install(cmdInstallInteractive(targetDir, ref, sourceRepo))
 				}
 				return fmt.Errorf("install requires a name. Run 'nav-pilot list' to see available collections and items")
 			}
 			if len(positional) > 1 {
 				return fmt.Errorf("install takes one name. Did you mean: nav-pilot install %s --type %s", positional[1], positional[0])
 			}
-			return cmdInstallAuto(positional[0], installType, scope, ref, sourceRepo, dryRun, force, jsonOutput)
+			return install(cmdInstallAuto(positional[0], installType, scope, ref, sourceRepo, dryRun, force, jsonOutput))
 		})
 	case "init":
 		return runWithCommandTelemetry("init", telemetryMode(), scope.Name, func() error {
@@ -553,6 +572,15 @@ func run(args []string) error {
 		return runWithCommandTelemetry("config", telemetryMode(), "none", func() error {
 			return cmdConfig(positional, force, jsonOutput)
 		})
+	case "validate":
+		// Distinct from `nav-pilot config validate`, which checks the user's own
+		// config: this validates a content repo against the agentpakke contract.
+		if len(positional) > 0 {
+			return fmt.Errorf("validate takes no arguments.\n\nUsage: nav-pilot validate [--source <repo>|<path>] [--ref <ref>]")
+		}
+		return runWithCommandTelemetry("validate", telemetryMode(), "none", func() error {
+			return cmdValidate(ref, sourceRepo, jsonOutput)
+		})
 	case "env":
 		return runWithCommandTelemetry("env", telemetryMode(), "none", cmdEnv)
 	case "feedback":
@@ -570,7 +598,7 @@ func run(args []string) error {
 		usage()
 		return nil
 	default:
-		knownCmds := []string{"install", "init", "export", "add", "ignore", "sync", "list", "doctor", "uninstall", "upgrade", "update", "config", "env", "feedback", "models", "version", "help"}
+		knownCmds := []string{"install", "init", "export", "add", "ignore", "sync", "list", "doctor", "uninstall", "upgrade", "update", "config", "validate", "env", "feedback", "models", "version", "help"}
 		if hint := suggest(command, knownCmds); hint != "" {
 			return fmt.Errorf("unknown command: %s. Did you mean %s?\nRun with --help for usage", command, hint)
 		}
@@ -610,6 +638,7 @@ func Main(info BuildInfo) {
 	Version = info.Version
 	buildInfo = info
 	providerpkg.SetVersion(info.Version)
+	agentpakke.SetVersion(info.Version)
 	providerpkg.FetchLatestVersion = func() (string, string, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()

--- a/cli/nav-pilot/internal/cli/cli.go
+++ b/cli/nav-pilot/internal/cli/cli.go
@@ -462,14 +462,8 @@ func run(args []string) error {
 	switch command {
 	case "install":
 		return runWithCommandTelemetry("install", telemetryMode(), scope.Name, func() error {
-			// B2: an explicit --source is persisted only after the install it
-			// was given to succeeded (and validated, which resolveSource does).
 			install := func(err error) error {
-				if err != nil {
-					return err
-				}
-				persistInstalledSource(sourceRepo, dryRun)
-				return nil
+				return finishInstall(err, sourceRepo, dryRun)
 			}
 			if userScope && (len(positional) == 0 || installAll) {
 				return install(cmdInstallAll(scope, ref, sourceRepo, dryRun, force, jsonOutput))

--- a/cli/nav-pilot/internal/cli/config.go
+++ b/cli/nav-pilot/internal/cli/config.go
@@ -71,6 +71,40 @@ func readConfigWithMeta() (*Config, toml.MetaData, error) {
 	return &cfg, meta, nil
 }
 
+// configuredSourceRepo returns the source persisted in the config file, or the
+// empty string when none is set (meaning the built-in default).
+func configuredSourceRepo() (string, error) {
+	cfg, err := readConfig()
+	if err != nil {
+		return "", err
+	}
+	if cfg == nil || cfg.Source == nil {
+		return "", nil
+	}
+	return strings.TrimSpace(*cfg.Source), nil
+}
+
+// sourceRepoFor applies the source precedence for content resolution:
+// explicit --source flag > config file `source` > built-in default (B1).
+// An empty result means the default, which resolveSource already implements.
+func sourceRepoFor(flagSource string) (string, error) {
+	if flagSource != "" {
+		return flagSource, nil
+	}
+	configured, err := configuredSourceRepo()
+	if err != nil {
+		return "", fmt.Errorf("%w\n\nFix %s or run `nav-pilot config validate`", err, configPath())
+	}
+	if configured == "" {
+		return "", nil
+	}
+	if err := validateSourceValue(configured); err != nil {
+		return "", fmt.Errorf("config key %s is invalid: %w\n\nFix %s, or clear it with `nav-pilot config set source \"\"`",
+			bold("source"), err, configPath())
+	}
+	return configured, nil
+}
+
 // validateConfigProblems checks semantic correctness of a parsed config and
 // returns a list of human-readable problem strings (empty = valid).
 // It does NOT check for unknown TOML keys — use MetaData.Undecoded() for that.
@@ -93,6 +127,13 @@ func validateConfigProblems(cfg *Config) []string {
 			client = *cfg.Client
 		}
 		if err := validateModelForClient(*cfg.Model, client); err != nil {
+			problems = append(problems, err.Error())
+		}
+	}
+	// An empty source is how the key is cleared back to the default, so only a
+	// non-empty value is checked for shape.
+	if cfg.Source != nil && strings.TrimSpace(*cfg.Source) != "" {
+		if err := validateSourceValue(*cfg.Source); err != nil {
 			problems = append(problems, err.Error())
 		}
 	}
@@ -209,6 +250,9 @@ func resolve(file *Config, cli CLIOverrides) ResolvedConfig {
 		if file.Client != nil {
 			r.Client = *file.Client
 		}
+		if file.Source != nil {
+			r.Source = strings.TrimSpace(*file.Source)
+		}
 		if file.Model != nil {
 			r.Model = *file.Model
 		}
@@ -250,6 +294,9 @@ func resolve(file *Config, cli CLIOverrides) ResolvedConfig {
 	// Apply CLI overrides (higher precedence than file).
 	if cli.Client != "" {
 		r.Client = cli.Client
+	}
+	if cli.Source != "" {
+		r.Source = cli.Source
 	}
 	if cli.Model != "" {
 		r.Model = cli.Model

--- a/cli/nav-pilot/internal/cli/config_cmd.go
+++ b/cli/nav-pilot/internal/cli/config_cmd.go
@@ -48,6 +48,14 @@ var configKeyDefs = []configKeyDef{
 		flag:        "--client",
 	},
 	{
+		name:        "source",
+		kind:        keyKindString,
+		description: "Agentpakke content source: a GitHub repo (owner/name) or an absolute path to a local checkout. Set it to \"\" to clear it and go back to the default.",
+		allowed:     nil,
+		defaultVal:  defaultSourceRepo,
+		flag:        "--source",
+	},
+	{
 		name:        "model",
 		kind:        keyKindString,
 		description: "Model id (e.g. auto, claude-opus-4.8, gpt-5.5). Format-validated; the catalog is checked downstream.",
@@ -175,6 +183,13 @@ version = 1
 # Coding-agent CLI nav-pilot launches.
 # Allowed: copilot, opencode, pi — Default: copilot
 # client = "copilot"
+
+# Agentpakke content source: a GitHub repo (owner/name) or an absolute path to a
+# local checkout. Set by "nav-pilot install --source <repo>" after a successful
+# install; clear it with: nav-pilot config set source ""
+# Default: navikt/copilot
+# Corresponds to nav-pilot flag: --source
+# source = "navikt/copilot"
 
 # Model id. Common Copilot models: auto, claude-opus-5, claude-sonnet-5,
 # claude-sonnet-4.6, claude-haiku-4.5, claude-opus-4.8, gpt-5.6-sol,
@@ -325,6 +340,7 @@ func cmdConfigShow(jsonOutput bool) error {
 	if jsonOutput {
 		return outputJSON(map[string]interface{}{
 			"client":           resolved.Client,
+			"source":           effectiveSourceLabel(resolved),
 			"model":            resolved.Model,
 			"mode":             resolved.Mode,
 			"reasoning_effort": resolved.ReasoningEffort,
@@ -361,6 +377,12 @@ func cmdConfigShow(jsonOutput bool) error {
 		clientSrc = "file"
 	}
 	printField("client", resolved.Client, clientSrc)
+
+	sourceSrc := "default"
+	if cfg != nil && cfg.Source != nil && strings.TrimSpace(*cfg.Source) != "" {
+		sourceSrc = "file"
+	}
+	printField("source", effectiveSourceLabel(resolved), sourceSrc)
 
 	modelSrc := "unset"
 	if cfg != nil && cfg.Model != nil {
@@ -458,6 +480,8 @@ func resolvedFieldStr(r ResolvedConfig, key string) string {
 		return "1" // version is always 1 when valid
 	case "client":
 		return r.Client
+	case "source":
+		return r.Source
 	case "model":
 		return r.Model
 	case "mode":
@@ -489,17 +513,44 @@ func resolvedFieldStr(r ResolvedConfig, key string) string {
 // ─── config set ──────────────────────────────────────────────────────────────
 
 func cmdConfigSet(key, value string) error {
+	tomlVal, err := writeConfigKey(key, value)
+	if err != nil {
+		return err
+	}
+	if key == "source" && strings.TrimSpace(value) == "" {
+		fmt.Printf("%s source cleared — nav-pilot installs and syncs from %s again.\n",
+			green("✓"), bold(defaultSourceRepo))
+		return nil
+	}
+	fmt.Printf("%s %s = %s\n", green("✓"), key, tomlVal)
+	return nil
+}
+
+// effectiveSourceLabel names the source a resolved config selects, spelling out
+// the built-in default when no source is persisted.
+func effectiveSourceLabel(r ResolvedConfig) string {
+	if r.Source == "" {
+		return defaultSourceRepo
+	}
+	return r.Source
+}
+
+// writeConfigKey validates a key/value pair and writes it into the config file,
+// replacing the first matching line (active or commented out) or appending it.
+// It returns the TOML literal written. Callers own the user-facing message —
+// `config set` prints one, install's source persistence prints another.
+func writeConfigKey(key, value string) (string, error) {
 	kd := findKeyDef(key)
 	if kd == nil {
-		return fmt.Errorf("unknown key: %q\n\nKnown keys: %s", key, knownKeyNames())
+		return "", fmt.Errorf("unknown key: %q\n\nKnown keys: %s", key, knownKeyNames())
 	}
 	if err := validateKeyValue(kd, value); err != nil {
-		return err
+		return "", err
 	}
 
 	tomlVal, err := formatTOMLValue(kd, value)
 	if err != nil {
-		return err
+		return "", err
 	}
 	newLine := key + " = " + tomlVal
 
@@ -510,7 +561,7 @@ func cmdConfigSet(key, value string) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("reading config: %w", err)
+			return "", fmt.Errorf("reading config: %w", err)
 		}
 		// New file: seed the required schema version so the resulting config
 		// passes on-launch validation (validateConfig requires version = 1).
@@ -537,18 +588,17 @@ func cmdConfigSet(key, value string) error {
 	}
 
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return fmt.Errorf("creating config directory: %w", err)
+		return "", fmt.Errorf("creating config directory: %w", err)
 	}
 	content := strings.Join(lines, "\n") + "\n"
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-		return fmt.Errorf("writing config: %w", err)
+		return "", fmt.Errorf("writing config: %w", err)
 	}
 	if err := os.Chmod(path, 0o600); err != nil {
-		return fmt.Errorf("setting config permissions: %w", err)
+		return "", fmt.Errorf("setting config permissions: %w", err)
 	}
 
-	fmt.Printf("%s %s = %s\n", green("✓"), key, tomlVal)
-	return nil
+	return tomlVal, nil
 }
 
 // isConfigKeyLine returns true if line (active or commented-out) represents the given key.
@@ -583,6 +633,13 @@ func validateKeyValue(kd *configKeyDef, value string) error {
 	// Key-specific validation beyond the generic kind/allowlist checks.
 	if kd.name == "model" {
 		if err := validateModelValue(value); err != nil {
+			return err
+		}
+	}
+	// An empty source is the documented way to clear the key and fall back to
+	// the default; any other value must name a repo or a local checkout.
+	if kd.name == "source" && strings.TrimSpace(value) != "" {
+		if err := validateSourceValue(value); err != nil {
 			return err
 		}
 	}

--- a/cli/nav-pilot/internal/cli/config_setup.go
+++ b/cli/nav-pilot/internal/cli/config_setup.go
@@ -45,6 +45,15 @@ func writeSetupConfig(answers setupAnswers) error {
 		"",
 	)
 
+	// Preserve a persisted agentpakke source: the wizard does not ask about it,
+	// and rewriting the file must not silently drop the user's selection (B2).
+	if existing, err := readConfig(); err == nil && existing != nil && existing.Source != nil {
+		if persisted := strings.TrimSpace(*existing.Source); persisted != "" {
+			sourceVal, _ := formatTOMLValue(findKeyDef("source"), persisted)
+			lines = append(lines, "source = "+sourceVal)
+		}
+	}
+
 	clientVal, _ := formatTOMLValue(findKeyDef("client"), answers.Client)
 	lines = append(lines, "client = "+clientVal)
 

--- a/cli/nav-pilot/internal/cli/helpers_test.go
+++ b/cli/nav-pilot/internal/cli/helpers_test.go
@@ -277,7 +277,7 @@ func TestCmdEnv_WithInstructions(t *testing.T) {
 
 func TestCollectAvailableItems_Empty(t *testing.T) {
 	tmp := t.TempDir()
-	result := collectAvailableItems(tmp)
+	result := collectAvailableItems(NewSourceResolver(tmp))
 	// Empty source dir should return empty map (no panics)
 	if result == nil {
 		t.Error("collectAvailableItems returned nil, want empty map")
@@ -300,7 +300,7 @@ Body.
 		t.Fatal(err)
 	}
 
-	result := collectAvailableItems(tmp)
+	result := collectAvailableItems(NewSourceResolver(tmp))
 	if len(result["agents"]) == 0 {
 		t.Error("expected nav-pilot agent in result")
 	}

--- a/cli/nav-pilot/internal/cli/ignore_test.go
+++ b/cli/nav-pilot/internal/cli/ignore_test.go
@@ -217,7 +217,7 @@ func TestDetectNewItems_IgnoredEntryNotReported(t *testing.T) {
 	}
 	writeScopedState(scope, state)
 
-	newItems := detectNewItems(scope, source)
+	newItems := detectNewItems(scope, NewSourceResolver(source))
 	if len(newItems) != 0 {
 		t.Errorf("expected no new items (instruction is ignored), got %v", newItems)
 	}

--- a/cli/nav-pilot/internal/cli/ignore_test.go
+++ b/cli/nav-pilot/internal/cli/ignore_test.go
@@ -217,7 +217,7 @@ func TestDetectNewItems_IgnoredEntryNotReported(t *testing.T) {
 	}
 	writeScopedState(scope, state)
 
-	newItems := detectNewItems(scope, NewSourceResolver(source))
+	newItems := detectNewItems(scope, NewSourceResolver(source), nil)
 	if len(newItems) != 0 {
 		t.Errorf("expected no new items (instruction is ignored), got %v", newItems)
 	}

--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -55,7 +56,11 @@ func installItems(resolver *SourceResolver, scope *InstallScope, manifest *Manif
 // manifest the installer already knows how to walk. It is the manifest-bearing
 // counterpart to loadManifest: the agentpakke manifest supersedes
 // collections/<name>/manifest.json rather than declaring entries in it.
-func pakkeContents(resolver *SourceResolver, pakke *agentpakke.Manifest) (*Manifest, error) {
+func pakkeContents(resolver *SourceResolver, src *Source) (*Manifest, error) {
+	if err := guardTier2Only(src); err != nil {
+		return nil, err
+	}
+	pakke := src.Pakke
 	manifest, err := collectAllItemsWith(resolver)
 	if err != nil {
 		return nil, err
@@ -139,6 +144,23 @@ func installArtifact(resolver *SourceResolver, scope *InstallScope, kind *Artifa
 }
 
 // ─── Commands ───────────────────────────────────────────────────────────────
+
+// finishInstall closes out an install command.
+//
+// B2: an explicit --source is persisted only after the install it was given to
+// actually succeeded (and validated, which resolveSource does). A cancelled
+// prompt installed nothing, so it persists nothing — and it is still a clean
+// exit, not an error the user has to read.
+func finishInstall(err error, flagSource string, dryRun bool) error {
+	if errors.Is(err, errInstallCancelled) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	persistInstalledSource(flagSource, dryRun)
+	return nil
+}
 
 // cmdInstallAuto resolves whether <name> is a collection or an individual artifact,
 // then dispatches to the appropriate installer. If --type is provided, it skips
@@ -267,6 +289,9 @@ func cmdInstallFromSource(collection string, src *Source, scope *InstallScope, d
 
 	// Fail closed before touching the filesystem (A3): a non-conforming
 	// agentpakke must not leave a partial install behind.
+	if err := guardTier2Only(src); err != nil {
+		return err
+	}
 	if err := validatePakkeSource(src); err != nil {
 		return err
 	}
@@ -274,7 +299,7 @@ func cmdInstallFromSource(collection string, src *Source, scope *InstallScope, d
 	var manifest *Manifest
 	var err error
 	if src.Pakke != nil {
-		manifest, err = pakkeContents(resolver, pakke)
+		manifest, err = pakkeContents(resolver, src)
 	} else {
 		manifest, err = loadManifest(src.Dir, collection)
 	}
@@ -502,7 +527,7 @@ func cmdList(ref, sourceRepo string, showItems bool, jsonOutput bool) error {
 	}
 
 	if src.Pakke != nil {
-		m, err := pakkeContents(resolver, src.Pakke)
+		m, err := pakkeContents(resolver, src)
 		if err != nil {
 			return err
 		}
@@ -602,25 +627,25 @@ func cmdInstallInteractive(targetDir, ref, sourceRepo string) error {
 		if scopeErr != nil {
 			return scopeErr
 		}
-		return interactiveUserInstallFromSource(scope, src)
+		return interactiveUserInstallFromSource(scope, src, sourceRepo)
 	}
 
 	// In a git repo: ask where to install
-	scope, err := promptInstallScope(targetDir)
+	scope, err := promptInstallScopeFn(targetDir)
 	if err != nil {
 		return err
 	}
 	if scope == nil {
 		fmt.Println(dim("Cancelled."))
-		return nil
+		return errInstallCancelled
 	}
 
 	if scope.IsUser() {
-		return interactiveUserInstallFromSource(scope, src)
+		return interactiveUserInstallFromSource(scope, src, sourceRepo)
 	}
 
 	// Repo scope: pick a collection
-	return interactiveRepoInstall(src, scope)
+	return interactiveRepoInstall(src, scope, sourceRepo)
 }
 
 // cmdInstallAll installs all agents and skills to user scope by scanning the source.
@@ -641,7 +666,7 @@ func cmdInstallAll(scope *InstallScope, ref, sourceRepo string, dryRun, force bo
 
 	// Interactive mode: offer the picker (same UX as `nav-pilot` root command)
 	if isInteractive() && !dryRun && !jsonOutput {
-		return interactiveUserInstallFromSource(scope, src)
+		return interactiveUserInstallFromSource(scope, src, sourceRepo)
 	}
 
 	return installAllFromSource(scope, src, nil, dryRun, force, jsonOutput)
@@ -656,6 +681,9 @@ func installAllFromSource(scope *InstallScope, src *Source, manifest *Manifest, 
 	resolver := resolverFor(src.Dir, pakke)
 
 	// Fail closed before touching the filesystem (A3).
+	if err := guardTier2Only(src); err != nil {
+		return err
+	}
 	if err := validatePakkeSource(src); err != nil {
 		return err
 	}

--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
 )
 
 type installResult struct {
@@ -15,8 +17,9 @@ type installResult struct {
 	Files       []InstalledFile
 }
 
-func installItems(sourceDir string, scope *InstallScope, manifest *Manifest, dryRun, force bool) (*installResult, error) {
-	resolver := NewSourceResolver(sourceDir)
+// installItems installs every artifact a collection manifest names, reading
+// content through the resolver the active agentpakke manifest produced.
+func installItems(resolver *SourceResolver, scope *InstallScope, manifest *Manifest, dryRun, force bool) (*installResult, error) {
 	result := &installResult{}
 
 	for _, group := range []struct {
@@ -46,6 +49,31 @@ func installItems(sourceDir string, scope *InstallScope, manifest *Manifest, dry
 	}
 
 	return result, nil
+}
+
+// pakkeContents lists everything an agentpakke's layout ships, as the content
+// manifest the installer already knows how to walk. It is the manifest-bearing
+// counterpart to loadManifest: the agentpakke manifest supersedes
+// collections/<name>/manifest.json rather than declaring entries in it.
+func pakkeContents(resolver *SourceResolver, pakke *agentpakke.Manifest) (*Manifest, error) {
+	manifest, err := collectAllItemsWith(resolver)
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range resolver.List(KindPrompt) {
+		manifest.Prompts = append(manifest.Prompts, p.Name)
+	}
+	manifest.Name = pakke.Name
+	manifest.Description = pakke.Description
+	if err := validateManifest(manifest); err != nil {
+		return nil, fmt.Errorf("agentpakke %q: %w", pakke.Name, err)
+	}
+	total := len(manifest.Agents) + len(manifest.Skills) + len(manifest.Instructions) + len(manifest.Prompts)
+	if total == 0 {
+		return nil, fmt.Errorf("agentpakke %q declares a layout but ships no agents, skills, instructions, or prompts.\n"+
+			"Check the layout paths in %s", pakke.Name, agentpakke.ManifestPath)
+	}
+	return manifest, nil
 }
 
 // installArtifact handles the install for any artifact type.
@@ -130,6 +158,10 @@ func cmdInstallAuto(name, itemType string, scope *InstallScope, ref, sourceRepo 
 		}
 	}
 
+	if err := guardScopeSource(scope, sourceRepo); err != nil {
+		return err
+	}
+
 	if !jsonOutput {
 		fmt.Println(dim("Resolving source..."))
 	}
@@ -139,18 +171,32 @@ func cmdInstallAuto(name, itemType string, scope *InstallScope, ref, sourceRepo 
 	}
 	defer src.Cleanup()
 
+	// A source that ships an agentpakke manifest supersedes the collection
+	// model: its single installable name is the agentpakke identity, and that
+	// name wins over an artifact of the same name (agentpakker commonly ship an
+	// agent named after themselves). The artifact stays installable with --type.
+	pakkeName := pakkeInstallName(src)
+	if pakkeName != "" && name == pakkeName {
+		return cmdInstallFromSource(name, src, scope, dryRun, force, jsonOutput)
+	}
+
 	// Check if name matches a collection
 	isCollection := false
-	collections, _ := listCollectionDirs(src.Dir) // ignore error: missing dir = no collections
-	for _, c := range collections {
-		if c == name {
-			isCollection = true
-			break
+	var collections []string
+	if pakkeName != "" {
+		collections = []string{pakkeName}
+	} else {
+		collections, _ = listCollectionDirs(src.Dir) // ignore error: missing dir = no collections
+		for _, c := range collections {
+			if c == name {
+				isCollection = true
+				break
+			}
 		}
 	}
 
 	// Check if name matches any artifact
-	resolver := NewSourceResolver(src.Dir)
+	resolver := resolverFor(src.Dir, pakkeFor(src, name))
 	var matchedKinds []*ArtifactKind
 	for _, kind := range AllKinds {
 		if _, ok := resolver.Get(kind, name); ok {
@@ -210,13 +256,33 @@ func articleFor(kind string) string {
 }
 
 // cmdInstallFromSource installs a collection from an already-resolved source.
+//
+// The active agentpakke manifest decides what "a collection" means here: a
+// manifest-bearing source supersedes collections/<name>/manifest.json and
+// installs everything its layout declares, while a manifest-less source keeps
+// reading the collection manifest exactly as before.
 func cmdInstallFromSource(collection string, src *Source, scope *InstallScope, dryRun, force bool, jsonOutput bool) error {
-	manifest, err := loadManifest(src.Dir, collection)
+	pakke := pakkeFor(src, collection)
+	resolver := resolverFor(src.Dir, pakke)
+
+	// Fail closed before touching the filesystem (A3): a non-conforming
+	// agentpakke must not leave a partial install behind.
+	if err := validatePakkeSource(src); err != nil {
+		return err
+	}
+
+	var manifest *Manifest
+	var err error
+	if src.Pakke != nil {
+		manifest, err = pakkeContents(resolver, pakke)
+	} else {
+		manifest, err = loadManifest(src.Dir, collection)
+	}
 	if err != nil {
 		return err
 	}
 
-	sourceLabel := "navikt/copilot"
+	sourceLabel := sourceLabelFor(src)
 
 	if !jsonOutput {
 		fmt.Println()
@@ -231,7 +297,7 @@ func cmdInstallFromSource(collection string, src *Source, scope *InstallScope, d
 		fmt.Println()
 	}
 
-	result, err := installItems(src.Dir, scope, manifest, dryRun, force)
+	result, err := installItems(resolver, scope, manifest, dryRun, force)
 	if err != nil {
 		return err
 	}
@@ -242,7 +308,7 @@ func cmdInstallFromSource(collection string, src *Source, scope *InstallScope, d
 	if jsonOutput {
 		return outputJSON(map[string]interface{}{
 			"command":     "install",
-			"collection":  collection,
+			"collection":  stateCollection(src, collection),
 			"scope":       scope.Name,
 			"source_sha":  src.SHA,
 			"version":     src.Version,
@@ -272,7 +338,7 @@ func cmdInstallFromSource(collection string, src *Source, scope *InstallScope, d
 	stateVersion := src.Version
 
 	state := &StateFile{
-		Collection:  collection,
+		Collection:  stateCollection(src, collection),
 		Version:     stateVersion,
 		Scope:       scope.Name,
 		SourceRepo:  src.Repo,
@@ -307,7 +373,7 @@ func cmdAddFromSource(itemType, name string, src *Source, scope *InstallScope, d
 		return fmt.Errorf("type %q is not supported in user scope. Only agents, skills, and instructions can be installed to ~/.copilot", itemType)
 	}
 
-	sourceLabel := "navikt/copilot"
+	sourceLabel := sourceLabelFor(src)
 
 	result := &installResult{}
 
@@ -324,7 +390,7 @@ func cmdAddFromSource(itemType, name string, src *Source, scope *InstallScope, d
 	}
 
 	kind := kindByName[itemType]
-	resolver := NewSourceResolver(src.Dir)
+	resolver := resolverFor(src.Dir, pakkeFor(src, name))
 	installErr := installArtifact(resolver, scope, kind, name, dryRun, force, result)
 	if installErr != nil {
 		return installErr
@@ -414,45 +480,67 @@ func cmdList(ref, sourceRepo string, showItems bool, jsonOutput bool) error {
 	}
 	defer src.Cleanup()
 
-	names, err := listCollectionDirs(src.Dir)
-	if err != nil {
-		return err
+	resolver := resolverFor(src.Dir, pakkeFor(src, ""))
+
+	// A source that ships an agentpakke manifest offers exactly one installable
+	// name — the agentpakke itself — because the manifest supersedes the
+	// collections/<name> model.
+	type collectionInfo struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		Items       int    `json:"items"`
+		agents      []string
+	}
+	var collections []collectionInfo
+	add := func(m *Manifest) {
+		collections = append(collections, collectionInfo{
+			Name:        m.Name,
+			Description: m.Description,
+			Items:       len(m.Agents) + len(m.Skills) + len(m.Instructions) + len(m.Prompts),
+			agents:      m.Agents,
+		})
 	}
 
-	if jsonOutput {
-		type collectionInfo struct {
-			Name        string `json:"name"`
-			Description string `json:"description"`
-			Items       int    `json:"items"`
+	if src.Pakke != nil {
+		m, err := pakkeContents(resolver, src.Pakke)
+		if err != nil {
+			return err
 		}
-		var collections []collectionInfo
+		add(m)
+	} else {
+		names, err := listCollectionDirs(src.Dir)
+		if err != nil {
+			return err
+		}
 		for _, name := range names {
 			m, err := loadManifest(src.Dir, name)
 			if err != nil {
 				continue
 			}
-			total := len(m.Agents) + len(m.Skills) + len(m.Instructions) + len(m.Prompts)
-			collections = append(collections, collectionInfo{Name: name, Description: m.Description, Items: total})
+			m.Name = name
+			add(m)
 		}
-		result := map[string]interface{}{"collections": collections}
+	}
+
+	if jsonOutput {
+		result := map[string]interface{}{"collections": collections, "source": sourceLabelFor(src)}
 		if showItems {
-			result["items"] = collectAvailableItems(src.Dir)
+			result["items"] = collectAvailableItems(resolver)
 		}
 		return outputJSON(result)
 	}
 
 	fmt.Println()
-	fmt.Println(bold("Available collections:"))
+	if src.Pakke != nil {
+		fmt.Println(bold(fmt.Sprintf("Agentpakke in %s:", sourceLabelFor(src))))
+	} else {
+		fmt.Println(bold("Available collections:"))
+	}
 	fmt.Println()
-	for _, name := range names {
-		m, err := loadManifest(src.Dir, name)
-		if err != nil {
-			continue
-		}
-		total := len(m.Agents) + len(m.Skills) + len(m.Instructions) + len(m.Prompts)
-		fmt.Printf("  %-20s %s %s\n", bold(name), m.Description, dim(fmt.Sprintf("(%d items)", total)))
-		if len(m.Agents) > 0 {
-			fmt.Printf("  %-20s %s\n", "", dim("agents: "+strings.Join(m.Agents, ", ")))
+	for _, c := range collections {
+		fmt.Printf("  %-20s %s %s\n", bold(c.Name), c.Description, dim(fmt.Sprintf("(%d items)", c.Items)))
+		if len(c.agents) > 0 {
+			fmt.Printf("  %-20s %s\n", "", dim("agents: "+strings.Join(c.agents, ", ")))
 		}
 	}
 	fmt.Println()
@@ -461,7 +549,7 @@ func cmdList(ref, sourceRepo string, showItems bool, jsonOutput bool) error {
 
 	if showItems {
 		fmt.Println()
-		if err := listAvailableItems(src.Dir); err != nil {
+		if err := listAvailableItems(resolver); err != nil {
 			return err
 		}
 	} else {
@@ -471,8 +559,7 @@ func cmdList(ref, sourceRepo string, showItems bool, jsonOutput bool) error {
 }
 
 // listAvailableItems prints all agents, skills, instructions, and prompts in the source.
-func listAvailableItems(sourceDir string) error {
-	resolver := NewSourceResolver(sourceDir)
+func listAvailableItems(resolver *SourceResolver) error {
 	for _, kind := range AllKinds {
 		items := resolver.List(kind)
 		if len(items) == 0 {
@@ -488,8 +575,7 @@ func listAvailableItems(sourceDir string) error {
 }
 
 // collectAvailableItems returns all available items as a structured map for JSON output.
-func collectAvailableItems(sourceDir string) map[string][]string {
-	resolver := NewSourceResolver(sourceDir)
+func collectAvailableItems(resolver *SourceResolver) map[string][]string {
 	result := make(map[string][]string)
 	for _, kind := range AllKinds {
 		for _, art := range resolver.List(kind) {
@@ -541,6 +627,9 @@ func cmdInstallInteractive(targetDir, ref, sourceRepo string) error {
 // Used when `nav-pilot install --user` is run without a collection name.
 // When interactive, offers the same picker as the root `nav-pilot` command.
 func cmdInstallAll(scope *InstallScope, ref, sourceRepo string, dryRun, force bool, jsonOutput bool) error {
+	if err := guardScopeSource(scope, sourceRepo); err != nil {
+		return err
+	}
 	if !jsonOutput {
 		fmt.Println(dim("Resolving source..."))
 	}
@@ -563,9 +652,17 @@ func cmdInstallAll(scope *InstallScope, ref, sourceRepo string, dryRun, force bo
 // extraStateFiles are appended to the state file after install (e.g. ignored items from picker).
 // Extracted so both cmdInstallAll and the interactive flow can share this.
 func installAllFromSource(scope *InstallScope, src *Source, manifest *Manifest, dryRun, force bool, jsonOutput bool, extraStateFiles ...InstalledFile) error {
+	pakke := pakkeFor(src, CollectionAll)
+	resolver := resolverFor(src.Dir, pakke)
+
+	// Fail closed before touching the filesystem (A3).
+	if err := validatePakkeSource(src); err != nil {
+		return err
+	}
+
 	if manifest == nil {
 		var err error
-		manifest, err = collectAllItems(src.Dir)
+		manifest, err = collectAllItemsWith(resolver)
 		if err != nil {
 			return err
 		}
@@ -576,7 +673,7 @@ func installAllFromSource(scope *InstallScope, src *Source, manifest *Manifest, 
 		return fmt.Errorf("no agents, skills, or instructions found in source")
 	}
 
-	sourceLabel := "navikt/copilot"
+	sourceLabel := sourceLabelFor(src)
 
 	if !jsonOutput {
 		fmt.Println()
@@ -590,7 +687,7 @@ func installAllFromSource(scope *InstallScope, src *Source, manifest *Manifest, 
 		fmt.Println()
 	}
 
-	result, err := installItems(src.Dir, scope, manifest, dryRun, force)
+	result, err := installItems(resolver, scope, manifest, dryRun, force)
 	if err != nil {
 		return err
 	}
@@ -606,7 +703,7 @@ func installAllFromSource(scope *InstallScope, src *Source, manifest *Manifest, 
 	if jsonOutput {
 		return outputJSON(map[string]interface{}{
 			"command":    "install",
-			"collection": CollectionAll,
+			"collection": stateCollection(src, CollectionAll),
 			"scope":      scope.Name,
 			"source_sha": src.SHA,
 			"version":    src.Version,
@@ -624,7 +721,7 @@ func installAllFromSource(scope *InstallScope, src *Source, manifest *Manifest, 
 	stateVersion := src.Version
 
 	state := &StateFile{
-		Collection:  CollectionAll,
+		Collection:  stateCollection(src, CollectionAll),
 		Version:     stateVersion,
 		Scope:       scope.Name,
 		SourceRepo:  src.Repo,

--- a/cli/nav-pilot/internal/cli/interactive.go
+++ b/cli/nav-pilot/internal/cli/interactive.go
@@ -267,7 +267,7 @@ func interactiveUserInstall(src *Source, resolved ResolvedConfig) error {
 // interactiveUserInstallFromSource is the shared implementation for user-scope interactive install.
 // Used by both the root `nav-pilot` command and `nav-pilot install --user`.
 func interactiveUserInstallFromSource(scope *InstallScope, src *Source) error {
-	manifest, err := collectAllItems(src.Dir)
+	manifest, err := collectAllItemsWith(resolverFor(src.Dir, pakkeFor(src, CollectionAll)))
 	if err != nil {
 		return err
 	}
@@ -488,6 +488,12 @@ func computeSkippedItems(full, selected *Manifest, scope *InstallScope) []Instal
 
 // interactiveRepoInstall handles repo-scope collection picker flow.
 func interactiveRepoInstall(src *Source, scope *InstallScope) error {
+	// A manifest-bearing source supersedes collections: there is exactly one
+	// thing to install, so there is nothing to pick.
+	if name := pakkeInstallName(src); name != "" {
+		return cmdInstallFromSource(name, src, scope, false, false, false)
+	}
+
 	names, err := listCollectionDirs(src.Dir)
 	if err != nil {
 		return err

--- a/cli/nav-pilot/internal/cli/interactive.go
+++ b/cli/nav-pilot/internal/cli/interactive.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +11,16 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
 )
+
+// errInstallCancelled reports that an interactive install ended because the
+// user cancelled a prompt, rather than because it succeeded.
+//
+// Cancelling used to be indistinguishable from success (both returned nil),
+// which made `install --source X` persist X as the user's source even though
+// nothing was installed. The sentinel never reaches the user: run() maps it
+// back to a clean exit, and the TUI flows swallow it where they already print
+// "Cancelled."
+var errInstallCancelled = errors.New("install cancelled")
 
 // isInteractive returns true when stdin is a terminal (not piped).
 func isInteractive() bool {
@@ -112,6 +123,35 @@ func cmdInteractive(overrides CLIOverrides) error {
 	return interactiveUserOnlyInstall(resolved)
 }
 
+// staleScope pairs a scope with the newer nav-pilot release found for it.
+type staleScope struct {
+	scope  *InstallScope
+	state  *StateFile
+	latest string
+}
+
+// scopeStaleness returns the newer nav-pilot release available for a scope's
+// install, or "" when the scope is current — or when staleness is not a
+// question that can be asked about it.
+//
+// The release feed it consults publishes navikt/copilot's nav-pilot/<version>
+// tags, so it only describes installs that came from there. A scope installed
+// from another agentpakke has that agentpakke's versions, and offering to sync
+// it to "nav-pilot/<latest>" would pull the default source's content into a
+// scope that never came from it (B3/B4). Such a scope is left alone: no
+// assessment, no "update available", no auto-sync.
+func scopeStaleness(scope *InstallScope, state *StateFile) string {
+	if !tracksDefaultSource(state) {
+		return ""
+	}
+	assessment := assessStaleness(state.Version)
+	recordFreshness("collection", scope.Name, assessment)
+	if assessment.LatestVersion != "" && versionNewer(assessment.LatestVersion, state.Version) {
+		return assessment.LatestVersion
+	}
+	return ""
+}
+
 // interactiveSyncAndLaunch handles the case where at least one scope has an install.
 // Checks for staleness in all scopes and offers to sync, then launches Copilot.
 func interactiveSyncAndLaunch(repoScope *InstallScope, repoState *StateFile, userScope *InstallScope, userState *StateFile, resolved ResolvedConfig) error {
@@ -129,27 +169,18 @@ func interactiveSyncAndLaunch(repoScope *InstallScope, repoState *StateFile, use
 	}
 	fmt.Printf("%s  %s\n", bold("🧭 nav-pilot"), dim(strings.Join(scopeParts, "  ·  ")))
 
-	type staleScope struct {
-		scope  *InstallScope
-		state  *StateFile
-		latest string
-	}
 	var stale []staleScope
 	var allAgents []string
 
 	if repoState != nil {
-		assessment := assessStaleness(repoState.Version)
-		recordFreshness("collection", repoScope.Name, assessment)
-		if assessment.LatestVersion != "" && versionNewer(assessment.LatestVersion, repoState.Version) {
-			stale = append(stale, staleScope{repoScope, repoState, assessment.LatestVersion})
+		if latest := scopeStaleness(repoScope, repoState); latest != "" {
+			stale = append(stale, staleScope{repoScope, repoState, latest})
 		}
 		allAgents = append(allAgents, installedAgents(repoState)...)
 	}
 	if userState != nil {
-		assessment := assessStaleness(userState.Version)
-		recordFreshness("collection", userScope.Name, assessment)
-		if assessment.LatestVersion != "" && versionNewer(assessment.LatestVersion, userState.Version) {
-			stale = append(stale, staleScope{userScope, userState, assessment.LatestVersion})
+		if latest := scopeStaleness(userScope, userState); latest != "" {
+			stale = append(stale, staleScope{userScope, userState, latest})
 		}
 		allAgents = append(allAgents, installedAgents(userState)...)
 	}
@@ -225,7 +256,10 @@ func interactiveFreshInstall(targetDir string, resolved ResolvedConfig) error {
 	}
 
 	// Repo scope: pick a collection
-	if err := interactiveRepoInstall(src, scope); err != nil {
+	if err := interactiveRepoInstall(src, scope, ""); err != nil {
+		if errors.Is(err, errInstallCancelled) {
+			return nil
+		}
 		return err
 	}
 	offerLaunchCopilot(resolved)
@@ -252,12 +286,19 @@ func interactiveUserOnlyInstall(resolved ResolvedConfig) error {
 // interactiveUserInstall installs agents, skills & instructions to user home.
 // Offers a two-step flow: install everything or customize selection.
 // Called from interactiveFreshInstall and interactiveUserOnlyInstall (root command only).
+//
+// The root TUI has no --source flag to thread, so the cross-source guard runs
+// against the configured source (B3), exactly as a bare `nav-pilot install`
+// would.
 func interactiveUserInstall(src *Source, resolved ResolvedConfig) error {
 	scope, err := ScopeUser()
 	if err != nil {
 		return err
 	}
-	if err := interactiveUserInstallFromSource(scope, src); err != nil {
+	if err := interactiveUserInstallFromSource(scope, src, ""); err != nil {
+		if errors.Is(err, errInstallCancelled) {
+			return nil
+		}
 		return err
 	}
 	offerLaunchCopilot(resolved)
@@ -266,7 +307,22 @@ func interactiveUserInstall(src *Source, resolved ResolvedConfig) error {
 
 // interactiveUserInstallFromSource is the shared implementation for user-scope interactive install.
 // Used by both the root `nav-pilot` command and `nav-pilot install --user`.
-func interactiveUserInstallFromSource(scope *InstallScope, src *Source) error {
+//
+// flagSource is the raw --source value, or "" when the caller is a TUI flow
+// that has none: the B3 guard must see the same input here as it does on the
+// non-interactive install paths, or picking a scope in a prompt would be a way
+// around it.
+func interactiveUserInstallFromSource(scope *InstallScope, src *Source, flagSource string) error {
+	if err := guardScopeSource(scope, flagSource); err != nil {
+		return err
+	}
+	// Before the item picker: a Tier 2-only agentpakke has nothing this binary
+	// can offer to select, and "no agents found in source" would be the wrong
+	// reason.
+	if err := guardTier2Only(src); err != nil {
+		return err
+	}
+
 	manifest, err := collectAllItemsWith(resolverFor(src.Dir, pakkeFor(src, CollectionAll)))
 	if err != nil {
 		return err
@@ -297,7 +353,7 @@ func interactiveUserInstallFromSource(scope *InstallScope, src *Source) error {
 			Run()
 		if err != nil || installChoice == "cancel" {
 			fmt.Println(dim("Cancelled."))
-			return nil
+			return errInstallCancelled
 		}
 
 		if installChoice == "custom" {
@@ -307,7 +363,7 @@ func interactiveUserInstallFromSource(scope *InstallScope, src *Source) error {
 			}
 			if selected == nil {
 				fmt.Println(dim("Cancelled."))
-				return nil
+				return errInstallCancelled
 			}
 			manifest = selected
 			skippedItems = skipped
@@ -487,7 +543,14 @@ func computeSkippedItems(full, selected *Manifest, scope *InstallScope) []Instal
 }
 
 // interactiveRepoInstall handles repo-scope collection picker flow.
-func interactiveRepoInstall(src *Source, scope *InstallScope) error {
+//
+// flagSource is the raw --source value, or "" for the root TUI, which has none
+// (see interactiveUserInstallFromSource).
+func interactiveRepoInstall(src *Source, scope *InstallScope, flagSource string) error {
+	if err := guardScopeSource(scope, flagSource); err != nil {
+		return err
+	}
+
 	// A manifest-bearing source supersedes collections: there is exactly one
 	// thing to install, so there is nothing to pick.
 	if name := pakkeInstallName(src); name != "" {
@@ -527,7 +590,7 @@ func interactiveRepoInstall(src *Source, scope *InstallScope) error {
 		WithTheme(navTheme()).
 		Run()
 	if err != nil {
-		return nil // user cancelled
+		return errInstallCancelled // user cancelled
 	}
 
 	// Show preview with contents
@@ -553,13 +616,17 @@ func interactiveRepoInstall(src *Source, scope *InstallScope) error {
 		Run()
 	if err != nil || installChoice != "yes" {
 		fmt.Println(dim("Cancelled."))
-		return nil
+		return errInstallCancelled
 	}
 
 	// Install using the already-resolved source (avoid redundant git clone)
 	fmt.Println()
 	return cmdInstallFromSource(selected, src, scope, false, false, false)
 }
+
+// promptInstallScopeFn is the scope prompt, overridable in tests so a cancelled
+// prompt can be exercised without a terminal.
+var promptInstallScopeFn = promptInstallScope
 
 // promptInstallScope asks the user where to install: repo or user home.
 // Returns nil if the user cancels.

--- a/cli/nav-pilot/internal/cli/main_test.go
+++ b/cli/nav-pilot/internal/cli/main_test.go
@@ -1117,7 +1117,7 @@ func TestInstallItems(t *testing.T) {
 	}
 
 	dstDir := t.TempDir()
-	result, err := installItems(srcDir, ScopeRepo(dstDir), manifest, false, false)
+	result, err := installItems(NewSourceResolver(srcDir), ScopeRepo(dstDir), manifest, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1605,7 +1605,7 @@ func TestDetectNewItems(t *testing.T) {
 		t.Fatalf("writeScopedState: %v", err)
 	}
 
-	newItems := detectNewItems(scope, source)
+	newItems := detectNewItems(scope, NewSourceResolver(source))
 	if len(newItems) != 2 {
 		t.Fatalf("newItems = %d, want 2 (got %v)", len(newItems), newItems)
 	}
@@ -1634,7 +1634,7 @@ func TestDetectNewItems_NoState(t *testing.T) {
 	target := t.TempDir()
 
 	scope := &InstallScope{Name: "user", RootDir: target, StateFile: ".nav-pilot-state.json", SupportedTypes: []string{"agent", "skill", "instruction"}}
-	newItems := detectNewItems(scope, source)
+	newItems := detectNewItems(scope, NewSourceResolver(source))
 	if len(newItems) != 0 {
 		t.Errorf("expected no items without state, got %v", newItems)
 	}
@@ -1654,7 +1654,7 @@ func TestDetectNewItems_NonAllCollection(t *testing.T) {
 	}
 	writeScopedState(scope, state)
 
-	newItems := detectNewItems(scope, source)
+	newItems := detectNewItems(scope, NewSourceResolver(source))
 	if len(newItems) != 0 {
 		t.Errorf("expected no items for non-all collection, got %v", newItems)
 	}
@@ -1679,7 +1679,7 @@ func TestDetectNewItems_AllUpToDate(t *testing.T) {
 	}
 	writeScopedState(scope, state)
 
-	newItems := detectNewItems(scope, source)
+	newItems := detectNewItems(scope, NewSourceResolver(source))
 	if len(newItems) != 0 {
 		t.Errorf("expected no new items, got %v", newItems)
 	}
@@ -1730,7 +1730,7 @@ func TestListAvailableItems_PromptDirectories(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	err := listAvailableItems(source)
+	err := listAvailableItems(NewSourceResolver(source))
 
 	w.Close()
 	os.Stdout = oldStdout
@@ -1891,7 +1891,7 @@ func TestDetectNewItems_Instructions(t *testing.T) {
 	data, _ := json.Marshal(state)
 	os.WriteFile(filepath.Join(target, ".nav-pilot-state.json"), data, 0o644)
 
-	newItems := detectNewItems(scope, source)
+	newItems := detectNewItems(scope, NewSourceResolver(source))
 	if len(newItems) != 1 {
 		t.Fatalf("expected 1 new item, got %d: %v", len(newItems), newItems)
 	}
@@ -2170,7 +2170,7 @@ func TestPickerInstallSyncCycle(t *testing.T) {
 	}
 
 	// Step 3: Verify resolveSyncFiles skips ignored items
-	syncFiles, _, err := resolveSyncFiles(scope, source, false)
+	syncFiles, _, err := resolveSyncFiles(scope, NewSourceResolver(source), false)
 	if err != nil {
 		t.Fatalf("resolveSyncFiles: %v", err)
 	}
@@ -2202,7 +2202,7 @@ func TestPickerInstallSyncCycle(t *testing.T) {
 	}
 
 	// Step 6: Verify detectNewItems does NOT report the ignored item
-	newItems := detectNewItems(scope, source)
+	newItems := detectNewItems(scope, NewSourceResolver(source))
 	for _, item := range newItems {
 		if strings.Contains(item, "rust-agent") {
 			t.Errorf("detectNewItems should not report ignored rust-agent: %v", newItems)
@@ -2237,7 +2237,7 @@ func TestPickerInstallSyncCycle_NewSourceItem(t *testing.T) {
 	os.WriteFile(filepath.Join(agentsDir, "brand-new.agent.md"), []byte("# New"), 0o644)
 
 	// detectNewItems should find it
-	newItems := detectNewItems(scope, source)
+	newItems := detectNewItems(scope, NewSourceResolver(source))
 	found := false
 	for _, item := range newItems {
 		if strings.Contains(item, "brand-new") {
@@ -2280,7 +2280,7 @@ func TestDetectNewItems_IgnoredItemNotReported(t *testing.T) {
 		t.Fatalf("writeScopedState: %v", err)
 	}
 
-	newItems := detectNewItems(scope, source)
+	newItems := detectNewItems(scope, NewSourceResolver(source))
 	for _, item := range newItems {
 		if strings.Contains(item, "rust-agent") {
 			t.Errorf("ignored item should not be reported as new: %v", newItems)

--- a/cli/nav-pilot/internal/cli/main_test.go
+++ b/cli/nav-pilot/internal/cli/main_test.go
@@ -1605,7 +1605,7 @@ func TestDetectNewItems(t *testing.T) {
 		t.Fatalf("writeScopedState: %v", err)
 	}
 
-	newItems := detectNewItems(scope, NewSourceResolver(source))
+	newItems := detectNewItems(scope, NewSourceResolver(source), nil)
 	if len(newItems) != 2 {
 		t.Fatalf("newItems = %d, want 2 (got %v)", len(newItems), newItems)
 	}
@@ -1634,7 +1634,7 @@ func TestDetectNewItems_NoState(t *testing.T) {
 	target := t.TempDir()
 
 	scope := &InstallScope{Name: "user", RootDir: target, StateFile: ".nav-pilot-state.json", SupportedTypes: []string{"agent", "skill", "instruction"}}
-	newItems := detectNewItems(scope, NewSourceResolver(source))
+	newItems := detectNewItems(scope, NewSourceResolver(source), nil)
 	if len(newItems) != 0 {
 		t.Errorf("expected no items without state, got %v", newItems)
 	}
@@ -1654,7 +1654,7 @@ func TestDetectNewItems_NonAllCollection(t *testing.T) {
 	}
 	writeScopedState(scope, state)
 
-	newItems := detectNewItems(scope, NewSourceResolver(source))
+	newItems := detectNewItems(scope, NewSourceResolver(source), nil)
 	if len(newItems) != 0 {
 		t.Errorf("expected no items for non-all collection, got %v", newItems)
 	}
@@ -1679,7 +1679,7 @@ func TestDetectNewItems_AllUpToDate(t *testing.T) {
 	}
 	writeScopedState(scope, state)
 
-	newItems := detectNewItems(scope, NewSourceResolver(source))
+	newItems := detectNewItems(scope, NewSourceResolver(source), nil)
 	if len(newItems) != 0 {
 		t.Errorf("expected no new items, got %v", newItems)
 	}
@@ -1891,7 +1891,7 @@ func TestDetectNewItems_Instructions(t *testing.T) {
 	data, _ := json.Marshal(state)
 	os.WriteFile(filepath.Join(target, ".nav-pilot-state.json"), data, 0o644)
 
-	newItems := detectNewItems(scope, NewSourceResolver(source))
+	newItems := detectNewItems(scope, NewSourceResolver(source), nil)
 	if len(newItems) != 1 {
 		t.Fatalf("expected 1 new item, got %d: %v", len(newItems), newItems)
 	}
@@ -2202,7 +2202,7 @@ func TestPickerInstallSyncCycle(t *testing.T) {
 	}
 
 	// Step 6: Verify detectNewItems does NOT report the ignored item
-	newItems := detectNewItems(scope, NewSourceResolver(source))
+	newItems := detectNewItems(scope, NewSourceResolver(source), nil)
 	for _, item := range newItems {
 		if strings.Contains(item, "rust-agent") {
 			t.Errorf("detectNewItems should not report ignored rust-agent: %v", newItems)
@@ -2237,7 +2237,7 @@ func TestPickerInstallSyncCycle_NewSourceItem(t *testing.T) {
 	os.WriteFile(filepath.Join(agentsDir, "brand-new.agent.md"), []byte("# New"), 0o644)
 
 	// detectNewItems should find it
-	newItems := detectNewItems(scope, NewSourceResolver(source))
+	newItems := detectNewItems(scope, NewSourceResolver(source), nil)
 	found := false
 	for _, item := range newItems {
 		if strings.Contains(item, "brand-new") {
@@ -2280,7 +2280,7 @@ func TestDetectNewItems_IgnoredItemNotReported(t *testing.T) {
 		t.Fatalf("writeScopedState: %v", err)
 	}
 
-	newItems := detectNewItems(scope, NewSourceResolver(source))
+	newItems := detectNewItems(scope, NewSourceResolver(source), nil)
 	for _, item := range newItems {
 		if strings.Contains(item, "rust-agent") {
 			t.Errorf("ignored item should not be reported as new: %v", newItems)

--- a/cli/nav-pilot/internal/cli/scope_test.go
+++ b/cli/nav-pilot/internal/cli/scope_test.go
@@ -261,7 +261,7 @@ func TestInstallItems_UserScope_SkipsUnsupported(t *testing.T) {
 		t.Fatalf("loadManifest: %v", err)
 	}
 
-	result, err := installItems(source, scope, manifest, false, false)
+	result, err := installItems(NewSourceResolver(source), scope, manifest, false, false)
 	if err != nil {
 		t.Fatalf("installItems: %v", err)
 	}

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -55,6 +55,9 @@ func cmdSync(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bool
 	if sourceRepo == "" {
 		if state, err := readScopedState(scope); err == nil && state != nil && state.SourceRepo != "" {
 			sourceRepo = state.SourceRepo
+			if !jsonOutput {
+				noteRecordedSourceWins(state.SourceRepo)
+			}
 		}
 	}
 	src, err := resolveSourceForSync(ref, sourceRepo)
@@ -234,7 +237,7 @@ func cmdSync(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bool
 				}
 			}
 		}
-		reportNewItems(scope, resolver)
+		reportNewItems(scope, resolver, src)
 		return nil
 	}
 
@@ -346,7 +349,7 @@ func cmdSync(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bool
 		return errSyncFailed
 	}
 
-	reportNewItems(scope, resolver)
+	reportNewItems(scope, resolver, src)
 	return nil
 }
 
@@ -492,11 +495,12 @@ func conflictStatePaths(scope *InstallScope) []string {
 	return conflicts
 }
 
-// detectNewItems checks if the source has agents/skills/instructions not in the state file.
-// Only relevant for "(all)" user-scope installs where new items may appear.
-func detectNewItems(scope *InstallScope, resolver *SourceResolver) []string {
+// detectNewItems checks if the source has agents/skills/instructions not in the
+// state file. Only relevant for installs that are meant to hold everything
+// their source ships — see [scopeTracksEverything].
+func detectNewItems(scope *InstallScope, resolver *SourceResolver, src *Source) []string {
 	state, err := readScopedState(scope)
-	if err != nil || state == nil || state.Collection != CollectionAll || !scope.IsUser() {
+	if err != nil || state == nil || !scopeTracksEverything(scope, state, src) {
 		return nil
 	}
 
@@ -755,9 +759,25 @@ func outputJSON(v interface{}) error {
 	return enc.Encode(v)
 }
 
+// scopeTracksEverything reports whether a scope's install is meant to hold all
+// of its source's content, which is what makes "the source grew an item" worth
+// reporting rather than noise about content the user never asked for.
+//
+// Legacy: the "(all)" user-scope install, the only collection that means
+// everything. Agentpakke: any pakke install — a pakke is installed whole, in
+// either scope, so anything its layout grows belongs to this scope too. Items
+// the user deselected in the picker are recorded as ignored and stay excluded
+// in both cases.
+func scopeTracksEverything(scope *InstallScope, state *StateFile, src *Source) bool {
+	if src != nil && src.Pakke != nil {
+		return state.Collection == src.Pakke.Name
+	}
+	return state.Collection == CollectionAll && scope.IsUser()
+}
+
 // reportNewItems prints a notice if the source has new items not yet installed.
-func reportNewItems(scope *InstallScope, resolver *SourceResolver) {
-	newItems := detectNewItems(scope, resolver)
+func reportNewItems(scope *InstallScope, resolver *SourceResolver, src *Source) {
+	newItems := detectNewItems(scope, resolver, src)
 	if len(newItems) == 0 {
 		return
 	}
@@ -766,5 +786,15 @@ func reportNewItems(scope *InstallScope, resolver *SourceResolver) {
 	for _, item := range newItems {
 		fmt.Printf("    %s\n", item)
 	}
-	fmt.Printf("  Run %s to add them.\n", bold("nav-pilot install --user"))
+	fmt.Printf("  Run %s to add them.\n", bold(installCommandFor(scope, src)))
+}
+
+// installCommandFor names the command that would pull new source items into
+// this scope: an agentpakke installs by name into a repo, everything else is
+// the user-scope install-all.
+func installCommandFor(scope *InstallScope, src *Source) string {
+	if src != nil && src.Pakke != nil && !scope.IsUser() {
+		return "nav-pilot install " + src.Pakke.Name
+	}
+	return "nav-pilot install --user"
 }

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -46,6 +46,12 @@ var cmdSyncFn = cmdSync
 //
 // Works with both state-based repos (nav-pilot install) and auto-detected repos.
 func cmdSync(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bool) error {
+	if err := guardScopeSyncSource(scope, sourceRepo); err != nil {
+		return err
+	}
+	// The source a scope was installed from wins over the persisted default:
+	// selection is per scope (B4), so syncing one scope never drags another
+	// scope's agentpakke into it.
 	if sourceRepo == "" {
 		if state, err := readScopedState(scope); err == nil && state != nil && state.SourceRepo != "" {
 			sourceRepo = state.SourceRepo
@@ -57,14 +63,19 @@ func cmdSync(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bool
 	}
 	defer src.Cleanup()
 
+	// One resolver for the whole sync, built from the agentpakke manifest that
+	// governs this source (the legacy adapter when it ships none).
+	syncState, _ := readScopedState(scope)
+	resolver := resolverForState(src, syncState)
+
 	// Determine which files to check
-	files, _, err := resolveSyncFiles(scope, src.Dir, apply)
+	files, _, err := resolveSyncFiles(scope, resolver, apply)
 	if err != nil {
 		return err
 	}
 
 	conflictPaths := conflictStatePaths(scope)
-	if err := clearResolvedConflicts(scope, src.Dir, conflictPaths); err != nil {
+	if err := clearResolvedConflicts(scope, resolver, conflictPaths); err != nil {
 		if !jsonOutput {
 			fmt.Fprintf(os.Stderr, "%s Could not clear resolved conflicts: %v\n", yellow("⚠"), err)
 		}
@@ -223,7 +234,7 @@ func cmdSync(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bool
 				}
 			}
 		}
-		reportNewItems(scope, src.Dir)
+		reportNewItems(scope, resolver)
 		return nil
 	}
 
@@ -335,7 +346,7 @@ func cmdSync(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bool
 		return errSyncFailed
 	}
 
-	reportNewItems(scope, src.Dir)
+	reportNewItems(scope, resolver)
 	return nil
 }
 
@@ -432,7 +443,7 @@ type syncFile struct {
 // resolveSyncFiles determines which files to sync.
 // If a state file exists, uses the installed file list.
 // Otherwise, auto-detects customization files in the target repo.
-func resolveSyncFiles(scope *InstallScope, sourceDir string, includeConflicts bool) ([]syncFile, string, error) {
+func resolveSyncFiles(scope *InstallScope, resolver *SourceResolver, includeConflicts bool) ([]syncFile, string, error) {
 	state, err := readScopedState(scope)
 	if err != nil {
 		return nil, "", fmt.Errorf("reading state: %w", err)
@@ -440,7 +451,6 @@ func resolveSyncFiles(scope *InstallScope, sourceDir string, includeConflicts bo
 
 	if state != nil {
 		// State-based: check all installed files, skip ignored and conflicted ones
-		resolver := NewSourceResolver(sourceDir)
 		var files []syncFile
 		for _, f := range state.Files {
 			if f.Status == fileStatusIgnored {
@@ -465,7 +475,7 @@ func resolveSyncFiles(scope *InstallScope, sourceDir string, includeConflicts bo
 	}
 
 	// Auto-detect: scan for customization files that also exist in source
-	return autoDetectSyncFiles(scope.RootDir, sourceDir)
+	return autoDetectSyncFiles(scope.RootDir, resolver)
 }
 
 func conflictStatePaths(scope *InstallScope) []string {
@@ -484,13 +494,11 @@ func conflictStatePaths(scope *InstallScope) []string {
 
 // detectNewItems checks if the source has agents/skills/instructions not in the state file.
 // Only relevant for "(all)" user-scope installs where new items may appear.
-func detectNewItems(scope *InstallScope, sourceDir string) []string {
+func detectNewItems(scope *InstallScope, resolver *SourceResolver) []string {
 	state, err := readScopedState(scope)
 	if err != nil || state == nil || state.Collection != CollectionAll || !scope.IsUser() {
 		return nil
 	}
-
-	resolver := NewSourceResolver(sourceDir)
 
 	installed := make(map[string]bool)
 	for _, f := range state.Files {
@@ -511,9 +519,7 @@ func detectNewItems(scope *InstallScope, sourceDir string) []string {
 
 // autoDetectSyncFiles finds customization files in the target that also exist in source.
 // Target files are always under .github/. Source may be at root or .github/.
-func autoDetectSyncFiles(targetDir, sourceDir string) ([]syncFile, string, error) {
-	resolver := NewSourceResolver(sourceDir)
-
+func autoDetectSyncFiles(targetDir string, resolver *SourceResolver) ([]syncFile, string, error) {
 	// Build file scan patterns from artifact kind definitions.
 	type scanPattern struct {
 		glob    string
@@ -640,7 +646,7 @@ func updateScopedStateHashes(scope *InstallScope, updates []syncUpdate) error {
 }
 
 // clearResolvedConflicts clears conflict status for files that currently match source.
-func clearResolvedConflicts(scope *InstallScope, sourceDir string, conflictPaths []string) error {
+func clearResolvedConflicts(scope *InstallScope, resolver *SourceResolver, conflictPaths []string) error {
 	if len(conflictPaths) == 0 {
 		return nil
 	}
@@ -655,7 +661,6 @@ func clearResolvedConflicts(scope *InstallScope, sourceDir string, conflictPaths
 		conflictSet[p] = true
 	}
 
-	resolver := NewSourceResolver(sourceDir)
 	changed := false
 	for i, f := range state.Files {
 		if !conflictSet[f.Path] {
@@ -664,7 +669,7 @@ func clearResolvedConflicts(scope *InstallScope, sourceDir string, conflictPaths
 
 		localFull := filepath.Join(scope.RootDir, f.Path)
 		sourcePath := resolver.MapLocalPath(f.Path, scope.IsUser())
-		sourceFull := filepath.Join(sourceDir, sourcePath)
+		sourceFull := filepath.Join(resolver.SourceDir(), sourcePath)
 		isDir := strings.HasSuffix(f.Path, "/")
 
 		localHash, localErr := comparableArtifactHash(localFull, isDir)
@@ -751,8 +756,8 @@ func outputJSON(v interface{}) error {
 }
 
 // reportNewItems prints a notice if the source has new items not yet installed.
-func reportNewItems(scope *InstallScope, sourceDir string) {
-	newItems := detectNewItems(scope, sourceDir)
+func reportNewItems(scope *InstallScope, resolver *SourceResolver) {
+	newItems := detectNewItems(scope, resolver)
 	if len(newItems) == 0 {
 		return
 	}

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -45,10 +45,29 @@ var cmdSyncFn = cmdSync
 //   - apply: update differing files in place
 //
 // Works with both state-based repos (nav-pilot install) and auto-detected repos.
+//
+// A scope whose state predates source tracking adopts the source it syncs from
+// (B3): the sync says so, runs, and records the source only once it succeeded,
+// so a failed sync leaves the scope exactly as sourceless as it found it.
 func cmdSync(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bool) error {
-	if err := guardScopeSyncSource(scope, sourceRepo); err != nil {
+	adopted, err := adoptSyncSource(scope, sourceRepo)
+	if err != nil {
 		return err
 	}
+	if adopted != "" && !jsonOutput {
+		noteAdoptedSource(scope, adopted)
+	}
+	if err := syncScope(scope, ref, sourceRepo, apply, jsonOutput); err != nil {
+		return err
+	}
+	if adopted != "" {
+		recordAdoptedSource(scope, adopted)
+	}
+	return nil
+}
+
+// syncScope is the sync itself, once the source question is settled.
+func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bool) error {
 	// The source a scope was installed from wins over the persisted default:
 	// selection is per scope (B4), so syncing one scope never drags another
 	// scope's agentpakke into it.

--- a/cli/nav-pilot/internal/cli/sync_test.go
+++ b/cli/nav-pilot/internal/cli/sync_test.go
@@ -32,7 +32,7 @@ func TestResolveSyncFiles_WithState(t *testing.T) {
 
 	writeState(dir, state)
 
-	files, collection, err := resolveSyncFiles(ScopeRepo(dir), sourceDir, false)
+	files, collection, err := resolveSyncFiles(ScopeRepo(dir), NewSourceResolver(sourceDir), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +64,7 @@ func TestResolveSyncFiles_ConflictHandling(t *testing.T) {
 	writeState(dir, state)
 
 	// Default sync check should skip conflicts
-	files, _, err := resolveSyncFiles(ScopeRepo(dir), sourceDir, false)
+	files, _, err := resolveSyncFiles(ScopeRepo(dir), NewSourceResolver(sourceDir), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestResolveSyncFiles_ConflictHandling(t *testing.T) {
 	}
 
 	// Apply mode should include conflicts so they can be overwritten
-	files, _, err = resolveSyncFiles(ScopeRepo(dir), sourceDir, true)
+	files, _, err = resolveSyncFiles(ScopeRepo(dir), NewSourceResolver(sourceDir), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +101,7 @@ func TestResolveSyncFiles_AutoDetect(t *testing.T) {
 	os.MkdirAll(filepath.Join(sourceDir, "skills", "api-design"), 0o755)
 	os.WriteFile(filepath.Join(sourceDir, "skills", "api-design", "SKILL.md"), []byte("# API"), 0o644)
 
-	files, collection, err := resolveSyncFiles(ScopeRepo(targetDir), sourceDir, false)
+	files, collection, err := resolveSyncFiles(ScopeRepo(targetDir), NewSourceResolver(sourceDir), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -146,7 +146,7 @@ func TestResolveSyncFiles_AutoDetect_RootLevelSource(t *testing.T) {
 	os.MkdirAll(filepath.Join(sourceDir, "skills", "api-design"), 0o755)
 	os.WriteFile(filepath.Join(sourceDir, "skills", "api-design", "SKILL.md"), []byte("new"), 0o644)
 
-	files, _, err := resolveSyncFiles(ScopeRepo(targetDir), sourceDir, false)
+	files, _, err := resolveSyncFiles(ScopeRepo(targetDir), NewSourceResolver(sourceDir), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -404,7 +404,7 @@ func TestResolveSyncFiles_UserScope_NoState_ReturnsEmpty(t *testing.T) {
 		SupportedTypes: []string{"agent", "skill", "instruction"},
 	}
 
-	files, collection, err := resolveSyncFiles(scope, "", false)
+	files, collection, err := resolveSyncFiles(scope, NewSourceResolver(""), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -530,7 +530,7 @@ func TestResolveSyncFiles_SkipsIgnoredFiles(t *testing.T) {
 	}
 	writeState(dir, state)
 
-	files, _, err := resolveSyncFiles(ScopeRepo(dir), sourceDir, false)
+	files, _, err := resolveSyncFiles(ScopeRepo(dir), NewSourceResolver(sourceDir), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -564,7 +564,7 @@ func TestResolveSyncFiles_SkipsConflictedFiles(t *testing.T) {
 	}
 	writeState(dir, state)
 
-	files, _, err := resolveSyncFiles(ScopeRepo(dir), sourceDir, false)
+	files, _, err := resolveSyncFiles(ScopeRepo(dir), NewSourceResolver(sourceDir), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -648,7 +648,7 @@ func TestStateFile_BackwardsCompat_NoStatusField(t *testing.T) {
 	}
 
 	// resolveSyncFiles should include all files (none ignored)
-	files, _, err := resolveSyncFiles(ScopeRepo(dir), "", false)
+	files, _, err := resolveSyncFiles(ScopeRepo(dir), NewSourceResolver(""), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -699,7 +699,7 @@ func TestResolveSyncFiles_AutoDetect_RootLevelAgents(t *testing.T) {
 	os.MkdirAll(filepath.Join(sourceDir, "agents"), 0o755)
 	os.WriteFile(filepath.Join(sourceDir, "agents", "nais.agent.md"), []byte("new"), 0o644)
 
-	files, _, err := resolveSyncFiles(ScopeRepo(targetDir), sourceDir, false)
+	files, _, err := resolveSyncFiles(ScopeRepo(targetDir), NewSourceResolver(sourceDir), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -731,7 +731,7 @@ func TestResolveSyncFiles_AutoDetect_RootLevelInstructions(t *testing.T) {
 	os.MkdirAll(filepath.Join(sourceDir, "instructions"), 0o755)
 	os.WriteFile(filepath.Join(sourceDir, "instructions", "go.instructions.md"), []byte("new"), 0o644)
 
-	files, _, err := resolveSyncFiles(ScopeRepo(targetDir), sourceDir, false)
+	files, _, err := resolveSyncFiles(ScopeRepo(targetDir), NewSourceResolver(sourceDir), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -763,7 +763,7 @@ func TestResolveSyncFiles_AutoDetect_RootLevelPromptDir(t *testing.T) {
 	os.MkdirAll(filepath.Join(sourceDir, "prompts", "review"), 0o755)
 	os.WriteFile(filepath.Join(sourceDir, "prompts", "review", "prompt.md"), []byte("new"), 0o644)
 
-	files, _, err := resolveSyncFiles(ScopeRepo(targetDir), sourceDir, false)
+	files, _, err := resolveSyncFiles(ScopeRepo(targetDir), NewSourceResolver(sourceDir), false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/nav-pilot/internal/cli/validate.go
+++ b/cli/nav-pilot/internal/cli/validate.go
@@ -1,0 +1,161 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
+)
+
+// errValidationFailed is returned when `nav-pilot validate` found violations.
+// The findings are already printed, so the message stays short.
+var errValidationFailed = errors.New("agentpakke validation failed")
+
+// cmdValidate checks whether a source repo conforms to the agentpakke contract
+// (A5). It is the command an agentpakke repo runs in its own CI, so it resolves
+// the source exactly like install does, reports every finding instead of the
+// first, and exits non-zero when any of them is a violation.
+//
+// A source without a manifest is not a failure: it is a legacy collection
+// source, and it is validated as one.
+func cmdValidate(ref, sourceRepo string, jsonOutput bool) error {
+	if !jsonOutput {
+		fmt.Println(dim("Resolving source..."))
+	}
+	src, err := resolveSourceRaw(ref, sourceRepo)
+	if err != nil {
+		return err
+	}
+	defer src.Cleanup()
+
+	label := sourceLabelFor(src)
+	kind, notes, findings := validateSourceTree(src)
+
+	if jsonOutput {
+		problems := make([]string, 0, len(findings))
+		for _, f := range findings {
+			problems = append(problems, f.Error())
+		}
+		if err := outputJSON(map[string]interface{}{
+			"command":  "validate",
+			"source":   label,
+			"sha":      src.SHA,
+			"kind":     kind,
+			"valid":    len(findings) == 0,
+			"notes":    notes,
+			"problems": problems,
+		}); err != nil {
+			return err
+		}
+		if len(findings) > 0 {
+			return errValidationFailed
+		}
+		return nil
+	}
+
+	fmt.Println()
+	fmt.Printf("%s %s\n", bold("Validating:"), fmt.Sprintf("%s@%s", label, src.SHA))
+	fmt.Println()
+	for _, n := range notes {
+		fmt.Printf("  %s %s\n", dim("ℹ"), n)
+	}
+	if len(findings) == 0 {
+		if kind == "legacy" {
+			fmt.Printf("\n%s %s is a valid legacy collection source.\n", green("✓"), label)
+			return nil
+		}
+		fmt.Printf("\n%s %s conforms to the agentpakke contract.\n", green("✓"), label)
+		return nil
+	}
+
+	fmt.Printf("\n%s %d problem(s):\n", red("✗"), len(findings))
+	for _, f := range findings {
+		fmt.Printf("  - %s\n", strings.ReplaceAll(f.Error(), "\n", "\n    "))
+	}
+	fmt.Println()
+	fmt.Printf("The agentpakke contract and its JSON Schema live in %s.\n",
+		dim("navikt/copilot: cli/nav-pilot/schemas"))
+	return errValidationFailed
+}
+
+// validateSourceTree runs the conformance checks for a resolved checkout and
+// returns the source kind ("agentpakke" or "legacy"), informational notes, and
+// every violation found.
+func validateSourceTree(src *Source) (kind string, notes []string, findings []error) {
+	m, err := agentpakke.Load(src.Dir)
+	if err != nil {
+		if !errors.Is(err, agentpakke.ErrNoManifest) {
+			return "agentpakke", []string{
+				fmt.Sprintf("manifest: %s", agentpakke.ManifestPath),
+			}, []error{err}
+		}
+		return "legacy", []string{
+			fmt.Sprintf("no manifest (legacy collection source) — %s is absent", agentpakke.ManifestPath),
+		}, validateLegacySource(src)
+	}
+
+	notes = append(notes,
+		fmt.Sprintf("manifest: %s", agentpakke.ManifestPath),
+		fmt.Sprintf("agentpakke: %s (contract version %s)", m.Name, m.ContractVersion),
+	)
+	if clients := m.ClientIDs(); len(clients) > 0 {
+		var parts []string
+		for _, id := range clients {
+			label := id
+			if !agentpakke.IsKnownClient(id) {
+				label += " (unknown to this nav-pilot — ignored)"
+			} else {
+				label += fmt.Sprintf(" (tier %d)", m.Tier(id))
+			}
+			parts = append(parts, label)
+		}
+		notes = append(notes, "clients: "+strings.Join(parts, ", "))
+	}
+	if m.MinNavPilotVersion != "" {
+		notes = append(notes, "minNavPilotVersion: "+m.MinNavPilotVersion)
+	}
+
+	return "agentpakke", notes, agentpakke.ValidateSource(src.Dir)
+}
+
+// validateLegacySource checks a source that ships no manifest. It must still be
+// installable the way every source is today: at least one collection whose
+// manifest loads and whose entries resolve in the canonical layout.
+func validateLegacySource(src *Source) []error {
+	names, err := listCollectionDirs(src.Dir)
+	if err != nil || len(names) == 0 {
+		return []error{fmt.Errorf(
+			"source ships neither %s nor a collections/ directory, so nav-pilot has nothing to install from it. "+
+				"Add an agentpakke manifest, or ship collections/<name>/manifest.json",
+			agentpakke.ManifestPath)}
+	}
+
+	resolver := resolverFor(src.Dir, agentpakke.SynthesizeLegacy(""))
+	var findings []error
+	for _, name := range names {
+		m, err := loadManifest(src.Dir, name)
+		if err != nil {
+			findings = append(findings, err)
+			continue
+		}
+		for _, entry := range []struct {
+			kind  *ArtifactKind
+			names []string
+		}{
+			{KindAgent, m.Agents},
+			{KindSkill, m.Skills},
+			{KindInstruction, m.Instructions},
+			{KindPrompt, m.Prompts},
+		} {
+			for _, item := range entry.names {
+				if _, ok := resolver.Get(entry.kind, item); !ok {
+					findings = append(findings, fmt.Errorf(
+						"collection %q lists %s %q, which does not exist in %s/",
+						name, entry.kind.Name, item, entry.kind.Dir))
+				}
+			}
+		}
+	}
+	return findings
+}

--- a/cli/nav-pilot/internal/domain/domain.go
+++ b/cli/nav-pilot/internal/domain/domain.go
@@ -15,6 +15,7 @@ import (
 type Config struct {
 	Version           int     `toml:"version"`
 	Client            *string `toml:"client"`
+	Source            *string `toml:"source"`
 	Model             *string `toml:"model"`
 	Mode              *string `toml:"mode"`
 	ReasoningEffort   *string `toml:"reasoning_effort"`
@@ -32,7 +33,10 @@ type Config struct {
 // ResolvedConfig holds the final configuration after applying precedence:
 // CLI flag > file value > built-in default.
 type ResolvedConfig struct {
-	Client            string
+	Client string
+	// Source is the agentpakke content source: a git repo "owner/name" or an
+	// absolute path. Empty means the built-in default (navikt/copilot).
+	Source            string
 	Model             string // empty = use agent default
 	Mode              string
 	ReasoningEffort   string // empty = unset
@@ -50,7 +54,10 @@ type ResolvedConfig struct {
 
 // CLIOverrides holds optional CLI flag values. Empty string means "not provided via CLI".
 type CLIOverrides struct {
-	Client          string
+	Client string
+	// Source is the --source flag value (agentpakke repo "owner/name" or an
+	// absolute path). It takes precedence over the config file's source key.
+	Source          string
 	Model           string
 	Mode            string
 	ReasoningEffort string

--- a/cli/nav-pilot/internal/domain/domain.go
+++ b/cli/nav-pilot/internal/domain/domain.go
@@ -241,6 +241,42 @@ func (s *InstallScope) ValidateStatePath(p string) error {
 	return nil
 }
 
+// PathWithinRoot reports whether abs is still inside root once every symlink on
+// the way to it has been resolved.
+//
+// Lstat on the final component is not containment: a source repo whose agents/
+// directory is a symlink to /etc still Lstats agents/passwd as a regular file,
+// and reading or copying it leaves the checkout. Every read of source content —
+// the content resolver, and the agentpakke conformance checks — asks this first,
+// so an intermediate symlink cannot hand nav-pilot a file from outside the
+// source it thinks it is reading.
+//
+// Both sides are resolved, so a checkout that itself sits behind a symlink
+// (macOS /tmp, /var) is compared like with like. A path that does not exist yet
+// is resolved as far as its existing ancestors go and judged on those: the
+// parents are what decide containment.
+func PathWithinRoot(root, abs string) bool {
+	rel, err := filepath.Rel(resolveSymlinks(root), resolveSymlinks(abs))
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// resolveSymlinks resolves p, falling back to its longest existing ancestor so
+// a not-yet-existing path is still judged by the parents that do exist.
+func resolveSymlinks(p string) string {
+	p = filepath.Clean(p)
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved
+	}
+	parent := filepath.Dir(p)
+	if parent == p {
+		return p
+	}
+	return filepath.Join(resolveSymlinks(parent), filepath.Base(p))
+}
+
 // CleanupDirs removes empty artifact directories after uninstall.
 func (s *InstallScope) CleanupDirs() {
 	if s.Name == "repo" {

--- a/cli/nav-pilot/internal/source/manifest.go
+++ b/cli/nav-pilot/internal/source/manifest.go
@@ -92,7 +92,13 @@ func ListCollectionDirs(sourceDir string) ([]string, error) {
 // CollectAllItems scans the source directory for all agents, skills, and instructions,
 // returning a synthetic manifest. Used for user-scope "install everything".
 func CollectAllItems(sourceDir string) (*Manifest, error) {
-	resolver := NewSourceResolver(sourceDir)
+	return CollectAllItemsWith(NewSourceResolver(sourceDir))
+}
+
+// CollectAllItemsWith is CollectAllItems for an already-built resolver, so a
+// caller that resolves content through an agentpakke manifest's layout paths
+// discovers items from those paths instead of the canonical directories.
+func CollectAllItemsWith(resolver *SourceResolver) (*Manifest, error) {
 	m := &Manifest{
 		Name:        "(all)",
 		Description: "All agents, skills, and instructions",

--- a/cli/nav-pilot/internal/source/resolver.go
+++ b/cli/nav-pilot/internal/source/resolver.go
@@ -2,10 +2,12 @@ package source
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
 
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
 	"github.com/navikt/copilot/cli/nav-pilot/internal/domain"
 )
 
@@ -71,11 +73,65 @@ func (k *ArtifactKind) RelPathForName(scope *domain.InstallScope, name string) s
 // SourceResolver centralizes all source-repo path resolution.
 type SourceResolver struct {
 	sourceDir string
+
+	// layout remaps a canonical artifact directory ("agents", "skills", …) to
+	// the repo-relative directory an agentpakke manifest declares for it. It is
+	// nil (and every lookup falls back to the canonical name) for sources that
+	// ship content at the canonical paths — which is what the legacy adapter
+	// synthesizes, so manifest-less sources resolve byte-for-byte as before.
+	layout map[string]string
 }
 
-// NewSourceResolver creates a resolver for the given source directory.
+// NewSourceResolver creates a resolver for the given source directory, reading
+// content from the canonical directories (agents/, skills/, …).
 func NewSourceResolver(sourceDir string) *SourceResolver {
 	return &SourceResolver{sourceDir: sourceDir}
+}
+
+// NewSourceResolverForLayout creates a resolver that reads content from an
+// agentpakke manifest's layout paths (D1). A nil layout, or one that only
+// repeats the canonical directory names, behaves exactly like
+// [NewSourceResolver].
+func NewSourceResolverForLayout(sourceDir string, layout *agentpakke.Layout) *SourceResolver {
+	r := &SourceResolver{sourceDir: sourceDir}
+	if layout == nil {
+		return r
+	}
+	declared := map[string]string{
+		KindAgent.Dir:       layout.Agents,
+		KindSkill.Dir:       layout.Skills,
+		KindInstruction.Dir: layout.Instructions,
+		KindPrompt.Dir:      layout.Prompts,
+	}
+	for canonical, dir := range declared {
+		dir = strings.TrimSpace(dir)
+		if dir == "" {
+			continue
+		}
+		clean := path.Clean(dir)
+		if clean == canonical {
+			continue
+		}
+		if r.layout == nil {
+			r.layout = make(map[string]string, len(declared))
+		}
+		r.layout[canonical] = filepath.FromSlash(clean)
+	}
+	return r
+}
+
+// SourceDir returns the checkout the resolver reads from. Callers that need to
+// join a resolved RelPath back to an absolute path use this instead of carrying
+// the directory alongside the resolver.
+func (r *SourceResolver) SourceDir() string { return r.sourceDir }
+
+// dirFor returns the source-relative directory that holds a canonical artifact
+// directory's content.
+func (r *SourceResolver) dirFor(canonical string) string {
+	if dir, ok := r.layout[canonical]; ok {
+		return dir
+	}
+	return canonical
 }
 
 // Get finds a single named artifact. Checks root first, then .github/.
@@ -106,7 +162,7 @@ func (r *SourceResolver) checkSafePath(abs string) (os.FileInfo, error) {
 
 func (r *SourceResolver) getSimpleFile(kind *ArtifactKind, name string) (Resolved, bool) {
 	fileName := name + kind.Suffix
-	rel := filepath.Join(kind.Dir, fileName)
+	rel := filepath.Join(r.dirFor(kind.Dir), fileName)
 	abs := filepath.Join(r.sourceDir, rel)
 	if _, err := r.checkSafePath(abs); err == nil {
 		return Resolved{Kind: kind, Name: name, AbsPath: abs, RelPath: rel, IsDir: false}, true
@@ -115,7 +171,7 @@ func (r *SourceResolver) getSimpleFile(kind *ArtifactKind, name string) (Resolve
 }
 
 func (r *SourceResolver) getDir(kind *ArtifactKind, name string) (Resolved, bool) {
-	rel := filepath.Join(kind.Dir, name)
+	rel := filepath.Join(r.dirFor(kind.Dir), name)
 	abs := filepath.Join(r.sourceDir, rel)
 
 	if _, err := r.checkSafePath(abs); err != nil {
@@ -135,12 +191,12 @@ func (r *SourceResolver) getDir(kind *ArtifactKind, name string) (Resolved, bool
 }
 
 func (r *SourceResolver) getCanBeDir(kind *ArtifactKind, name string) (Resolved, bool) {
-	dirRel := filepath.Join(kind.Dir, name)
+	dirRel := filepath.Join(r.dirFor(kind.Dir), name)
 	dirAbs := filepath.Join(r.sourceDir, dirRel)
 	if info, err := r.checkSafePath(dirAbs); err == nil && info.IsDir() {
 		return Resolved{Kind: kind, Name: name, AbsPath: dirAbs, RelPath: dirRel, IsDir: true}, true
 	}
-	fileRel := filepath.Join(kind.Dir, name+kind.Suffix)
+	fileRel := filepath.Join(r.dirFor(kind.Dir), name+kind.Suffix)
 	fileAbs := filepath.Join(r.sourceDir, fileRel)
 	if _, err := r.checkSafePath(fileAbs); err == nil {
 		return Resolved{Kind: kind, Name: name, AbsPath: fileAbs, RelPath: fileRel, IsDir: false}, true
@@ -150,7 +206,7 @@ func (r *SourceResolver) getCanBeDir(kind *ArtifactKind, name string) (Resolved,
 
 // GetFile resolves a specific file by typeDir + fileName.
 func (r *SourceResolver) GetFile(typeDir, fileName string) (absPath, relPath string, ok bool) {
-	rel := filepath.Join(typeDir, fileName)
+	rel := filepath.Join(r.dirFor(typeDir), fileName)
 	abs := filepath.Join(r.sourceDir, rel)
 	if _, err := r.checkSafePath(abs); err == nil {
 		return abs, rel, true
@@ -175,7 +231,7 @@ func (r *SourceResolver) discoverNames(kind *ArtifactKind) []string {
 	var names []string
 
 	for _, base := range [1]string{
-		filepath.Join(r.sourceDir, kind.Dir),
+		filepath.Join(r.sourceDir, r.dirFor(kind.Dir)),
 	} {
 		entries, err := os.ReadDir(base)
 		if err != nil {

--- a/cli/nav-pilot/internal/source/resolver.go
+++ b/cli/nav-pilot/internal/source/resolver.go
@@ -145,6 +145,12 @@ func (r *SourceResolver) Get(kind *ArtifactKind, name string) (Resolved, bool) {
 	return r.getSimpleFile(kind, name)
 }
 
+// checkSafePath refuses to hand back anything the source checkout does not
+// actually contain: a path that is textually outside it, a symlink, or a path
+// that leaves the checkout through a symlinked parent directory (an agentpakke
+// whose layout.agents is a link to somewhere else on the machine, say). The
+// containment check covers the canonical directories too, not only
+// manifest-declared ones.
 func (r *SourceResolver) checkSafePath(abs string) (os.FileInfo, error) {
 	rel, err := filepath.Rel(r.sourceDir, abs)
 	if err != nil || strings.HasPrefix(rel, "..") || rel == ".." {
@@ -155,6 +161,9 @@ func (r *SourceResolver) checkSafePath(abs string) (os.FileInfo, error) {
 		return nil, err
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, os.ErrNotExist
+	}
+	if !domain.PathWithinRoot(r.sourceDir, abs) {
 		return nil, os.ErrNotExist
 	}
 	return info, nil

--- a/cli/nav-pilot/internal/source/resolver_test.go
+++ b/cli/nav-pilot/internal/source/resolver_test.go
@@ -361,3 +361,53 @@ func TestCollectAllItemsWithLayout(t *testing.T) {
 		t.Errorf("agents = %v, want [chef]", m.Agents)
 	}
 }
+
+// ─── containment ────────────────────────────────────────────────────────────
+
+// TestResolverRefusesSymlinkedContentDir covers the canonical directories as
+// well as manifest layout paths: an intermediate symlink out of the checkout
+// must not become a read path, even though Lstat of the final component sees an
+// ordinary file.
+func TestResolverRefusesSymlinkedContentDir(t *testing.T) {
+	outside := t.TempDir()
+	mkFile(t, outside, "elsewhere.agent.md")
+	mkFile(t, outside, "leaked", "SKILL.md")
+
+	tmp := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(tmp, "agents")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(tmp, "skills")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	r := NewSourceResolver(tmp)
+	if art, ok := r.Get(KindAgent, "elsewhere"); ok {
+		t.Errorf("resolved %q through a symlinked agents/ directory", art.AbsPath)
+	}
+	if art, ok := r.Get(KindSkill, "leaked"); ok {
+		t.Errorf("resolved %q through a symlinked skills/ directory", art.AbsPath)
+	}
+	if _, _, ok := r.GetFile("agents", "elsewhere.agent.md"); ok {
+		t.Error("GetFile resolved a file through a symlinked agents/ directory")
+	}
+	if items := r.List(KindAgent); len(items) != 0 {
+		t.Errorf("List returned %d agent(s) from outside the checkout", len(items))
+	}
+}
+
+// TestResolverAllowsSymlinkedDirInsideCheckout keeps the containment check from
+// overreaching: a link that stays inside the source is still readable, which is
+// how a repo may lay its content out.
+func TestResolverAllowsSymlinkedDirInsideCheckout(t *testing.T) {
+	tmp := t.TempDir()
+	mkFile(t, tmp, "content", "agents", "nais.agent.md")
+	if err := os.Symlink(filepath.Join(tmp, "content", "agents"), filepath.Join(tmp, "agents")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	r := NewSourceResolver(tmp)
+	if _, ok := r.Get(KindAgent, "nais"); !ok {
+		t.Error("agents/ symlinked to a directory inside the checkout should still resolve")
+	}
+}

--- a/cli/nav-pilot/internal/source/resolver_test.go
+++ b/cli/nav-pilot/internal/source/resolver_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
 )
 
 // ─── Get ────────────────────────────────────────────────────────────────────
@@ -267,5 +269,95 @@ func mkDir(t *testing.T, parts ...string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Join(parts...), 0o755); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// --- layout-aware resolution (agentpakke Tier 1) ---
+
+func TestNewSourceResolverForLayout(t *testing.T) {
+	tmp := t.TempDir()
+	mkFile(t, tmp, "plugin", "agents", "chef.agent.md")
+	mkFile(t, tmp, "plugin", "skills", "grilling", "SKILL.md")
+	mkFile(t, tmp, "agents", "canonical.agent.md")
+
+	tests := []struct {
+		name       string
+		layout     *agentpakke.Layout
+		kind       *ArtifactKind
+		item       string
+		wantFound  bool
+		wantRelDir string
+	}{
+		{
+			name:       "nil layout reads the canonical directories",
+			layout:     nil,
+			kind:       KindAgent,
+			item:       "canonical",
+			wantFound:  true,
+			wantRelDir: "agents",
+		},
+		{
+			name:       "declared layout reads the manifest paths",
+			layout:     &agentpakke.Layout{Agents: "plugin/agents", Skills: "plugin/skills"},
+			kind:       KindAgent,
+			item:       "chef",
+			wantFound:  true,
+			wantRelDir: filepath.Join("plugin", "agents"),
+		},
+		{
+			name:      "declared layout hides the canonical directories",
+			layout:    &agentpakke.Layout{Agents: "plugin/agents", Skills: "plugin/skills"},
+			kind:      KindAgent,
+			item:      "canonical",
+			wantFound: false,
+		},
+		{
+			name:       "directory artifacts follow the layout too",
+			layout:     &agentpakke.Layout{Agents: "plugin/agents", Skills: "plugin/skills"},
+			kind:       KindSkill,
+			item:       "grilling",
+			wantFound:  true,
+			wantRelDir: filepath.Join("plugin", "skills"),
+		},
+		{
+			name:       "layout repeating the canonical name is a no-op",
+			layout:     &agentpakke.Layout{Agents: "agents", Skills: "skills"},
+			kind:       KindAgent,
+			item:       "canonical",
+			wantFound:  true,
+			wantRelDir: "agents",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewSourceResolverForLayout(tmp, tt.layout)
+			art, ok := r.Get(tt.kind, tt.item)
+			if ok != tt.wantFound {
+				t.Fatalf("Get(%s, %q) found = %v, want %v", tt.kind.Name, tt.item, ok, tt.wantFound)
+			}
+			if !tt.wantFound {
+				return
+			}
+			if got := filepath.Dir(art.RelPath); got != tt.wantRelDir {
+				t.Errorf("RelPath dir = %q, want %q", got, tt.wantRelDir)
+			}
+			if r.SourceDir() != tmp {
+				t.Errorf("SourceDir() = %q, want %q", r.SourceDir(), tmp)
+			}
+		})
+	}
+}
+
+func TestCollectAllItemsWithLayout(t *testing.T) {
+	tmp := t.TempDir()
+	mkFile(t, tmp, "plugin", "agents", "chef.agent.md")
+
+	m, err := CollectAllItemsWith(NewSourceResolverForLayout(tmp, &agentpakke.Layout{Agents: "plugin/agents", Skills: "plugin/skills"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Agents) != 1 || m.Agents[0] != "chef" {
+		t.Errorf("agents = %v, want [chef]", m.Agents)
 	}
 }

--- a/cli/nav-pilot/internal/source/source.go
+++ b/cli/nav-pilot/internal/source/source.go
@@ -9,8 +9,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
 	"github.com/navikt/copilot/cli/nav-pilot/internal/domain"
 )
+
+// DefaultRepo is the content source used when neither --source nor the config
+// file's source key names one.
+const DefaultRepo = "navikt/copilot"
 
 // Source holds a resolved source directory and optional temp dir to clean up.
 type Source struct {
@@ -19,6 +24,40 @@ type Source struct {
 	SHA     string
 	Version string // release version (e.g. "2026.04.14-..."), empty for local dev
 	Repo    string // git repository owner/name (e.g. "navikt/copilot")
+
+	// Pakke is the agentpakke manifest shipped by this checkout, or nil when it
+	// ships none. It is attached by the CLI's source funnel
+	// (internal/cli/aliases.go) rather than by ResolveSource, so that
+	// `nav-pilot validate` can resolve a non-conforming source and report its
+	// findings instead of failing at resolution.
+	//
+	// nil is not "no agentpakke": callers turn it into a Manifest with
+	// agentpakke.SynthesizeLegacy so everything downstream reads one type (see
+	// the agentpakke package doc's migration path).
+	Pakke *agentpakke.Manifest
+}
+
+// ValidateSourceValue checks a persisted or flag-provided source value. Accepted
+// forms mirror what ResolveSource understands: a GitHub "owner/name" repo, or an
+// absolute path to a local checkout.
+func ValidateSourceValue(v string) error {
+	if v != strings.TrimSpace(v) {
+		return fmt.Errorf("source %q must not be padded with whitespace", v)
+	}
+	if v == "" {
+		return fmt.Errorf("source must not be empty")
+	}
+	if filepath.IsAbs(v) {
+		return nil
+	}
+	if strings.HasPrefix(v, "~") || strings.HasPrefix(v, ".") {
+		return fmt.Errorf("source %q must be a GitHub repo (owner/name) or an absolute path", v)
+	}
+	owner, name, ok := strings.Cut(v, "/")
+	if !ok || owner == "" || name == "" || strings.Contains(name, "/") {
+		return fmt.Errorf("source %q must be a GitHub repo (owner/name) or an absolute path", v)
+	}
+	return nil
 }
 
 // CloneRemoteFn is overridable in tests.
@@ -61,7 +100,7 @@ func ResolveSource(ref, sourceRepo, cliVersion string) (*Source, error) {
 		if v := strings.TrimPrefix(ref, "nav-pilot/"); v != ref {
 			src.Version = v
 		}
-		src.Repo = "navikt/copilot"
+		src.Repo = DefaultRepo
 		return src, nil
 	}
 
@@ -85,7 +124,7 @@ func ResolveSource(ref, sourceRepo, cliVersion string) (*Source, error) {
 		return nil, err
 	}
 	src.Version = cliVersion
-	src.Repo = "navikt/copilot"
+	src.Repo = DefaultRepo
 	return src, nil
 }
 
@@ -126,12 +165,12 @@ func cloneRemote(ref, sourceRepo string) (*Source, error) {
 		return nil, fmt.Errorf("creating temp dir: %w", err)
 	}
 
-	repoURL := "https://github.com/navikt/copilot.git"
+	repoURL := "https://github.com/" + DefaultRepo + ".git"
 	if sourceRepo != "" {
 		repoURL = "https://github.com/" + sourceRepo + ".git"
 	}
 
-	label := "navikt/copilot"
+	label := DefaultRepo
 	if sourceRepo != "" {
 		label = sourceRepo
 	}
@@ -191,7 +230,7 @@ func cloneRemote(ref, sourceRepo string) (*Source, error) {
 	}
 
 	sha := getGitSHA(tmpDir)
-	repo := "navikt/copilot"
+	repo := DefaultRepo
 	if sourceRepo != "" {
 		repo = sourceRepo
 	}

--- a/cli/nav-pilot/internal/telemetry/telemetry.go
+++ b/cli/nav-pilot/internal/telemetry/telemetry.go
@@ -529,7 +529,7 @@ func normalizeTelemetryDimension(v, fallback string) string {
 	}
 	switch v {
 	case "install", "sync", "upgrade", "list", "startup", "launch", "doctor",
-		"init", "export", "uninstall", "config", "env", "feedback", "models", "ignore", "add",
+		"init", "export", "uninstall", "config", "validate", "env", "feedback", "models", "ignore", "add",
 		"interactive", "non_interactive",
 		"repo", "user", "auto", "none", "unknown",
 		"go", "node", "jvm", "python", "na",

--- a/cli/nav-pilot/main.go
+++ b/cli/nav-pilot/main.go
@@ -8,6 +8,7 @@
 //	nav-pilot sync                         # check for updates
 //	nav-pilot list                         # list available collections and items
 //	nav-pilot list --installed             # show installed state
+//	nav-pilot validate                     # check a source against the agentpakke contract
 //	nav-pilot uninstall                    # remove installed files
 package main
 

--- a/cli/nav-pilot/schemas/agentpakke-v1.json
+++ b/cli/nav-pilot/schemas/agentpakke-v1.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/navikt/copilot/cli/nav-pilot/schemas/agentpakke-v1.json",
+  "title": "nav-pilot agentpakke manifest (v1)",
+  "description": "Contract between an agentpakke repo and the nav-pilot binary. Lives at .nav-pilot/agentpakke.json in the agentpakke repo. Unknown client keys, context keys, and additional fields are ignored by consumers (A3/A4), so growth of the ecosystem never invalidates an existing manifest on an older binary.",
+  "type": "object",
+  "required": ["contractVersion", "name", "description", "clients"],
+  "additionalProperties": true,
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$"
+    },
+    "relativePath": {
+      "description": "Repo-relative path. Absolute paths and parent traversal are rejected by nav-pilot's semantic validation.",
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "properties": {
+    "contractVersion": {
+      "description": "Manifest schema-and-semantics version. nav-pilot supports major version 1.",
+      "type": "string",
+      "pattern": "^1(\\.\\d+)?$"
+    },
+    "name": {
+      "description": "Agentpakke identity. Recorded as the install's collection name (the agentpakke manifest supersedes the collection manifest).",
+      "$ref": "#/$defs/identifier"
+    },
+    "description": {
+      "type": "string"
+    },
+    "owner": {
+      "description": "Attribution only; the install source is wherever the manifest was cloned from.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "repo": { "type": "string", "pattern": "^[^/]+/[^/]+$" },
+        "team": { "type": "string" }
+      }
+    },
+    "clients": {
+      "description": "One entry per supported client (keys today: copilot, opencode, pi). Keys are pattern-validated, not enumerated: a consumer MUST ignore client keys it does not recognize — that client is unavailable, the manifest stays valid (A3/A4). Tier is derived from shape: an entry with `payloads` is Tier 2; an entry relying on the top-level `layout` is Tier 1 (A1).",
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": { "$ref": "#/$defs/identifier" },
+      "additionalProperties": {
+        "type": "object",
+        "required": ["primaryAgents"],
+        "additionalProperties": true,
+        "properties": {
+          "primaryAgents": {
+            "description": "Agent names treated as primary personas for this client (C1-C2). Every other agent materializes as a subagent.",
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "minItems": 1
+          },
+          "compatibility": {
+            "description": "Supported client version RANGE (A1); exact pins belong only to the local/security-profile tier (M4).",
+            "type": "string"
+          },
+          "defaultModel": {
+            "description": "Default model id, or the literal \"inherit\" (F3).",
+            "type": "string"
+          },
+          "defaultContext": {
+            "description": "Which payload context launches by default (G3); defaults to \"full\".",
+            "$ref": "#/$defs/identifier"
+          },
+          "payloads": {
+            "description": "Tier 2: one entry per context (keys today: full, focused) — same ignore-unknown rule as client keys. Payload manifest is `<path>/manifest.json` by convention (A7); `manifest` only overrides that.",
+            "type": "object",
+            "minProperties": 1,
+            "propertyNames": { "$ref": "#/$defs/identifier" },
+            "additionalProperties": {
+              "type": "object",
+              "required": ["path"],
+              "additionalProperties": true,
+              "properties": {
+                "path": { "$ref": "#/$defs/relativePath" },
+                "manifest": { "$ref": "#/$defs/relativePath" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "layout": {
+      "description": "Tier 1 clients only: repo-relative paths to content directories (D1).",
+      "type": "object",
+      "required": ["agents", "skills"],
+      "additionalProperties": true,
+      "properties": {
+        "agents": { "$ref": "#/$defs/relativePath" },
+        "skills": { "$ref": "#/$defs/relativePath" },
+        "instructions": { "$ref": "#/$defs/relativePath" },
+        "prompts": { "$ref": "#/$defs/relativePath" }
+      }
+    },
+    "provenance": {
+      "description": "For composed content (H2): base repo + digest, overlay components with versions.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "base": {
+          "type": "object",
+          "required": ["repo", "digest"],
+          "additionalProperties": true,
+          "properties": {
+            "repo": { "type": "string", "minLength": 1 },
+            "digest": { "type": "string", "minLength": 1 }
+          }
+        },
+        "overlays": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["component", "version"],
+            "additionalProperties": true,
+            "properties": {
+              "component": { "type": "string", "minLength": 1 },
+              "version": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    "policies": {
+      "description": "Optional pointers to policy artifacts materialized by nav-pilot for Tier 1 clients (E1).",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "opencodePermissions": { "$ref": "#/$defs/relativePath" }
+      }
+    },
+    "profiles": {
+      "description": "Optional launch profiles: a directory of profile files plus the manifest-declared default (E2).",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "dir": { "$ref": "#/$defs/relativePath" },
+        "default": { "type": "string" }
+      }
+    },
+    "minNavPilotVersion": {
+      "description": "Minimum nav-pilot version required. Format: YYYY.MM.DD-HHMMSS-sha7.",
+      "type": "string"
+    }
+  }
+}

--- a/cli/nav-pilot/schemas/agentpakke-v1.json
+++ b/cli/nav-pilot/schemas/agentpakke-v1.json
@@ -143,8 +143,9 @@
       }
     },
     "minNavPilotVersion": {
-      "description": "Minimum nav-pilot version required. Format: YYYY.MM.DD-HHMMSS-sha7.",
-      "type": "string"
+      "description": "Minimum nav-pilot version required, in the release format YYYY.MM.DD-HHMMSS-sha7 (the build sha is optional). A value outside this format is rejected rather than ignored: nav-pilot cannot compare it, so accepting it would silently disable the gate the manifest asked for.",
+      "type": "string",
+      "pattern": "^\\d{4}\\.\\d{2}\\.\\d{2}-\\d{6}(-[0-9a-zA-Z][0-9a-zA-Z.-]*)?$"
     }
   }
 }

--- a/cli/nav-pilot/schemas/schemas.go
+++ b/cli/nav-pilot/schemas/schemas.go
@@ -1,0 +1,16 @@
+// Package schemas publishes nav-pilot's JSON Schemas as embeddable bytes.
+//
+// The .json files in this directory are the source of truth: an agentpakke repo
+// lints its manifest against the same file (by URL or vendored copy) that the
+// nav-pilot binary validates with, so the two can never disagree. The package
+// exists only because go:embed cannot reach outside its own directory — keep it
+// free of logic.
+package schemas
+
+import _ "embed"
+
+// AgentpakkeV1 is the agentpakke manifest schema, contract version 1.
+// Its $id is https://github.com/navikt/copilot/cli/nav-pilot/schemas/agentpakke-v1.json.
+//
+//go:embed agentpakke-v1.json
+var AgentpakkeV1 []byte

--- a/docs/README.agentpakke.md
+++ b/docs/README.agentpakke.md
@@ -1,0 +1,356 @@
+# 📦 Agentpakke
+
+En **agentpakke** er et innholdsrepo som beskriver seg selv for nav-pilot: agenter, skills, instruksjoner og prompts, pluss et manifest som sier hvilke klienter pakka støtter, hvilke agenter som er primære personaer, og hvor innholdet ligger i repoet. Et team kan dermed distribuere sitt eget sett med tilpasninger uten å forke nav-pilot eller sende PR til `navikt/copilot` — brukerne installerer pakka med `nav-pilot install --source <owner>/<repo>`. Manifestet ligger på `.nav-pilot/agentpakke.json` i agentpakke-repoet og er hele kontrakten mellom repoet og binæren.
+
+Kontrakten er publisert som JSON Schema i [`cli/nav-pilot/schemas/agentpakke-v1.json`](../cli/nav-pilot/schemas/agentpakke-v1.json). Nøyaktig samme fil er kompilert inn i nav-pilot-binæren, så repoets egen CI-lint og nav-pilot validerer mot identiske bytes.
+
+Dette dokumentet er for team som lager en agentpakke. Interndesignet (hvordan manifestet trådes gjennom install og sync) står i [cli/nav-pilot/DESIGN.md](../cli/nav-pilot/DESIGN.md).
+
+## Repoform
+
+```
+<agentpakke-repo>/
+├── .nav-pilot/
+│   └── agentpakke.json      # manifestet
+├── agents/                  # layout.agents        — <navn>.agent.md
+├── skills/                  # layout.skills        — <navn>/SKILL.md
+├── instructions/            # layout.instructions  — <navn>.instructions.md
+└── prompts/                 # layout.prompts       — <navn>.prompt.md eller <navn>/
+```
+
+Katalognavnene er ikke låst — `layout` peker på hvor innholdet faktisk ligger, og nav-pilot leser kun der. Filnavnkonvensjonene inne i katalogene er derimot låst, fordi det er dem nav-pilot bruker til å finne og navngi artefaktene. Agentfiler må åpne med en `---`-avgrenset YAML-frontmatter som minst deklarerer `name` og `description`.
+
+## Feltreferanse
+
+Generert fra `cli/nav-pilot/schemas/agentpakke-v1.json`. Ukjente felt på alle nivåer er tillatt (`additionalProperties: true`) og ignoreres av konsumenten.
+
+### Rotnivå
+
+| Felt | Type | Påkrevd | Betydning |
+| --- | --- | --- | --- |
+| `contractVersion` | string, `^1(\.\d+)?$` | ja | Manifestets kontraktversjon. Denne binæren støtter major `1`. |
+| `name` | identifikator, `^[a-z][a-z0-9-]*$` | ja | Pakkas identitet. Dette er navnet brukeren installerer (`nav-pilot install <name>`), og det som registreres som installasjonens `collection` i state. |
+| `description` | string | ja | Én linje, vises i `nav-pilot list`. |
+| `clients` | objekt, minst én nøkkel | ja | Én oppføring per klient. Se under. |
+| `owner` | objekt: `repo` (`^[^/]+/[^/]+$`), `team` | nei | Kun attribusjon. Kilden til en installasjon er der manifestet ble klonet fra, ikke `owner.repo`. |
+| `layout` | objekt: `agents`\*, `skills`\*, `instructions`, `prompts` | ja for Tier 1 | Repo-relative stier til innholdskatalogene. `agents` og `skills` er påkrevd når `layout` først er til stede. |
+| `policies` | objekt: `opencodePermissions` | nei | Peker på policy-artefakter. Sti-sjekkes i dag, materialiseres ikke ennå. |
+| `profiles` | objekt: `dir`, `default` | nei | Katalog med launch-profiler og navnet på standardprofilen (`<dir>/<default>.json`). Sti-sjekkes i dag, brukes ikke ennå. |
+| `provenance` | objekt: `base` (`repo`\*, `digest`\*), `overlays[]` (`component`\*, `version`\*) | nei | Opphav for komponert innhold. Ren metadata; nav-pilot verifiserer ikke digest. |
+| `minNavPilotVersion` | string, `YYYY.MM.DD-HHMMSS[-sha]` | nei | Minste nav-pilot-versjon. Se [Versjonsgate](#versjonsgate). |
+
+### `clients.<klient>`
+
+Nøkkelen er en identifikator (`^[a-z][a-z0-9-]*$`). Klientene denne binæren kan starte er `copilot`, `opencode` og `pi`. Andre nøkler er *ikke* feil — de ignoreres, og klienten er bare utilgjengelig her.
+
+| Felt | Type | Påkrevd | Betydning |
+| --- | --- | --- | --- |
+| `primaryAgents` | array av string, minst ett element | ja | Agentene som er valgbare som primære personaer i klienten. Alt annet i `agents/` materialiseres som subagent. |
+| `compatibility` | string | nei | Støttet klientversjon som **range** (f.eks. `">=1.18.20,<2"`), ikke en eksakt pin. |
+| `defaultModel` | string | nei | Modell-id, eller literalen `"inherit"` (ikke pin noe; arv provider-/sesjonsvalget). |
+| `defaultContext` | identifikator | nei | Hvilken payload-kontekst som startes som standard. Uten verdi: `"full"`. |
+| `payloads` | objekt, minst én nøkkel | nei | Tier 2: én oppføring per kontekst (i dag `full`, `focused`). Tilstedeværelsen av dette feltet er det som gjør oppføringen til Tier 2. |
+
+### `clients.<klient>.payloads.<kontekst>`
+
+Kontekstnøkkelen er en identifikator, og ukjente kontekstnøkler ignoreres på samme måte som ukjente klientnøkler.
+
+| Felt | Type | Påkrevd | Betydning |
+| --- | --- | --- | --- |
+| `path` | repo-relativ sti | ja | Katalogen som holder det ferdigbygde payload-treet. |
+| `manifest` | repo-relativ sti | nei | Overstyrer payload-manifestets plassering. Uten dette feltet er konvensjonen `<path>/manifest.json`. |
+
+## Tier utledes av form
+
+En klients konformanstier deklareres ikke — den utledes av formen på oppføringen, slik at den ikke kan drifte fra innholdet:
+
+- **Tier 1 (layout):** klientoppføringen har ingen `payloads`. nav-pilot materialiserer innholdet selv fra stiene i `layout`. Da må `layout` finnes.
+- **Tier 2 (payloads):** klientoppføringen har `payloads`. nav-pilot verifiserer og stager ferdigbygde trær. Ingen `layout` kreves for slike klienter.
+
+En pakke kan blande: `copilot` på Tier 2 og `opencode` på Tier 1 i samme manifest er gyldig, forutsatt at `layout` finnes for Tier 1-klienten.
+
+Mangler `layout` mens en *kjent* klient er Tier 1, avvises manifestet:
+
+```
+client(s) opencode declare no payloads, which makes them Tier 1, but the manifest has no "layout".
+Add a layout with agents and skills paths, or declare payloads to make them Tier 2
+```
+
+## Ignorer-ukjent, og hva som feiler lukket
+
+Regelen har to halvdeler, og de gjelder samtidig:
+
+- **Ukjente konstruksjoner ignoreres.** Ukjente klientnøkler, ukjente kontekstnøkler i `payloads`, og ekstra felt på ethvert nivå gjør ikke manifestet ugyldig. En eldre binær tilbyr bare ikke det den ikke kjenner navnet på. Dermed kan økosystemet vokse uten å ugyldiggjøre manifester som allerede er ute.
+- **Feilformede *kjente* konstruksjoner feiler lukket.** Er `primaryAgents` tom, er `layout` fraværende for en Tier 1-klient, er `contractVersion` en major nav-pilot ikke implementerer, eller er `minNavPilotVersion` skrevet på et format nav-pilot ikke kan sammenligne — så stopper det. Et repo som *har* et manifest må ha et gyldig et: install avbrytes før første filoperasjon, og ingenting skrives delvis.
+
+Et repo helt uten `.nav-pilot/agentpakke.json` er ikke en feil. Det behandles som en legacy-samlingskilde (`collections/<navn>/manifest.json`) akkurat som før.
+
+## Stiregler
+
+Alle repo-relative stier i manifestet (`layout.*`, `policies.*`, `profiles.dir`, `payloads.*.path`, `payloads.*.manifest`) valideres etter samme regler:
+
+1. Ikke tom, ikke omgitt av whitespace.
+2. Skråstrek forover (`/`). Backslash avvises, også på Linux.
+3. Relativ. Absolutte stier og `~`-prefiks avvises.
+4. Ingen escape: en sti som normaliseres til `..` eller starter med `../` avvises.
+5. **Symlinker må holde seg inne i checkouten.** En sti som *er* en symlink avvises. En sti som når ut av repoet via en symlinket foreldrekatalog avvises også — hele stikjeden løses opp, ikke bare siste ledd. Det samme gjelder enkeltfiler i `agents/`.
+
+Regel 1–4 er tekstlige og kjøres når manifestet parses. Regel 5 krever checkouten på disk og kjøres av `nav-pilot validate` og av install før noe skrives.
+
+## Innholdssjekker på disk
+
+Utover manifestets form sjekker `nav-pilot validate` (og install) innholdet:
+
+- Hver `layout`-katalog som er deklarert, finnes og er en katalog.
+- `layout.agents` inneholder minst én `*.agent.md`, og hver av dem åpner med YAML-frontmatter.
+- Hver Tier 2 `payloads.<kontekst>.path` finnes som katalog.
+- Hver Tier 2-payload har et payload-manifest — `<path>/manifest.json`, eller filen `manifest` peker på. nav-pilot nekter å stage en payload uten manifest.
+- `policies.opencodePermissions` finnes som fil hvis den er satt.
+- `profiles.dir` finnes som katalog, og `<dir>/<default>.json` finnes hvis `profiles.default` er satt.
+
+Alle funn rapporteres samlet, ikke bare det første.
+
+## Versjonsgate
+
+`minNavPilotVersion` må skrives på nav-pilots releaseformat: `YYYY.MM.DD-HHMMSS`, eventuelt med build-sha (`2026.09.01-120000-a1b2c3d`). Andre formater avvises framfor å ignoreres — nav-pilot kan ikke sammenligne dem, og å godta dem ville stille av akkurat den gaten manifestet ba om.
+
+Kjører brukeren en eldre release enn kravet:
+
+```
+agentpakke "grillmester" requires nav-pilot 2026.09.01-120000 or newer, but this binary is
+2026.08.01-100000-abc1234. Run `nav-pilot update` (or reinstall via Homebrew) and try again
+```
+
+Utviklingsbygg (`dev`) er unntatt gaten, slik at lokalt arbeid på en agentpakke ikke blokkeres.
+
+## Kompatibilitet
+
+Kontrakten er bygget for at en agentpakke skal kunne vokse uten å knekke brukere på eldre binærer.
+
+**Trygt å legge til uten bump av `contractVersion`:**
+
+- Nye klientnøkler i `clients` (eldre binærer ignorerer dem).
+- Nye kontekstnøkler i `payloads` (samme regel).
+- Nye felt på ethvert objekt i manifestet.
+- Flere `primaryAgents`, endret `defaultModel`, endret `compatibility`, ny `provenance`.
+- Nytt innhold i `layout`-katalogene.
+
+**Krever varsomhet, men ikke bump:**
+
+- Å flytte innhold ved å endre `layout`-stier: eksisterende brukere får det nye innholdet ved neste sync, men repoet må fortsatt validere. `nav-pilot export opencode` støtter foreløpig bare kanoniske stier (se [Begrensninger](#begrensninger-i-dag)).
+- Å endre `name`: eksisterende installasjoner er registrert under det gamle navnet i state, så nav-pilot kjenner dem ikke igjen som samme pakke. `nav-pilot install <nytt-navn>` blir en ny installasjon i samme scope.
+- Å heve `minNavPilotVersion`: eldre binærer blokkeres bevisst, med en melding som sier hva de skal gjøre.
+
+**Krever bump av `contractVersion`:**
+
+- Å endre betydningen av et eksisterende felt.
+- Å gjøre et tidligere valgfritt felt påkrevd, eller å fjerne et felt konsumenter leser.
+- Å endre en konvensjon konsumenten har innebygget, for eksempel hvor payload-manifestet ligger.
+
+Motsatt vei har nav-pilot en tilsvarende forpliktelse: en fjerning på kontrakten skjer med deprekeringsvindu, ikke i én release.
+
+## Validering i CI
+
+```bash
+nav-pilot validate [--source <owner/repo>|<absolutt sti>] [--ref <ref>] [--json]
+```
+
+Kommandoen kjører hele konformanssjekken mot en kilde: manifestet mot schemaet, semantikken (kontraktversjon, versjonsgate, tier/layout, stiregler) og innholdet på disk. Den er ment for agentpakke-repoets egen CI.
+
+> Ikke å forveksle med `nav-pilot config validate`, som sjekker brukerens egen `~/.nav-pilot/config.toml`.
+
+`--source` tar enten `owner/repo` (klones) eller en **absolutt** sti til en checkout. Relative stier og `.` avvises. Uten `--source` faller kommandoen tilbake på kildepresedensen (`--source` > `source`-nøkkelen i config > `navikt/copilot`), og lokal auto-deteksjon slår kun til for et repo som har en `collections/`-katalog — altså ikke for en vanlig agentpakke. I CI skal du derfor peke eksplisitt på checkouten:
+
+```yaml
+- uses: actions/checkout@v7
+- run: nav-pilot validate --source "$GITHUB_WORKSPACE"
+```
+
+### Exit-koder
+
+| Kode | Betydning |
+| --- | --- |
+| `0` | Kilden er konform (eller er en gyldig legacy-samlingskilde). |
+| `1` | Ett eller flere funn, eller en feil (kilden kunne ikke resolves, manifestet er ikke gyldig JSON, …). |
+
+Ved funn skriver kommandoen problemene og avslutter med `Error: agentpakke validation failed` på stderr. Det gjelder også med `--json`: JSON-en skrives til stdout først, exit-koden er fortsatt `1`.
+
+### `--json`
+
+| Felt | Type | Innhold |
+| --- | --- | --- |
+| `command` | string | Alltid `"validate"`. |
+| `source` | string | Kildeetiketten (`owner/repo`, stien, eller `navikt/copilot`). |
+| `sha` | string | Commit-sha for checkouten som ble validert. |
+| `kind` | string | `"agentpakke"` hvis manifestet finnes, `"legacy"` hvis kilden ikke har noe manifest. |
+| `valid` | bool | `true` når `problems` er tom. |
+| `notes` | array av string | Informasjon, ikke funn: manifeststi, pakkenavn og kontraktversjon, klientliste med tier (og hvilke klientnøkler denne binæren ignorerer), `minNavPilotVersion`. |
+| `problems` | array av string | Ett element per funn, samme tekst som i den menneskelige utskriften. |
+
+```json
+{
+  "command": "validate",
+  "kind": "agentpakke",
+  "notes": [
+    "manifest: .nav-pilot/agentpakke.json",
+    "agentpakke: grillmester (contract version 1)",
+    "clients: copilot (tier 2), opencode (tier 2), zed (unknown to this nav-pilot — ignored)",
+    "minNavPilotVersion: 2026.09.01-000000-0000000"
+  ],
+  "problems": [
+    "clients.copilot.payloads.full.path references \"plugin\", which does not exist in the agentpakke repo"
+  ],
+  "sha": "a1b2c3d",
+  "source": "navikt/grillmester",
+  "valid": false
+}
+```
+
+## Slik installerer brukerne pakka
+
+```bash
+nav-pilot install --source <owner>/<repo> <pakkenavn>
+```
+
+Et repo med manifest **erstatter** samlingsmodellen: det tilbyr nøyaktig ett installerbart navn, nemlig manifestets `name`. `nav-pilot list --source <owner>/<repo>` viser det under overskriften `Agentpakke in <kilde>:`. Kjører brukeren `nav-pilot install --source <owner>/<repo>` uten navn i et repo, hopper den interaktive flyten over samlingsvelgeren og installerer pakka — det er ingenting å velge mellom.
+
+Er navnet på pakka også navnet på en agent i den (vanlig), vinner pakka. Agenten kan fortsatt installeres alene med `--type agent`.
+
+**Kilden huskes.** Etter en vellykket install med eksplisitt `--source` lagres verdien som `source` i `~/.nav-pilot/config.toml`:
+
+```
+✓ Saved navikt/grillmester as your source in /Users/<deg>/.nav-pilot/config.toml.
+  Future runs use it without --source; clear it with nav-pilot config set source "".
+```
+
+Presedensen er `--source` > `source` i config > `navikt/copilot`. Tøm nøkkelen med:
+
+```bash
+nav-pilot config set source ""
+```
+
+**Valget er per scope.** Repo-scope (`.github/` i et repo) og bruker-scope (`~/.copilot`, `--user`) huskes hver for seg, og hvert scope registrerer kilden sin i sin egen state. Ulike repoer kan derfor følge ulike agentpakker.
+
+**Kryss-kilde-vakt.** nav-pilot blander ikke innhold fra to agentpakker i én installasjon. Er scopet installert fra én kilde mens config peker på en annen, stopper install med valgene skrevet ut:
+
+```
+the repo scope was installed from navikt/grillmester, but your configured source is navikt/copilot.
+nav-pilot will not silently mix content from two agentpakker into one install.
+
+  Keep this scope on its current source:  nav-pilot install --source navikt/grillmester <name>
+  Switch this scope to the new source:    nav-pilot install --source navikt/copilot <name>
+  Or clear the persisted source:          nav-pilot config set source ""
+```
+
+Et eksplisitt `--source` er overstyringen — da har brukeren sagt hvilken kilde som skal inn i hvilket scope. Vakten gjelder også de interaktive flytene, så det å velge scope i en meny er ingen vei rundt den.
+
+**Sync.** `nav-pilot sync` bruker kilden som er registrert for scopet, ikke den konfigurerte, og sier fra når de to er ulike. Et scope som ble installert *før* nav-pilot begynte å registrere kilder har ingen registrert kilde: da synkes det fra den konfigurerte kilden, det skrives én informasjonslinje om det (ikke i `--json`), og kilden festes i state først **etter** en vellykket sync — en sync som feiler registrerer ingenting. Fra neste kjøring gjelder den vanlige vakten. Uten `source` i config, og med eksplisitt `--source`, adopteres ingenting.
+
+```
+ℹ The repo scope predates source tracking; syncing from navikt/copilot and recording it as this scope's source.
+```
+
+Stiformede kilder sammenlignes symlink-oppløst, så en symlink og checkouten bak den regnes som samme kilde.
+
+## Begrensninger i dag
+
+Dette er statusen i milepæl 1. Alt under er kjent og planlagt, ikke feil:
+
+- **Tier 2 kan valideres, men ikke installeres.** En agentpakke uten `layout` der klientene har `payloads` validerer fint, men install avvises med sin egen begrunnelse: payload-staging kommer i en senere release (M2). En pakke som skal installeres i dag må ha Tier 1-innhold.
+- **`policies` og `profiles` parses og sti-sjekkes, men materialiseres ikke.** nav-pilot skriver hverken opencode-permissions eller launch-profiler ut fra manifestet ennå (M3).
+- **Persona, modell og launch leser fortsatt Nav-defaults.** `primaryAgents`, `defaultModel`, `defaultContext` og `compatibility` valideres, men kallstedene i `internal/provider` og `internal/source` er ennå hardkodet. De flyttes over til manifestet i M2. En agentpakke bør deklarere feltene riktig nå, slik at oppførselen blir riktig når koden begynner å lese dem.
+- **`nav-pilot export opencode` støtter bare kanoniske stier.** Export leser `agents/`, `skills/`, `instructions/` og `prompts/` direkte. En agentpakke som legger innholdet et annet sted avvises av export med en forklaring, framfor å skrive et tomt `.opencode/`-tre.
+- **Ferskhetssjekken i rot-TUI-en beskriver bare standardkilden.** Scope som ikke kommer fra `navikt/copilot` hoppes over der, fordi release-feeden til nav-pilot bare sier noe om standardkilden.
+- **`provenance` verifiseres ikke.** Feltet er metadata; nav-pilot sjekker ikke digest mot innholdet.
+
+## Eksempler
+
+### Minimal Tier 1
+
+Alt en pakke trenger for å kunne installeres i dag:
+
+```json
+{
+  "contractVersion": "1",
+  "name": "grillmester",
+  "description": "Agentteam for tydelig leveranse, design og produktarbeid",
+  "owner": { "repo": "navikt/grillmester", "team": "Team eSyfo" },
+  "clients": {
+    "copilot": {
+      "primaryAgents": ["grillmester"]
+    },
+    "opencode": {
+      "primaryAgents": ["grillmester", "barista"],
+      "defaultModel": "inherit"
+    }
+  },
+  "layout": {
+    "agents": "agents",
+    "skills": "skills",
+    "instructions": "instructions",
+    "prompts": "prompts"
+  }
+}
+```
+
+Med repoform:
+
+```
+grillmester/
+├── .nav-pilot/agentpakke.json
+├── agents/grillmester.agent.md      # --- name: grillmester / description: … ---
+├── agents/barista.agent.md
+├── skills/nav-plan/SKILL.md
+├── instructions/kotlin.instructions.md
+└── prompts/ny-tjeneste.prompt.md
+```
+
+### Tier 2 med ferdigbygde payloads
+
+Formen en komponert pakke har. Denne validerer, men kan ennå ikke installeres av nav-pilot (se [Begrensninger](#begrensninger-i-dag)):
+
+```json
+{
+  "contractVersion": "1",
+  "name": "grillmester",
+  "description": "A Copilot agent team for clarified software delivery, design, and product work with portable progressive skills.",
+  "owner": { "repo": "navikt/grillmester", "team": "Team eSyfo" },
+  "clients": {
+    "copilot": {
+      "primaryAgents": ["grillmester", "barista", "designer", "doctor-who"],
+      "compatibility": ">=1.0.79,<2",
+      "defaultModel": "gpt-5.6-sol",
+      "defaultContext": "full",
+      "payloads": {
+        "full": { "path": "plugin" },
+        "focused": { "path": "targets/copilot-cli-focused-v1" }
+      }
+    },
+    "opencode": {
+      "primaryAgents": ["grillmester", "barista", "designer", "doctor-who"],
+      "compatibility": ">=1.18.20,<2",
+      "defaultModel": "inherit",
+      "payloads": {
+        "full": { "path": "targets/opencode-v1" },
+        "focused": { "path": "targets/opencode-v1-focused" }
+      }
+    }
+  },
+  "provenance": {
+    "base": { "repo": "navikt/copilot", "digest": "sha256:abc" },
+    "overlays": [{ "component": "grillmester", "version": "0.3.0-rc.8" }]
+  },
+  "profiles": { "dir": "profiles/opencode", "default": "hybrid" },
+  "minNavPilotVersion": "2026.09.01-000000-0000000"
+}
+```
+
+Hver payload-katalog må ha et payload-manifest: `plugin/manifest.json`, `targets/opencode-v1/manifest.json`, og så videre — eller en `manifest`-overstyring i oppføringen.
+
+## Se også
+
+- [JSON Schema: `cli/nav-pilot/schemas/agentpakke-v1.json`](../cli/nav-pilot/schemas/agentpakke-v1.json) — kontrakten selv
+- [nav-pilot](README.nav-pilot.md) — CLI-et som konsumerer agentpakker
+- [Samlinger](README.collections.md) — legacy-modellen en agentpakke erstatter
+- [Sync](README.sync.md) — hvordan installert innhold holdes oppdatert
+- [cli/nav-pilot/DESIGN.md](../cli/nav-pilot/DESIGN.md) — internt design, sømmer og migrasjonsplan

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -114,6 +114,21 @@ nav-pilot install --user --all
 eval "$(nav-pilot env)"
 ```
 
+## Agentpakker fra andre team
+
+Et team kan distribuere sitt eget innhold som en **agentpakke** — et repo med
+manifest på `.nav-pilot/agentpakke.json`. Installer det med `--source`; kilden
+huskes per scope til du tømmer den.
+
+```bash
+nav-pilot install --source navikt/<repo> <pakkenavn>
+nav-pilot config set source ""     # tilbake til navikt/copilot
+nav-pilot validate --source navikt/<repo>   # sjekk en pakke mot kontrakten
+```
+
+**[Lag din egen agentpakke →](README.agentpakke.md)** — manifestreferanse,
+kompatibilitetsregler og CI-validering.
+
 ## Telemetry (pilot, default on)
 
 nav-pilot sender OTel-metrikker som standard i pilot.


### PR DESCRIPTION
Implements milestone **M1** of the agentpakke PRD (#435): the versioned agentpakke contract, persisted source selection, and the `nav-pilot validate` command — the foundation for running agentpakker from other navikt repos (reference case: navikt/grillmester) through the nav-pilot binary.

## What's in here

**Contract (`internal/agentpakke` + `schemas/agentpakke-v1.json`)**
- A pakke repo ships `.nav-pilot/agentpakke.json`; the published JSON Schema lives at `cli/nav-pilot/schemas/agentpakke-v1.json` and is embedded into the binary (single source of truth — pakke repos can lint against the same file in their CI).
- Consolidated per-client declaration; tier derived from shape (`payloads` present = Tier 2, otherwise Tier 1 via `layout`); unknown clients/contexts/fields are ignored per the contract's additive-compatibility rules; malformed known constructs fail closed with actionable errors.
- `contractVersion` and `minNavPilotVersion` gates (release-version format enforced at both schema and semantic layers).

**Single internal currency + migration path**
- The `Manifest` is the only internal representation. Sources without a manifest are adapted by `SynthesizeLegacy`, which expresses today's collection conventions in manifest form — no legacy-vs-manifest branches anywhere downstream.
- Migration: phase 1 (this PR) manifest optional; phase 2 navikt/copilot ships its own manifest and becomes the default agentpakke; phase 3 the adapter and collection mechanism are removed under the contract's deprecation window.

**CLI**
- `source` config key (precedence: `--source` flag > config > default), persisted only after a successful explicit-source install, cleared with `config set source ""`.
- Per-scope cross-source guards: install/sync refuse to silently mix content from a different source into an existing scope (explicit `--source` overrides); different scopes can track different agentpakker.
- Supersede install: a manifest-bearing source validates fail-closed **before any write**, installs from its declared layout, and records the pakke name as the state collection.
- `nav-pilot validate [--source <repo>|<path>]` — agentpakke conformance for CI use, non-zero exit on findings; legacy sources validate as collections.
- Tier 2-only pakker (grillmester's current shape) get an explicit "ships pre-built payloads, not installable yet" error — payload staging/launch is M2.

**Hardening**
- Path containment resolves intermediate symlinks on the resolver read path (including today's canonical dirs) and in source validation; manifest-declared paths are rejected if they escape the checkout.

## Backward compatibility

No behavior change for existing users: with no `source` configured the guards are inert, the synthesized manifest maps to the canonical layout with no remapping, and old config/state files behave exactly as today. Asserted by a golden legacy-install test, and an adversarial review pass whose explicit charge was "construct an existing-user break" came back empty. All nine review findings (2 major, 7 minor) are fixed in the final commit.

## Out of scope (per the PRD milestones)

- M2: Tier 2 payload verify/stage/launch, data-driven personas/model call sites (`internal/provider`, frontmatter allowlist untouched).
- M3: Tier 1 policy/profile materialization, provenance enforcement.

Closes nothing; tracks #435.
