### PR TITLE
docs: språkvask av norsk tekst i rtk-endringene

### DIFF
--- a/apps/my-copilot/src/app/praksis/sections/cost-optimization.tsx
+++ b/apps/my-copilot/src/app/praksis/sections/cost-optimization.tsx
@@ -33,8 +33,8 @@ export default function CostOptimization() {
             <BodyShort size="small" className="text-gray-700">
               VS Code 1.125 introduserte et innebygd «Spend Meter» som viser ditt eget AI Credits-forbruk i sanntid.
               Finn det under <code>View → Status Bar → Copilot Usage</code>. Bruk det aktivt for å oppdage dyre mønstre
-              tidlig. Måler du effekten av et tiltak, bruk fakturert kostnad per fullført oppgave — ikke sparetallet et
-              verktøy rapporterer om seg selv.
+              tidlig. Måler du effekten av et tiltak, bruk fakturert kostnad per fullført oppgave — ikke sparetallet
+              verktøyet oppgir selv.
             </BodyShort>
           </Box>
 

--- a/docs/news/articles/token-forbruk-verktoy-teknikker.md
+++ b/docs/news/articles/token-forbruk-verktoy-teknikker.md
@@ -184,7 +184,7 @@ Andre tips for vedlikeholdere:
 
 ### RTK — komprimerer terminaloutput
 
-> **Oppdatert 2026-08-24:** Denne seksjonen påsto opprinnelig at «RTK rapporterer 60–90 % reduksjon på verktøydata». Det tallet er verktøyets egen selvrapportering, og den er ikke bekreftet av kontrollert måling. Avsnittet er rettet, og nav-pilot anbefaler ikke lenger RTK aktivt.
+> **Oppdatert 2026-08-24:** Denne seksjonen påsto opprinnelig at «RTK rapporterer 60–90 % reduksjon på verktøydata». Det tallet er verktøyets egen selvrapportering, og ingen kontrollert måling bekrefter det. Vi har rettet avsnittet, og nav-pilot anbefaler ikke lenger RTK aktivt.
 
 [RTK](https://github.com/rtk-ai/rtk) er en CLI-proxy som filtrerer og komprimerer kommando-output (testresultater, diff, kubectl) før den når kontekstvinduet.
 
@@ -193,13 +193,19 @@ brew install rtk
 rtk init -g --copilot
 ```
 
-**Hva vi vet om effekten:** RTK har en innebygd teller (`rtk gain`) som viser hvor mye den mener den har spart. Den tellingen er ikke det samme som lavere regning: den regner hele den rå kommando-outputen som «spart» selv om agenten uansett kutter store verktøyresultater, den priser fjernede tokens til full input-pris selv om det meste av sesjonsinput er cachede gjenlesninger til rundt en tidel av prisen, og bare en del av verktøyresultatene går gjennom hooken i det hele tatt (innebygde lese- og søkeverktøy går utenom).
+**Hva vi vet om effekten:** RTK har en innebygd teller (`rtk gain`) som viser hvor mye verktøyet mener det har spart. Den tellingen er ikke det samme som lavere regning:
 
-Den eneste store offentlige kontrollerte studien — [JetBrains, 425 kjøringer over 86 oppgaver](https://blog.jetbrains.com/ai/2026/07/rtk-claude-code-token-savings/) med forhåndsregistrerte endepunkter — fant ingen besparelse: 7,6 % *høyere* kostnad per oppgave ved lavt resonneringsnivå (p = 0,004) og ingen målbar forskjell ved høyt nivå (+0,1 %, p = 0,99), uten kvalitetsforskjell. Merk omfanget: studien målte RTK i Claude Code, og hook-dekningen over er et arkitekturtrekk ved den agenten. Tilsvarende kontrollert måling finnes ikke for Copilot CLI eller OpenCode — der er effekten rett og slett ikke målt. Liknende resultater er rapportert for andre komprimerende verktøy: [0,6 % av en faktisk regning på 755 dollar](https://jayn.app/caveman), og en prompt-komprimerende proxy som [kuttet tokens 39 % men brøt prompt-cachen 123 ganger](https://brandonbarker.me/writing/headroom-fewer-tokens-bigger-bill) og dermed flyttet millioner av tokens til full pris.
+- Den regner hele den rå kommando-outputen som «spart», selv om agenten uansett kutter store verktøyresultater.
+- Den priser fjernede tokens til full input-pris, selv om det meste av sesjonsinput er cachede gjenlesninger til rundt en tidel av prisen.
+- Bare en del av verktøyresultatene går gjennom hooken i det hele tatt — innebygde lese- og søkeverktøy går utenom.
 
-Den strukturelle grunnen er at output-tokens er en liten andel av totalen i en agent-sesjon, og at cache-treffraten er høy. Da er det lite igjen å hente på å komprimere tekst.
+Den eneste store offentlige kontrollerte studien — [JetBrains, 425 kjøringer over 86 oppgaver](https://blog.jetbrains.com/ai/2026/07/rtk-claude-code-token-savings/) med forhåndsregistrerte endepunkter — fant ingen besparelse: 7,6 % *høyere* kostnad per oppgave ved lavt resonneringsnivå (p = 0,004) og ingen målbar forskjell ved høyt nivå (+0,1 %, p = 0,99), uten kvalitetsforskjell.
 
-**Praktisk konklusjon:** RTK gjør terminaloutput lettere å lese, og det kan i seg selv være verdt noe. Men ikke regn med lavere regning, og ikke bruk verktøyets eget sparetall som bevis — mål heller fakturert kostnad per fullført oppgave. Grepene som faktisk har dokumentert effekt er modellvalg, resonneringsnivå, å holde prompt-cachen intakt, og å gjøre mindre arbeid.
+Merk omfanget: studien målte RTK i Claude Code, og hook-dekningen over er et arkitekturtrekk ved den agenten. Tilsvarende kontrollert måling finnes ikke for Copilot CLI eller OpenCode — der er effekten ikke målt. Andre har rapportert liknende for andre komprimerende verktøy: [0,6 % av en faktisk regning på 755 dollar](https://jayn.app/caveman), og en prompt-komprimerende proxy som [kuttet tokens 39 % men brøt prompt-cachen 123 ganger](https://brandonbarker.me/writing/headroom-fewer-tokens-bigger-bill) og dermed flyttet millioner av tokens til full pris.
+
+Grunnen er strukturell: output-tokens utgjør en liten andel av totalen i en agent-sesjon, og cache-treffraten er høy. Da er det lite å hente på å komprimere tekst.
+
+**Praktisk konklusjon:** RTK gjør terminaloutput lettere å lese, og det kan være verdt noe i seg selv. Men ikke regn med lavere regning, og ikke bruk verktøyets eget sparetall som bevis — mål heller fakturert kostnad per fullført oppgave. Grepene som faktisk har dokumentert effekt, er modellvalg, resonneringsnivå, å holde prompt-cachen intakt og å gjøre mindre arbeid.
 
 **Merk:** RTK prosesserer terminaloutput lokalt. Sjekk at verktøyet er godkjent for ditt team før du bruker det med output som kan inneholde sensitive data.
 

--- a/docs/video-demoer-kost-token-optimalisering.md
+++ b/docs/video-demoer-kost-token-optimalisering.md
@@ -796,11 +796,11 @@ Output: nummerert liste.
 
 **Overlay:** E · orange/amber · lever-meter · modell / resonneringsnivå / cache / mindre arbeid · kr per oppgave
 
-**Mål:** Vise de fire grepene som har dokumentert effekt på tokenkostnad — og lære seeren å måle effekt på fakturert kostnad per fullført oppgave i stedet for på et verktøys eget sparetall.
+**Mål:** Vise de fire grepene som har dokumentert effekt på tokenkostnad, og lære seeren å måle effekten i fakturert kostnad per fullført oppgave — ikke i et verktøys eget sparetall.
 
-**Kan sees alene fordi:** Vi starter med hvorfor «spart tokens» og «lavere regning» ikke er samme sak, og går rett på fire grep man kan gjøre samme dag.
+**Kan sees alene fordi:** Vi starter med hvorfor «spart tokens» og «lavere regning» ikke er samme sak, og går rett på fire grep du kan gjøre samme dag.
 
-**Bakgrunn (til deg som spiller inn):** Denne episoden erstatter et tidligere utkast som handlet om `rtk` og CLI-output-komprimering med en påstand om 60–90 % besparelse. Den påstanden er verktøyets egen selvrapportering. Den eneste store offentlige kontrollerte studien ([JetBrains, 425 kjøringer over 86 oppgaver](https://blog.jetbrains.com/ai/2026/07/rtk-claude-code-token-savings/)) fant 7,6 % *høyere* kostnad per oppgave ved lavt resonneringsnivå (p = 0,004) og ingen forskjell ved høyt nivå (+0,1 %, p = 0,99), uten kvalitetsforskjell. Ikke bruk tall fra verktøydashbord i videoen.
+**Bakgrunn (til deg som spiller inn):** Denne episoden erstatter et tidligere utkast om `rtk` og CLI-output-komprimering. Utkastet påsto 60–90 % besparelse, men det tallet er verktøyets egen selvrapportering. Den eneste store offentlige kontrollerte studien ([JetBrains, 425 kjøringer over 86 oppgaver](https://blog.jetbrains.com/ai/2026/07/rtk-claude-code-token-savings/)) fant 7,6 % *høyere* kostnad per oppgave ved lavt resonneringsnivå (p = 0,004) og ingen forskjell ved høyt nivå (+0,1 %, p = 0,99), uten kvalitetsforskjell. Ikke bruk tall fra verktøydashbord i videoen.
 
 **Oppsett før demo:** Ingen installasjon. Du trenger tilgang til modellvalg, resonneringsnivå og en kostnadsvisning (Spend Meter i VS Code eller statistikk i my-copilot).
 
@@ -823,16 +823,16 @@ Output: nummerert liste.
 
 **Demo-kontekst (referanserepo):** Bruk dette monorepoet. Velg én reell oppgave (f.eks. en liten endring i `apps/copilot-metrics`) og kjør den to ganger med ulikt modell-/resonneringsvalg.
 
-**📄 Referanse:** Se referanseseksjonen nederst i denne fila for kilder, tall og opptaks-sjekkliste.
+**📄 Referanse:** Se referanseseksjonen nederst i denne fila for kilder, tall og opptakssjekkliste.
 
 **Reell oppgave i repo (velg én før opptak):**
 - Kjør samme lille endring to ganger med ulik modell og ulikt resonneringsnivå, og noter fakturert kostnad per fullført oppgave for begge.
 
-**Ta med deg videre:** Velg riktig modell og riktig resonneringsnivå, ikke komprimer tekst. Mål i kroner per fullført oppgave.
+**Ta med deg videre:** Velg riktig modell og riktig resonneringsnivå — ikke komprimer tekst. Mål i kroner per fullført oppgave.
 
 **Oppsummering:** De fire spakene med dokumentert effekt er modellvalg, resonneringsnivå, intakt prompt-cache og mindre arbeid.
 
-**Outro:** Neste gang du vurderer et token-sparende verktøy: be om fakturert kostnad per fullført oppgave, ikke et skjermbilde av verktøyets eget dashbord.
+**Outro:** Neste gang du vurderer et token-sparende verktøy, be om fakturert kostnad per fullført oppgave — ikke et skjermbilde av verktøyets eget dashbord.
 
 **Prompt-manus (copy/paste):**
 
@@ -857,7 +857,7 @@ Rapporter bare feilende tester.
 Sekvens 1 (0:00–0:50): Rammen
 - "Alle vil spare tokens. Men det er kroner du blir fakturert for."
 - Vis fordelingen: input dominerer, det meste er cachet, output er en liten andel.
-- "Derfor er det å komprimere tekst en liten spak — og noen ganger negativ, hvis den bryter cachen."
+- "Derfor er tekstkomprimering en liten spak — og noen ganger negativ, hvis den bryter cachen."
 
 Sekvens 2 (0:50–1:50): Modellvalg
 - Samme oppgave, to modeller, side ved side
@@ -883,7 +883,7 @@ Sekvens 6 (4:00–4:20): Måleregel og sjekkliste
   - Ikke bryt cachen midt i en sesjon
   - Mål i kroner per fullført oppgave
 
-**Forventet respons-signal:** Seeren kan navngi de fire spakene, og vet at et verktøys eget sparetall ikke er bevis for lavere regning.
+**Forventet respons-signal:** Seeren kan navngi de fire spakene og vet at et verktøys eget sparetall ikke er bevis for lavere regning.
 
 **Kilder:**
 - JetBrains: [Measuring rtk's token savings in Claude Code](https://blog.jetbrains.com/ai/2026/07/rtk-claude-code-token-savings/) — 425 kjøringer, 86 oppgaver, forhåndsregistrerte endepunkter
@@ -1007,7 +1007,7 @@ Resultatet: 10x raskere svar, 90% færre tokens, og færre feil—fordi du gir L
 
 ### Episode 5: Kort output uten kvalitetstap
 
-LLM-er gir deg lange, detaljerte svar som regel. Det er fint når du trenger full forklaring, men når du bare vil ha koden eller punktene, er halvparten av outputen bortkastet. I denne videoen introduserer vi `/terse`-modus: den samme svarene, men uten fyllord, unødvendige forklaringer og repetisjon. Du får kortere output med samme kjerneinnhold. Hvor mye det utgjør varierer med oppgaven, så mål det på dine egne oppgaver framfor å stole på et fasttall.
+LLM-er gir deg lange, detaljerte svar som regel. Det er fint når du trenger full forklaring, men når du bare vil ha koden eller punktene, er halvparten av outputen bortkastet. I denne videoen introduserer vi `/terse`-modus: den samme svarene, men uten fyllord, unødvendige forklaringer og repetisjon. Du får kortere output med samme kjerneinnhold. Hvor mye det utgjør, varierer — mål det på dine egne oppgaver framfor å stole på et fasttall.
 
 /terse er perfekt når du allerede skjønner domenet og bare vil ha resultatet raskt. Vi viser før/etter-eksempler med kodegenering, planlegging og debugging. Etter denne videoen bruker du `/terse` som standard, og velger full-mode bare når du trenger læring, ikke speed.
 
@@ -1043,9 +1043,9 @@ Bruk sandboxen til å eksperimentere med nye workflows, teste optimaliseringstek
 
 ### Bonus episode E: Fire grep som faktisk senker regningen
 
-De fleste råd om tokensparing handler om å komprimere tekst. Problemet er at tekst er den minste posten på regningen: i en agent-sesjon er input dominerende, og det meste av input er cachede gjenlesninger som faktureres til en brøkdel av full pris. Verktøy som komprimerer output kan derfor vise imponerende tall i sitt eget dashbord uten at regningen flytter seg — og et tiltak som bryter prompt-cachen kan gjøre den dyrere.
+De fleste råd om tokensparing handler om å komprimere tekst. Problemet er at tekst er den minste posten på regningen: i en agent-sesjon dominerer input, og det meste av input er cachede gjenlesninger som koster en brøkdel av full pris. Verktøy som komprimerer output kan derfor vise imponerende tall i sitt eget dashbord uten at regningen flytter seg — og et tiltak som bryter prompt-cachen kan gjøre den dyrere.
 
-I denne videoen ser vi på de fire grepene som faktisk har målbar effekt: modellvalg (den største spaken, fordi den endrer pris per token), bevisst resonneringsnivå, å holde prompt-cachen intakt, og å gjøre mindre arbeid i stedet for å skrive kortere. Vi kjører den samme oppgaven i dette repoet med ulike valg og sammenligner.
+I denne videoen ser vi på de fire grepene som faktisk har målbar effekt: modellvalg (den største spaken, fordi den endrer pris per token), bevisst resonneringsnivå, å holde prompt-cachen intakt og å gjøre mindre arbeid i stedet for å skrive kortere. Vi kjører den samme oppgaven i dette repoet med ulike valg og sammenligner.
 
 Til slutt får du målereglen som gjør deg immun mot markedsføring: sammenlign fakturert kostnad per *fullført* oppgave før og etter, aldri et verktøys eget sparetall. Etter denne videoen vet du hvilke fire knapper du skal skru på, og hvordan du sjekker at det virket.
 
@@ -1053,7 +1053,11 @@ Til slutt får du målereglen som gjør deg immun mot markedsføring: sammenlign
 
 #### Hvorfor output-komprimering er en liten spak
 
-Output-tokens utgjør en liten andel av tokenbruken i en agent-sesjon, og cache-treffraten på input er høy. Tellere i komprimeringsverktøy overvurderer typisk effekten på tre måter: de regner hele den rå verktøyoutputen som «spart» selv om agenten uansett kutter store resultater, de priser fjernede tokens til full input-pris i stedet for cache-pris, og de fanger bare den delen av verktøyresultatene som faktisk går gjennom hooken.
+Output-tokens utgjør en liten andel av tokenbruken i en agent-sesjon, og cache-treffraten på input er høy. Tellere i komprimeringsverktøy overvurderer typisk effekten på tre måter:
+
+- De regner hele den rå verktøyoutputen som «spart», selv om agenten uansett kutter store resultater.
+- De priser fjernede tokens til full input-pris i stedet for cache-pris.
+- De fanger bare den delen av verktøyresultatene som går gjennom hooken.
 
 #### Kilder du kan vise på skjerm
 
@@ -1091,4 +1095,4 @@ Kjør et fast sett oppgaver før og etter endringen, og sammenlign fakturert kos
 
 #### Nevn gjerne, men uten anbefaling
 
-`rtk` finnes fortsatt og kan installeres med `brew install rtk`. Den gjør terminaloutput lettere å lese. Hvis du nevner den i videoen, si samtidig at den offentlige kontrollerte målingen ikke gjenskapte den annonserte besparelsen — og ikke bruk `rtk gain` som bevis for noe.
+`rtk` finnes fortsatt, og du installerer den med `brew install rtk`. Den gjør terminaloutput lettere å lese. Hvis du nevner den i videoen, si samtidig at den offentlige kontrollerte målingen ikke gjenskapte den annonserte besparelsen — og ikke bruk `rtk gain` som bevis for noe.


### PR DESCRIPTION
Språkvask av den norske teksten som ble endret i #438, etter standarden i `agents/forfatter.agent.md`. Endringene rakk ikke å bli med før #438 ble merget.

Kun språk, form og struktur. Ingen tall, p-verdier, kildehenvisninger eller lenker er endret — presisjonen i de påstandene er hele poenget med #438.

**Endringer**
- **Struktur:** to lange oppramsinger på ~70 ord med kommaseparerte ledd delt i kulepunkter; JetBrains-avsnittet delt i to (studien vs. omfang)
- **Passiv → aktiv, substantivsyke:** «Avsnittet er rettet» → «Vi har rettet avsnittet»; «kan installeres med» → «du installerer den med»
- **Pronomenfeil:** «den er ikke bekreftet» viste til «tallet» (intetkjønn) → «ingen kontrollert måling bekrefter det»
- **Oxford-komma** fjernet tre steder (anglisisme)
- **Tegnsetting:** dobbel kolon, komma-splice og manglende komma etter leddsetning rettet
- **Klarspråk:** «man» → «du»; ryddet i en setning som leste som om episoden ble erstattet *med* påstanden om 60–90 %; fjernet fyllord og en gjentakelse
- **Særskriving:** «opptaks-sjekkliste» → «opptakssjekkliste»

**Nynorsk-/svenskinnblanding: ingen funnet.** Teksten er konsekvent moderne bokmål, og «Nav» er skrevet riktig overalt.

**Vurdert, men ikke endret:** overskriften «### RTK — komprimerer terminaloutput» ble foreslått utvidet med «men senker ikke regningen». Det ville overdrevet i motsatt retning — den kildebelagte posisjonen er at målinger ikke har reprodusert besparelsen på den agenten den ble målt på, ikke at verktøyet ikke senker regningen. Overskriften er presis som den står.

`mise run docs:check` grønn.