### PR TITLE
fix(rtk): stop promoting unverified savings claim, fix install path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,35 +14,30 @@ Monorepo for Nav’s Copilot ecosystem:
 
 Security model and trust boundaries: see `SECURITY.md`.
 
-## Efficiency rule (mandatory)
+## Efficiency rule
 
-Always prefix shell commands with `rtk`.
+Keep tool output small: run targeted commands, avoid dumping whole files or full
+build logs into context, and prefer deterministic tools over asking the model to
+guess.
 
-```bash
-rtk git status
-rtk mise check
-rtk gh pr view 123
-rtk go test ./...
-```
-
-In chained commands, prefix every command:
-
-```bash
-rtk git add . && rtk git commit -m "msg" && rtk git push
-```
+`rtk` is an optional CLI proxy that filters terminal output before it reaches the
+model. It is available if you want it (`rtk git status`), but it is not required
+and not assumed anywhere in this repo — public controlled measurement has not
+reproduced its advertised savings
+([JetBrains study](https://blog.jetbrains.com/ai/2026/07/rtk-claude-code-token-savings/)).
 
 ## Standard commands
 
 From repo root:
 
 ```bash
-rtk mise check
-rtk mise test
-rtk mise build
-rtk mise all
+mise check
+mise test
+mise build
+mise all
 ```
 
-Per app: run `rtk mise check` in the app directory after edits.
+Per app: run `mise check` in the app directory after edits.
 
 ## Repo conventions that matter
 
@@ -55,5 +50,5 @@ Per app: run `rtk mise check` in the app directory after edits.
 ## When in doubt
 
 - Start with the smallest safe change.
-- Validate with existing checks (`rtk mise check`, or `rtk mise all` for cross-repo impact).
-- Prefer deterministic tools first (`rtk rg`, `rtk git`, `rtk gh`), then LLM synthesis.
+- Validate with existing checks (`mise check`, or `mise all` for cross-repo impact).
+- Prefer deterministic tools first (`rg`, `git`, `gh`), then LLM synthesis.

--- a/apps/copilot-metrics/README.md
+++ b/apps/copilot-metrics/README.md
@@ -34,33 +34,33 @@ Explicit tasks so "backfill" is unambiguous:
 
 ```bash
 # Usage metrics only
-rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:usage'
+bash -lc 'cd apps/copilot-metrics && mise backfill:usage'
 
 # Monthly billing only
-rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:billing-monthly'
+bash -lc 'cd apps/copilot-metrics && mise backfill:billing-monthly'
 
 # Daily billing usage reports only
-rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:billing-daily-report'
+bash -lc 'cd apps/copilot-metrics && mise backfill:billing-daily-report'
 
 # Daily model billing usage only
-rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:billing-model-daily'
+bash -lc 'cd apps/copilot-metrics && mise backfill:billing-model-daily'
 
 # Per-repository usage metrics only
-rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:repo-metrics'
+bash -lc 'cd apps/copilot-metrics && mise backfill:repo-metrics'
 
 # Everything
-rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:all'
+bash -lc 'cd apps/copilot-metrics && mise backfill:all'
 ```
 
 Prod variants:
 
 ```bash
-rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:usage:prod'
-rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:billing-monthly:prod'
-rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:billing-daily-report:prod'
-rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:billing-model-daily:prod'
-rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:repo-metrics:prod'
-rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:all:prod'
+bash -lc 'cd apps/copilot-metrics && mise backfill:usage:prod'
+bash -lc 'cd apps/copilot-metrics && mise backfill:billing-monthly:prod'
+bash -lc 'cd apps/copilot-metrics && mise backfill:billing-daily-report:prod'
+bash -lc 'cd apps/copilot-metrics && mise backfill:billing-model-daily:prod'
+bash -lc 'cd apps/copilot-metrics && mise backfill:repo-metrics:prod'
+bash -lc 'cd apps/copilot-metrics && mise backfill:all:prod'
 ```
 
 ### Nightly job (default)
@@ -68,7 +68,7 @@ rtk bash -lc 'cd apps/copilot-metrics && rtk mise backfill:all:prod'
 Runs as a Kubernetes CronJob via NAIS. Automatically detects missing days in BigQuery and fills gaps:
 
 ```bash
-rtk copilot-metrics --run-once
+copilot-metrics --run-once
 ```
 
 ### Historical backfill
@@ -76,8 +76,8 @@ rtk copilot-metrics --run-once
 One-time operation to load historical data:
 
 ```bash
-rtk copilot-metrics --backfill
-rtk copilot-metrics --backfill --backfill-from=2025-10-10
+copilot-metrics --backfill
+copilot-metrics --backfill --backfill-from=2025-10-10
 ```
 
 ### Billing usage backfill
@@ -85,9 +85,9 @@ rtk copilot-metrics --backfill --backfill-from=2025-10-10
 One-time operation to load premium request billing data per model (requires `GITHUB_BILLING_TOKEN`):
 
 ```bash
-rtk copilot-metrics --billing-monthly-backfill
-rtk copilot-metrics --billing-monthly-backfill --billing-monthly-from=2025-01
-rtk copilot-metrics --billing-monthly-backfill --billing-monthly-from=2025-01 --force
+copilot-metrics --billing-monthly-backfill
+copilot-metrics --billing-monthly-backfill --billing-monthly-from=2025-01
+copilot-metrics --billing-monthly-backfill --billing-monthly-from=2025-01 --force
 ```
 
 ### Billing usage report backfill (daily rows)
@@ -95,9 +95,9 @@ rtk copilot-metrics --billing-monthly-backfill --billing-monthly-from=2025-01 --
 One-time operation to load daily organization billing usage report rows (requires `GITHUB_BILLING_TOKEN`):
 
 ```bash
-rtk copilot-metrics --billing-daily-report-backfill
-rtk copilot-metrics --billing-daily-report-backfill --billing-daily-report-from=2025-10-10
-rtk copilot-metrics --billing-daily-report-backfill --billing-daily-report-from=2025-10-10 --force
+copilot-metrics --billing-daily-report-backfill
+copilot-metrics --billing-daily-report-backfill --billing-daily-report-from=2025-10-10
+copilot-metrics --billing-daily-report-backfill --billing-daily-report-from=2025-10-10 --force
 ```
 
 ### Billing daily model backfill
@@ -105,9 +105,9 @@ rtk copilot-metrics --billing-daily-report-backfill --billing-daily-report-from=
 One-time operation to load daily model-level premium request billing data (requires `GITHUB_BILLING_TOKEN`):
 
 ```bash
-rtk copilot-metrics --billing-model-daily-backfill
-rtk copilot-metrics --billing-model-daily-backfill --billing-model-daily-from=2025-10-10
-rtk copilot-metrics --billing-model-daily-backfill --billing-model-daily-from=2025-10-10 --force
+copilot-metrics --billing-model-daily-backfill
+copilot-metrics --billing-model-daily-backfill --billing-model-daily-from=2025-10-10
+copilot-metrics --billing-model-daily-backfill --billing-model-daily-from=2025-10-10 --force
 ```
 
 ### Repository metrics backfill
@@ -120,9 +120,9 @@ GA date (2026-07-17) and the deploy of repository ingestion fall outside that
 window permanently. This flag closes those gaps.
 
 ```bash
-rtk copilot-metrics --repo-metrics-backfill
-rtk copilot-metrics --repo-metrics-backfill --repo-metrics-from=2026-07-17
-rtk copilot-metrics --repo-metrics-backfill --repo-metrics-from=2026-07-17 --force
+copilot-metrics --repo-metrics-backfill
+copilot-metrics --repo-metrics-backfill --repo-metrics-from=2026-07-17
+copilot-metrics --repo-metrics-backfill --repo-metrics-from=2026-07-17 --force
 ```
 
 Days that already have data are skipped before the API call, so the command is
@@ -139,7 +139,7 @@ export GITHUB_APP_INSTALLATION_ID=789
 export GCP_TEAM_PROJECT_ID=my-project
 export LOG_LEVEL=DEBUG
 
-rtk go run . --run-once
+go run . --run-once
 ```
 
 ## Configuration
@@ -285,13 +285,13 @@ Set `GITHUB_BILLING_TOKEN` in the `copilot-metrics` secret to enable billing ing
 Deployed as a NAIS Job in the `copilot` namespace:
 
 ```bash
-rtk kubectl apply -f .nais/naisjob.yaml -f .nais/dev.yaml
+kubectl apply -f .nais/naisjob.yaml -f .nais/dev.yaml
 ```
 
 Manual trigger:
 
 ```bash
-rtk kubectl create job --from=cronjob/copilot-metrics copilot-metrics-manual -n copilot
+kubectl create job --from=cronjob/copilot-metrics copilot-metrics-manual -n copilot
 ```
 
 ## Related

--- a/apps/my-copilot/src/app/praksis/sections/cost-optimization.tsx
+++ b/apps/my-copilot/src/app/praksis/sections/cost-optimization.tsx
@@ -33,8 +33,8 @@ export default function CostOptimization() {
             <BodyShort size="small" className="text-gray-700">
               VS Code 1.125 introduserte et innebygd «Spend Meter» som viser ditt eget AI Credits-forbruk i sanntid.
               Finn det under <code>View → Status Bar → Copilot Usage</code>. Bruk det aktivt for å oppdage dyre mønstre
-              tidlig. Kombinert med <code>rtk</code>-proxyen (60–90 % token-besparelse) er dette de to viktigste
-              verktøyene for å holde kostnadene nede.
+              tidlig. Måler du effekten av et tiltak, bruk fakturert kostnad per fullført oppgave — ikke sparetallet et
+              verktøy rapporterer om seg selv.
             </BodyShort>
           </Box>
 

--- a/apps/my-copilot/src/components/nav-pilot/interactive-setup-wizard.test.tsx
+++ b/apps/my-copilot/src/components/nav-pilot/interactive-setup-wizard.test.tsx
@@ -15,7 +15,7 @@ describe("generateSetupScript", () => {
 
     it("generates correct CLI script", () => {
       const result = generateSetupScript(os, "cli", "kotlin-backend");
-      expect(result.code).toContain("brew install navikt/tap/nav-pilot navikt/tap/cplt rtk");
+      expect(result.code).toContain("brew install navikt/tap/nav-pilot navikt/tap/cplt");
       expect(result.code).toContain("npm install -g @github/copilot");
       expect(result.code).toContain("nav-pilot install kotlin-backend");
       expect(result.code).not.toContain("opencode");
@@ -23,7 +23,7 @@ describe("generateSetupScript", () => {
 
     it("generates correct OpenCode script", () => {
       const result = generateSetupScript(os, "opencode", "kotlin-backend");
-      expect(result.code).toContain("brew install navikt/tap/nav-pilot navikt/tap/cplt rtk");
+      expect(result.code).toContain("brew install navikt/tap/nav-pilot navikt/tap/cplt");
       expect(result.code).toContain("curl -fsSL https://opencode.ai/install | bash");
       expect(result.code).toContain("nav-pilot config set client opencode");
       expect(result.code).toContain("nav-pilot --client opencode");

--- a/apps/my-copilot/src/components/nav-pilot/interactive-setup-wizard.tsx
+++ b/apps/my-copilot/src/components/nav-pilot/interactive-setup-wizard.tsx
@@ -70,12 +70,12 @@ export function generateSetupScript(os: OS, workflow: Workflow, stack: Collectio
 
   if (isMac) {
     blocks.push({
-      title: "# 2. Installer Nav-verktøy (inkluderer rtk for token-sparing)",
-      commands: ["brew install navikt/tap/nav-pilot navikt/tap/cplt rtk"],
+      title: "# 2. Installer Nav-verktøy",
+      commands: ["brew install navikt/tap/nav-pilot navikt/tap/cplt"],
     });
   } else {
     blocks.push({
-      title: "# 2. Last ned verktøy (inkluderer rtk for token-sparing og sandbox)",
+      title: "# 2. Last ned verktøy (inkluderer sandbox)",
       commands: ["curl -fsSL https://raw.githubusercontent.com/navikt/copilot/main/scripts/install.sh | bash"],
     });
   }

--- a/cli/nav-pilot/RUNBOOKS.md
+++ b/cli/nav-pilot/RUNBOOKS.md
@@ -67,7 +67,7 @@ Pluss resource-attributtene `service.name`, `service.version`, `os`, `arch`, `de
 2. **Was there a recent code push?**
    ```bash
    # Check git log for installs.go changes in last 2h
-   rtk git log --oneline -n 20 -- cli/nav-pilot/install.go
+   git log --oneline -n 20 -- cli/nav-pilot/install.go
    ```
 
 3. **Which error types are causing failures?**
@@ -154,7 +154,7 @@ On-call determines: fix in place, or revert to stable version
 
 2. **Recent error message changes?**
    ```bash
-   rtk git log --oneline -n 10 -- cli/nav-pilot/output.go cli/nav-pilot/interactive.go
+   git log --oneline -n 10 -- cli/nav-pilot/output.go cli/nav-pilot/interactive.go
    ```
 
 3. **Check error context:**
@@ -242,7 +242,7 @@ Check rate next day
 
 2. **Any recent changes to scope handling?**
    ```bash
-   rtk git log --oneline -n 5 -- cli/nav-pilot/scope.go
+   git log --oneline -n 5 -- cli/nav-pilot/scope.go
    ```
 
 3. **What does the error message say?**
@@ -322,7 +322,7 @@ Følg med neste uke
 1. **When did this spike start?**
    - Recent change to prompts?
    ```bash
-   rtk git log --oneline -n 5 -- cli/nav-pilot/interactive.go
+   git log --oneline -n 5 -- cli/nav-pilot/interactive.go
    ```
 
 2. **Which action is being declined?**
@@ -409,7 +409,7 @@ Følg med neste vakt
 
 2. **Recent changes to merge algorithm?**
    ```bash
-   rtk git log --oneline -n 5 -- cli/nav-pilot/sync.go cli/nav-pilot/manifest.go
+   git log --oneline -n 5 -- cli/nav-pilot/sync.go cli/nav-pilot/manifest.go
    ```
 
 3. **Are users aborting on conflicts?**

--- a/cli/nav-pilot/internal/cli/doctor.go
+++ b/cli/nav-pilot/internal/cli/doctor.go
@@ -198,8 +198,17 @@ func cmdDoctor() error {
 			fmt.Printf("    %s %s: OK\n", green("✓"), name)
 		}
 	}
-	checkDep("rtk")
+	// checkOptionalDep reports presence without failing the health check. rtk is
+	// optional: nav-pilot works fully without it.
+	checkOptionalDep := func(name string) {
+		if p, _ := exec.LookPath(name); p == "" {
+			fmt.Printf("    %s %s: Not installed (optional)\n", dim("-"), name)
+		} else {
+			fmt.Printf("    %s %s: OK\n", green("✓"), name)
+		}
+	}
 	checkDep("git")
+	checkOptionalDep("rtk")
 	fmt.Println()
 
 	if hasErrors {

--- a/cli/nav-pilot/internal/cli/rtk_setup.go
+++ b/cli/nav-pilot/internal/cli/rtk_setup.go
@@ -45,16 +45,18 @@ func promptAndInstallRtk(cfg ResolvedConfig) error {
 	hasRtk := isRtkInstalled()
 
 	fmt.Println()
-	fmt.Printf("%s Terminal Token Optimizer (rtk)\n", bold("🚀"))
-	fmt.Println(dim("  Safely filters terminal noise before it reaches the AI, saving 60-90% on token costs."))
-	fmt.Println(dim("  It runs entirely in the background and won't change how your commands work."))
+	fmt.Printf("%s Terminal output filter (rtk)\n", bold("🔧"))
+	fmt.Println(dim("  rtk filters and compresses terminal output before it reaches the model's context."))
+	fmt.Println(dim("  It runs in the background and won't change how your commands work."))
+	fmt.Println(dim("  Note: public controlled measurement has not reproduced the vendor's savings claim —"))
+	fmt.Println(dim("  https://blog.jetbrains.com/ai/2026/07/rtk-claude-code-token-savings/"))
 	fmt.Println()
 
 	var choice string
 	err := huh.NewSelect[string]().
-		Title(fmt.Sprintf("Install Terminal Token Optimizer for %s?", cfg.Client)).
+		Title(fmt.Sprintf("Install the terminal output filter (rtk) for %s?", cfg.Client)).
 		Options(
-			huh.NewOption("Yes, set it up (Highly Recommended)", "yes"),
+			huh.NewOption("Yes, set it up", "yes"),
 			huh.NewOption("No thanks", "no"),
 		).
 		Value(&choice).
@@ -121,26 +123,40 @@ func isRtkInstalled() bool {
 	return err == nil
 }
 
+// installRtk installs rtk through Homebrew only.
+//
+// Why there is no scripted fallback: the previous implementation ran
+// `brew install navikt/tap/rtk`, but navikt/homebrew-tap has no rtk formula
+// (only cplt and nav-pilot), so the brew step always failed and every user
+// silently fell through to `curl … refs/heads/master/install.sh | sh` — an
+// unpinned pipe-to-shell from a moving upstream branch. rtk ships in
+// homebrew-core, so `brew install rtk` gets us a checksum-verified bottle and
+// Homebrew's own supply-chain handling. If Homebrew is unavailable we print
+// manual instructions rather than reintroducing an unverified install script.
 func installRtk() (string, string, error) {
-	var brewErr error
-	if _, err := exec.LookPath("brew"); err == nil {
-		p, res, err := installRtkViaBrew()
-		if err == nil {
-			return p, res, nil
-		}
-		brewErr = err
-		fmt.Fprintf(os.Stderr, "Brew installation failed: %v. Retrying with curl installation method...\n", err)
+	if _, err := exec.LookPath("brew"); err != nil {
+		printManualRtkInstructions()
+		return "", "brew_missing", fmt.Errorf("homebrew not found; rtk must be installed manually")
 	}
-	p, res, curlErr := installRtkViaCurl()
-	if curlErr != nil && brewErr != nil {
-		return "", "install_failed", fmt.Errorf("brew install failed (%v) and curl install failed (%w)", brewErr, curlErr)
+	p, res, err := installRtkViaBrew()
+	if err != nil {
+		printManualRtkInstructions()
+		return "", res, err
 	}
-	return p, res, curlErr
+	return p, res, nil
+}
+
+// printManualRtkInstructions tells the user how to install rtk themselves.
+func printManualRtkInstructions() {
+	fmt.Fprint(os.Stderr, "\n  Install rtk manually, then run nav-pilot again:\n")
+	fmt.Fprint(os.Stderr, "    brew install rtk    (homebrew-core, checksum-verified)\n")
+	fmt.Fprint(os.Stderr, "    or download a signed release archive from https://github.com/rtk-ai/rtk/releases\n\n")
 }
 
 func installRtkViaBrew() (string, string, error) {
 	fmt.Printf("%s Installing rtk via brew...\n", dim("→"))
-	cmd := exec.Command("brew", "install", "navikt/tap/rtk")
+	// homebrew-core formula (https://formulae.brew.sh/formula/rtk), not a Nav tap.
+	cmd := exec.Command("brew", "install", "rtk")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -158,35 +174,6 @@ func installRtkViaBrew() (string, string, error) {
 	}
 
 	return "rtk", "success", nil
-}
-
-func installRtkViaCurl() (string, string, error) {
-	fmt.Printf("%s Installing rtk via curl script...\n", dim("→"))
-	cmd := exec.Command("sh", "-c", "curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return "", "curl_failed", err
-	}
-
-	// The install script might drop it somewhere not immediately in PATH
-	rtkBinName := "rtk"
-	if runtime.GOOS == "windows" {
-		rtkBinName = "rtk.exe"
-	}
-	if p, err := exec.LookPath(rtkBinName); err == nil {
-		return p, "success", nil
-	}
-
-	// Check common cargo bin if the script is rust-based or uses cargo
-	home, _ := os.UserHomeDir()
-	cargoBin := filepath.Join(home, ".cargo", "bin", rtkBinName)
-	if _, err := os.Stat(cargoBin); err == nil {
-		return cargoBin, "success", nil
-	}
-
-	// Just return the binary name and let the exec fail if it still can't find it
-	return rtkBinName, "success", nil
 }
 
 func getOpenCodeConfigDir() string {

--- a/cli/nav-pilot/internal/telemetry/telemetry.go
+++ b/cli/nav-pilot/internal/telemetry/telemetry.go
@@ -545,7 +545,7 @@ func normalizeTelemetryDimension(v, fallback string) string {
 		"amd64", "arm64", "arm", "386",
 		"copilot", "opencode", "pi",
 		"client_not_found", "launch_failed", "network_error", "auth_error", "sync_failed", "panic",
-		"yes", "no", "aborted", "brew_failed", "curl_failed", "init_failed", "already_installed":
+		"yes", "no", "aborted", "brew_failed", "brew_missing", "init_failed", "already_installed":
 		return v
 	default:
 		if strings.Count(v, ".") >= 1 || strings.Count(v, "-") >= 1 {

--- a/docs/news/articles/token-forbruk-verktoy-teknikker.md
+++ b/docs/news/articles/token-forbruk-verktoy-teknikker.md
@@ -184,14 +184,22 @@ Andre tips for vedlikeholdere:
 
 ### RTK — komprimerer terminaloutput
 
-[RTK](https://github.com/rtk-ai/rtk) komprimerer kommando-output (testresultater, diff, kubectl) før den når kontekstvinduet. Nyttig hvis du bruker Copilot CLI mye.
+> **Oppdatert 2026-08-24:** Denne seksjonen påsto opprinnelig at «RTK rapporterer 60–90 % reduksjon på verktøydata». Det tallet er verktøyets egen selvrapportering, og den er ikke bekreftet av kontrollert måling. Avsnittet er rettet, og nav-pilot anbefaler ikke lenger RTK aktivt.
+
+[RTK](https://github.com/rtk-ai/rtk) er en CLI-proxy som filtrerer og komprimerer kommando-output (testresultater, diff, kubectl) før den når kontekstvinduet.
 
 ```bash
 brew install rtk
 rtk init -g --copilot
 ```
 
-RTK rapporterer 60–90 % reduksjon på verktøydata. RTK og terse-mode utfyller hverandre: RTK kutter det agenten *leser*, terse-mode kutter det agenten *skriver*.
+**Hva vi vet om effekten:** RTK har en innebygd teller (`rtk gain`) som viser hvor mye den mener den har spart. Den tellingen er ikke det samme som lavere regning: den regner hele den rå kommando-outputen som «spart» selv om agenten uansett kutter store verktøyresultater, den priser fjernede tokens til full input-pris selv om det meste av sesjonsinput er cachede gjenlesninger til rundt en tidel av prisen, og bare en del av verktøyresultatene går gjennom hooken i det hele tatt (innebygde lese- og søkeverktøy går utenom).
+
+Den eneste store offentlige kontrollerte studien — [JetBrains, 425 kjøringer over 86 oppgaver](https://blog.jetbrains.com/ai/2026/07/rtk-claude-code-token-savings/) med forhåndsregistrerte endepunkter — fant ingen besparelse: 7,6 % *høyere* kostnad per oppgave ved lavt resonneringsnivå (p = 0,004) og ingen målbar forskjell ved høyt nivå (+0,1 %, p = 0,99), uten kvalitetsforskjell. Merk omfanget: studien målte RTK i Claude Code, og hook-dekningen over er et arkitekturtrekk ved den agenten. Tilsvarende kontrollert måling finnes ikke for Copilot CLI eller OpenCode — der er effekten rett og slett ikke målt. Liknende resultater er rapportert for andre komprimerende verktøy: [0,6 % av en faktisk regning på 755 dollar](https://jayn.app/caveman), og en prompt-komprimerende proxy som [kuttet tokens 39 % men brøt prompt-cachen 123 ganger](https://brandonbarker.me/writing/headroom-fewer-tokens-bigger-bill) og dermed flyttet millioner av tokens til full pris.
+
+Den strukturelle grunnen er at output-tokens er en liten andel av totalen i en agent-sesjon, og at cache-treffraten er høy. Da er det lite igjen å hente på å komprimere tekst.
+
+**Praktisk konklusjon:** RTK gjør terminaloutput lettere å lese, og det kan i seg selv være verdt noe. Men ikke regn med lavere regning, og ikke bruk verktøyets eget sparetall som bevis — mål heller fakturert kostnad per fullført oppgave. Grepene som faktisk har dokumentert effekt er modellvalg, resonneringsnivå, å holde prompt-cachen intakt, og å gjøre mindre arbeid.
 
 **Merk:** RTK prosesserer terminaloutput lokalt. Sjekk at verktøyet er godkjent for ditt team før du bruker det med output som kan inneholde sensitive data.
 

--- a/docs/video-demoer-kost-token-optimalisering.md
+++ b/docs/video-demoer-kost-token-optimalisering.md
@@ -41,7 +41,7 @@ Kort serie for alle utviklere i Nav som bruker Copilot i det daglige.
 2. Bonus episode B: Mål effekt i statistikk
 3. Bonus episode C: Chronicle — forstå og optimaliser context
 4. Bonus episode D: Cplt sandbox — kom i gang på 3 minutter
-5. Bonus episode E: rtk — CLI-output-komprimering (60-90% token-besparelse)
+5. Bonus episode E: Fire grep som faktisk senker regningen
 
 ## Produksjonsstatus
 
@@ -57,7 +57,7 @@ Kort serie for alle utviklere i Nav som bruker Copilot i det daglige.
 | Bonus B | Planlagt | Kan fortsatt justeres. |
 | Bonus C | Planlagt | Fokus: `/context`, `tips`, `cost-tips`, `improve`. |
 | Bonus D | Spilt inn | Lås manus, metadata og overlay. |
-| Bonus E | Planlagt | Fokus: rtk gain/discover, git/go test, side-by-side output. |
+| Bonus E | Planlagt | Fokus: modellvalg, resonneringsnivå, prompt-cache, mindre arbeid. Erstatter tidligere rtk-utkast. |
 
 **Regel:** Ikke endre innholdet i episoder merket **Spilt inn**. Juster bare status, beskrivelser eller produksjonsnotater ved behov.
 
@@ -790,139 +790,118 @@ Output: nummerert liste.
 
 ---
 
-## Bonus episode E: rtk — CLI-output-komprimering (60-90% token-besparelse)
+## Bonus episode E: Fire grep som faktisk senker regningen
 
 **Status:** Planlagt
 
-**Overlay:** E · orange/amber · before/after compression meter · git log / git status / go test / git diff · 60-90% ↓
+**Overlay:** E · orange/amber · lever-meter · modell / resonneringsnivå / cache / mindre arbeid · kr per oppgave
 
-**Mål:** Vise hvordan `rtk`-prefiksen på CLI-kommandoer automatisk senker tokenbruk på kommandoer med tydelig output — med visuell før/etter-sammenligning av output.
+**Mål:** Vise de fire grepene som har dokumentert effekt på tokenkostnad — og lære seeren å måle effekt på fakturert kostnad per fullført oppgave i stedet for på et verktøys eget sparetall.
 
-**Kan sees alene fordi:** Vi forklarer `rtk`-prinsippet i 30 sek og viser fem konkrete kommandoer der effekten er tydelig.
+**Kan sees alene fordi:** Vi starter med hvorfor «spart tokens» og «lavere regning» ikke er samme sak, og går rett på fire grep man kan gjøre samme dag.
 
-**Oppsett før demo:** Installer og initialiser `rtk` for Copilot først:
+**Bakgrunn (til deg som spiller inn):** Denne episoden erstatter et tidligere utkast som handlet om `rtk` og CLI-output-komprimering med en påstand om 60–90 % besparelse. Den påstanden er verktøyets egen selvrapportering. Den eneste store offentlige kontrollerte studien ([JetBrains, 425 kjøringer over 86 oppgaver](https://blog.jetbrains.com/ai/2026/07/rtk-claude-code-token-savings/)) fant 7,6 % *høyere* kostnad per oppgave ved lavt resonneringsnivå (p = 0,004) og ingen forskjell ved høyt nivå (+0,1 %, p = 0,99), uten kvalitetsforskjell. Ikke bruk tall fra verktøydashbord i videoen.
 
-```bash
-brew install rtk
-rtk init -g --copilot
-```
+**Oppsett før demo:** Ingen installasjon. Du trenger tilgang til modellvalg, resonneringsnivå og en kostnadsvisning (Spend Meter i VS Code eller statistikk i my-copilot).
 
 **Script-outline (one-take):**
-1. "Hei og velkommen! I dag lærer du ett enkelt grep som senker tokens på alt du kjører fra terminalen."
-2. Vis installasjon og init: `brew install rtk` og `rtk init -g --copilot`.
-3. Vis samme kommando to ganger: uten og med `rtk` foran.
-4. Demonstrer effekten med fire kommandoer som gir tydelig forskjell (git log, git status, go test med cache av, git diff).
-5. Kjør `rtk gain` bare som bonus hvis tracking-databasen er tilgjengelig; ellers bruk `rtk discover` som status-sjekk.
-6. Avslutt med: "Add `rtk` to the start of any command."
+1. "Hei og velkommen! I dag ser vi på hva som faktisk senker AI-regningen — og hvorfor det vanligste rådet ikke gjør det."
+2. Vis forskjellen på «tokens spart» og «kroner fakturert»: output-tokens er en liten del av en sesjon, og det meste av input er cachede gjenlesninger til rundt en tidel av prisen.
+3. Grep 1 — modellvalg: samme oppgave på to modeller, vis pris per token og resultat.
+4. Grep 2 — resonneringsnivå: kjør en rutineoppgave på lavt nivå og vis at kvaliteten holder.
+5. Grep 3 — hold prompt-cachen intakt: vis hva som bryter cachen, og hva det koster.
+6. Grep 4 — gjør mindre arbeid: målrettet test i stedet for full pipeline, én oppgave per sesjon.
+7. Avslutt med målereglen: sammenlign fakturert kostnad per fullført oppgave, aldri et verktøys eget sparetall.
 
 **Innhold (3–5 min):**
-1. Vis hva `rtk` gjør i 20 sek (filter + compress).
-2. **Setup (20 sek):** `brew install rtk` og `rtk init -g --copilot`.
-3. **Demo 1 (45 sek):** `git log --oneline --decorate --all` uten vs med rtk.
-   - Uten: ~80 linjer med mye padding og dekor
-   - Med rtk: ~20 linjer, signal-only
-4. **Demo 2 (45 sek):** `git status` uten vs med rtk.
-   - Uten: verbose forklaringer og lange blokker
-   - Med rtk: kompakt liste som er lett å lese på skjerm
-5. **Demo 3 (45 sek):** `go test -count=1 -v ./...` uten vs med rtk.
-   - Uten: test-for-test output og pakkevis støy
-   - Med rtk: aggregert resultat som fortsatt viser om noe feiler
-6. **Demo 4 (30 sek):** `git diff` på en ekte, større endring uten vs med rtk.
-   - Uten: mange hunk-linjer og kontekst
-   - Med rtk: kort oppsummering av hva som faktisk endret seg
-7. **Demo 5 (20 sek, valgfri):** `rtk gain` eller `rtk discover` hvis tracking er tilgjengelig.
-   - Brukes som bonus, ikke som hovedbevis
-8. **Avslutt (30 sek):** Kort sjekkliste: add rtk til kommandoer som faktisk produserer mye output.
+1. **Rammen (40 sek):** Hvorfor «spart output» ≈ 0 kroner. Output-tokens er en liten andel av en agent-sesjon, cache-treffraten er høy, og de fleste tellere priser fjernede tokens til full input-pris.
+2. **Grep 1 — modellvalg (60 sek):** Den største spaken, fordi den endrer pris per token og ikke bare antall tokens. Kjør samme oppgave på en rask og en tung modell, og vis at rutineoppgaven ikke ble bedre av den dyre modellen.
+3. **Grep 2 — resonneringsnivå (45 sek):** Leverandørens egen innstilling for resonneringsnivå er et reelt kostnadsvalg. Vis en rutineoppgave på lavt nivå med samme resultat, og si tydelig når du *bør* skru opp igjen.
+4. **Grep 3 — prompt-cache (45 sek):** Vis hva som bryter cachen (endre systemprompt/instruksjonsfiler midt i sesjonen, injisere ny kontekst tidlig i prompten) og hva som bevarer den. Poeng: et tiltak som «sparer tokens» men bryter cachen kan gi *høyere* regning.
+5. **Grep 4 — mindre arbeid (45 sek):** `./gradlew test --tests *MinTest` i stedet for full pipeline, én oppgave per sesjon, la agenten lese selv i stedet for å lime inn. Færre runder slår kortere tekst.
+6. **Måleregel (30 sek):** Kjør samme oppgavesett før og etter, og sammenlign fakturert kostnad per *fullført* oppgave. Verktøyets eget sparetall teller ikke som bevis.
 
-**Demo-kontekst (referanserepo):** Monorepo med go, git, docker — gir flere virkelige eksempler.
-**Viktig:** Ikke bruk `go build` som hoveddemo; cache kan gjøre at forskjellen blir usynlig. Bruk heller `go test -count=1 -v` eller kommandoer som alltid er støynete.
+**Demo-kontekst (referanserepo):** Bruk dette monorepoet. Velg én reell oppgave (f.eks. en liten endring i `apps/copilot-metrics`) og kjør den to ganger med ulikt modell-/resonneringsvalg.
 
-**📄 Referanse:** Se eksempelseksjonen nederst i denne fila for konkrete før/etter-eksempler, copy-paste-klare kommandoer, og opptak-sjekkliste.
+**📄 Referanse:** Se referanseseksjonen nederst i denne fila for kilder, tall og opptaks-sjekkliste.
 
 **Reell oppgave i repo (velg én før opptak):**
-- Optimaliser fire kommandoer du kjører regelmessig ved å legge `rtk` foran — vis tydelig forskjell i output.
+- Kjør samme lille endring to ganger med ulik modell og ulikt resonneringsnivå, og noter fakturert kostnad per fullført oppgave for begge.
 
-**Ta med deg videre:** Prefix alle CLI-kommandoer med `rtk` når output faktisk blir kortere og klarere. En vane som sparer gjentakende.
+**Ta med deg videre:** Velg riktig modell og riktig resonneringsnivå, ikke komprimer tekst. Mål i kroner per fullført oppgave.
 
-**Oppsummering:** `rtk` er en enveisventil som klipper støy fra alle kommandoer. Null læringskurve, umiddelbar effekt.
+**Oppsummering:** De fire spakene med dokumentert effekt er modellvalg, resonneringsnivå, intakt prompt-cache og mindre arbeid.
 
-**Outro:** Bruk `rtk` på kommandoene som produserer mye støy, og sjekk `rtk gain` når tracking er satt opp for å se den kumulative sparingen.
+**Outro:** Neste gang du vurderer et token-sparende verktøy: be om fakturert kostnad per fullført oppgave, ikke et skjermbilde av verktøyets eget dashbord.
 
 **Prompt-manus (copy/paste):**
 
-```bash
-# Vis hvordan rtk virker (talk-through, ikke prompt)
-brew install rtk
-rtk init -g --copilot
+```text
+Gjør denne endringen. Bruk en rask modell og lavt resonneringsnivå.
+Oppgave: legg til en manglende feilmelding i <fil>.
+Output: bare diffen.
+```
 
-git log --oneline --decorate --all | head -20
+```text
+Samme oppgave, men bruk høyt resonneringsnivå.
+Sammenlign resultatet med forrige kjøring.
+```
 
-rtk git log --oneline --decorate --all
-
-# Go test (disable cache so the difference is visible)
-go test -count=1 -v ./... | head -30
-
-rtk go test -count=1 -v ./...
-
-# Samlet sparing denne økten (valgfri, hvis tracking er tilgjengelig)
-rtk gain
-
-# Per-kommando historikk (valgfri)
-rtk gain --history
-
-# Finn kommandoer du kjørte uten rtk
-rtk discover
-
-# Rå kommando uten filtering (benchmark/feilsøking)
-rtk proxy git status
+```text
+Kjør bare testene som dekker <fil>, ikke hele pipelinen.
+Rapporter bare feilende tester.
 ```
 
 **Demo-senario for videoen:**
 
-Sekvens 1 (0:00-1:00): Introduksjon
-- "Logs og output fra CLI er ofte fulle av støy."
-- "rtk er en filter som sitter foran alle kommandoer."
-- "Bare legg `rtk` foran — og bespar 60–90 % tokens."
+Sekvens 1 (0:00–0:50): Rammen
+- "Alle vil spare tokens. Men det er kroner du blir fakturert for."
+- Vis fordelingen: input dominerer, det meste er cachet, output er en liten andel.
+- "Derfor er det å komprimere tekst en liten spak — og noen ganger negativ, hvis den bryter cachen."
 
-Sekvens 2 (1:00-2:15): Før/etter-demo (split screen hvis mulig)
-- **Venstre (uten rtk):** `git log --oneline --decorate --all`
-  - Vis 20–30 linjer av output med mye dekor
-  - Teller tokens mentalt eller med overlay
-- **Høyre (med rtk):** `rtk git log --oneline --decorate --all`
-  - Vis samme kommando, 8–10 linjer, ren output
-  - Overlay viser "60% fewer tokens"
+Sekvens 2 (0:50–1:50): Modellvalg
+- Samme oppgave, to modeller, side ved side
+- Vis pris per token for begge og resultatet av begge
+- Overlay: "Største spaken: pris per token"
 
-Sekvens 3 (2:15-3:00): Go-test eksempel
-- `go test -count=1 -v ./...` (cache av, verbose, mye noise)
-- `rtk go test -count=1 -v ./...` (aggregert)
+Sekvens 3 (1:50–2:35): Resonneringsnivå
+- Rutineoppgave på lavt nivå, samme resultat
+- Nevn når du skal skru opp igjen (arkitektur, feilsøking i ukjent kode)
 
-Sekvens 4 (3:00-3:30): Git status / diff
-- `git status` og `git diff` på ekte endring
-- `rtk git status` og `rtk git diff` viser renere, kortere output
+Sekvens 4 (2:35–3:20): Prompt-cache
+- Vis en sesjon der cachen holder, og en der den brytes
+- Overlay: "Cachet input ≈ 1/10 pris"
 
-Sekvens 5 (3:30-4:00): Måling og impact (valgfri)
-- Kjør `rtk gain` hvis tracking-databasen finnes
-- Ellers vis `rtk discover` som status-sjekk
-- Overlay animerer token-meter oppover
+Sekvens 5 (3:20–4:00): Mindre arbeid
+- Målrettet test vs full pipeline
+- Én oppgave per sesjon
 
-Sekvens 6 (4:00-4:20): Avslutting og sjekkliste
+Sekvens 6 (4:00–4:20): Måleregel og sjekkliste
 - "Her er hva du gjør neste gang:"
-  - Prefix all CLI med `rtk`
-  - Kjør `rtk gain` når tracking er satt opp
-  - Sjekk `rtk gain --history` ukentlig hvis den er tilgjengelig
+  - Velg modell etter oppgave, ikke etter vane
+  - Sett resonneringsnivå bevisst
+  - Ikke bryt cachen midt i en sesjon
+  - Mål i kroner per fullført oppgave
 
-**Forventet respons-signal:** Tydelig før/etter-kontrast. Målbar token-sparing. Enkelt regel.
+**Forventet respons-signal:** Seeren kan navngi de fire spakene, og vet at et verktøys eget sparetall ikke er bevis for lavere regning.
+
+**Kilder:**
+- JetBrains: [Measuring rtk's token savings in Claude Code](https://blog.jetbrains.com/ai/2026/07/rtk-claude-code-token-savings/) — 425 kjøringer, 86 oppgaver, forhåndsregistrerte endepunkter
+- [jayn caveman-replay](https://jayn.app/caveman) ([data](https://github.com/jaynapp/jayn-caveman)) — 0,6 % av en faktisk regning på 755 dollar
+- Brandon Barker: [Fewer tokens, bigger bill](https://brandonbarker.me/writing/headroom-fewer-tokens-bigger-bill) — 39 % færre tokens, men cachen brutt 123 ganger
+- [Token savings: wrong number](https://zernie.com/blog/token-savings-wrong-number/) — ca. −6 % målt mot −65 % annonsert
+- Nav: [Slik holder du token-forbruket nede](news/articles/token-forbruk-verktoy-teknikker.md)
 
 **Overlay metadata (OverlayComponent format):**
 
 ```ts
 {
-  id: "bonus-e-rtk",
-  title: "rtk — CLI Output Compression",
+  id: "bonus-e-kostnadsspaker",
+  title: "Fire grep som faktisk senker regningen",
   accent: "#ff8c42", // orange
   secondaryAccent: "#ffc857", // amber
-  motif: "compression-wave", // visual representation of filtering
-  poster: "bonus-e-rtk-poster.png",
+  motif: "lever-meter", // fire spaker med ulik lengde
+  poster: "bonus-e-kostnadsspaker-poster.png",
   components: [
     {
       kind: "episode-number",
@@ -930,32 +909,31 @@ Sekvens 6 (4:00-4:20): Avslutting og sjekkliste
       labels: ["E"]
     },
     {
-      kind: "compare-bars",
+      kind: "ladder",
+      anchor: "center-left",
+      labels: ["Modellvalg", "Resonneringsnivå", "Prompt-cache", "Mindre arbeid"],
+      highlightIndex: 0
+    },
+    {
+      kind: "rule-pill",
       anchor: "bottom-full",
-      labels: ["Without rtk (200 lines)", "With rtk (30 lines)"],
-      highlightIndex: 1
+      labels: ["Mål i kroner per fullført oppgave"]
     },
     {
       kind: "chip",
       anchor: "top-right",
-      labels: ["60-90% saved"],
+      labels: ["ikke verktøyets eget sparetall"],
       monospace: true
-    },
-    {
-      kind: "counter",
-      anchor: "center-left",
-      labels: ["git log", "git status", "go test", "git diff"],
-      highlightIndex: 0
     }
   ]
 }
 ```
 
 **Frontend rendering hints:**
-- Compression wave motif: show concentric lines squeezing inward, suggesting "filtering"
-- Compare bars: stacked or side-by-side bar chart showing lines reduced
-- Token counter chip: small monospace text in top-right showing percentage
-- Command list: vertical stack of 3 commands with checkmarks
+- Lever-meter motif: fire vannrette spaker med synkende lengde, øverste tydelig lengst
+- Ladder: vertikal liste med de fire spakene, øverste uthevet
+- Rule-pill: én bred pille nederst med målereglen
+- Chip: liten monospace-tekst øverst til høyre som advarsel mot selvrapporterte tall
 
 ---
 
@@ -1029,7 +1007,7 @@ Resultatet: 10x raskere svar, 90% færre tokens, og færre feil—fordi du gir L
 
 ### Episode 5: Kort output uten kvalitetstap
 
-LLM-er gir deg lange, detaljerte svar som regel. Det er fint når du trenger full forklaring, men når du bare vil ha koden eller punktene, er halvparten av outputen bortkastet. I denne videoen introduserer vi `/terse`-modus: den samme svarene, men uten fyllord, unødvendige forklaringer og repetisjon. Du får 40-50% færre tokens—og eksakt samme informasjon.
+LLM-er gir deg lange, detaljerte svar som regel. Det er fint når du trenger full forklaring, men når du bare vil ha koden eller punktene, er halvparten av outputen bortkastet. I denne videoen introduserer vi `/terse`-modus: den samme svarene, men uten fyllord, unødvendige forklaringer og repetisjon. Du får kortere output med samme kjerneinnhold. Hvor mye det utgjør varierer med oppgaven, så mål det på dine egne oppgaver framfor å stole på et fasttall.
 
 /terse er perfekt når du allerede skjønner domenet og bare vil ha resultatet raskt. Vi viser før/etter-eksempler med kodegenering, planlegging og debugging. Etter denne videoen bruker du `/terse` som standard, og velger full-mode bare når du trenger læring, ikke speed.
 
@@ -1063,69 +1041,54 @@ Med Chronicle kan du måle hvor mye hver fil/agent/instruksjon koster, og målre
 
 Bruk sandboxen til å eksperimentere med nye workflows, teste optimaliseringsteknikker, eller lære agentdelegeringen uten å påvirke din normale setup. Det er som en sikker øvingsgrunn for Copilot-bruken din. Etter denne videoen kan du starte eksperimenter med det samme.
 
-### Bonus episode E: rtk — CLI-output-komprimering (60-90% token-besparelse)
+### Bonus episode E: Fire grep som faktisk senker regningen
 
-Hver gang du kjører `go test -count=1 -v` fra terminalen, scrolles du gjennom hundrevis av linjer. Mye støy, lite signal. Med `rtk` foran kommandoen får du det samme resultatet på én linje—og 95% færre tokens. Videoen viser også hvordan du installerer og initialiserer verktøyet for Copilot med `brew install rtk` og `rtk init -g --copilot`.
+De fleste råd om tokensparing handler om å komprimere tekst. Problemet er at tekst er den minste posten på regningen: i en agent-sesjon er input dominerende, og det meste av input er cachede gjenlesninger som faktureres til en brøkdel av full pris. Verktøy som komprimerer output kan derfor vise imponerende tall i sitt eget dashbord uten at regningen flytter seg — og et tiltak som bryter prompt-cachen kan gjøre den dyrere.
 
-Ingen oppsetting, ingen læringskurve. Bare legg `rtk` foran kommandoer som faktisk produserer mye output, og se resultatene med `rtk discover` eller `rtk gain` når tracking er satt opp. Vi viser fire konkrete eksempler: git log, git status, go test med cache av, og git diff—hver med 60-90% besparelse. Prøv `rtk` foran din neste kommando. Du merker resultatet med en gang.
+I denne videoen ser vi på de fire grepene som faktisk har målbar effekt: modellvalg (den største spaken, fordi den endrer pris per token), bevisst resonneringsnivå, å holde prompt-cachen intakt, og å gjøre mindre arbeid i stedet for å skrive kortere. Vi kjører den samme oppgaven i dette repoet med ulike valg og sammenligner.
 
-### rtk — konkrete demoer og opptaksnotater
+Til slutt får du målereglen som gjør deg immun mot markedsføring: sammenlign fakturert kostnad per *fullført* oppgave før og etter, aldri et verktøys eget sparetall. Etter denne videoen vet du hvilke fire knapper du skal skru på, og hvordan du sjekker at det virket.
 
-#### Setup: installer og initialiser
+### Kostnadsspaker — kilder og opptaksnotater
 
-```bash
-brew install rtk
-rtk init -g --copilot
-```
+#### Hvorfor output-komprimering er en liten spak
 
-Bruk dette før opptak så seeren ser hele løypa fra null til bruksklar Copilot-integrasjon.
+Output-tokens utgjør en liten andel av tokenbruken i en agent-sesjon, og cache-treffraten på input er høy. Tellere i komprimeringsverktøy overvurderer typisk effekten på tre måter: de regner hele den rå verktøyoutputen som «spart» selv om agenten uansett kutter store resultater, de priser fjernede tokens til full input-pris i stedet for cache-pris, og de fanger bare den delen av verktøyresultatene som faktisk går gjennom hooken.
 
-#### Demo 1: git log
+#### Kilder du kan vise på skjerm
 
-Uten `rtk` får du lang og dekorert historikk. Med `rtk git log --oneline --decorate --all` blir output kortere, renere og lettere å lese på skjerm. Dette er den enkleste måten å vise at verktøyet kutter støy uten å kutte signal.
+- JetBrains: [Measuring rtk's token savings in Claude Code](https://blog.jetbrains.com/ai/2026/07/rtk-claude-code-token-savings/) — 425 kjøringer, 86 oppgaver, forhåndsregistrerte endepunkter. Resultat: +7,6 % kostnad per oppgave ved lavt resonneringsnivå (p = 0,004), +0,1 % (p = 0,99) ved høyt, ingen kvalitetsforskjell.
+- [jayn caveman-replay](https://jayn.app/caveman), [data](https://github.com/jaynapp/jayn-caveman) — 0,6 % spart av en faktisk regning på 755 dollar.
+- Brandon Barker: [Fewer tokens, bigger bill](https://brandonbarker.me/writing/headroom-fewer-tokens-bigger-bill) — 39 % færre tokens, men prompt-cachen brutt 123 ganger.
+- [Token savings: wrong number](https://zernie.com/blog/token-savings-wrong-number/) — ca. −6 % målt mot −65 % annonsert.
 
-#### Demo 2: git status
+#### Demo 1: modellvalg
 
-`git status` gir ofte både forklaringer og lange blokker med endringer. `rtk git status` gjør resultatet kompakt nok til at seeren faktisk ser hva som er endret uten å scrolle. Dette er en tydelig før/etter-demo fordi samme informasjon blir mye lettere å konsumere.
+Kjør samme lille oppgave to ganger med ulik modell. Vis pris per token for begge før du starter, og vis at resultatet på en rutineoppgave er likeverdig. Dette er den sterkeste demoen fordi den endrer prisen, ikke bare mengden.
 
-#### Demo 3: go test
+#### Demo 2: resonneringsnivå
 
-Bruk `go test -count=1 -v ./...` for å unngå cache og få en synlig forskjell. Kjør deretter `rtk go test -count=1 -v ./...` for en aggregert og mer lesbar output. Dette er den sterkeste demoen når du vil vise hvor mye støy som vanligvis ligger i testkjøring.
+Kjør en rutineoppgave på lavt resonneringsnivå og vis at kvaliteten holder. Si tydelig når du bør skru opp igjen: arkitekturvalg, feilsøking i ukjent kode, sikkerhetsvurderinger.
 
-#### Demo 4: git diff
+#### Demo 3: prompt-cache
 
-På en større endring er `git diff` perfekt for å vise forskjellen mellom rå og filtrert output. Uten `rtk` blir hunkene lange og tunge. Med `rtk git diff` får du kortere oppsummering av selve endringen, som gjør poenget umiddelbart synlig.
+Vis to sesjoner: én der instruksjoner og systemprompt ligger i ro, og én der du endrer kontekst tidlig i prompten midt i sesjonen. Poenget er at cachet input koster rundt en tidel, og at et «sparetiltak» som bryter cachen kan gi høyere regning.
 
-#### Demo 5: måling og status
+#### Demo 4: mindre arbeid
 
-`rtk gain` er valgfri bonus hvis tracking-databasen er tilgjengelig. Hvis ikke, bruk `rtk discover` for å vise status og eventuelle savnede besparelser. Poenget er at måling ikke skal være en blokkering for selve demoen.
+Kjør en målrettet test i stedet for full pipeline, og la agenten lese filer selv i stedet for at du limer inn. Færre runder slår kortere tekst.
+
+#### Måleregel
+
+Kjør et fast sett oppgaver før og etter endringen, og sammenlign fakturert kostnad per fullført oppgave. Ta med kvalitet: en «besparelse» som gir flere runder er ingen besparelse.
 
 #### Opptaksregel
 
-- Vis installasjon først: `brew install rtk` og `rtk init -g --copilot`
-- Velg bare kommandoer med tydelig output-forskjell
-- Ikke bruk `go build` som hoveddemo når cache kan skjule effekten
-- Hold `rtk gain` som bonus, ikke som hovedbevis
-- Vis alltid same kommando med og uten `rtk` før du går videre
+- Ikke vis tall fra et verktøys eget sparedashbord som bevis
+- Bruk fakturerte tall (Spend Meter i VS Code eller statistikk i my-copilot)
+- Velg en oppgave som er liten nok til å kjøres flere ganger på opptak
+- Vær tydelig på hva som *ikke* er testet: én studie, ett verktøy, to resonneringsnivåer
 
-#### Kopiérbare kommandoer
+#### Nevn gjerne, men uten anbefaling
 
-```bash
-brew install rtk
-rtk init -g --copilot
-
-git log --oneline --decorate --all | head -20
-rtk git log --oneline --decorate --all
-
-git status
-rtk git status
-
-go test -count=1 -v ./... | head -30
-rtk go test -count=1 -v ./...
-
-git diff HEAD~1..HEAD -- docs/large-file.md
-rtk git diff HEAD~1..HEAD -- docs/large-file.md
-
-rtk discover
-rtk gain
-```
+`rtk` finnes fortsatt og kan installeres med `brew install rtk`. Den gjør terminaloutput lettere å lese. Hvis du nevner den i videoen, si samtidig at den offentlige kontrollerte målingen ikke gjenskapte den annonserte besparelsen — og ikke bruk `rtk gain` som bevis for noe.

--- a/scripts/install.bats
+++ b/scripts/install.bats
@@ -185,12 +185,14 @@ EOF
   [[ "$output" == *"Got:      badhash"* ]]
 }
 
-@test "installs cplt and rtk dependencies" {
+@test "installs cplt and only mentions rtk as optional" {
   run bash "$SCRIPT" --dir "${TMP_DIR}/install-dest"
-  
+
   [ "$status" -eq 0 ]
   [[ "$output" == *"Installing cplt (sandbox)"* ]]
   [[ "$output" == *"Installed cplt"* ]]
-  [[ "$output" == *"Installing rtk (token optimizer)"* ]]
-  [[ "$output" == *"Installed rtk"* ]]
+  [[ "$output" == *"Optional: rtk (terminal output filter)"* ]]
+  [[ "$output" == *"brew install rtk"* ]]
+  # rtk must never be auto-installed from an unpinned upstream branch
+  [[ "$output" != *"refs/heads/master/install.sh"* ]]
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -70,7 +70,7 @@ ASSET="${BINARY}-${OS}-${ARCH}"
 
 if [[ "$OS" == "darwin" && "$NO_BREW" == false && -z "$VERSION" && -z "$INSTALL_DIR" ]] && command -v brew &>/dev/null; then
   echo "→ Installing via Homebrew..."
-  brew install navikt/tap/nav-pilot navikt/tap/cplt rtk
+  brew install navikt/tap/nav-pilot navikt/tap/cplt
   echo ""
   INSTALLED_VERSION=$(nav-pilot version 2>/dev/null || echo "unknown")
   echo "✓ nav-pilot is ready! (${INSTALLED_VERSION})"
@@ -241,26 +241,30 @@ mv "${TMP_DIR}/${ASSET}" "${INSTALL_DIR}/${BINARY}"
 
 echo "  ✓ Installed nav-pilot to ${INSTALL_DIR}/${BINARY}"
 
-# ─── Install Dependencies (cplt, rtk) ────────────────────────────────────────
+# ─── Install Dependencies (cplt) ─────────────────────────────────────────────
 
 echo ""
 echo "→ Installing cplt (sandbox)..."
-# NOTE: cplt and rtk are installed via their own install scripts without
-# provenance verification. These scripts are fetched from external repos
-# and are not controlled by nav-pilot's release pipeline.
+# NOTE: cplt is installed via its own install script without provenance
+# verification. The script is fetched from navikt/cplt and is not controlled by
+# nav-pilot's release pipeline.
 if curl -fsSL https://raw.githubusercontent.com/navikt/cplt/main/install.sh | bash; then
   echo "  ✓ Installed cplt"
 else
   echo "  ⚠ Failed to install cplt"
 fi
 
+# rtk (terminal output filter) is optional and no longer installed automatically.
+#
+# It used to be installed with `curl … rtk/refs/heads/master/install.sh | sh` —
+# an unpinned pipe-to-shell from a moving upstream branch. rtk is in
+# homebrew-core, so users who want it can install a checksum-verified build
+# themselves. It is also no longer promoted: public controlled measurement has
+# not reproduced its advertised token savings.
+# https://blog.jetbrains.com/ai/2026/07/rtk-claude-code-token-savings/
 echo ""
-echo "→ Installing rtk (token optimizer)..."
-if curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh; then
-  echo "  ✓ Installed rtk"
-else
-  echo "  ⚠ Failed to install rtk"
-fi
+echo "→ Optional: rtk (terminal output filter) — install it yourself if you want it:"
+echo "    brew install rtk"
 
 # ─── Verify ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
nav-pilot advertised rtk as saving **"60-90% on token costs"** and labelled it **"Highly Recommended"**. That figure is rtk's own self-report. This PR removes the promotion, fixes a real install defect, and points the guidance at levers that have evidence.

rtk remains available and installable. It is no longer promoted, and no longer installed automatically.

## Why

The only well-powered public controlled study — [JetBrains](https://blog.jetbrains.com/ai/2026/07/rtk-claude-code-token-savings/), 425 billed trials over 86 SkillsBench tasks, pre-registered endpoints — measured **+7.6% cost per task at low reasoning effort (p=0.004)** and no difference at high effort (+0.1%, p=0.99), with no quality difference. **Scope matters and is stated in the docs: that study measured Claude Code.** No equivalent measurement exists for Copilot CLI or OpenCode.

Three documented reasons a tool's own counter overstates savings — none specific to rtk:
1. It credits full raw output as "saved" although the host agent already truncates large tool results.
2. It prices removed tokens at list input rate, while most session input is cached re-reads billed roughly 10× cheaper.
3. Only ~20% of tool-result characters pass its hook, since built-in file-read/search tools bypass it (a Claude Code architecture fact).

Independent corroboration that output-side compression underperforms its marketing: a [real-billing replay](https://jayn.app/caveman) measured 0.6% of a $755 bill; a [prompt-compressing proxy](https://brandonbarker.me/writing/headroom-fewer-tokens-bigger-bill) cut tokens 39% while busting the prompt cache 123 times and moving ~6M tokens to full-price billing. These are cited for their **mechanisms**, not their headline cost claims, which were not statistically significant.

## The install defect

`installRtkViaBrew()` ran `brew install navikt/tap/rtk`, but `navikt/homebrew-tap` contains only `cplt.rb` and `nav-pilot.rb`. That path **always failed**, so every user fell through to:

```
curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
```

An unpinned pipe-to-shell from a moving branch, outside the cplt sandbox, on Nav equipment. rtk is in homebrew-core (0.45.0, bottled), so installation now goes there with checksum verification; the curl fallback is removed and a bats test asserts the `refs/heads/master` URL never appears in installer output.

**Honest note on scope:** `scripts/install.sh` separately ran plain `brew install ... rtk`, which *worked*. So macOS/Homebrew users were getting rtk installed successfully, and this PR removes that. That is a deliberate behavior change following from the opt-in decision, not the removal of dead code.

## Changes

- **`rtk_setup.go`** — percentage and "Highly Recommended" removed; one factual line on the state of public measurement; install via homebrew-core; curl fallback deleted.
- **`doctor.go`** — new `checkOptionalDep`: a missing *optional* tool no longer fails the health check. `git` stays a hard dependency.
- **`scripts/install.sh` + `install.bats`**, **web setup wizard** — rtk no longer auto-installed; instructions printed instead.
- **`docs/news/articles/token-forbruk-verktoy-teknikker.md`** — RTK section corrected under a dated note naming the removed claim, rather than silently rewriting history. Sensitive-data caveat kept.
- **`docs/video-demoer-kost-token-optimalisering.md`** — planned Bonus Episode E rewritten from "rtk 60-90%" to *"Fire grep som faktisk senker regningen"* (model choice, reasoning effort, prompt cache, doing less work). Episode 5's unsourced figure replaced with "measure it on your own tasks". Only *planned* episodes were touched; recorded ones are untouched per the file's own rule.
- **`AGENTS.md`** — the mandatory rtk prefix becomes an optional mention; the 35 rtk-prefixed commands in `apps/copilot-metrics/README.md` and `cli/nav-pilot/RUNBOOKS.md` are unprefixed so the claim is actually true.
- **`cost-optimization.tsx`** — the one other place repeating the figure now states the measurement rule instead.
- **telemetry** — `brew_missing` added to the allowlist so the new state is measurable; dead `curl_failed` removed.

## What the guidance says now

Judge tools on **billed cost per completed task**, never on a tool's own savings dashboard. Nav is on token-based billing (AI Credits since 1 June), so this is real money — and the levers with evidence are model routing, reasoning-effort defaults, keeping the prompt cache intact, and doing less work.

## Verification

`mise run nav-pilot:check` and `mise run docs:check` pass; wizard tests 7/7; prettier clean. Reviewed adversarially with the explicit charge of catching overcorrection — every published claim was checked to stay within *"measurement has not reproduced the vendor's claim"* rather than *"rtk is harmful"*.
