### PR TITLE
docs(nav-pilot): fjern utdatert begrensning om argument-passthrough

### DIFF
--- a/cli/nav-pilot/DESIGN.md
+++ b/cli/nav-pilot/DESIGN.md
@@ -894,22 +894,6 @@ Kjør `scripts/nav-pilot-golden.sh` før og etter (se [Testbarhet](#testbarhet))
 
 Dokumenterte designbegrensninger som kan endres i fremtidige versjoner.
 
-### Ingen passthrough av argumenter til Copilot CLI
-
-Når nav-pilot starter Copilot CLI interaktivt (etter install/sync-flyt), er det ingen måte å sende ekstra argumenter til `copilot`/`cplt`. Launchen er hardkodet til kun å videresende `--agent nav-pilot`:
-
-```go
-// interactive.go — launchCopilotWithAgent()
-args := []string{}
-if agent != "" {
-    args = append(args, "--", "--agent", agent)  // cplt
-    // eller: args = append(args, "--agent", agent)  // copilot
-}
-cmd := exec.Command(cliPath, args...)
-```
-
-Brukere som vil sende andre flagg (f.eks. `--model`, egne prompts, eller en annen agent) må kjøre `copilot`/`cplt` direkte etter at nav-pilot har satt opp miljøet.
-
 **Status:** OTel-metrics er aktivert som standard og kan deaktiveres med `NAV_PILOT_TELEMETRY_ENABLED=0`. OTLP-endepunkt kan overstyres ved behov.
 
 ---


### PR DESCRIPTION
`DESIGN.md` listet «Ingen passthrough av argumenter til Copilot CLI» under Kjente begrensninger, med et kodeeksempel som ikke lenger finnes i repoet.

Passthrough er implementert: `--` fanges opp i `internal/cli/cli.go:289` og legges på i begge launch-stiene via `resolved.ExtraArgs` (`internal/provider/copilot_launch.go:101,103`).

Den etterfølgende **Status:**-linja om OTel er beholdt — den hørte ikke til dette avsnittet.

Closes #214.