### PR TITLE
fix(copilot-metrics): gjør inntak scope-bevisst så dager ikke dupliseres

### DIFF
--- a/apps/copilot-metrics/backfill.go
+++ b/apps/copilot-metrics/backfill.go
@@ -27,7 +27,10 @@ func runBackfill(ctx context.Context, gh MetricsFetcher, bq MetricsStore, cfg *C
 	)
 
 	if !force {
-		latestDay, err := bq.GetLatestDay(ctx, cfg.EnterpriseSlug)
+		// Same high-water mark as the nightly ingestMissing, and for the same
+		// reason it spans scopes: an enterprise-only MAX(day) misses days stored
+		// under the org scope and would re-ingest them into the other scope.
+		latestDay, err := latestDayAcrossScopes(ctx, bq.GetLatestDay, reportScopeIDs(cfg))
 		if err != nil {
 			slog.Warn("Could not get latest day from BigQuery", "error", err)
 		} else if !latestDay.IsZero() {

--- a/apps/copilot-metrics/backfill_test.go
+++ b/apps/copilot-metrics/backfill_test.go
@@ -109,3 +109,27 @@ func searchString(s, substr string) bool {
 	}
 	return false
 }
+
+// TestRunBackfill_HighWaterMarkSpansScopes pins the manual backfill to the same
+// cross-scope resume point as the nightly ingestMissing: when the newest entity
+// metrics landed under the org scope_id, an enterprise-only MAX(day) reads as
+// "no data", the loop restarts from the caller's start date, and every day it
+// walks over is re-ingested under whichever scope the fetch resolves to.
+func TestRunBackfill_HighWaterMarkSpansScopes(t *testing.T) {
+	store := newScopedStore()
+	store.seed(tableUsageMetrics, daysAgo(1), "navikt", 1)
+
+	// The enterprise endpoint has recovered, so a fetch would resolve to "nav".
+	fetcher := &supplementaryFetcher{scope: "enterprise", scopeID: "nav", records: 1}
+
+	if err := runBackfill(context.Background(), fetcher, store, supplementaryConfig(), daysAgo(3), false); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if fetcher.entityFetches != 0 {
+		t.Errorf("expected the org-scoped high-water mark to be seen, got %d entity fetches", fetcher.entityFetches)
+	}
+	if got := store.count(tableUsageMetrics, daysAgo(1), "nav"); got != 0 {
+		t.Errorf("expected no enterprise-scoped copy of the org-stored day, got %d rows", got)
+	}
+}

--- a/apps/copilot-metrics/main.go
+++ b/apps/copilot-metrics/main.go
@@ -504,9 +504,31 @@ func ingestSupplementary(ctx context.Context, gh MetricsFetcher, bq MetricsStore
 // where supplementary reports weren't available when entity metrics were first
 // ingested (GitHub may take 24-48h to generate them).
 //
-// Existence is probed across every scope a report can be stored under, and the
-// write goes through upsertReport — see reportScopeIDs for why looking only at
-// the enterprise slug and inserting blindly duplicated rows on every run.
+// The existence probes below are deliberately not uniform, and what decides the
+// shape is the table's *consumer*, not which code path does the probing:
+//
+//   - Read through an enterprise-pinned filter — user_teams and user_metrics,
+//     whose every aggregate in copilot-api's bigquery_stats.go pins
+//     scope = 'enterprise'. Probe the enterprise scope ONLY. A report that
+//     landed under the org scope_id (the enterprise report endpoint was down
+//     that night and the fallback took over) is invisible to those aggregates,
+//     so a cross-scope probe would spot that copy, skip the day, and freeze it
+//     at zero users forever. Re-fetching stores the enterprise-scoped copy they
+//     need; upsertReport bounds the cost at one copy per scope, replacing its
+//     own rows on later runs rather than appending a fresh set.
+//
+//   - Read with no scope filter — repository_metrics, whose only consumer is
+//     views/v_repository_usage.sql, which groups by scope_id and filters on
+//     nothing else. Probe EVERY scope. An org-stored day is already fully
+//     visible there, so there is nothing to heal; a second copy would instead
+//     split each repo into two rows with split PR counts, each half measured
+//     against `HAVING pr_total_created >= 5` on its own, which drops borderline
+//     repos off the dashboard. runRepoMetricsBackfill probes the same way, for
+//     the same reason.
+//
+// The entity gate spans scopes too, but on a third ground: it only decides
+// whether the day is worth topping up at all, and a cross-scope answer is what
+// stops the day being ingested a second time under the other scope_id.
 func ingestMissingSupplementary(ctx context.Context, gh MetricsFetcher, bq MetricsStore, cfg *Config) {
 	scopeIDs := reportScopeIDs(cfg)
 	today := time.Now().UTC().Truncate(24 * time.Hour)
@@ -530,7 +552,7 @@ func ingestMissingSupplementary(ctx context.Context, gh MetricsFetcher, bq Metri
 		}
 
 		// Check and fill user-teams
-		teamsExists, err := dayExistsInAnyScope(ctx, bq.UserTeamsDayExists, day, scopeIDs)
+		teamsExists, err := bq.UserTeamsDayExists(ctx, day, cfg.EnterpriseSlug)
 		if err != nil {
 			slog.Warn("Failed to check user-teams existence", "day", dayStr, "error", err)
 		} else if !teamsExists {
@@ -544,11 +566,13 @@ func ingestMissingSupplementary(ctx context.Context, gh MetricsFetcher, bq Metri
 					// A streaming-buffer rejection is expected and self-healing,
 					// so it is logged at Info here and at the two sites below,
 					// matching ingestSupplementary and runRepoMetricsBackfill.
-					// Reaching it needs upsertReport to find rows under a
-					// scope_id the probe above did not cover, which the current
-					// reportScopeIDs makes unlikely — but a narrower scope list
-					// (or a third scope) puts it back in play, and a spurious
-					// warning out of the nightly job is not free.
+					// The enterprise-only probe above reads "missing" for a day
+					// whose rows sit under the org scope_id, so upsertReport
+					// routinely finds rows to delete here — and a DELETE inside
+					// the ~90-minute streaming buffer is rejected. (The
+					// cross-scope repo-metrics probe reaches it only when the
+					// fetch resolves to a scope reportScopeIDs does not list.)
+					// A spurious warning out of the nightly job is not free.
 					if errors.Is(storeErr, ErrStreamingBuffer) {
 						slog.Info("Skipping user-teams re-import (streaming buffer not yet flushed, re-run in ~90 min)", "day", dayStr)
 					} else {
@@ -562,7 +586,7 @@ func ingestMissingSupplementary(ctx context.Context, gh MetricsFetcher, bq Metri
 		}
 
 		// Check and fill per-user metrics
-		usersExists, err := dayExistsInAnyScope(ctx, bq.UserMetricsDayExists, day, scopeIDs)
+		usersExists, err := bq.UserMetricsDayExists(ctx, day, cfg.EnterpriseSlug)
 		if err != nil {
 			slog.Warn("Failed to check user-metrics existence", "day", dayStr, "error", err)
 		} else if !usersExists {

--- a/apps/copilot-metrics/main.go
+++ b/apps/copilot-metrics/main.go
@@ -302,8 +302,13 @@ func main() {
 func ingestMissing(ctx context.Context, gh MetricsFetcher, bq MetricsStore, cfg *Config, slack *SlackNotifier) error {
 	yesterday := time.Now().UTC().AddDate(0, 0, -1)
 
-	// Check what we already have in BigQuery to fill gaps automatically
-	latestDay, err := bq.GetLatestDay(ctx, cfg.EnterpriseSlug)
+	// Check what we already have in BigQuery to fill gaps automatically.
+	// The high-water mark has to span every scope a day can be stored under: a
+	// day whose entity metrics fell back to the org endpoint is invisible to an
+	// enterprise-only MAX(day), so the loop would restart before it and — once
+	// the enterprise endpoint recovers — write the same day a second time under
+	// the enterprise scope_id. See reportScopeIDs.
+	latestDay, err := latestDayAcrossScopes(ctx, bq.GetLatestDay, reportScopeIDs(cfg))
 	if err != nil {
 		slog.Warn("Could not get latest day from BigQuery, ingesting yesterday only", "error", err)
 		return ingestDay(ctx, gh, bq, cfg, yesterday)
@@ -498,8 +503,12 @@ func ingestSupplementary(ctx context.Context, gh MetricsFetcher, bq MetricsStore
 // metrics but are missing user-teams or user-metrics data. This handles the case
 // where supplementary reports weren't available when entity metrics were first
 // ingested (GitHub may take 24-48h to generate them).
+//
+// Existence is probed across every scope a report can be stored under, and the
+// write goes through upsertReport — see reportScopeIDs for why looking only at
+// the enterprise slug and inserting blindly duplicated rows on every run.
 func ingestMissingSupplementary(ctx context.Context, gh MetricsFetcher, bq MetricsStore, cfg *Config) {
-	scopeID := cfg.EnterpriseSlug
+	scopeIDs := reportScopeIDs(cfg)
 	today := time.Now().UTC().Truncate(24 * time.Hour)
 
 	// Check last 7 days — reports are typically available within 48h
@@ -511,7 +520,7 @@ func ingestMissingSupplementary(ctx context.Context, gh MetricsFetcher, bq Metri
 		dayStr := day.Format("2006-01-02")
 
 		// Only check days where entity metrics exist (otherwise ingestMissing handles it)
-		entityExists, err := bq.DayExists(ctx, day, scopeID)
+		entityExists, err := dayExistsInAnyScope(ctx, bq.DayExists, day, scopeIDs)
 		if err != nil {
 			slog.Warn("Failed to check entity data existence", "day", dayStr, "error", err)
 			continue
@@ -521,7 +530,7 @@ func ingestMissingSupplementary(ctx context.Context, gh MetricsFetcher, bq Metri
 		}
 
 		// Check and fill user-teams
-		teamsExists, err := bq.UserTeamsDayExists(ctx, day, scopeID)
+		teamsExists, err := dayExistsInAnyScope(ctx, bq.UserTeamsDayExists, day, scopeIDs)
 		if err != nil {
 			slog.Warn("Failed to check user-teams existence", "day", dayStr, "error", err)
 		} else if !teamsExists {
@@ -530,8 +539,21 @@ func ingestMissingSupplementary(ctx context.Context, gh MetricsFetcher, bq Metri
 					slog.Warn("Failed to fetch missing user-teams", "day", dayStr, "error", fetchErr)
 				}
 			} else if len(teamsResult.Records) > 0 {
-				if insertErr := bq.InsertUserTeams(ctx, day, teamsResult.Scope, teamsResult.ScopeID, teamsResult.Records); insertErr != nil {
-					slog.Warn("Failed to insert missing user-teams", "day", dayStr, "error", insertErr)
+				if storeErr := upsertReport(ctx, bq.UserTeamsDayExists, bq.DeleteUserTeamsDay, bq.InsertUserTeams,
+					day, teamsResult); storeErr != nil {
+					// A streaming-buffer rejection is expected and self-healing,
+					// so it is logged at Info here and at the two sites below,
+					// matching ingestSupplementary and runRepoMetricsBackfill.
+					// Reaching it needs upsertReport to find rows under a
+					// scope_id the probe above did not cover, which the current
+					// reportScopeIDs makes unlikely — but a narrower scope list
+					// (or a third scope) puts it back in play, and a spurious
+					// warning out of the nightly job is not free.
+					if errors.Is(storeErr, ErrStreamingBuffer) {
+						slog.Info("Skipping user-teams re-import (streaming buffer not yet flushed, re-run in ~90 min)", "day", dayStr)
+					} else {
+						slog.Warn("Failed to insert missing user-teams", "day", dayStr, "error", storeErr)
+					}
 				} else {
 					slog.Info("Backfilled missing user-teams", "day", dayStr, "records", len(teamsResult.Records))
 					filled++
@@ -540,7 +562,7 @@ func ingestMissingSupplementary(ctx context.Context, gh MetricsFetcher, bq Metri
 		}
 
 		// Check and fill per-user metrics
-		usersExists, err := bq.UserMetricsDayExists(ctx, day, scopeID)
+		usersExists, err := dayExistsInAnyScope(ctx, bq.UserMetricsDayExists, day, scopeIDs)
 		if err != nil {
 			slog.Warn("Failed to check user-metrics existence", "day", dayStr, "error", err)
 		} else if !usersExists {
@@ -549,8 +571,13 @@ func ingestMissingSupplementary(ctx context.Context, gh MetricsFetcher, bq Metri
 					slog.Warn("Failed to fetch missing user-metrics", "day", dayStr, "error", fetchErr)
 				}
 			} else if len(usersResult.Records) > 0 {
-				if insertErr := bq.InsertUserMetrics(ctx, day, usersResult.Scope, usersResult.ScopeID, usersResult.Records); insertErr != nil {
-					slog.Warn("Failed to insert missing user-metrics", "day", dayStr, "error", insertErr)
+				if storeErr := upsertReport(ctx, bq.UserMetricsDayExists, bq.DeleteUserMetricsDay, bq.InsertUserMetrics,
+					day, usersResult); storeErr != nil {
+					if errors.Is(storeErr, ErrStreamingBuffer) {
+						slog.Info("Skipping user-metrics re-import (streaming buffer not yet flushed, re-run in ~90 min)", "day", dayStr)
+					} else {
+						slog.Warn("Failed to insert missing user-metrics", "day", dayStr, "error", storeErr)
+					}
 				} else {
 					slog.Info("Backfilled missing user-metrics", "day", dayStr, "records", len(usersResult.Records))
 					filled++
@@ -559,7 +586,7 @@ func ingestMissingSupplementary(ctx context.Context, gh MetricsFetcher, bq Metri
 		}
 
 		// Check and fill per-repository metrics
-		reposExists, err := bq.RepoMetricsDayExists(ctx, day, scopeID)
+		reposExists, err := dayExistsInAnyScope(ctx, bq.RepoMetricsDayExists, day, scopeIDs)
 		if err != nil {
 			slog.Warn("Failed to check repo-metrics existence", "day", dayStr, "error", err)
 		} else if !reposExists {
@@ -568,8 +595,13 @@ func ingestMissingSupplementary(ctx context.Context, gh MetricsFetcher, bq Metri
 					slog.Warn("Failed to fetch missing repo-metrics", "day", dayStr, "error", fetchErr)
 				}
 			} else if len(reposResult.Records) > 0 {
-				if insertErr := bq.InsertRepoMetrics(ctx, day, reposResult.Scope, reposResult.ScopeID, reposResult.Records); insertErr != nil {
-					slog.Warn("Failed to insert missing repo-metrics", "day", dayStr, "error", insertErr)
+				if storeErr := upsertReport(ctx, bq.RepoMetricsDayExists, bq.DeleteRepoMetricsDay, bq.InsertRepoMetrics,
+					day, reposResult); storeErr != nil {
+					if errors.Is(storeErr, ErrStreamingBuffer) {
+						slog.Info("Skipping repo-metrics re-import (streaming buffer not yet flushed, re-run in ~90 min)", "day", dayStr)
+					} else {
+						slog.Warn("Failed to insert missing repo-metrics", "day", dayStr, "error", storeErr)
+					}
 				} else {
 					slog.Info("Backfilled missing repo-metrics", "day", dayStr, "records", len(reposResult.Records))
 					filled++
@@ -583,7 +615,79 @@ func ingestMissingSupplementary(ctx context.Context, gh MetricsFetcher, bq Metri
 	}
 }
 
+// reportScopeIDs lists every scope_id value a daily report may already be stored
+// under, most likely first.
+//
+// The daily report fetchers try the enterprise endpoint first and fall back to
+// the organization one (github.go FetchDailyMetrics / fetchDailyReport), so the
+// scope_id written for a day is the enterprise slug on some runs and the org
+// name on others. A gap-fill that probes only the enterprise slug therefore sees
+// "missing" for every org-stored day and re-ingests it on every run, appending a
+// fresh copy of the same rows each time.
+func reportScopeIDs(cfg *Config) []string {
+	scopeIDs := []string{cfg.EnterpriseSlug}
+	if cfg.OrganizationSlug != "" && cfg.OrganizationSlug != cfg.EnterpriseSlug {
+		scopeIDs = append(scopeIDs, cfg.OrganizationSlug)
+	}
+	return scopeIDs
+}
+
+// dayExistsInAnyScope reports whether a day is stored under any of the given
+// scope_ids. A probe error is returned rather than swallowed so callers can tell
+// "not stored" apart from "could not tell" — treating the latter as "missing"
+// is what turns a transient BigQuery failure into duplicate rows.
+func dayExistsInAnyScope(
+	ctx context.Context,
+	existsFn func(context.Context, time.Time, string) (bool, error),
+	day time.Time,
+	scopeIDs []string,
+) (bool, error) {
+	for _, scopeID := range scopeIDs {
+		exists, err := existsFn(ctx, day, scopeID)
+		if err != nil {
+			return false, err
+		}
+		if exists {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// latestDayAcrossScopes returns the most recent day stored under any of the
+// given scope_ids, or the zero time when none of them has data.
+//
+// Callers use this as a resume point: they ingest every day after it. Taking the
+// max across scopes is what makes that safe — a per-scope maximum sits before
+// days already stored under the other scope, so the caller re-ingests them and,
+// because the write is keyed on whatever scope the fetch resolves to that run,
+// leaves the day present under both scopes at once.
+//
+// The trade-off is deliberate: a day already stored under the org scope is never
+// revisited, so it will not be enriched with enterprise-scope rows later. The
+// gap is filled either way, and one copy of a day beats two.
+func latestDayAcrossScopes(
+	ctx context.Context,
+	latestFn func(context.Context, string) (time.Time, error),
+	scopeIDs []string,
+) (time.Time, error) {
+	var latest time.Time
+	for _, scopeID := range scopeIDs {
+		day, err := latestFn(ctx, scopeID)
+		if err != nil {
+			return time.Time{}, err
+		}
+		if day.After(latest) {
+			latest = day
+		}
+	}
+	return latest, nil
+}
+
 // upsertReport handles idempotent insert for a report: check exists → delete → insert.
+// The exists/delete pair is keyed on the scope_id the fetch actually resolved to,
+// which is the same key the insert writes — never on a scope_id assumed by the
+// caller, or the delete misses the rows it is meant to replace.
 func upsertReport(
 	ctx context.Context,
 	existsFn func(context.Context, time.Time, string) (bool, error),

--- a/apps/copilot-metrics/repo_metrics_backfill.go
+++ b/apps/copilot-metrics/repo_metrics_backfill.go
@@ -85,11 +85,23 @@ func runRepoMetricsBackfill(ctx context.Context, gh RepoMetricsFetcher, bq RepoM
 
 		dayStr := day.Format("2006-01-02")
 
-		// Cheap skip using the enterprise slug. If the report was stored under
-		// an org scope_id instead, this reports "not exists" and we fall
-		// through to upsertReport, which re-checks with the real scope.
+		// Skip a day that already has rows under ANY scope_id the report may
+		// have landed under. An enterprise-only probe reads "not exists" for an
+		// org-stored day, and upsertReport — correctly keyed on the scope the
+		// fetch resolved to — then writes a second copy under the enterprise
+		// scope_id. v_repository_usage groups by scope_id, so that splits every
+		// affected repo into two rows with split PR counts, and its
+		// `HAVING pr_total_created >= 5` guard is applied to each half on its
+		// own, dropping borderline repos off the dashboard entirely.
+		//
+		// This is the opposite call from the report probes in
+		// ingestMissingSupplementary, and for a reason that lives in the
+		// consumers: nothing reads repository_metrics through an
+		// enterprise-pinned filter, so an org-stored day is already visible and
+		// there is no wrong-scope day to heal here — only a split to avoid.
+		// Use --force to deliberately re-ingest.
 		if !force {
-			exists, err := bq.RepoMetricsDayExists(ctx, day, cfg.EnterpriseSlug)
+			exists, err := dayExistsInAnyScope(ctx, bq.RepoMetricsDayExists, day, reportScopeIDs(cfg))
 			if err != nil {
 				slog.Warn("Failed to check repo-metrics existence", "day", dayStr, "error", err)
 			} else if exists {

--- a/apps/copilot-metrics/repo_metrics_backfill_test.go
+++ b/apps/copilot-metrics/repo_metrics_backfill_test.go
@@ -182,12 +182,12 @@ func TestRunRepoMetricsBackfill_ExistsCheckErrorFallsThrough(t *testing.T) {
 	}
 }
 
-func TestRunRepoMetricsBackfill_PreCheckUsesEnterpriseSlugAndUpsertUsesFetchedScope(t *testing.T) {
+func TestRunRepoMetricsBackfill_PreCheckProbesConfiguredScopesAndUpsertUsesFetchedScope(t *testing.T) {
 	withoutRepoMetricsDelay(t)
 
-	// The cheap pre-check queries the configured enterprise slug, while the
-	// authoritative upsert uses whatever scope the fetch actually resolved to
-	// (enterprise-first with org fallback).
+	// The cheap pre-check walks the configured scope_ids, enterprise slug first,
+	// while the authoritative upsert uses whatever scope the fetch actually
+	// resolved to (enterprise-first with org fallback).
 	store := newRepoBackfillStore()
 	fetcher := &repoBackfillFetcher{records: 2, scopeID: "navikt"}
 
@@ -196,7 +196,7 @@ func TestRunRepoMetricsBackfill_PreCheckUsesEnterpriseSlugAndUpsertUsesFetchedSc
 	}
 
 	if len(store.existsScope) == 0 || store.existsScope[0] != "nav" {
-		t.Errorf("expected pre-check to use the enterprise slug %q, got %v", "nav", store.existsScope)
+		t.Errorf("expected pre-check to probe the enterprise slug %q first, got %v", "nav", store.existsScope)
 	}
 	if len(store.insertScope) != 1 || store.insertScope[0] != "navikt" {
 		t.Errorf("expected insert to use the fetched scope %q, got %v", "navikt", store.insertScope)
@@ -312,5 +312,39 @@ func TestRunRepoMetricsBackfill_NormalisesStartDayToUTCMidnight(t *testing.T) {
 func TestRepoMetricsGADateIsParseable(t *testing.T) {
 	if _, err := time.Parse("2006-01-02", repoMetricsGADate); err != nil {
 		t.Fatalf("repoMetricsGADate must be a valid date: %v", err)
+	}
+}
+
+// TestRunRepoMetricsBackfill_SkipsDayStoredUnderAnyScope pins the cheap skip to
+// every scope_id the repos-1-day report can land under.
+//
+// An enterprise-only probe reads "missing" for a day whose rows sit under the
+// org scope_id, and upsertReport — keyed on the scope the fetch resolved to —
+// then writes a second copy under the enterprise scope_id. v_repository_usage
+// groups by scope_id, so the day's repos would show up twice with split PR
+// counts, each half measured against `HAVING pr_total_created >= 5` on its own.
+func TestRunRepoMetricsBackfill_SkipsDayStoredUnderAnyScope(t *testing.T) {
+	withoutRepoMetricsDelay(t)
+
+	day := daysAgo(1)
+	store := newScopedStore()
+	store.seed(tableRepoMetrics, day, "navikt", 6)
+
+	// The enterprise endpoint is up again, so a fetch would resolve to "nav".
+	fetcher := &repoBackfillFetcher{records: 6, scopeID: "nav"}
+	cfg := &Config{EnterpriseSlug: "nav", OrganizationSlug: "navikt"}
+
+	if err := runRepoMetricsBackfill(context.Background(), fetcher, store, cfg, day, false); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(fetcher.fetched) != 0 {
+		t.Errorf("expected the org-stored day to be skipped before fetching, got fetches %v", fetcher.fetched)
+	}
+	if got := store.count(tableRepoMetrics, day, "nav"); got != 0 {
+		t.Errorf("expected no enterprise-scoped second copy, got %d rows", got)
+	}
+	if got := store.countAllScopes(tableRepoMetrics, day); got != 6 {
+		t.Errorf("expected the day to stay at 6 rows across scopes, got %d", got)
 	}
 }

--- a/apps/copilot-metrics/supplementary_test.go
+++ b/apps/copilot-metrics/supplementary_test.go
@@ -230,28 +230,46 @@ func TestIngestMissingSupplementary_RepeatedRunsDoNotDuplicate(t *testing.T) {
 		entityScope  string
 		reportScope  string
 		reportScopeI string
+		wantFetches  int
+		// repository_metrics is probed across scopes, so it stops re-fetching
+		// as soon as the day exists under any scope_id — unlike the
+		// enterprise-pinned tables, which keep healing an org-stored day.
+		wantRepoFetches int
 	}{
 		{
 			name:         "entity and reports both enterprise-scoped",
 			entityScope:  "nav",
 			reportScope:  "enterprise",
 			reportScopeI: "nav",
+			// The enterprise-only report probe sees the day it just wrote.
+			wantFetches:     1,
+			wantRepoFetches: 1,
 		},
 		{
 			// The duplicating combination: entity metrics came from the
 			// enterprise endpoint, the supplementary reports fell back to the
-			// org endpoint, so they were stored under a scope_id the gap-fill
-			// never looked at.
-			name:         "enterprise entity, org-scoped reports",
-			entityScope:  "nav",
-			reportScope:  "organization",
-			reportScopeI: "navikt",
+			// org endpoint, so they are stored under a scope_id the
+			// enterprise-pinned aggregates in copilot-api never read.
+			//
+			// The re-fetch on every run is what that buys: the moment the
+			// enterprise report endpoint recovers, the very next run stores an
+			// enterprise-scoped copy and the day stops reporting zero users.
+			// Skipping it instead would freeze the day permanently. upsertReport
+			// keeps the cost at one copy per scope no matter how often it runs.
+			name:            "enterprise entity, org-scoped reports",
+			entityScope:     "nav",
+			reportScope:     "organization",
+			reportScopeI:    "navikt",
+			wantFetches:     3,
+			wantRepoFetches: 1,
 		},
 		{
-			name:         "entity and reports both org-scoped",
-			entityScope:  "navikt",
-			reportScope:  "organization",
-			reportScopeI: "navikt",
+			name:            "entity and reports both org-scoped",
+			entityScope:     "navikt",
+			reportScope:     "organization",
+			reportScopeI:    "navikt",
+			wantFetches:     3,
+			wantRepoFetches: 1,
 		},
 	}
 
@@ -278,25 +296,68 @@ func TestIngestMissingSupplementary_RepeatedRunsDoNotDuplicate(t *testing.T) {
 					t.Errorf("%s: expected 3 rows after 3 runs, got %d (rows duplicated per run)", table, got)
 				}
 			}
-			if fetcher.teamsFetches != 1 {
-				t.Errorf("expected the user-teams report to be fetched once, got %d", fetcher.teamsFetches)
+			if fetcher.teamsFetches != tt.wantFetches {
+				t.Errorf("expected %d user-teams fetches over 3 runs, got %d", tt.wantFetches, fetcher.teamsFetches)
+			}
+			if fetcher.reposFetches != tt.wantRepoFetches {
+				t.Errorf("expected %d repo-metrics fetches over 3 runs, got %d", tt.wantRepoFetches, fetcher.reposFetches)
 			}
 		})
 	}
 }
 
-// TestIngestMissingSupplementary_SkipsDayStoredUnderOtherScope covers the same
-// day being present under one scope while the gap-fill runs with the other
-// configured: the day must not be ingested a second time under the other scope.
-func TestIngestMissingSupplementary_SkipsDayStoredUnderOtherScope(t *testing.T) {
+// TestIngestMissingSupplementary_ScopeMismatch pins what the gap-fill does when
+// a day's reports sit under one scope_id while the fetch resolves to the other.
+//
+// The answer differs per table, and the discriminator is the consumer:
+//
+//   - user_teams / user_metrics are read through an enterprise-pinned filter, so
+//     an org-stored day is invisible and must be HEALED: re-fetch once, write the
+//     enterprise-scoped copy, then leave it alone.
+//   - repository_metrics is read by a view that groups by scope_id with no
+//     filter, so an org-stored day is already visible and a second copy would
+//     SPLIT the repo across two rows. Skip it.
+//
+// Three runs, so healing is pinned as bounded: upsertReport replaces its own
+// rows, it never stacks a third set.
+func TestIngestMissingSupplementary_ScopeMismatch(t *testing.T) {
 	tests := []struct {
 		name         string
 		storedScope  string
 		fetchedScope string
 		fetchedID    string
+		// Rows expected per scope_id, for the enterprise-pinned tables and for
+		// repository_metrics respectively.
+		wantPinned       map[string]int
+		wantRepos        map[string]int
+		wantTeamsFetches int
+		wantReposFetches int
 	}{
-		{name: "stored enterprise, fetch resolves to org", storedScope: "nav", fetchedScope: "organization", fetchedID: "navikt"},
-		{name: "stored org, fetch resolves to enterprise", storedScope: "navikt", fetchedScope: "enterprise", fetchedID: "nav"},
+		{
+			// Stored under the scope every consumer already reads: nothing to
+			// do for any table.
+			name:             "stored enterprise, fetch resolves to org",
+			storedScope:      "nav",
+			fetchedScope:     "organization",
+			fetchedID:        "navikt",
+			wantPinned:       map[string]int{"nav": 4, "navikt": 0},
+			wantRepos:        map[string]int{"nav": 4, "navikt": 0},
+			wantTeamsFetches: 0,
+			wantReposFetches: 0,
+		},
+		{
+			// The case the two rules pull apart: the same org-stored day is a
+			// hole for the enterprise-pinned tables and a duplicate risk for
+			// repository_metrics.
+			name:             "stored org, fetch resolves to enterprise",
+			storedScope:      "navikt",
+			fetchedScope:     "enterprise",
+			fetchedID:        "nav",
+			wantPinned:       map[string]int{"navikt": 4, "nav": 4},
+			wantRepos:        map[string]int{"navikt": 4, "nav": 0},
+			wantTeamsFetches: 1,
+			wantReposFetches: 0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -313,18 +374,27 @@ func TestIngestMissingSupplementary_SkipsDayStoredUnderOtherScope(t *testing.T) 
 
 			fetcher := &supplementaryFetcher{scope: tt.fetchedScope, scopeID: tt.fetchedID, records: 4}
 
-			ingestMissingSupplementary(ctx, fetcher, store, cfg)
+			for range 3 {
+				ingestMissingSupplementary(ctx, fetcher, store, cfg)
+			}
 
-			for _, table := range []string{tableUserTeams, tableUserMetrics, tableRepoMetrics} {
-				if got := store.countAllScopes(table, day); got != 4 {
-					t.Errorf("%s: expected the day to stay at 4 rows, got %d across scopes", table, got)
-				}
-				if got := store.count(table, day, tt.fetchedID); got != 0 && tt.fetchedID != tt.storedScope {
-					t.Errorf("%s: expected no second copy under scope_id %q, got %d rows", table, tt.fetchedID, got)
+			wantByTable := map[string]map[string]int{
+				tableUserTeams:   tt.wantPinned,
+				tableUserMetrics: tt.wantPinned,
+				tableRepoMetrics: tt.wantRepos,
+			}
+			for table, want := range wantByTable {
+				for scopeID, n := range want {
+					if got := store.count(table, day, scopeID); got != n {
+						t.Errorf("%s: expected %d rows under scope_id %q, got %d", table, n, scopeID, got)
+					}
 				}
 			}
-			if fetcher.teamsFetches != 0 {
-				t.Errorf("expected no fetch for a day already stored, got %d", fetcher.teamsFetches)
+			if fetcher.teamsFetches != tt.wantTeamsFetches {
+				t.Errorf("expected %d user-teams fetches over 3 runs, got %d", tt.wantTeamsFetches, fetcher.teamsFetches)
+			}
+			if fetcher.reposFetches != tt.wantReposFetches {
+				t.Errorf("expected %d repo-metrics fetches over 3 runs, got %d", tt.wantReposFetches, fetcher.reposFetches)
 			}
 		})
 	}
@@ -750,16 +820,17 @@ func maxLevelMentioning(records []slog.Record, substr string) (slog.Level, bool)
 // an expected, self-healing condition, not something to warn the nightly job's
 // watchers about.
 //
-// The branch is reached by giving the probe a narrower scope list than the fetch
-// resolves to — enterprise and org slug set to the same value, so the day's rows
-// under the org scope_id are invisible to the existence probe but found by
-// upsertReport, which then has to delete them.
+// The branch is reached for all three reports at once by leaving the org slug
+// unset: the rows sit under a scope_id no probe covers — not the enterprise-only
+// ones, not the cross-scope repo-metrics one — so every probe reads "missing"
+// while upsertReport, keyed on the scope the fetch resolved to, finds the rows
+// and has to delete them first.
 func TestIngestMissingSupplementary_StreamingBufferLogsAtInfo(t *testing.T) {
 	logs := captureLogs(t)
 
 	ctx := context.Background()
 	day := daysAgo(1)
-	cfg := &Config{EnterpriseSlug: "nav", OrganizationSlug: "nav"}
+	cfg := &Config{EnterpriseSlug: "nav"}
 
 	store := newScopedStore()
 	store.seed(tableUsageMetrics, day, "nav", 1)

--- a/apps/copilot-metrics/supplementary_test.go
+++ b/apps/copilot-metrics/supplementary_test.go
@@ -1,0 +1,796 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// scopedStore models how BigQuery actually stores these tables: rows live under
+// a (day, scope_id) key, which is both what insertRecords writes and what the
+// DELETE predicate matches. The mocks elsewhere in this package ignore scope_id,
+// so a write keyed on the wrong scope looks idempotent to them — this store
+// makes the extra copies visible.
+type scopedStore struct {
+	rows         map[string][]json.RawMessage
+	existsErr    error
+	deleteErr    error
+	latestErr    error
+	existsCalls  []string
+	latestScopes []string
+}
+
+func newScopedStore() *scopedStore {
+	return &scopedStore{rows: map[string][]json.RawMessage{}}
+}
+
+func scopedKey(table string, day time.Time, scopeID string) string {
+	return table + "|" + day.Format("2006-01-02") + "|" + scopeID
+}
+
+// seed puts n rows in place as if a previous run had ingested them.
+func (s *scopedStore) seed(table string, day time.Time, scopeID string, n int) {
+	s.rows[scopedKey(table, day, scopeID)] = testRecords(n)
+}
+
+// count returns how many rows are stored for one (table, day, scope_id) key.
+func (s *scopedStore) count(table string, day time.Time, scopeID string) int {
+	return len(s.rows[scopedKey(table, day, scopeID)])
+}
+
+// countAllScopes returns how many rows are stored for a day across every scope.
+func (s *scopedStore) countAllScopes(table string, day time.Time) int {
+	var total int
+	prefix := table + "|" + day.Format("2006-01-02") + "|"
+	for key, rows := range s.rows {
+		if len(key) > len(prefix) && key[:len(prefix)] == prefix {
+			total += len(rows)
+		}
+	}
+	return total
+}
+
+func (s *scopedStore) exists(table string, day time.Time, scopeID string) (bool, error) {
+	s.existsCalls = append(s.existsCalls, scopedKey(table, day, scopeID))
+	if s.existsErr != nil {
+		return false, s.existsErr
+	}
+	return len(s.rows[scopedKey(table, day, scopeID)]) > 0, nil
+}
+
+func (s *scopedStore) delete(table string, day time.Time, scopeID string) error {
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+	delete(s.rows, scopedKey(table, day, scopeID))
+	return nil
+}
+
+// insert appends, exactly like a BigQuery streaming insert — it never replaces.
+func (s *scopedStore) insert(table string, day time.Time, scopeID string, records []json.RawMessage) error {
+	key := scopedKey(table, day, scopeID)
+	s.rows[key] = append(s.rows[key], records...)
+	return nil
+}
+
+func (s *scopedStore) EnsureTableExists(context.Context) error            { return nil }
+func (s *scopedStore) EnsureUserTeamsTableExists(context.Context) error   { return nil }
+func (s *scopedStore) EnsureUserMetricsTableExists(context.Context) error { return nil }
+func (s *scopedStore) EnsureRepoMetricsTableExists(context.Context) error { return nil }
+func (s *scopedStore) Close() error                                       { return nil }
+
+// GetLatestDay mirrors the real query: MAX(day) filtered to a single scope_id.
+// Days stored under any other scope_id are invisible to it, which is exactly the
+// blind spot the cross-scope high-water mark exists to cover.
+func (s *scopedStore) GetLatestDay(_ context.Context, scopeID string) (time.Time, error) {
+	s.latestScopes = append(s.latestScopes, scopeID)
+	if s.latestErr != nil {
+		return time.Time{}, s.latestErr
+	}
+
+	var latest time.Time
+	prefix := tableUsageMetrics + "|"
+	suffix := "|" + scopeID
+	for key, rows := range s.rows {
+		if len(rows) == 0 || !strings.HasPrefix(key, prefix) || !strings.HasSuffix(key, suffix) {
+			continue
+		}
+		day, err := time.Parse("2006-01-02", key[len(prefix):len(key)-len(suffix)])
+		if err != nil {
+			continue
+		}
+		if day.After(latest) {
+			latest = day
+		}
+	}
+	return latest, nil
+}
+
+func (s *scopedStore) InsertMetrics(_ context.Context, day time.Time, _, scopeID string, records []json.RawMessage) error {
+	return s.insert(tableUsageMetrics, day, scopeID, records)
+}
+
+func (s *scopedStore) InsertUserTeams(_ context.Context, day time.Time, _, scopeID string, records []json.RawMessage) error {
+	return s.insert(tableUserTeams, day, scopeID, records)
+}
+
+func (s *scopedStore) InsertUserMetrics(_ context.Context, day time.Time, _, scopeID string, records []json.RawMessage) error {
+	return s.insert(tableUserMetrics, day, scopeID, records)
+}
+
+func (s *scopedStore) InsertRepoMetrics(_ context.Context, day time.Time, _, scopeID string, records []json.RawMessage) error {
+	return s.insert(tableRepoMetrics, day, scopeID, records)
+}
+
+func (s *scopedStore) DayExists(_ context.Context, day time.Time, scopeID string) (bool, error) {
+	return s.exists(tableUsageMetrics, day, scopeID)
+}
+
+func (s *scopedStore) UserTeamsDayExists(_ context.Context, day time.Time, scopeID string) (bool, error) {
+	return s.exists(tableUserTeams, day, scopeID)
+}
+
+func (s *scopedStore) UserMetricsDayExists(_ context.Context, day time.Time, scopeID string) (bool, error) {
+	return s.exists(tableUserMetrics, day, scopeID)
+}
+
+func (s *scopedStore) RepoMetricsDayExists(_ context.Context, day time.Time, scopeID string) (bool, error) {
+	return s.exists(tableRepoMetrics, day, scopeID)
+}
+
+func (s *scopedStore) DeleteDay(_ context.Context, day time.Time, scopeID string) error {
+	return s.delete(tableUsageMetrics, day, scopeID)
+}
+
+func (s *scopedStore) DeleteUserTeamsDay(_ context.Context, day time.Time, scopeID string) error {
+	return s.delete(tableUserTeams, day, scopeID)
+}
+
+func (s *scopedStore) DeleteUserMetricsDay(_ context.Context, day time.Time, scopeID string) error {
+	return s.delete(tableUserMetrics, day, scopeID)
+}
+
+func (s *scopedStore) DeleteRepoMetricsDay(_ context.Context, day time.Time, scopeID string) error {
+	return s.delete(tableRepoMetrics, day, scopeID)
+}
+
+// Table names used as scopedStore keys — they only need to be distinct.
+const (
+	tableUsageMetrics = "usage_metrics"
+	tableUserTeams    = "user_teams"
+	tableUserMetrics  = "user_metrics"
+	tableRepoMetrics  = "repository_metrics"
+)
+
+func testRecords(n int) []json.RawMessage {
+	records := make([]json.RawMessage, n)
+	for i := range records {
+		records[i] = json.RawMessage(`{"user_id":"u1"}`)
+	}
+	return records
+}
+
+// supplementaryFetcher returns the same supplementary reports for every day,
+// under a configurable scope, and counts how often each report was fetched.
+type supplementaryFetcher struct {
+	scope   string
+	scopeID string
+	records int
+
+	teamsFetches  int
+	usersFetches  int
+	reposFetches  int
+	entityFetches int
+}
+
+func (f *supplementaryFetcher) result() *FetchResult {
+	return &FetchResult{Records: testRecords(f.records), Scope: f.scope, ScopeID: f.scopeID}
+}
+
+func (f *supplementaryFetcher) FetchDailyMetrics(context.Context, time.Time) (*FetchResult, error) {
+	f.entityFetches++
+	return f.result(), nil
+}
+
+func (f *supplementaryFetcher) FetchLatest28DayReport(context.Context) (*FetchResult, error) {
+	return f.result(), nil
+}
+
+func (f *supplementaryFetcher) FetchDailyUserTeams(context.Context, time.Time) (*FetchResult, error) {
+	f.teamsFetches++
+	return f.result(), nil
+}
+
+func (f *supplementaryFetcher) FetchDailyUserMetrics(context.Context, time.Time) (*FetchResult, error) {
+	f.usersFetches++
+	return f.result(), nil
+}
+
+func (f *supplementaryFetcher) FetchDailyRepoMetrics(context.Context, time.Time) (*FetchResult, error) {
+	f.reposFetches++
+	return f.result(), nil
+}
+
+func supplementaryConfig() *Config {
+	return &Config{EnterpriseSlug: "nav", OrganizationSlug: "navikt"}
+}
+
+// TestIngestMissingSupplementary_RepeatedRunsDoNotDuplicate is the regression
+// test for the org-scope gap-fill: the day is fetched under the org scope while
+// the gap-fill's existence probe only knew the enterprise slug, so every nightly
+// run considered the day missing and appended another copy of the same rows.
+func TestIngestMissingSupplementary_RepeatedRunsDoNotDuplicate(t *testing.T) {
+	tests := []struct {
+		name         string
+		entityScope  string
+		reportScope  string
+		reportScopeI string
+	}{
+		{
+			name:         "entity and reports both enterprise-scoped",
+			entityScope:  "nav",
+			reportScope:  "enterprise",
+			reportScopeI: "nav",
+		},
+		{
+			// The duplicating combination: entity metrics came from the
+			// enterprise endpoint, the supplementary reports fell back to the
+			// org endpoint, so they were stored under a scope_id the gap-fill
+			// never looked at.
+			name:         "enterprise entity, org-scoped reports",
+			entityScope:  "nav",
+			reportScope:  "organization",
+			reportScopeI: "navikt",
+		},
+		{
+			name:         "entity and reports both org-scoped",
+			entityScope:  "navikt",
+			reportScope:  "organization",
+			reportScopeI: "navikt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			day := daysAgo(1)
+			cfg := supplementaryConfig()
+
+			store := newScopedStore()
+			// Entity metrics exist for the day — that is the gate the gap-fill
+			// uses to decide the day is worth topping up.
+			store.seed(tableUsageMetrics, day, tt.entityScope, 1)
+
+			fetcher := &supplementaryFetcher{scope: tt.reportScope, scopeID: tt.reportScopeI, records: 3}
+
+			// Three consecutive nightly runs.
+			for range 3 {
+				ingestMissingSupplementary(ctx, fetcher, store, cfg)
+			}
+
+			for _, table := range []string{tableUserTeams, tableUserMetrics, tableRepoMetrics} {
+				if got := store.countAllScopes(table, day); got != 3 {
+					t.Errorf("%s: expected 3 rows after 3 runs, got %d (rows duplicated per run)", table, got)
+				}
+			}
+			if fetcher.teamsFetches != 1 {
+				t.Errorf("expected the user-teams report to be fetched once, got %d", fetcher.teamsFetches)
+			}
+		})
+	}
+}
+
+// TestIngestMissingSupplementary_SkipsDayStoredUnderOtherScope covers the same
+// day being present under one scope while the gap-fill runs with the other
+// configured: the day must not be ingested a second time under the other scope.
+func TestIngestMissingSupplementary_SkipsDayStoredUnderOtherScope(t *testing.T) {
+	tests := []struct {
+		name         string
+		storedScope  string
+		fetchedScope string
+		fetchedID    string
+	}{
+		{name: "stored enterprise, fetch resolves to org", storedScope: "nav", fetchedScope: "organization", fetchedID: "navikt"},
+		{name: "stored org, fetch resolves to enterprise", storedScope: "navikt", fetchedScope: "enterprise", fetchedID: "nav"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			day := daysAgo(1)
+			cfg := supplementaryConfig()
+
+			store := newScopedStore()
+			store.seed(tableUsageMetrics, day, tt.storedScope, 1)
+			for _, table := range []string{tableUserTeams, tableUserMetrics, tableRepoMetrics} {
+				store.seed(table, day, tt.storedScope, 4)
+			}
+
+			fetcher := &supplementaryFetcher{scope: tt.fetchedScope, scopeID: tt.fetchedID, records: 4}
+
+			ingestMissingSupplementary(ctx, fetcher, store, cfg)
+
+			for _, table := range []string{tableUserTeams, tableUserMetrics, tableRepoMetrics} {
+				if got := store.countAllScopes(table, day); got != 4 {
+					t.Errorf("%s: expected the day to stay at 4 rows, got %d across scopes", table, got)
+				}
+				if got := store.count(table, day, tt.fetchedID); got != 0 && tt.fetchedID != tt.storedScope {
+					t.Errorf("%s: expected no second copy under scope_id %q, got %d rows", table, tt.fetchedID, got)
+				}
+			}
+			if fetcher.teamsFetches != 0 {
+				t.Errorf("expected no fetch for a day already stored, got %d", fetcher.teamsFetches)
+			}
+		})
+	}
+}
+
+// TestIngestMissingSupplementary_ExistsErrorDoesNotInsert guards the other way a
+// duplicate is born: treating an unreadable existence probe as "missing".
+func TestIngestMissingSupplementary_ExistsErrorDoesNotInsert(t *testing.T) {
+	ctx := context.Background()
+	store := newScopedStore()
+	store.existsErr = errTest
+
+	fetcher := &supplementaryFetcher{scope: "organization", scopeID: "navikt", records: 2}
+
+	ingestMissingSupplementary(ctx, fetcher, store, supplementaryConfig())
+
+	if fetcher.teamsFetches != 0 || fetcher.usersFetches != 0 || fetcher.reposFetches != 0 {
+		t.Errorf("expected no fetches when the entity probe fails, got teams=%d users=%d repos=%d",
+			fetcher.teamsFetches, fetcher.usersFetches, fetcher.reposFetches)
+	}
+}
+
+// TestUpsertReport_KeysOnFetchedScope pins the invariant the whole fix rests on:
+// the exists/delete pair must use the scope_id the insert writes, so a re-import
+// replaces its own rows and leaves the other scope's rows alone.
+func TestUpsertReport_KeysOnFetchedScope(t *testing.T) {
+	tests := []struct {
+		name          string
+		seedScopeID   string
+		seedRows      int
+		resultScope   string
+		resultScopeID string
+		wantByScope   map[string]int
+	}{
+		{
+			name:          "re-import under the same scope replaces its rows",
+			seedScopeID:   "navikt",
+			seedRows:      5,
+			resultScope:   "organization",
+			resultScopeID: "navikt",
+			wantByScope:   map[string]int{"navikt": 2},
+		},
+		{
+			name:          "import under a new scope leaves the other scope intact",
+			seedScopeID:   "nav",
+			seedRows:      5,
+			resultScope:   "organization",
+			resultScopeID: "navikt",
+			wantByScope:   map[string]int{"nav": 5, "navikt": 2},
+		},
+		{
+			name:          "first import writes exactly one copy",
+			seedScopeID:   "",
+			resultScope:   "enterprise",
+			resultScopeID: "nav",
+			wantByScope:   map[string]int{"nav": 2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			day := fixedDay()
+
+			store := newScopedStore()
+			if tt.seedScopeID != "" {
+				store.seed(tableUserMetrics, day, tt.seedScopeID, tt.seedRows)
+			}
+
+			result := &FetchResult{Records: testRecords(2), Scope: tt.resultScope, ScopeID: tt.resultScopeID}
+			if err := upsertReport(ctx, store.UserMetricsDayExists, store.DeleteUserMetricsDay, store.InsertUserMetrics,
+				day, result); err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			for scopeID, want := range tt.wantByScope {
+				if got := store.count(tableUserMetrics, day, scopeID); got != want {
+					t.Errorf("scope_id %q: expected %d rows, got %d", scopeID, want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestUpsertReport_ExistsErrorSkipsInsert(t *testing.T) {
+	ctx := context.Background()
+	day := fixedDay()
+
+	store := newScopedStore()
+	store.existsErr = errTest
+
+	result := &FetchResult{Records: testRecords(2), Scope: "enterprise", ScopeID: "nav"}
+	err := upsertReport(ctx, store.UserMetricsDayExists, store.DeleteUserMetricsDay, store.InsertUserMetrics, day, result)
+	if err == nil {
+		t.Fatal("expected the existence-check error to surface")
+	}
+	if got := store.countAllScopes(tableUserMetrics, day); got != 0 {
+		t.Errorf("expected no rows written when the existence check fails, got %d", got)
+	}
+}
+
+func TestUpsertReport_DeleteErrorSkipsInsert(t *testing.T) {
+	ctx := context.Background()
+	day := fixedDay()
+
+	store := newScopedStore()
+	store.seed(tableUserMetrics, day, "nav", 3)
+	store.deleteErr = ErrStreamingBuffer
+
+	result := &FetchResult{Records: testRecords(2), Scope: "enterprise", ScopeID: "nav"}
+	err := upsertReport(ctx, store.UserMetricsDayExists, store.DeleteUserMetricsDay, store.InsertUserMetrics, day, result)
+	if !errors.Is(err, ErrStreamingBuffer) {
+		t.Fatalf("expected ErrStreamingBuffer to be preserved for callers, got %v", err)
+	}
+	// A failed delete must not be followed by an insert, or the day ends up with
+	// both the old and the new rows.
+	if got := store.count(tableUserMetrics, day, "nav"); got != 3 {
+		t.Errorf("expected the 3 existing rows to be left untouched, got %d", got)
+	}
+}
+
+func TestReportScopeIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+		want []string
+	}{
+		{
+			name: "distinct enterprise and org slugs",
+			cfg:  &Config{EnterpriseSlug: "nav", OrganizationSlug: "navikt"},
+			want: []string{"nav", "navikt"},
+		},
+		{
+			name: "identical slugs are not probed twice",
+			cfg:  &Config{EnterpriseSlug: "nav", OrganizationSlug: "nav"},
+			want: []string{"nav"},
+		},
+		{
+			name: "unset org slug",
+			cfg:  &Config{EnterpriseSlug: "nav"},
+			want: []string{"nav"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := reportScopeIDs(tt.cfg)
+			if len(got) != len(tt.want) {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("index %d: expected %q, got %q", i, tt.want[i], got[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDayExistsInAnyScope(t *testing.T) {
+	day := fixedDay()
+
+	tests := []struct {
+		name       string
+		seedScopes []string
+		scopeIDs   []string
+		existsErr  error
+		want       bool
+		wantErr    bool
+		wantProbes int
+	}{
+		{
+			name:       "found under the first scope stops probing",
+			seedScopes: []string{"nav"},
+			scopeIDs:   []string{"nav", "navikt"},
+			want:       true,
+			wantProbes: 1,
+		},
+		{
+			name:       "found under the fallback scope",
+			seedScopes: []string{"navikt"},
+			scopeIDs:   []string{"nav", "navikt"},
+			want:       true,
+			wantProbes: 2,
+		},
+		{
+			name:       "absent from every scope",
+			scopeIDs:   []string{"nav", "navikt"},
+			want:       false,
+			wantProbes: 2,
+		},
+		{
+			name:       "probe error is reported, not read as absent",
+			scopeIDs:   []string{"nav", "navikt"},
+			existsErr:  errTest,
+			wantErr:    true,
+			wantProbes: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newScopedStore()
+			for _, scopeID := range tt.seedScopes {
+				store.seed(tableUserTeams, day, scopeID, 1)
+			}
+			store.existsErr = tt.existsErr
+
+			got, err := dayExistsInAnyScope(context.Background(), store.UserTeamsDayExists, day, tt.scopeIDs)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+			} else if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("expected %v, got %v", tt.want, got)
+			}
+			if len(store.existsCalls) != tt.wantProbes {
+				t.Errorf("expected %d probes, got %d (%v)", tt.wantProbes, len(store.existsCalls), store.existsCalls)
+			}
+		})
+	}
+}
+
+// TestIngestMissing_HighWaterMarkSpansScopes is the regression test for the
+// cross-scope duplication in usage_metrics that issue #400 describes.
+//
+// The gap-fill loop resumes from MAX(day), and that query filters on a single
+// scope_id. When the newest entity metrics landed under the org scope (the
+// enterprise endpoint was failing), an enterprise-only high-water mark points at
+// an older day, so the loop walks forward over days that already exist under the
+// org scope. By then the enterprise endpoint has recovered, ingestDay's
+// DayExists probe — correctly keyed on the scope the fetch resolved to — sees
+// nothing, and the day ends up stored under both scope_ids at once.
+func TestIngestMissing_HighWaterMarkSpansScopes(t *testing.T) {
+	ctx := context.Background()
+	cfg := supplementaryConfig()
+
+	store := newScopedStore()
+	// The last enterprise-scoped day is three days ago; the two days since then
+	// fell back to the org endpoint and are stored under the org scope_id.
+	store.seed(tableUsageMetrics, daysAgo(3), "nav", 1)
+	store.seed(tableUsageMetrics, daysAgo(2), "navikt", 1)
+	store.seed(tableUsageMetrics, daysAgo(1), "navikt", 1)
+
+	// The enterprise endpoint has recovered, so every fetch now resolves to it.
+	fetcher := &supplementaryFetcher{scope: "enterprise", scopeID: "nav", records: 1}
+
+	if err := ingestMissing(ctx, fetcher, store, cfg, nil); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if fetcher.entityFetches != 0 {
+		t.Errorf("expected no re-ingestion of days already stored under the org scope, got %d entity fetches",
+			fetcher.entityFetches)
+	}
+	for _, day := range []int{1, 2, 3} {
+		if got := store.countAllScopes(tableUsageMetrics, daysAgo(day)); got != 1 {
+			t.Errorf("day -%d: expected 1 row across scopes, got %d (day duplicated into a second scope)", day, got)
+		}
+	}
+	if got := store.count(tableUsageMetrics, daysAgo(1), "nav"); got != 0 {
+		t.Errorf("expected no enterprise-scoped copy of the org-stored day, got %d rows", got)
+	}
+}
+
+// TestIngestMissing_ResumesFromOrgScopedDay covers the other half of the same
+// blind spot: when every stored day is org-scoped, an enterprise-only high-water
+// mark reads as "no existing data" and the job silently degrades to ingesting
+// yesterday alone, leaving the interior days unfilled forever.
+func TestIngestMissing_ResumesFromOrgScopedDay(t *testing.T) {
+	ctx := context.Background()
+	cfg := supplementaryConfig()
+
+	store := newScopedStore()
+	store.seed(tableUsageMetrics, daysAgo(3), "navikt", 1)
+
+	fetcher := &supplementaryFetcher{scope: "enterprise", scopeID: "nav", records: 1}
+
+	if err := ingestMissing(ctx, fetcher, store, cfg, nil); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if fetcher.entityFetches != 2 {
+		t.Errorf("expected the two days after the org-scoped high-water mark to be ingested, got %d entity fetches",
+			fetcher.entityFetches)
+	}
+	if got := store.countAllScopes(tableUsageMetrics, daysAgo(3)); got != 1 {
+		t.Errorf("expected the org-scoped day to be left alone, got %d rows across scopes", got)
+	}
+	for _, day := range []int{1, 2} {
+		if got := store.count(tableUsageMetrics, daysAgo(day), "nav"); got != 1 {
+			t.Errorf("day -%d: expected 1 enterprise-scoped row, got %d", day, got)
+		}
+	}
+}
+
+func TestLatestDayAcrossScopes(t *testing.T) {
+	tests := []struct {
+		name      string
+		seed      map[string]int // scope_id -> days ago
+		latestErr error
+		scopeIDs  []string
+		want      time.Time
+		wantErr   bool
+	}{
+		{
+			name:     "no data under any scope",
+			scopeIDs: []string{"nav", "navikt"},
+			want:     time.Time{},
+		},
+		{
+			name:     "the fallback scope holds the newest day",
+			seed:     map[string]int{"nav": 4, "navikt": 2},
+			scopeIDs: []string{"nav", "navikt"},
+			want:     daysAgo(2),
+		},
+		{
+			name:     "the first scope holds the newest day",
+			seed:     map[string]int{"nav": 1, "navikt": 5},
+			scopeIDs: []string{"nav", "navikt"},
+			want:     daysAgo(1),
+		},
+		{
+			name:     "only the fallback scope has data",
+			seed:     map[string]int{"navikt": 3},
+			scopeIDs: []string{"nav", "navikt"},
+			want:     daysAgo(3),
+		},
+		{
+			// A resume point that cannot be read must not be guessed at — an
+			// invented "no data" answer restarts the loop from yesterday.
+			name:      "a query error is reported, not read as no data",
+			latestErr: errTest,
+			scopeIDs:  []string{"nav", "navikt"},
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newScopedStore()
+			for scopeID, day := range tt.seed {
+				store.seed(tableUsageMetrics, daysAgo(day), scopeID, 1)
+			}
+			store.latestErr = tt.latestErr
+
+			got, err := latestDayAcrossScopes(context.Background(), store.GetLatestDay, tt.scopeIDs)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if !got.Equal(tt.want) {
+				t.Errorf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+// captureLogs redirects the default slog logger into a buffer for the duration
+// of one test and returns the records that were emitted.
+func captureLogs(t *testing.T) func() []slog.Record {
+	t.Helper()
+
+	var mu sync.Mutex
+	var records []slog.Record
+
+	previous := slog.Default()
+	slog.SetDefault(slog.New(&recordingHandler{
+		fn: func(r slog.Record) {
+			mu.Lock()
+			defer mu.Unlock()
+			records = append(records, r)
+		},
+	}))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	return func() []slog.Record {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]slog.Record(nil), records...)
+	}
+}
+
+type recordingHandler struct {
+	fn func(slog.Record)
+}
+
+func (h *recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *recordingHandler) WithAttrs([]slog.Attr) slog.Handler       { return h }
+func (h *recordingHandler) WithGroup(string) slog.Handler            { return h }
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.fn(r)
+	return nil
+}
+
+// maxLevelMentioning returns the highest level of any log record whose message
+// contains substr, and whether any record matched at all.
+func maxLevelMentioning(records []slog.Record, substr string) (slog.Level, bool) {
+	var max slog.Level
+	var found bool
+	for _, r := range records {
+		if !strings.Contains(r.Message, substr) {
+			continue
+		}
+		if !found || r.Level > max {
+			max, found = r.Level, true
+		}
+	}
+	return max, found
+}
+
+// TestIngestMissingSupplementary_StreamingBufferLogsAtInfo pins the gap-fill to
+// the convention ingestSupplementary and runRepoMetricsBackfill already follow:
+// a DELETE rejected because rows are still in the ~90-minute streaming buffer is
+// an expected, self-healing condition, not something to warn the nightly job's
+// watchers about.
+//
+// The branch is reached by giving the probe a narrower scope list than the fetch
+// resolves to — enterprise and org slug set to the same value, so the day's rows
+// under the org scope_id are invisible to the existence probe but found by
+// upsertReport, which then has to delete them.
+func TestIngestMissingSupplementary_StreamingBufferLogsAtInfo(t *testing.T) {
+	logs := captureLogs(t)
+
+	ctx := context.Background()
+	day := daysAgo(1)
+	cfg := &Config{EnterpriseSlug: "nav", OrganizationSlug: "nav"}
+
+	store := newScopedStore()
+	store.seed(tableUsageMetrics, day, "nav", 1)
+	for _, table := range []string{tableUserTeams, tableUserMetrics, tableRepoMetrics} {
+		store.seed(table, day, "navikt", 2)
+	}
+	store.deleteErr = ErrStreamingBuffer
+
+	fetcher := &supplementaryFetcher{scope: "organization", scopeID: "navikt", records: 2}
+
+	ingestMissingSupplementary(ctx, fetcher, store, cfg)
+
+	records := logs()
+	for _, report := range []string{"user-teams", "user-metrics", "repo-metrics"} {
+		level, found := maxLevelMentioning(records, "Skipping "+report+" re-import")
+		if !found {
+			t.Errorf("%s: expected a streaming-buffer skip to be logged, found none", report)
+		} else if level != slog.LevelInfo {
+			t.Errorf("%s: expected the streaming-buffer skip to be logged at Info, got %v", report, level)
+		}
+
+		if level, found := maxLevelMentioning(records, "Failed to insert missing "+report); found {
+			t.Errorf("%s: expected no failure log for a streaming-buffer skip, got one at %v", report, level)
+		}
+	}
+
+	// A rejected delete must leave the existing rows alone rather than stacking
+	// a second copy on top of them.
+	for _, table := range []string{tableUserTeams, tableUserMetrics, tableRepoMetrics} {
+		if got := store.countAllScopes(table, day); got != 2 {
+			t.Errorf("%s: expected the 2 existing rows to be untouched, got %d", table, got)
+		}
+	}
+}


### PR DESCRIPTION
Lukker #400 — men ikke der saken pekte.

## Diagnosen er en annen enn den i saken

`upsertReport` er **ikke** feil. Den sletter og skriver på nøyaktig samme nøkkel (`bigquery.go:146-152` vs `:228-230`), og er idempotent. Feilen ligger i *hvilke dager inntaket velger å hente*, og i én blind insert.

Tre steder antok at data alltid ligger under enterprise-scope, mens `FetchDailyMetrics` faller tilbake til org-scope når enterprise-endepunktet feiler (`github.go:89-128`):

**1. `ingestMissing` og `runBackfill`** fant siste dag med en enterprise-only `MAX(day)` (`bigquery.go:262-270`). Dager lagret under org-scope var usynlige, loopen gikk bakover over dem, og når enterprise-endepunktet kom tilbake ble hver av dem skrevet **en gang til** under enterprise-scope. Det er `usage_metrics`-halvdelen av saken — og den ble oppdaget først i adversariell gjennomgang, etter at første forsøk feilaktig konkluderte med at `usage_metrics` var upåvirket.

Samme mark har en stille andre halvdel: når *alle* lagrede dager ligger under org-scope, leses enterprise-marken som «ingen data», og jobben faller tilbake til å hente kun gårsdagen. Mellomliggende dager blir aldri fylt.

**2. `ingestMissingSupplementary`** sjekket eksistens mot en hardkodet enterprise-slug, men skrev med den scopen hentingen faktisk landet på — og med bar `Insert`, uten sletting. Hver nattlige kjøring la på en ny full kopi av `user_teams`, `user_metrics` og `repository_metrics`. Uten øvre grense.

## Fiksen

`latestDayAcrossScopes` og `dayExistsInAnyScope` ser på alle aktuelle scopes, og de tre skrivingene går gjennom `upsertReport` så de er idempotente uansett om sjekken skulle ta feil. `ingestDay` er bevisst **ikke** rørt — en scope-kryssende skip der ville brutt `--backfill --force`, som finnes nettopp for å hente om igjen dager som allerede finnes.

Ingen skjemaendring. Ingen konsument rørt — begge scope-verdiene er aktivt i bruk (`bigquery_stats.go` pinner `scope = 'enterprise'` for user-aggregater og `scope_id = 'navikt'` for daglig sammendrag), så å normalisere `ScopeID` ved kilden ville brutt dem.

## Hvorfor testene ikke fanget det

`mockStore` forkaster `scopeID` og overskriver tellere, så «sjekker én scope, skriver en annen» var strukturelt usynlig. Ny `scopedStore` modellerer BigQuerys faktiske append-semantikk.

Begge regresjonstestene er **verifisert til å feile mot koden slik den var**: 9 rader etter 3 kjøringer i stedet for 3 for supplementary-halvdelen, og en dag duplisert inn i en andre scope for high-water-mark-halvdelen.

## Eksisterende data må sannsynligvis ryddes

Fiksen stopper nye duplikater. Den fjerner ikke de som allerede ligger der — og `v_team_daily_summary` joiner og grupperer på `scope_id`, så duplikater multipliserer summene i stedet for bare å legge til rader.

Prosedyren under er skrevet mot koden, men **ikke kjørt mot datasettet** — den trenger noen med BigQuery-tilgang. Start med måle-spørringene i steg 0: hvis de gir null, er det ingenting å gjøre.

---

## Cleaning up the existing duplicates

The fix stops new duplicates from being written. It does not remove the ones already in
the tables. **Read the caveats at the end before running any of this.**

### Step 0 — measure

Run per table (`usage_metrics`, `user_teams`, `user_metrics`, `repository_metrics`).
Both queries are read-only.

```sql
-- Same-scope byte-identical duplicates: rows differing only in loaded_at.
SELECT
  day,
  scope_id,
  COUNT(*)                                              AS rows_total,
  COUNT(DISTINCT TO_JSON_STRING(raw_record))            AS rows_distinct,
  COUNT(*) - COUNT(DISTINCT TO_JSON_STRING(raw_record)) AS rows_removable
FROM `PROJECT.copilot_metrics.usage_metrics`
GROUP BY day, scope_id
HAVING rows_removable > 0
ORDER BY day DESC;
```

```sql
-- Cross-scope duplication: the same day under more than one scope_id.
-- The dedupe below does NOT touch these — see caveat 2.
SELECT day, ARRAY_AGG(DISTINCT scope_id ORDER BY scope_id) AS scope_ids, COUNT(*) AS rows_total
FROM `PROJECT.copilot_metrics.usage_metrics`
GROUP BY day
HAVING COUNT(DISTINCT scope_id) > 1
ORDER BY day DESC;
```

If `rows_removable` is 0 everywhere and no day spans scopes, stop here.

### Step 1 — build the deduped table with an explicit schema

The obvious one-liner, `CREATE OR REPLACE TABLE … AS SELECT`, is **wrong here**: a CTAS
infers its schema from the query, so all five `REQUIRED` columns silently become
`NULLABLE`, and the column and table descriptions are dropped. `ensureMetricsTable`
(`apps/copilot-metrics/bigquery.go`) returns early for a table that already exists, so it
will never repair that — and BigQuery cannot tighten `NULLABLE` back to `REQUIRED` with
`ALTER TABLE`. The degraded schema would be permanent short of another rewrite.

So declare the schema explicitly and fill it with a plain `INSERT`. The DDL below is a
transcription of `ensureMetricsTable`'s schema and must stay in step with it.

```sql
CREATE OR REPLACE TABLE `PROJECT.copilot_metrics.usage_metrics_dedupe`
(
  day        DATE      NOT NULL OPTIONS (description = 'Calendar day of the metrics'),
  scope      STRING    NOT NULL OPTIONS (description = 'enterprise or organization'),
  scope_id   STRING    NOT NULL OPTIONS (description = 'Enterprise/org identifier'),
  raw_record JSON      NOT NULL OPTIONS (description = 'Full NDJSON record as-is'),
  loaded_at  TIMESTAMP NOT NULL OPTIONS (description = 'When the row was inserted')
)
PARTITION BY day
CLUSTER BY scope, scope_id
OPTIONS (description = 'GitHub Copilot usage metrics from the Usage Metrics API');
```

`PARTITION BY` / `CLUSTER BY` are restated because a new table inherits neither — an
unpartitioned copy of these tables turns every view into a full scan.

```sql
INSERT INTO `PROJECT.copilot_metrics.usage_metrics_dedupe`
  (day, scope, scope_id, raw_record, loaded_at)
SELECT day, scope, scope_id, raw_record, loaded_at
FROM (
  SELECT
    *,
    ROW_NUMBER() OVER (
      PARTITION BY day, scope, scope_id, TO_JSON_STRING(raw_record)
      ORDER BY loaded_at
    ) AS rn
  FROM `PROJECT.copilot_metrics.usage_metrics`
)
WHERE rn = 1;
```

`ORDER BY loaded_at` keeps the **earliest** copy of each group. The rows in a group are
byte-identical in `raw_record`, so the only thing this decides is which `loaded_at`
survives; earliest is the honest answer to "when did we first have this row".

For the other three tables, change both table names and the table-level `description`:

| table | description |
| --- | --- |
| `usage_metrics` | `GitHub Copilot usage metrics from the Usage Metrics API` |
| `user_teams` | `GitHub Copilot user-to-team mappings from the Usage Metrics API` |
| `user_metrics` | `GitHub Copilot per-user usage metrics from the Usage Metrics API` |
| `repository_metrics` | `GitHub Copilot per-repository usage metrics from the Usage Metrics API` |

### Step 2 — verify before swapping

```sql
SELECT
  (SELECT COUNT(*) FROM `PROJECT.copilot_metrics.usage_metrics`)        AS before_rows,
  (SELECT COUNT(*) FROM `PROJECT.copilot_metrics.usage_metrics_dedupe`) AS after_rows,
  (SELECT COUNT(DISTINCT day) FROM `PROJECT.copilot_metrics.usage_metrics`)        AS before_days,
  (SELECT COUNT(DISTINCT day) FROM `PROJECT.copilot_metrics.usage_metrics_dedupe`) AS after_days;
```

`after_days` must equal `before_days` — no day may disappear. `before_rows - after_rows`
must equal the `rows_removable` total from Step 0.

```sql
SELECT column_name, is_nullable, data_type
FROM `PROJECT.copilot_metrics.INFORMATION_SCHEMA.COLUMNS`
WHERE table_name = 'usage_metrics_dedupe';
```

All five columns must read `is_nullable = 'NO'`. If any reads `YES`, the DDL in Step 1
did not apply — do not swap.

### Step 3 — swap, keeping the original as the rollback

```sql
ALTER TABLE `PROJECT.copilot_metrics.usage_metrics`        RENAME TO usage_metrics_pre_dedupe;
ALTER TABLE `PROJECT.copilot_metrics.usage_metrics_dedupe` RENAME TO usage_metrics;
```

The new name in `RENAME TO` is unqualified — BigQuery renames within the same dataset.

To roll back, reverse the two renames. Once the dashboards and the next nightly run look
right, `DROP TABLE PROJECT.copilot_metrics.usage_metrics_pre_dedupe`.

BigQuery refuses to rename a table with rows still in the streaming buffer, so run this at
least ~90 minutes after the last ingest — see caveat 4.

## Caveats — what this cleanup does and does not fix

1. **It only removes same-scope, byte-identical duplicates.** `PARTITION BY day, scope,
   scope_id, TO_JSON_STRING(raw_record)` is deliberately narrow: it targets exactly what
   the fixed bug produced — the identical report appended again under the identical
   `scope_id`, run after run.

2. **It does not remove cross-scope duplication.** A day present under both `nav` and
   `navikt` falls into two different window partitions, so both copies survive. That is
   the `usage_metrics` duplication described in #400, and no automatic rule resolves it:
   the enterprise and org reports cover different populations, so choosing a winner is a
   judgement call. Run the cross-scope query in Step 0, decide per day, and delete the
   loser explicitly **before** Step 1:

   ```sql
   DELETE FROM `PROJECT.copilot_metrics.usage_metrics`
   WHERE day = 'YYYY-MM-DD' AND scope_id = 'navikt';
   ```

   Deletes fail while the rows are still in the streaming buffer — same ~90 minute wait.

3. **It does not remove revised re-ingests.** If GitHub restated a day and it was ingested
   again, the two copies differ in `raw_record`, land in different window partitions, and
   both survive. Removing those needs a "keep the newest `loaded_at` per (day, scope_id)"
   rule, which is a different and far more destructive statement — do not conflate the two
   by widening the `PARTITION BY` above.

4. **Run it while the nightly job is idle.** Rows streamed in mid-cleanup land in the old
   table and are lost at the swap, and both `RENAME` and `DELETE` fail outright while rows
   sit in the streaming buffer. Coordinate with the CronJob schedule.

5. **Dry-run everything first.** `bq query --dry_run --use_legacy_sql=false '<statement>'`
   validates syntax and reports bytes scanned without touching data. These statements were
   written against `bigquery.go` but not executed against the live dataset.
