### PR TITLE
aksel-builder: presiser at Alert er avviklet i skill-referansene

### DIFF
--- a/skills/aksel-builder/references/components.md
+++ b/skills/aksel-builder/references/components.md
@@ -13,7 +13,7 @@ trust the table alone for props.
 
 > Names move over time — some are new (`Dialog`, `LinkCard`, `GlobalAlert`, `LocalAlert`,
 > `InfoCard`, `InlineMessage`), some carry prefixes (`UNSAFE_Combobox`), some are deprecated
-> (`LinkPanel`, `Panel`, `Box.New`). Let MCP confirm the current name when unsure.
+> (`Alert`, `LinkPanel`, `Panel`, `Box.New`). Let MCP confirm the current name when unsure.
 
 ## Need → component
 
@@ -71,7 +71,7 @@ trust the table alone for props.
 
 | Need                 | Use                                                                        |
 | -------------------- | -------------------------------------------------------------------------- |
-| Inline page alert    | `Alert` (or `LocalAlert` / `GlobalAlert` / `InfoCard` — verify which fits) |
+| Inline page alert    | `LocalAlert` / `GlobalAlert` / `InfoCard` — verify which fits              |
 | Short inline message | `InlineMessage`                                                            |
 | Loading spinner      | `Loader`                                                                   |
 | Determinate progress | `ProgressBar`                                                              |

--- a/skills/aksel-builder/references/migrations.md
+++ b/skills/aksel-builder/references/migrations.md
@@ -60,7 +60,7 @@ encodes a color, the code predates v8 — migrate it.
 | `Box.New` / `BoxNew`             | `Box` ([primitives-layout.md](primitives-layout.md)) |
 | `variant="…"` that names a color | `variant` (emphasis) + `data-color` (role)           |
 | Numeric/px spacing on primitives | `space-*` tokens                                     |
-| `LinkPanel`, `Panel`             | deprecated — check docs for the current component    |
+| `Alert`, `LinkPanel`, `Panel`    | deprecated — check docs for the current component    |
 
 When you encounter outdated patterns while editing, prefer running the matching codemod over
 piecemeal hand-edits, then review the diff.


### PR DESCRIPTION
Oppdaterer `aksel-builder`-skillen slik at den ikke lenger anbefaler den avviklede `Alert`-komponenten (https://aksel.nav.no/komponenter/legacy/alert):

- `components.md`: «Inline page alert» peker nå på `LocalAlert` / `GlobalAlert` /  `InfoCard` i stedet for `Alert`, og `Alert` er lagt til i listen over avviklede  komponenter i innledningsnotisen
- `migrations.md`: `Alert` lagt til i «Spotting outdated code»-tabellen