### PR TITLE
feat(nav-pilot): interactive settings page and install scope prompt

### DIFF
--- a/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
+++ b/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
@@ -268,7 +268,10 @@ const PLANNING_SKILLS = [
 const CLI_COMMANDS = [
   { command: "nav-pilot", description: "Interaktivt: installer, oppgrader eller start Copilot-sandkassen (cplt)" },
   { command: "nav-pilot --client opencode", description: "Start OpenCode-sesjonen med Nav-kontekst levert automatisk" },
-  { command: "nav-pilot install <collection>", description: "Installer en collection i repoet ditt" },
+  {
+    command: "nav-pilot install <collection>",
+    description: "Installer en collection — spør om repoet (.github/) eller hjemmekatalogen (~/.copilot/)",
+  },
   {
     command: "nav-pilot install --user",
     description: "Installer agenter, skills og instruksjoner til ~/.copilot (alle repoer)",
@@ -301,6 +304,7 @@ const CLI_COMMANDS = [
   { command: "nav-pilot feedback --feature", description: "Foreslå ny funksjon" },
   { command: "nav-pilot export opencode", description: "Eksporter til .opencode/-format (OpenCode / oh-my-openagent)" },
   { command: "nav-pilot export opencode --user", description: "Eksporter til ~/.config/opencode/ (globalt)" },
+  { command: "nav-pilot config", description: "Interaktiv innstillingsside i terminalen" },
   { command: "nav-pilot config init", description: "Opprett ~/.nav-pilot/config.toml med alle valg kommentert ut" },
   { command: "nav-pilot config setup", description: "Interaktiv konfigurasjonsveileder (klient, modell, modus)" },
   { command: "nav-pilot config show", description: "Vis effektiv konfigurasjon (fil + standardverdier)" },
@@ -719,7 +723,7 @@ nav-pilot`}
                   <CodeBlock compact>{`nav-pilot`}</CodeBlock>
                 </div>
                 <BodyLong className="mt-1" size="small" style={{ color: "#94a3b8" }}>
-                  Starter interaktiv modus — sjekker oppdateringer og tilbyr å starte Copilot med valgt agent.
+                  Starter interaktiv modus — sjekker oppdateringer og starter Copilot med valgt agent.
                 </BodyLong>
               </div>
             </div>
@@ -1836,6 +1840,14 @@ function KlienterOgKonfigurasjonSection() {
           <div className="mt-4 space-y-3">
             <div>
               <Label size="small" style={{ color: "#64748b" }}>
+                Interaktiv innstillingsside i terminalen
+              </Label>
+              <div className="mt-1">
+                <CodeBlock compact>{`nav-pilot config`}</CodeBlock>
+              </div>
+            </div>
+            <div>
+              <Label size="small" style={{ color: "#64748b" }}>
                 Opprett konfigurasjonsfil (alle nøkler kommentert ut)
               </Label>
               <div className="mt-1">
@@ -2047,6 +2059,13 @@ function CliReferenceSection() {
               </tbody>
             </table>
           </div>
+          <BodyLong size="small" className="mt-3" style={{ color: "#475569" }}>
+            <code className="font-mono text-xs">install</code> spør hvor den skal installere — i repoet (
+            <code className="font-mono text-xs">.github/</code>) eller i hjemmekatalogen (
+            <code className="font-mono text-xs">~/.copilot/</code>). Bruk{" "}
+            <code className="font-mono text-xs">--repo</code> eller <code className="font-mono text-xs">--user</code>{" "}
+            for å svare på forhånd og hoppe over spørsmålet.
+          </BodyLong>
         </div>
 
         {/* Advanced examples — basics are shown in "Kom i gang" and "Sync og oppdatering" */}

--- a/apps/my-copilot/src/components/nav-pilot/interactive-setup-wizard.tsx
+++ b/apps/my-copilot/src/components/nav-pilot/interactive-setup-wizard.tsx
@@ -82,7 +82,7 @@ export function generateSetupScript(os: OS, workflow: Workflow, stack: Collectio
 
   blocks.push({
     title: "# 3. Sett opp for ditt prosjekt",
-    commands: [`nav-pilot install ${stack}`, ...WORKFLOW_COMMANDS[workflow]],
+    commands: [`nav-pilot install ${stack} --repo`, ...WORKFLOW_COMMANDS[workflow]],
   });
 
   const codeString = blocks.map((b) => [b.title, ...b.commands].filter(Boolean).join("\n")).join("\n\n");

--- a/apps/my-copilot/src/lib/install-commands.test.ts
+++ b/apps/my-copilot/src/lib/install-commands.test.ts
@@ -314,13 +314,13 @@ describe("getGhSkillInstallCommand", () => {
 describe("getNavPilotAddCommand", () => {
   it("generates nav-pilot install command for agent", () => {
     const result = getNavPilotAddCommand(agent)!;
-    expect(result.repo).toBe("nav-pilot install nais --type agent");
+    expect(result.repo).toBe("nav-pilot install nais --type agent --repo");
     expect(result.user).toBe("nav-pilot install nais --type agent --user");
   });
 
   it("generates nav-pilot install command for agent with explicit id", () => {
     const result = getNavPilotAddCommand(authAgent)!;
-    expect(result.repo).toBe("nav-pilot install auth-agent --type agent");
+    expect(result.repo).toBe("nav-pilot install auth-agent --type agent --repo");
     expect(result.user).toBe("nav-pilot install auth-agent --type agent --user");
   });
 
@@ -335,25 +335,25 @@ describe("getNavPilotAddCommand", () => {
       tools: [],
     };
     const result = getNavPilotAddCommand(securityChampionAgent)!;
-    expect(result.repo).toBe("nav-pilot install security-champion --type agent");
+    expect(result.repo).toBe("nav-pilot install security-champion --type agent --repo");
     expect(result.user).toBe("nav-pilot install security-champion --type agent --user");
   });
 
   it("generates nav-pilot install command for instruction using id, not display name", () => {
     const result = getNavPilotAddCommand(instruction)!;
-    expect(result.repo).toBe("nav-pilot install nextjs-aksel --type instruction");
+    expect(result.repo).toBe("nav-pilot install nextjs-aksel --type instruction --repo");
     expect(result.user).toBe("nav-pilot install nextjs-aksel --type instruction --user");
   });
 
   it("generates nav-pilot install command for prompt", () => {
     const result = getNavPilotAddCommand(prompt)!;
-    expect(result.repo).toBe("nav-pilot install code-review --type prompt");
+    expect(result.repo).toBe("nav-pilot install code-review --type prompt --repo");
     expect(result.user).toBe("nav-pilot install code-review --type prompt --user");
   });
 
   it("generates nav-pilot install command for skill", () => {
     const result = getNavPilotAddCommand(skill)!;
-    expect(result.repo).toBe("nav-pilot install aksel-spacing --type skill");
+    expect(result.repo).toBe("nav-pilot install aksel-spacing --type skill --repo");
     expect(result.user).toBe("nav-pilot install aksel-spacing --type skill --user");
   });
 
@@ -363,7 +363,7 @@ describe("getNavPilotAddCommand", () => {
 
   it("falls back to rawGitHubUrl stem when filePath is unexpected", () => {
     const result = getNavPilotAddCommand({ ...authAgent, filePath: "invalid-path" })!;
-    expect(result.repo).toBe("nav-pilot install auth --type agent");
+    expect(result.repo).toBe("nav-pilot install auth --type agent --repo");
     expect(result.user).toBe("nav-pilot install auth --type agent --user");
   });
 
@@ -378,7 +378,7 @@ describe("getNavPilotAddCommand", () => {
       tools: [],
     };
     const result = getNavPilotAddCommand(kafkaAgent)!;
-    expect(result.repo).toBe("nav-pilot install kafka --type agent");
+    expect(result.repo).toBe("nav-pilot install kafka --type agent --repo");
     expect(result.user).toBe("nav-pilot install kafka --type agent --user");
   });
 });

--- a/apps/my-copilot/src/lib/install-commands.ts
+++ b/apps/my-copilot/src/lib/install-commands.ts
@@ -98,7 +98,7 @@ export function getGhSkillInstallCommand(item: AnyCustomization): string {
 export function getNavPilotAddCommand(item: AnyCustomization): { repo: string; user: string } | null {
   if (item.type === "mcp") return null;
   const cmd = `nav-pilot install ${getNavPilotInstallName(item)} --type ${item.type}`;
-  return { repo: cmd, user: `${cmd} --user` };
+  return { repo: `${cmd} --repo`, user: `${cmd} --user` };
 }
 
 function stemFromPath(path: string | undefined, suffix: string): string | null {

--- a/cli/nav-pilot/internal/cli/aliases.go
+++ b/cli/nav-pilot/internal/cli/aliases.go
@@ -67,8 +67,9 @@ var (
 
 	recordFreshness = providerpkg.RecordFreshness
 
-	copilotEnv = providerpkg.CopilotEnv
-	launchPi   = providerpkg.LaunchPi
+	copilotEnv     = providerpkg.CopilotEnv
+	findCopilotCLI = providerpkg.FindCopilotCLI
+	launchPi       = providerpkg.LaunchPi
 
 	openCodeDefaultModel  = providerpkg.OpenCodeDefaultModel
 	isKnownCopilotModel   = providerpkg.IsKnownCopilotModel

--- a/cli/nav-pilot/internal/cli/cli.go
+++ b/cli/nav-pilot/internal/cli/cli.go
@@ -131,6 +131,28 @@ After installing, use @nav-pilot in GitHub Copilot Chat.
 
 // run parses args and dispatches to the appropriate command.
 // It returns an error instead of calling os.Exit, making it testable.
+// requestedType is the artifact type the invocation asks for, "" when it is up
+// to the installer to work out (a collection or agentpakke name).
+func requestedType(command, installType string, positional []string) string {
+	if command == "add" && len(positional) > 0 {
+		return positional[0]
+	}
+	return installType
+}
+
+// userScopeAccepts reports whether ~/.copilot can hold the given type. An
+// unknown home directory is not a reason to hide the question.
+func userScopeAccepts(itemType string) bool {
+	if itemType == "" {
+		return true
+	}
+	u, err := ScopeUser()
+	if err != nil {
+		return true
+	}
+	return u.SupportsType(itemType)
+}
+
 func run(args []string) error {
 	// Self-check: warn if nav-pilot binary is outdated (fast, cached)
 	assessment := assessStaleness(Version)
@@ -279,8 +301,12 @@ func run(args []string) error {
 			case "--no-ask-user":
 				f := false
 				cliOverrides.AskUser = &f
-			// Retired: accepted and ignored so old aliases and scripts keep working.
-			case "--auto-launch", "--no-auto-launch":
+			case "--auto-launch":
+				t := true
+				cliOverrides.AutoLaunch = &t
+			case "--no-auto-launch":
+				f := false
+				cliOverrides.AutoLaunch = &f
 			case "--":
 				cliOverrides.ExtraArgs = append(cliOverrides.ExtraArgs, args[i+1:]...)
 				i = len(args) // consume the rest
@@ -432,9 +458,10 @@ func run(args []string) error {
 	} else {
 		// For repo scope without explicit --target, resolve to git root
 		// so commands work from any subdirectory.
+		gitRoot := ""
 		if !targetProvided {
-			if root := findGitRoot(targetDir); root != "" {
-				targetDir = root
+			if gitRoot = findGitRoot(targetDir); gitRoot != "" {
+				targetDir = gitRoot
 			}
 		}
 		// An explicit `install <name>` (or `add <type> <name>`) without --user
@@ -445,18 +472,33 @@ func run(args []string) error {
 		// error rather than open a picker.
 		wellFormed := (command == "install" && len(positional) == 1) ||
 			(command == "add" && len(positional) >= 2)
-		if wellFormed && !targetProvided && !jsonOutput && !dryRun && isInteractive() {
+		switch {
+		case !(wellFormed && !targetProvided && !jsonOutput && !dryRun && isInteractive()):
+			scope = ScopeRepo(targetDir)
+		case gitRoot == "":
+			// Outside a git repo the repo answer fails later on, so don't ask.
+			var err error
+			scope, err = ScopeUser()
+			if err != nil {
+				return fmt.Errorf("resolving user home: %w", err)
+			}
+		case !userScopeAccepts(requestedType(command, installType, positional)):
+			// A type user scope cannot hold makes the user answer fail later.
+			scope = ScopeRepo(targetDir)
+		default:
 			var err error
 			scope, err = promptInstallScopeFn(targetDir)
-			if err != nil {
-				return err
-			}
-			if scope == nil {
+			switch {
+			case err != nil:
+				// No usable terminal: keep the pre-prompt behaviour instead of
+				// silently installing nothing.
+				fmt.Fprintf(os.Stderr, "%s Could not ask where to install (%v) — using this repository. Pass %s or %s to choose.\n",
+					yellow("⚠"), err, bold("--user"), bold("--target <dir>"))
+				scope = ScopeRepo(targetDir)
+			case scope == nil:
 				fmt.Println(dim("Cancelled."))
 				return nil
 			}
-		} else {
-			scope = ScopeRepo(targetDir)
 		}
 	}
 

--- a/cli/nav-pilot/internal/cli/cli.go
+++ b/cli/nav-pilot/internal/cli/cli.go
@@ -102,6 +102,7 @@ Flags:
   -r, --ref <ref>         Git branch or tag to install from
   -s, --source <repo>     Source repository or absolute path (default: the config's source key, else navikt/copilot)
   -u, --user              Install to ~/.copilot — works across all repos (agents, skills & instructions only)
+  --repo                  Install to this repository's .github/ (opposite of --user; skips the scope question)
   --type <type>           Artifact type for install (agent, skill, instruction, prompt)
   --all                   Install everything (use with --user)
   --apply                 Apply available updates (sync only)
@@ -120,6 +121,7 @@ Get started:
   nav-pilot install kotlin-backend       # Install a collection to .github/
   nav-pilot install --user --all         # Install everything to ~/.copilot (all repos)
   nav-pilot install security-champion    # Install a single agent
+  nav-pilot install frontend --repo      # Install to this repo without being asked
   nav-pilot sync                         # Check for updates
   nav-pilot export opencode              # Export for OpenCode/oh-my-openagent
   nav-pilot install --source navikt/x    # Install another team's agentpakke (and remember it)
@@ -361,7 +363,7 @@ func run(args []string) error {
 		command = canonical
 	}
 
-	var dryRun, force, apply, jsonOutput, listItems, featureRequest, userScope, targetProvided, installAll, listInstalled bool
+	var dryRun, force, apply, jsonOutput, listItems, featureRequest, userScope, repoScope, targetProvided, installAll, listInstalled bool
 	var targetDir, ref, sourceRepo, installType string
 	var positional []string
 
@@ -387,6 +389,8 @@ func run(args []string) error {
 			featureRequest = true
 		case "-u", "--user":
 			userScope = true
+		case "--repo":
+			repoScope = true
 		case "-t", "--target":
 			if i+1 >= len(rest) {
 				return fmt.Errorf("--target requires a value")
@@ -436,6 +440,14 @@ func run(args []string) error {
 	if userScope && targetProvided {
 		return fmt.Errorf("--user and --target are mutually exclusive")
 	}
+	if repoScope && userScope {
+		return fmt.Errorf("--repo and --user are mutually exclusive")
+	}
+	if repoScope && targetProvided {
+		return fmt.Errorf("--repo and --target are mutually exclusive")
+	}
+	// Any explicit scope flag answers the repo-vs-user question up front.
+	scopeProvided := userScope || repoScope || targetProvided
 
 	// --source participates in the config precedence too, so a launch triggered
 	// from a subcommand resolves the same source the command installed from.
@@ -473,7 +485,7 @@ func run(args []string) error {
 		wellFormed := (command == "install" && len(positional) == 1) ||
 			(command == "add" && len(positional) >= 2)
 		switch {
-		case !(wellFormed && !targetProvided && !jsonOutput && !dryRun && isInteractive()):
+		case !(wellFormed && !scopeProvided && !jsonOutput && !dryRun && isInteractive()):
 			scope = ScopeRepo(targetDir)
 		case gitRoot == "":
 			// Outside a git repo the repo answer fails later on, so don't ask.
@@ -493,7 +505,7 @@ func run(args []string) error {
 				// No usable terminal: keep the pre-prompt behaviour instead of
 				// silently installing nothing.
 				fmt.Fprintf(os.Stderr, "%s Could not ask where to install (%v) — using this repository. Pass %s or %s to choose.\n",
-					yellow("⚠"), err, bold("--user"), bold("--target <dir>"))
+					yellow("⚠"), err, bold("--user"), bold("--repo"))
 				scope = ScopeRepo(targetDir)
 			case scope == nil:
 				fmt.Println(dim("Cancelled."))
@@ -502,13 +514,17 @@ func run(args []string) error {
 		}
 	}
 
-	// Reject --user for commands that don't support scoped installs
-	if userScope {
+	// Reject --user/--repo for commands that don't support scoped installs
+	if userScope || repoScope {
+		flag := "--user"
+		if repoScope {
+			flag = "--repo"
+		}
 		switch command {
 		case "install", "add", "ignore", "sync", "doctor", "uninstall", "export", "list":
-			// These commands support --user
+			// These commands support --user and --repo
 		default:
-			return fmt.Errorf("--user is not supported for %q", command)
+			return fmt.Errorf("%s is not supported for %q", flag, command)
 		}
 	}
 
@@ -580,23 +596,23 @@ func run(args []string) error {
 		})
 	case "sync":
 		syncScope := "auto"
-		if userScope || targetProvided {
+		if scopeProvided {
 			syncScope = scope.Name
 		}
 		return runWithCommandTelemetry("sync", telemetryMode(), syncScope, func() error {
-			if userScope || targetProvided {
+			if scopeProvided {
 				return cmdSync(scope, ref, sourceRepo, apply, jsonOutput)
 			}
 			return cmdSyncAuto(targetDir, ref, sourceRepo, apply, jsonOutput)
 		})
 	case "list":
 		listScope := "none"
-		if userScope || targetProvided {
+		if scopeProvided {
 			listScope = scope.Name
 		}
 		return runWithCommandTelemetry("list", telemetryMode(), listScope, func() error {
 			if listInstalled {
-				if userScope || targetProvided {
+				if scopeProvided {
 					return cmdListInstalledScoped(scope, false, jsonOutput)
 				}
 				return cmdListInstalledAuto(targetDir, jsonOutput)

--- a/cli/nav-pilot/internal/cli/cli.go
+++ b/cli/nav-pilot/internal/cli/cli.go
@@ -279,12 +279,8 @@ func run(args []string) error {
 			case "--no-ask-user":
 				f := false
 				cliOverrides.AskUser = &f
-			case "--auto-launch":
-				t := true
-				cliOverrides.AutoLaunch = &t
-			case "--no-auto-launch":
-				f := false
-				cliOverrides.AutoLaunch = &f
+			// Retired: accepted and ignored so old aliases and scripts keep working.
+			case "--auto-launch", "--no-auto-launch":
 			case "--":
 				cliOverrides.ExtraArgs = append(cliOverrides.ExtraArgs, args[i+1:]...)
 				i = len(args) // consume the rest

--- a/cli/nav-pilot/internal/cli/cli.go
+++ b/cli/nav-pilot/internal/cli/cli.go
@@ -88,7 +88,7 @@ Commands:
   upgrade (up)            Update nav-pilot CLI to the latest version
   uninstall (rm)          Remove installed collection files
   export <format>         Export Nav customizations to another tool's format
-  config <subcommand>     Manage user-specific nav-pilot configuration (init, setup, show, get, set, validate)
+  config [subcommand]     Manage user-specific nav-pilot configuration; no subcommand opens the interactive settings page
   validate                Check that a source repo conforms to the agentpakke contract
   env                     Print shell exports for Copilot CLI integration
   ignore <type> <name>    Suppress new-item reminders for a specific item (--user)
@@ -441,7 +441,27 @@ func run(args []string) error {
 				targetDir = root
 			}
 		}
-		scope = ScopeRepo(targetDir)
+		// An explicit `install <name>` (or `add <type> <name>`) without --user
+		// or --target used to silently fill the repo's .github/. Ask the same
+		// question the bare interactive flow asks. Only well-formed invocations
+		// are prompted: `install` with no name has its own picker in
+		// cmdInstallInteractive, and malformed ones must still report the usage
+		// error rather than open a picker.
+		wellFormed := (command == "install" && len(positional) == 1) ||
+			(command == "add" && len(positional) >= 2)
+		if wellFormed && !targetProvided && !jsonOutput && !dryRun && isInteractive() {
+			var err error
+			scope, err = promptInstallScopeFn(targetDir)
+			if err != nil {
+				return err
+			}
+			if scope == nil {
+				fmt.Println(dim("Cancelled."))
+				return nil
+			}
+		} else {
+			scope = ScopeRepo(targetDir)
+		}
 	}
 
 	// Reject --user for commands that don't support scoped installs

--- a/cli/nav-pilot/internal/cli/config.go
+++ b/cli/nav-pilot/internal/cli/config.go
@@ -178,8 +178,12 @@ func configAdvisories(cfg *Config, meta toml.MetaData) []string {
 	if cfg == nil {
 		return nil
 	}
+	var out []string
+	if cfg.AutoLaunch != nil {
+		out = append(out, fmt.Sprintf("auto_launch is no longer used — nav-pilot launches directly after install; you can remove it from %s", configPath()))
+	}
 	if cfg.Model == nil || validateModelValue(*cfg.Model) != nil {
-		return nil
+		return out
 	}
 	clientID := "copilot"
 	if cfg.Client != nil {
@@ -187,12 +191,12 @@ func configAdvisories(cfg *Config, meta toml.MetaData) []string {
 	}
 	p, err := providerFor(clientID)
 	if err != nil {
-		return nil
+		return out
 	}
 	if msg := p.ModelAdvisory(*cfg.Model); msg != "" {
-		return []string{msg}
+		out = append(out, msg)
 	}
-	return nil
+	return out
 }
 
 // loadConfigForLaunch reads, validates, and resolves the user config ahead of a
@@ -271,9 +275,6 @@ func resolve(file *Config, cli CLIOverrides) ResolvedConfig {
 		if file.AskUser != nil {
 			r.AskUser = *file.AskUser
 		}
-		if file.AutoLaunch != nil {
-			r.AutoLaunch = *file.AutoLaunch
-		}
 		if file.AutoUpdate != nil {
 			r.AutoUpdate = *file.AutoUpdate
 		}
@@ -315,9 +316,6 @@ func resolve(file *Config, cli CLIOverrides) ResolvedConfig {
 	}
 	if cli.AskUser != nil {
 		r.AskUser = *cli.AskUser
-	}
-	if cli.AutoLaunch != nil {
-		r.AutoLaunch = *cli.AutoLaunch
 	}
 	if cli.LogLevel != "" {
 		r.LogLevel = cli.LogLevel

--- a/cli/nav-pilot/internal/cli/config.go
+++ b/cli/nav-pilot/internal/cli/config.go
@@ -178,12 +178,8 @@ func configAdvisories(cfg *Config, meta toml.MetaData) []string {
 	if cfg == nil {
 		return nil
 	}
-	var out []string
-	if cfg.AutoLaunch != nil {
-		out = append(out, fmt.Sprintf("auto_launch is no longer used — nav-pilot launches directly after install; you can remove it from %s", configPath()))
-	}
 	if cfg.Model == nil || validateModelValue(*cfg.Model) != nil {
-		return out
+		return nil
 	}
 	clientID := "copilot"
 	if cfg.Client != nil {
@@ -191,12 +187,12 @@ func configAdvisories(cfg *Config, meta toml.MetaData) []string {
 	}
 	p, err := providerFor(clientID)
 	if err != nil {
-		return out
+		return nil
 	}
 	if msg := p.ModelAdvisory(*cfg.Model); msg != "" {
-		out = append(out, msg)
+		return []string{msg}
 	}
-	return out
+	return nil
 }
 
 // loadConfigForLaunch reads, validates, and resolves the user config ahead of a
@@ -246,6 +242,7 @@ func resolve(file *Config, cli CLIOverrides) ResolvedConfig {
 		Client:       "copilot",
 		Mode:         "default",
 		AskUser:      true,
+		AutoLaunch:   true,
 		OtelLogLevel: "none",
 	}
 
@@ -274,6 +271,9 @@ func resolve(file *Config, cli CLIOverrides) ResolvedConfig {
 		}
 		if file.AskUser != nil {
 			r.AskUser = *file.AskUser
+		}
+		if file.AutoLaunch != nil {
+			r.AutoLaunch = *file.AutoLaunch
 		}
 		if file.AutoUpdate != nil {
 			r.AutoUpdate = *file.AutoUpdate
@@ -316,6 +316,9 @@ func resolve(file *Config, cli CLIOverrides) ResolvedConfig {
 	}
 	if cli.AskUser != nil {
 		r.AskUser = *cli.AskUser
+	}
+	if cli.AutoLaunch != nil {
+		r.AutoLaunch = *cli.AutoLaunch
 	}
 	if cli.LogLevel != "" {
 		r.LogLevel = cli.LogLevel

--- a/cli/nav-pilot/internal/cli/config_cmd.go
+++ b/cli/nav-pilot/internal/cli/config_cmd.go
@@ -104,14 +104,6 @@ var configKeyDefs = []configKeyDef{
 		flag:        "--no-ask-user (when false)",
 	},
 	{
-		name:        "auto_launch",
-		kind:        keyKindBool,
-		description: "Launch the coding-agent CLI immediately, skipping the \"Launch X now?\" confirmation.",
-		allowed:     nil,
-		defaultVal:  "false",
-		flag:        "--auto-launch / --no-auto-launch",
-	},
-	{
 		name:        "auto_update",
 		kind:        keyKindBool,
 		description: "Automatically upgrade nav-pilot when a new version is available, skipping the interactive prompt.",
@@ -227,12 +219,6 @@ version = 1
 # Default: true
 # Corresponds to Copilot CLI flag: --no-ask-user (when false)
 # ask_user = true
-
-# Launch the coding-agent CLI immediately after sync/install, skipping the
-# interactive "Launch <client> now?" confirmation prompt.
-# Default: false
-# Corresponds to nav-pilot flag: --auto-launch / --no-auto-launch
-# auto_launch = false
 
 # Automatically upgrade nav-pilot when a new version is available, skipping the
 # interactive prompt.
@@ -352,7 +338,6 @@ func cmdConfigShow(jsonOutput bool) error {
 			"context_tier":     resolved.ContextTier,
 			"allow_all_tools":  resolved.AllowAllTools,
 			"ask_user":         resolved.AskUser,
-			"auto_launch":      resolved.AutoLaunch,
 			"auto_update":      resolved.AutoUpdate,
 			"log_level":        resolved.LogLevel,
 			"otel_log_level":   resolved.OtelLogLevel,
@@ -424,8 +409,6 @@ func resolvedFieldStr(r ResolvedConfig, key string) string {
 		return strconv.FormatBool(r.AllowAllTools)
 	case "ask_user":
 		return strconv.FormatBool(r.AskUser)
-	case "auto_launch":
-		return strconv.FormatBool(r.AutoLaunch)
 	case "auto_update":
 		return strconv.FormatBool(r.AutoUpdate)
 	case "log_level":

--- a/cli/nav-pilot/internal/cli/config_cmd.go
+++ b/cli/nav-pilot/internal/cli/config_cmd.go
@@ -104,6 +104,14 @@ var configKeyDefs = []configKeyDef{
 		flag:        "--no-ask-user (when false)",
 	},
 	{
+		name:        "auto_launch",
+		kind:        keyKindBool,
+		description: "Launch the coding agent automatically after install/sync. Set to false to never launch it; nav-pilot prints the command instead.",
+		allowed:     nil,
+		defaultVal:  "true",
+		flag:        "--auto-launch / --no-auto-launch",
+	},
+	{
 		name:        "auto_update",
 		kind:        keyKindBool,
 		description: "Automatically upgrade nav-pilot when a new version is available, skipping the interactive prompt.",
@@ -220,6 +228,12 @@ version = 1
 # Corresponds to Copilot CLI flag: --no-ask-user (when false)
 # ask_user = true
 
+# Launch the coding agent automatically after sync/install. Set to false to
+# never launch it; nav-pilot prints the ready-to-run command instead.
+# Default: true
+# Corresponds to nav-pilot flag: --auto-launch / --no-auto-launch
+# auto_launch = true
+
 # Automatically upgrade nav-pilot when a new version is available, skipping the
 # interactive prompt.
 # Default: false
@@ -248,12 +262,25 @@ version = 1
 
 // ─── Subcommand dispatch ──────────────────────────────────────────────────────
 
+// cmdConfigPageFn is the settings page, overridable in tests so the fallback
+// can be exercised without a terminal.
+var cmdConfigPageFn = cmdConfigPage
+
 func cmdConfig(args []string, force bool, jsonOutput bool) error {
 	if len(args) == 0 {
 		// On a terminal, bare `config` opens the interactive settings page;
-		// scripts keep the usage error.
-		if isInteractive() {
-			return cmdConfigPage()
+		// scripts and --json keep the usage error, and so does a page that
+		// could not start (stdin on a char device with no controlling tty).
+		if isInteractive() && !jsonOutput {
+			err := cmdConfigPageFn()
+			if err == nil {
+				return nil
+			}
+			// A page that could not start falls back to the usage error; a
+			// broken config file must still say so.
+			if !errors.Is(err, errConfigPageUnavailable) {
+				return err
+			}
 		}
 		return fmt.Errorf("config requires a subcommand.\n\nUsage: nav-pilot config <subcommand> [options]\n\nSubcommands:\n  init      Create ~/.nav-pilot/config.toml with all options commented out\n  setup     Run the interactive first-run setup wizard\n  show      Print effective configuration (file values merged with defaults)\n  path      Print the config file path\n  get       Print one key value\n  set       Set a key value (creates file if missing)\n  validate  Validate config syntax, unknown keys, and values\n  explain   Describe configuration keys\n  sandbox   Interactively configure cplt sandbox profile")
 	}
@@ -338,6 +365,7 @@ func cmdConfigShow(jsonOutput bool) error {
 			"context_tier":     resolved.ContextTier,
 			"allow_all_tools":  resolved.AllowAllTools,
 			"ask_user":         resolved.AskUser,
+			"auto_launch":      resolved.AutoLaunch,
 			"auto_update":      resolved.AutoUpdate,
 			"log_level":        resolved.LogLevel,
 			"otel_log_level":   resolved.OtelLogLevel,
@@ -409,6 +437,8 @@ func resolvedFieldStr(r ResolvedConfig, key string) string {
 		return strconv.FormatBool(r.AllowAllTools)
 	case "ask_user":
 		return strconv.FormatBool(r.AskUser)
+	case "auto_launch":
+		return strconv.FormatBool(r.AutoLaunch)
 	case "auto_update":
 		return strconv.FormatBool(r.AutoUpdate)
 	case "log_level":
@@ -487,16 +517,26 @@ func writeConfigKey(key, value string) (string, error) {
 		}
 	}
 
-	// Find and replace the first matching line (active or commented-out).
-	found := false
+	// Replace an active line for the key if there is one anywhere in the file,
+	// and only otherwise a commented-out one: replacing the comment while an
+	// active line lives further down would define the key twice and leave the
+	// config unparseable.
+	replace := -1
 	for i, line := range lines {
-		if isConfigKeyLine(line, key) {
-			lines[i] = newLine
-			found = true
+		if !isConfigKeyLine(line, key) {
+			continue
+		}
+		if !strings.HasPrefix(strings.TrimLeft(line, " \t"), "#") {
+			replace = i
 			break
 		}
+		if replace == -1 {
+			replace = i
+		}
 	}
-	if !found {
+	if replace >= 0 {
+		lines[replace] = newLine
+	} else {
 		lines = append(lines, newLine)
 	}
 

--- a/cli/nav-pilot/internal/cli/config_cmd.go
+++ b/cli/nav-pilot/internal/cli/config_cmd.go
@@ -264,6 +264,11 @@ version = 1
 
 func cmdConfig(args []string, force bool, jsonOutput bool) error {
 	if len(args) == 0 {
+		// On a terminal, bare `config` opens the interactive settings page;
+		// scripts keep the usage error.
+		if isInteractive() {
+			return cmdConfigPage()
+		}
 		return fmt.Errorf("config requires a subcommand.\n\nUsage: nav-pilot config <subcommand> [options]\n\nSubcommands:\n  init      Create ~/.nav-pilot/config.toml with all options commented out\n  setup     Run the interactive first-run setup wizard\n  show      Print effective configuration (file values merged with defaults)\n  path      Print the config file path\n  get       Print one key value\n  set       Set a key value (creates file if missing)\n  validate  Validate config syntax, unknown keys, and values\n  explain   Describe configuration keys\n  sandbox   Interactively configure cplt sandbox profile")
 	}
 
@@ -361,88 +366,13 @@ func cmdConfigShow(jsonOutput bool) error {
 		fmt.Printf("# Config file: %s\n\n", path)
 	}
 
-	printField := func(key, val, src string) {
+	for _, key := range configPageKeys {
+		val := configKeyValue(resolved, key)
 		if val == "" {
-			fmt.Printf("  %-20s = %-20s (%s)\n", key, "(unset)", src)
-		} else {
-			fmt.Printf("  %-20s = %-20s (%s)\n", key, val, src)
+			val = "(unset)"
 		}
+		fmt.Printf("  %-20s = %-20s (%s)\n", key, val, configKeySource(cfg, key))
 	}
-	printBoolField := func(key string, val bool, src string) {
-		fmt.Printf("  %-20s = %-20s (%s)\n", key, strconv.FormatBool(val), src)
-	}
-
-	clientSrc := "default"
-	if cfg != nil && cfg.Client != nil {
-		clientSrc = "file"
-	}
-	printField("client", resolved.Client, clientSrc)
-
-	sourceSrc := "default"
-	if cfg != nil && cfg.Source != nil && strings.TrimSpace(*cfg.Source) != "" {
-		sourceSrc = "file"
-	}
-	printField("source", effectiveSourceLabel(resolved), sourceSrc)
-
-	modelSrc := "unset"
-	if cfg != nil && cfg.Model != nil {
-		modelSrc = "file"
-	}
-	printField("model", resolved.Model, modelSrc)
-
-	modeSrc := "default"
-	if cfg != nil && cfg.Mode != nil {
-		modeSrc = "file"
-	}
-	printField("mode", resolved.Mode, modeSrc)
-
-	effortSrc := "unset"
-	if cfg != nil && cfg.ReasoningEffort != nil {
-		effortSrc = "file"
-	}
-	printField("reasoning_effort", resolved.ReasoningEffort, effortSrc)
-
-	tierSrc := "unset"
-	if cfg != nil && cfg.ContextTier != nil {
-		tierSrc = "file"
-	}
-	printField("context_tier", resolved.ContextTier, tierSrc)
-
-	toolsSrc := "default"
-	if cfg != nil && cfg.AllowAllTools != nil {
-		toolsSrc = "file"
-	}
-	printBoolField("allow_all_tools", resolved.AllowAllTools, toolsSrc)
-
-	askSrc := "default"
-	if cfg != nil && cfg.AskUser != nil {
-		askSrc = "file"
-	}
-	printBoolField("ask_user", resolved.AskUser, askSrc)
-
-	autoLaunchSrc := "default"
-	if cfg != nil && cfg.AutoLaunch != nil {
-		autoLaunchSrc = "file"
-	}
-	printBoolField("auto_launch", resolved.AutoLaunch, autoLaunchSrc)
-
-	autoUpdateSrc := "default"
-	if cfg != nil && cfg.AutoUpdate != nil {
-		autoUpdateSrc = "file"
-	}
-	printBoolField("auto_update", resolved.AutoUpdate, autoUpdateSrc)
-
-	logSrc := "unset"
-	if cfg != nil && cfg.LogLevel != nil {
-		logSrc = "file"
-	}
-	printField("log_level", resolved.LogLevel, logSrc)
-
-	otelSrc := "default"
-	if cfg != nil && cfg.OtelLogLevel != nil {
-		otelSrc = "file"
-	}
-	printField("otel_log_level", resolved.OtelLogLevel, otelSrc)
 
 	return nil
 }

--- a/cli/nav-pilot/internal/cli/config_cmd_test.go
+++ b/cli/nav-pilot/internal/cli/config_cmd_test.go
@@ -225,7 +225,7 @@ func TestCmdConfigExplain_AllKeys(t *testing.T) {
 	if explainErr != nil {
 		t.Fatalf("cmdConfigExplain(\"\") returned error: %v", explainErr)
 	}
-	for _, key := range []string{"client", "model", "mode", "reasoning_effort", "context_tier", "allow_all_tools", "ask_user", "auto_launch", "log_level", "otel_log_level", "version"} {
+	for _, key := range []string{"client", "model", "mode", "reasoning_effort", "context_tier", "allow_all_tools", "ask_user", "log_level", "otel_log_level", "version"} {
 		if !strings.Contains(out, key) {
 			t.Errorf("expected key %q in all-keys explain output", key)
 		}

--- a/cli/nav-pilot/internal/cli/config_cmd_test.go
+++ b/cli/nav-pilot/internal/cli/config_cmd_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -225,7 +226,7 @@ func TestCmdConfigExplain_AllKeys(t *testing.T) {
 	if explainErr != nil {
 		t.Fatalf("cmdConfigExplain(\"\") returned error: %v", explainErr)
 	}
-	for _, key := range []string{"client", "model", "mode", "reasoning_effort", "context_tier", "allow_all_tools", "ask_user", "log_level", "otel_log_level", "version"} {
+	for _, key := range []string{"client", "model", "mode", "reasoning_effort", "context_tier", "allow_all_tools", "ask_user", "auto_launch", "log_level", "otel_log_level", "version"} {
 		if !strings.Contains(out, key) {
 			t.Errorf("expected key %q in all-keys explain output", key)
 		}
@@ -432,5 +433,70 @@ func TestConfigHints_EmptyShortIDFallsBack(t *testing.T) {
 	}
 	if strings.Contains(hints[0], "model \"\"") {
 		t.Errorf("hint should not suggest empty model: %s", hints[0])
+	}
+}
+
+// Bare `config` opens the settings page only on a terminal without --json, and
+// a page that cannot start falls back to the usage error instead of the raw
+// TTY error.
+func TestCmdConfig_NoArgsJSONAndPageFallback(t *testing.T) {
+	isolatedConfig(t)
+	forceInteractive(t)
+
+	opened := false
+	orig := cmdConfigPageFn
+	t.Cleanup(func() { cmdConfigPageFn = orig })
+	cmdConfigPageFn = func() error {
+		opened = true
+		return fmt.Errorf("%w: huh: could not open a new TTY", errConfigPageUnavailable)
+	}
+
+	err := cmdConfig(nil, false, true)
+	if err == nil || !strings.Contains(err.Error(), "requires a subcommand") {
+		t.Errorf("config --json = %v, want the usage error", err)
+	}
+	if opened {
+		t.Error("config --json must not open the settings page")
+	}
+
+	err = cmdConfig(nil, false, false)
+	if err == nil || !strings.Contains(err.Error(), "requires a subcommand") {
+		t.Errorf("config with an unstartable page = %v, want the usage error", err)
+	}
+	if !opened {
+		t.Error("config on a terminal must try the settings page")
+	}
+}
+
+// A commented-out key must not be rewritten while an active one exists: that
+// defines the key twice and leaves the config unparseable.
+func TestWriteConfigKey_PrefersActiveLineOverComment(t *testing.T) {
+	path := writeTempConfig(t, "version = 1\n# model = \"auto\"\nclient = \"copilot\"\nmodel = \"gpt-5.5\"\n")
+	t.Setenv("NAV_PILOT_CONFIG", path)
+
+	if _, err := writeConfigKey("model", "claude-opus-4.8"); err != nil {
+		t.Fatalf("writeConfigKey: %v", err)
+	}
+
+	cfg, err := readConfig()
+	if err != nil {
+		t.Fatalf("config no longer parses: %v", err)
+	}
+	if cfg.Model == nil || *cfg.Model != "claude-opus-4.8" {
+		t.Errorf("model = %v, want claude-opus-4.8", cfg.Model)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	active := 0
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "model") {
+			active++
+		}
+	}
+	if active != 1 {
+		t.Errorf("%d active model keys, want 1:\n%s", active, data)
 	}
 }

--- a/cli/nav-pilot/internal/cli/config_page.go
+++ b/cli/nav-pilot/internal/cli/config_page.go
@@ -22,6 +22,7 @@ var configPageKeys = []string{
 	"context_tier",
 	"allow_all_tools",
 	"ask_user",
+	"auto_launch",
 	"auto_update",
 	"log_level",
 	"otel_log_level",
@@ -69,6 +70,8 @@ func configKeyInFile(cfg *Config, key string) bool {
 		return cfg.AllowAllTools != nil
 	case "ask_user":
 		return cfg.AskUser != nil
+	case "auto_launch":
+		return cfg.AutoLaunch != nil
 	case "auto_update":
 		return cfg.AutoUpdate != nil
 	case "log_level":
@@ -123,10 +126,17 @@ const (
 	configPageDone    = "\x00done"
 )
 
+// errConfigPageUnavailable reports that the settings page never started, e.g.
+// because there is no usable terminal. Callers fall back to their non-
+// interactive behaviour; every other error is a real failure worth surfacing.
+var errConfigPageUnavailable = errors.New("settings page unavailable")
+
 // cmdConfigPage runs the interactive settings page: pick a key, edit it, repeat.
 // It is what `nav-pilot config` with no subcommand does on a terminal.
 func cmdConfigPage() error {
-	fmt.Printf("%s %s\n\n", dim("Config file:"), configPath())
+	// The header waits for the first successful render: a page that cannot open
+	// a TTY must leave no trace before its caller falls back.
+	rendered := false
 
 	for {
 		cfg, err := readConfig()
@@ -163,7 +173,14 @@ func cmdConfigPage() error {
 			if errors.Is(err, huh.ErrUserAborted) {
 				return nil
 			}
+			if !rendered {
+				return fmt.Errorf("%w: %v", errConfigPageUnavailable, err)
+			}
 			return err
+		}
+		if !rendered {
+			rendered = true
+			fmt.Printf("%s %s\n\n", dim("Config file:"), configPath())
 		}
 
 		switch choice {

--- a/cli/nav-pilot/internal/cli/config_page.go
+++ b/cli/nav-pilot/internal/cli/config_page.go
@@ -22,7 +22,6 @@ var configPageKeys = []string{
 	"context_tier",
 	"allow_all_tools",
 	"ask_user",
-	"auto_launch",
 	"auto_update",
 	"log_level",
 	"otel_log_level",
@@ -70,8 +69,6 @@ func configKeyInFile(cfg *Config, key string) bool {
 		return cfg.AllowAllTools != nil
 	case "ask_user":
 		return cfg.AskUser != nil
-	case "auto_launch":
-		return cfg.AutoLaunch != nil
 	case "auto_update":
 		return cfg.AutoUpdate != nil
 	case "log_level":

--- a/cli/nav-pilot/internal/cli/config_page.go
+++ b/cli/nav-pilot/internal/cli/config_page.go
@@ -1,0 +1,270 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+)
+
+// ─── Key listing (shared with config show) ───────────────────────────────────
+
+// configPageKeys lists the user-facing keys, in display order. Internal
+// bookkeeping keys (version, rtk_prompted_*) are deliberately left out.
+var configPageKeys = []string{
+	"client",
+	"source",
+	"model",
+	"mode",
+	"reasoning_effort",
+	"context_tier",
+	"allow_all_tools",
+	"ask_user",
+	"auto_launch",
+	"auto_update",
+	"log_level",
+	"otel_log_level",
+}
+
+// configKeyValue returns the effective value of a key as displayed, spelling
+// out the built-in default repo when no source is persisted.
+func configKeyValue(r ResolvedConfig, key string) string {
+	if key == "source" {
+		return effectiveSourceLabel(r)
+	}
+	return resolvedFieldStr(r, key)
+}
+
+// configKeySource labels where a key's effective value comes from: "file" when
+// the config file sets it, otherwise "default" or "unset" depending on whether
+// the key has a built-in default.
+func configKeySource(cfg *Config, key string) string {
+	if cfg != nil && configKeyInFile(cfg, key) {
+		return "file"
+	}
+	if kd := findKeyDef(key); kd != nil && kd.defaultVal != "" {
+		return "default"
+	}
+	return "unset"
+}
+
+// configKeyInFile reports whether the config file sets the key. An empty source
+// counts as unset — it is the documented way to fall back to the default.
+func configKeyInFile(cfg *Config, key string) bool {
+	switch key {
+	case "client":
+		return cfg.Client != nil
+	case "source":
+		return cfg.Source != nil && strings.TrimSpace(*cfg.Source) != ""
+	case "model":
+		return cfg.Model != nil
+	case "mode":
+		return cfg.Mode != nil
+	case "reasoning_effort":
+		return cfg.ReasoningEffort != nil
+	case "context_tier":
+		return cfg.ContextTier != nil
+	case "allow_all_tools":
+		return cfg.AllowAllTools != nil
+	case "ask_user":
+		return cfg.AskUser != nil
+	case "auto_launch":
+		return cfg.AutoLaunch != nil
+	case "auto_update":
+		return cfg.AutoUpdate != nil
+	case "log_level":
+		return cfg.LogLevel != nil
+	case "otel_log_level":
+		return cfg.OtelLogLevel != nil
+	}
+	return false
+}
+
+// configPageEntry is one row of the settings page.
+type configPageEntry struct {
+	Key         string
+	Value       string // "" = unset
+	Source      string // file / default / unset
+	Description string
+}
+
+// label renders the entry as the select option text.
+func (e configPageEntry) label() string {
+	val := e.Value
+	if val == "" {
+		val = "(unset)"
+	}
+	return fmt.Sprintf("%s = %s  (%s)", e.Key, val, e.Source)
+}
+
+// buildConfigPageEntries lists the user-facing keys with their current value,
+// source and description.
+func buildConfigPageEntries(cfg *Config, r ResolvedConfig) []configPageEntry {
+	entries := make([]configPageEntry, 0, len(configPageKeys))
+	for _, key := range configPageKeys {
+		kd := findKeyDef(key)
+		if kd == nil {
+			continue
+		}
+		entries = append(entries, configPageEntry{
+			Key:         key,
+			Value:       configKeyValue(r, key),
+			Source:      configKeySource(cfg, key),
+			Description: kd.description,
+		})
+	}
+	return entries
+}
+
+// ─── The page ────────────────────────────────────────────────────────────────
+
+// Sentinel option values; no config key can collide with them.
+const (
+	configPageSandbox = "\x00sandbox"
+	configPageDone    = "\x00done"
+)
+
+// cmdConfigPage runs the interactive settings page: pick a key, edit it, repeat.
+// It is what `nav-pilot config` with no subcommand does on a terminal.
+func cmdConfigPage() error {
+	fmt.Printf("%s %s\n\n", dim("Config file:"), configPath())
+
+	for {
+		cfg, err := readConfig()
+		if err != nil {
+			return err
+		}
+		resolved := resolve(cfg, CLIOverrides{})
+		entries := buildConfigPageEntries(cfg, resolved)
+
+		descriptions := map[string]string{
+			configPageSandbox: "Runs the cplt sandbox wizard (requires cplt on your PATH).",
+			configPageDone:    "Leave the settings page.",
+		}
+		opts := make([]huh.Option[string], 0, len(entries)+2)
+		for _, e := range entries {
+			opts = append(opts, huh.NewOption(e.label(), e.Key))
+			descriptions[e.Key] = e.Description
+		}
+		opts = append(opts,
+			huh.NewOption("Configure cplt sandbox settings…", configPageSandbox),
+			huh.NewOption("Done", configPageDone),
+		)
+
+		choice := entries[0].Key
+		err = huh.NewSelect[string]().
+			Title("nav-pilot settings").
+			Options(opts...).
+			DescriptionFunc(func() string { return descriptions[choice] }, &choice).
+			Value(&choice).
+			WithTheme(navTheme()).
+			Run()
+		if err != nil {
+			// Esc / Ctrl-C is a normal way to leave the page.
+			if errors.Is(err, huh.ErrUserAborted) {
+				return nil
+			}
+			return err
+		}
+
+		switch choice {
+		case configPageDone:
+			return nil
+		case configPageSandbox:
+			// "cplt not on PATH" is a notice, not a reason to leave the page.
+			if err := cmdConfigSandbox(); err != nil {
+				fmt.Printf("%s %v\n", yellow("⚠"), err)
+			}
+		default:
+			if err := editConfigKey(choice, resolved); err != nil {
+				fmt.Printf("%s %v\n", red("✗"), err)
+			}
+		}
+		fmt.Println()
+	}
+}
+
+// editConfigKey prompts for a new value for one key and persists it.
+func editConfigKey(key string, r ResolvedConfig) error {
+	kd := findKeyDef(key)
+	if kd == nil {
+		return fmt.Errorf("unknown key: %q", key)
+	}
+	current := configKeyValue(r, key)
+
+	value := current
+
+	var opts []huh.Option[string]
+	switch {
+	case kd.kind == keyKindBool:
+		opts = []huh.Option[string]{huh.NewOption("true", "true"), huh.NewOption("false", "false")}
+	case len(kd.allowed) > 0:
+		for _, a := range kd.allowed {
+			opts = append(opts, huh.NewOption(a, a))
+		}
+		// Keys without a built-in default can be cleared again.
+		if kd.defaultVal == "" {
+			opts = append(opts, huh.NewOption("(unset)", ""))
+		}
+	}
+
+	var field huh.Field
+	if opts == nil {
+		field = huh.NewInput().Title(key).Description(kd.description).Value(&value)
+	} else {
+		field = huh.NewSelect[string]().Title(key).Description(kd.description).Options(opts...).Value(&value)
+	}
+
+	if err := field.WithTheme(navTheme()).Run(); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return nil
+		}
+		return err
+	}
+
+	value = strings.TrimSpace(value)
+	if value == "" {
+		if err := clearConfigKey(key); err != nil {
+			return err
+		}
+		fmt.Printf("%s %s cleared\n", green("✓"), key)
+		return nil
+	}
+	tomlVal, err := writeConfigKey(key, value)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s %s = %s\n", green("✓"), key, tomlVal)
+	return nil
+}
+
+// clearConfigKey drops a key from the config file so it falls back to its
+// built-in default. writeConfigKey cannot express this: an allowlisted key
+// rejects the empty string.
+func clearConfigKey(key string) error {
+	if findKeyDef(key) == nil {
+		return fmt.Errorf("unknown key: %q", key)
+	}
+	path := configPath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("reading config: %w", err)
+	}
+	var kept []string
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimLeft(line, " \t")
+		if isConfigKeyLine(line, key) && !strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(kept, "\n")), 0o600); err != nil {
+		return fmt.Errorf("writing config: %w", err)
+	}
+	return os.Chmod(path, 0o600)
+}

--- a/cli/nav-pilot/internal/cli/config_page_test.go
+++ b/cli/nav-pilot/internal/cli/config_page_test.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ─── bare `config` routing ────────────────────────────────────────────────────
+
+func TestCmdConfig_NoArgs_NonInteractiveKeepsUsageError(t *testing.T) {
+	t.Setenv("CI", "1") // makes isInteractive() false
+
+	err := cmdConfig(nil, false, false)
+	if err == nil {
+		t.Fatal("expected usage error when no subcommand given")
+	}
+	for _, want := range []string{"config requires a subcommand", "Usage: nav-pilot config <subcommand>", "sandbox"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error missing %q:\n%v", want, err)
+		}
+	}
+}
+
+// ─── key listing ──────────────────────────────────────────────────────────────
+
+// writeTestConfig points NAV_PILOT_CONFIG at a temp file with the given content.
+func writeTestConfig(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing test config: %v", err)
+	}
+	t.Setenv("NAV_PILOT_CONFIG", path)
+	return path
+}
+
+func TestBuildConfigPageEntries(t *testing.T) {
+	writeTestConfig(t, "version = 1\nmodel = \"gpt-5.5\"\nask_user = false\n")
+
+	cfg, err := readConfig()
+	if err != nil {
+		t.Fatalf("readConfig: %v", err)
+	}
+	entries := buildConfigPageEntries(cfg, resolve(cfg, CLIOverrides{}))
+
+	byKey := map[string]configPageEntry{}
+	for _, e := range entries {
+		byKey[e.Key] = e
+	}
+
+	// Internal bookkeeping keys must not be offered on the page.
+	for _, hidden := range []string{"version", "rtk_prompted_client", "rtk_prompted_at"} {
+		if _, ok := byKey[hidden]; ok {
+			t.Errorf("internal key %q must not be listed", hidden)
+		}
+	}
+	if len(entries) != len(configPageKeys) {
+		t.Errorf("got %d entries, want %d", len(entries), len(configPageKeys))
+	}
+
+	tests := []struct {
+		key, wantValue, wantSource string
+	}{
+		{"client", "copilot", "default"},
+		{"source", defaultSourceRepo, "default"},
+		{"model", "gpt-5.5", "file"},
+		{"mode", "default", "default"},
+		{"reasoning_effort", "", "unset"},
+		{"context_tier", "", "unset"},
+		{"ask_user", "false", "file"},
+		{"allow_all_tools", "false", "default"},
+		{"log_level", "", "unset"},
+		{"otel_log_level", "none", "default"},
+	}
+	for _, tc := range tests {
+		e, ok := byKey[tc.key]
+		if !ok {
+			t.Errorf("key %q missing from page", tc.key)
+			continue
+		}
+		if e.Value != tc.wantValue || e.Source != tc.wantSource {
+			t.Errorf("%s = %q (%s), want %q (%s)", tc.key, e.Value, e.Source, tc.wantValue, tc.wantSource)
+		}
+		if e.Description == "" {
+			t.Errorf("key %q has no description", tc.key)
+		}
+	}
+}
+
+func TestConfigPageEntryLabel(t *testing.T) {
+	tests := []struct {
+		entry configPageEntry
+		want  string
+	}{
+		{configPageEntry{Key: "model", Value: "gpt-5.5", Source: "file"}, "model = gpt-5.5  (file)"},
+		{configPageEntry{Key: "log_level", Value: "", Source: "unset"}, "log_level = (unset)  (unset)"},
+	}
+	for _, tc := range tests {
+		if got := tc.entry.label(); got != tc.want {
+			t.Errorf("label() = %q, want %q", got, tc.want)
+		}
+	}
+}
+
+// ─── clearing a key ───────────────────────────────────────────────────────────
+
+func TestClearConfigKey(t *testing.T) {
+	path := writeTestConfig(t, "version = 1\nmode = \"plan\"\n# model = \"auto\"\n")
+
+	if err := clearConfigKey("mode"); err != nil {
+		t.Fatalf("clearConfigKey: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+	if strings.Contains(string(data), "mode = ") {
+		t.Errorf("mode still set:\n%s", data)
+	}
+	// Commented-out lines and other keys are left alone.
+	if !strings.Contains(string(data), "# model = \"auto\"") || !strings.Contains(string(data), "version = 1") {
+		t.Errorf("unrelated lines were dropped:\n%s", data)
+	}
+
+	cfg, err := readConfig()
+	if err != nil {
+		t.Fatalf("readConfig: %v", err)
+	}
+	if cfg.Mode != nil {
+		t.Errorf("mode still parsed as %q", *cfg.Mode)
+	}
+}

--- a/cli/nav-pilot/internal/cli/config_setup.go
+++ b/cli/nav-pilot/internal/cli/config_setup.go
@@ -19,7 +19,6 @@ type setupAnswers struct {
 	Mode            string
 	ReasoningEffort string // empty = don't write the key
 	AutoUpdate      string // "true" or "false"
-	AutoLaunch      string // "true" or "false"
 }
 
 // writeSetupConfig writes a new config file from wizard answers.
@@ -73,12 +72,6 @@ func writeSetupConfig(answers setupAnswers) error {
 		lines = append(lines, "auto_update = true")
 	} else if answers.AutoUpdate == "false" {
 		lines = append(lines, "auto_update = false")
-	}
-
-	if answers.AutoLaunch == "true" {
-		lines = append(lines, "auto_launch = true")
-	} else if answers.AutoLaunch == "false" {
-		lines = append(lines, "auto_launch = false")
 	}
 
 	content := strings.Join(lines, "\n") + "\n"
@@ -235,21 +228,6 @@ func runConfigSetup() error {
 			huh.NewOption("max", "max"),
 		).
 		Value(&answers.ReasoningEffort).
-		WithTheme(navTheme()).
-		Run()
-	if err != nil {
-		fmt.Println(dim("  Setup skipped — run 'nav-pilot config setup' anytime."))
-		return errors.New("setup aborted by user")
-	}
-
-	err = huh.NewSelect[string]().
-		Title("Auto-launch").
-		Description("Launch the coding agent immediately after sync/install, skipping the \"Launch now?\" prompt.").
-		Options(
-			huh.NewOption("No (ask each time, default)", "false"),
-			huh.NewOption("Yes (launch immediately)", "true"),
-		).
-		Value(&answers.AutoLaunch).
 		WithTheme(navTheme()).
 		Run()
 	if err != nil {

--- a/cli/nav-pilot/internal/cli/config_setup_test.go
+++ b/cli/nav-pilot/internal/cli/config_setup_test.go
@@ -185,16 +185,19 @@ func TestWriteSetupConfig_AllValidEfforts(t *testing.T) {
 	}
 }
 
-func TestWriteSetupConfig_AutoLaunch(t *testing.T) {
+func TestWriteSetupConfig_AutoUpdate(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("NAV_PILOT_CONFIG", filepath.Join(dir, "config.toml"))
 
-	if err := writeSetupConfig(setupAnswers{Client: "copilot", Mode: "default", AutoLaunch: "true"}); err != nil {
+	if err := writeSetupConfig(setupAnswers{Client: "copilot", Mode: "default", AutoUpdate: "true"}); err != nil {
 		t.Fatalf("writeSetupConfig() error: %v", err)
 	}
 	data, _ := os.ReadFile(configPath())
-	if !strings.Contains(string(data), "auto_launch = true") {
-		t.Errorf("expected auto_launch = true in config, got:\n%s", string(data))
+	if !strings.Contains(string(data), "auto_update = true") {
+		t.Errorf("expected auto_update = true in config, got:\n%s", string(data))
+	}
+	if strings.Contains(string(data), "auto_launch") {
+		t.Errorf("auto_launch should no longer be written, got:\n%s", string(data))
 	}
 }
 

--- a/cli/nav-pilot/internal/cli/config_test.go
+++ b/cli/nav-pilot/internal/cli/config_test.go
@@ -443,6 +443,9 @@ func TestResolve_Defaults(t *testing.T) {
 	if r.AllowAllTools != false {
 		t.Error("AllowAllTools = true, want false")
 	}
+	if !r.AutoLaunch {
+		t.Error("AutoLaunch = false, want true (default)")
+	}
 	if r.Model != "" {
 		t.Errorf("Model = %q, want empty", r.Model)
 	}
@@ -468,6 +471,7 @@ func TestResolve_FileOverridesDefaults(t *testing.T) {
 	tier := "long_context"
 	allowAll := true
 	askUser := false
+	autoLaunch := false
 	logLevel := "debug"
 
 	cfg := &Config{
@@ -479,6 +483,7 @@ func TestResolve_FileOverridesDefaults(t *testing.T) {
 		ContextTier:     &tier,
 		AllowAllTools:   &allowAll,
 		AskUser:         &askUser,
+		AutoLaunch:      &autoLaunch,
 		LogLevel:        &logLevel,
 	}
 
@@ -504,8 +509,29 @@ func TestResolve_FileOverridesDefaults(t *testing.T) {
 	if r.AskUser {
 		t.Error("AskUser = true, want false")
 	}
+	if r.AutoLaunch {
+		t.Error("AutoLaunch = true, want false (file overrides default)")
+	}
 	if r.LogLevel != "debug" {
 		t.Errorf("LogLevel = %q, want debug", r.LogLevel)
+	}
+}
+
+func TestResolve_AutoLaunch_CLIOverridesFile(t *testing.T) {
+	// File says false; CLI --auto-launch (true) wins.
+	fileFalse := false
+	trueVal := true
+	r := resolve(&Config{Version: 1, AutoLaunch: &fileFalse}, CLIOverrides{AutoLaunch: &trueVal})
+	if !r.AutoLaunch {
+		t.Error("AutoLaunch = false, want true (CLI overrides file)")
+	}
+
+	// File says true; CLI --no-auto-launch (false) wins.
+	fileTrue := true
+	falseVal := false
+	r = resolve(&Config{Version: 1, AutoLaunch: &fileTrue}, CLIOverrides{AutoLaunch: &falseVal})
+	if r.AutoLaunch {
+		t.Error("AutoLaunch = true, want false (CLI overrides file)")
 	}
 }
 
@@ -971,6 +997,9 @@ func TestValidateKeyValue(t *testing.T) {
 		{"allow_all_tools", "maybe", true},
 		{"ask_user", "true", false},
 		{"ask_user", "false", false},
+		{"auto_launch", "true", false},
+		{"auto_launch", "false", false},
+		{"auto_launch", "nope", true},
 		{"version", "1", false},
 		{"version", "2", true},
 		{"version", "abc", true},
@@ -1075,8 +1104,8 @@ func TestConfigAdvisories_Nil(t *testing.T) {
 	}
 }
 
-func TestConfigAdvisories_AutoLaunchDeprecated(t *testing.T) {
-	path := writeTempConfig(t, "version = 1\nauto_launch = true\n")
+func TestReadConfig_AutoLaunchOptOut(t *testing.T) {
+	path := writeTempConfig(t, "version = 1\nauto_launch = false\n")
 	t.Setenv("NAV_PILOT_CONFIG", path)
 
 	cfg, meta, err := readConfigWithMeta()
@@ -1086,9 +1115,22 @@ func TestConfigAdvisories_AutoLaunchDeprecated(t *testing.T) {
 	if len(meta.Undecoded()) != 0 {
 		t.Errorf("auto_launch must stay a known key, got undecoded %v", meta.Undecoded())
 	}
-	w := configAdvisories(cfg, meta)
-	if len(w) != 1 || !strings.Contains(w[0], "auto_launch is no longer used") {
-		t.Errorf("configAdvisories() = %v, want one auto_launch deprecation advisory", w)
+	if w := configAdvisories(cfg, meta); len(w) != 0 {
+		t.Errorf("configAdvisories() = %v, want none for auto_launch", w)
+	}
+	if resolve(cfg, CLIOverrides{}).AutoLaunch {
+		t.Error("AutoLaunch = true, want false (auto_launch = false in the file)")
+	}
+
+	// An absent key means launch.
+	path = writeTempConfig(t, "version = 1\n")
+	t.Setenv("NAV_PILOT_CONFIG", path)
+	cfg, _, err = readConfigWithMeta()
+	if err != nil {
+		t.Fatalf("config failed to load: %v", err)
+	}
+	if !resolve(cfg, CLIOverrides{}).AutoLaunch {
+		t.Error("AutoLaunch = false, want true (key absent)")
 	}
 }
 

--- a/cli/nav-pilot/internal/cli/config_test.go
+++ b/cli/nav-pilot/internal/cli/config_test.go
@@ -443,9 +443,6 @@ func TestResolve_Defaults(t *testing.T) {
 	if r.AllowAllTools != false {
 		t.Error("AllowAllTools = true, want false")
 	}
-	if r.AutoLaunch != false {
-		t.Error("AutoLaunch = true, want false (default)")
-	}
 	if r.Model != "" {
 		t.Errorf("Model = %q, want empty", r.Model)
 	}
@@ -471,7 +468,6 @@ func TestResolve_FileOverridesDefaults(t *testing.T) {
 	tier := "long_context"
 	allowAll := true
 	askUser := false
-	autoLaunch := true
 	logLevel := "debug"
 
 	cfg := &Config{
@@ -483,7 +479,6 @@ func TestResolve_FileOverridesDefaults(t *testing.T) {
 		ContextTier:     &tier,
 		AllowAllTools:   &allowAll,
 		AskUser:         &askUser,
-		AutoLaunch:      &autoLaunch,
 		LogLevel:        &logLevel,
 	}
 
@@ -509,31 +504,8 @@ func TestResolve_FileOverridesDefaults(t *testing.T) {
 	if r.AskUser {
 		t.Error("AskUser = true, want false")
 	}
-	if !r.AutoLaunch {
-		t.Error("AutoLaunch = false, want true (file overrides default)")
-	}
 	if r.LogLevel != "debug" {
 		t.Errorf("LogLevel = %q, want debug", r.LogLevel)
-	}
-}
-
-func TestResolve_AutoLaunch_CLIOverridesFile(t *testing.T) {
-	fileFalse := false
-	cfg := &Config{Version: 1, AutoLaunch: &fileFalse}
-
-	// File says false; CLI --auto-launch (true) wins.
-	trueVal := true
-	r := resolve(cfg, CLIOverrides{AutoLaunch: &trueVal})
-	if !r.AutoLaunch {
-		t.Error("AutoLaunch = false, want true (CLI overrides file)")
-	}
-
-	// File says true; CLI --no-auto-launch (false) wins.
-	fileTrue := true
-	falseVal := false
-	r = resolve(&Config{Version: 1, AutoLaunch: &fileTrue}, CLIOverrides{AutoLaunch: &falseVal})
-	if r.AutoLaunch {
-		t.Error("AutoLaunch = true, want false (CLI overrides file)")
 	}
 }
 
@@ -999,9 +971,6 @@ func TestValidateKeyValue(t *testing.T) {
 		{"allow_all_tools", "maybe", true},
 		{"ask_user", "true", false},
 		{"ask_user", "false", false},
-		{"auto_launch", "true", false},
-		{"auto_launch", "false", false},
-		{"auto_launch", "nope", true},
 		{"version", "1", false},
 		{"version", "2", true},
 		{"version", "abc", true},
@@ -1103,6 +1072,23 @@ func TestKnownCopilotModelIDs(t *testing.T) {
 func TestConfigAdvisories_Nil(t *testing.T) {
 	if w := configAdvisories(nil, tomlMetaForTest(t, "")); len(w) != 0 {
 		t.Errorf("configAdvisories(nil) = %v, want empty", w)
+	}
+}
+
+func TestConfigAdvisories_AutoLaunchDeprecated(t *testing.T) {
+	path := writeTempConfig(t, "version = 1\nauto_launch = true\n")
+	t.Setenv("NAV_PILOT_CONFIG", path)
+
+	cfg, meta, err := readConfigWithMeta()
+	if err != nil {
+		t.Fatalf("auto_launch config failed to load: %v", err)
+	}
+	if len(meta.Undecoded()) != 0 {
+		t.Errorf("auto_launch must stay a known key, got undecoded %v", meta.Undecoded())
+	}
+	w := configAdvisories(cfg, meta)
+	if len(w) != 1 || !strings.Contains(w[0], "auto_launch is no longer used") {
+		t.Errorf("configAdvisories() = %v, want one auto_launch deprecation advisory", w)
 	}
 }
 

--- a/cli/nav-pilot/internal/cli/interactive.go
+++ b/cli/nav-pilot/internal/cli/interactive.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -723,86 +724,89 @@ func launchClient(resolved ResolvedConfig) error {
 	return p.Launch(resolved)
 }
 
-// offerLaunchCopilot prompts the user to launch the configured agent after install.
-// If the provider binary is not found in PATH, the prompt is skipped.
+// launchDecision is what offerLaunchCopilot should do about launching.
+type launchDecision int
+
+const (
+	launchSkipUnavailable    launchDecision = iota // client binary missing: warn, don't launch
+	launchSkipQuiet                                // no terminal: do nothing
+	launchGo                                       // launch
+	launchConfirmUnsandboxed                       // warn about the missing sandbox, ask, then launch
+)
+
+// decideLaunch maps the post-install state to a launch decision. sandboxed is
+// false only when the copilot client resolved to the plain, unsandboxed CLI.
+// Without a terminal nothing is ever launched.
+func decideLaunch(available, sandboxed, interactive bool) launchDecision {
+	switch {
+	case !available:
+		return launchSkipUnavailable
+	case !interactive:
+		return launchSkipQuiet
+	case sandboxed:
+		return launchGo
+	default:
+		return launchConfirmUnsandboxed
+	}
+}
+
+// offerLaunchCopilot launches the configured agent after install. A healthy
+// setup launches without asking; a missing binary is warned about, and an
+// unsandboxed launch is confirmed interactively.
 func offerLaunchCopilot(resolved ResolvedConfig) {
 	p, err := providerFor(resolved.Client)
-	if err != nil || !p.Available() {
+	if err != nil {
 		return
 	}
 
-	if resolved.AutoLaunch {
+	sandboxed := true
+	if resolved.Client == "copilot" {
+		_, name := findCopilotCLI()
+		sandboxed = name == "cplt"
+	}
+
+	decision := decideLaunch(p.Available(), sandboxed, isInteractive())
+	if decision == launchSkipQuiet {
+		return
+	}
+
+	fmt.Println()
+	switch decision {
+	case launchSkipUnavailable:
+		missing := p.DisplayName()
+		// opencode needs both opencode and cplt; name whichever is missing.
+		if resolved.Client == "opencode" {
+			if _, err := exec.LookPath("opencode"); err == nil {
+				missing = "cplt"
+			}
+		}
+		fmt.Printf("%s %s was not found on PATH — skipping launch. Run %s to diagnose.\n",
+			yellow("⚠"), missing, bold("nav-pilot doctor"))
+		return
+	case launchConfirmUnsandboxed:
+		fmt.Printf("%s The cplt sandbox was not found — %s would run unsandboxed.\n",
+			yellow("⚠"), p.DisplayName())
+		var ok bool
+		if err := huh.NewConfirm().
+			Title("Launch without the cplt sandbox?").
+			Value(&ok).
+			WithTheme(navTheme()).
+			Run(); err != nil || !ok {
+			return
+		}
 		fmt.Println()
-		fmt.Printf("%s Launching %s...\n", dim("→"), p.DisplayName())
-		_ = runWithCommandTelemetry("launch", telemetryMode(), "none", func() error {
-			return launchClient(resolved)
-		})
-		return
 	}
 
-	if !isInteractive() {
-		return
-	}
-
-	fmt.Println()
-	var choice string
-	err = huh.NewSelect[string]().
-		Title(fmt.Sprintf("Launch %s now?", p.DisplayName())).
-		Options(
-			huh.NewOption("Yes", "yes"),
-			huh.NewOption("No", "no"),
-		).
-		Value(&choice).
-		WithTheme(navTheme()).
-		Run()
-	if err != nil || choice != "yes" {
-		return
-	}
-	fmt.Println()
+	fmt.Printf("%s Launching %s...\n", dim("→"), p.DisplayName())
 	_ = runWithCommandTelemetry("launch", telemetryMode(), "none", func() error {
 		return launchClient(resolved)
 	})
 }
 
-// offerLaunchCopilotWithAgents prompts the user to launch the configured agent
-// using the resolved launch config. If the provider binary is not found, skipped.
+// offerLaunchCopilotWithAgents is offerLaunchCopilot for callers that have the
+// installed agent list at hand; the launch config already carries the persona,
+// so the list is unused.
 func offerLaunchCopilotWithAgents(agents []string, resolved ResolvedConfig) {
 	_ = agents
-	p, err := providerFor(resolved.Client)
-	if err != nil || !p.Available() {
-		return
-	}
-
-	if resolved.AutoLaunch {
-		fmt.Println()
-		fmt.Printf("%s Launching %s...\n", dim("→"), p.DisplayName())
-		_ = runWithCommandTelemetry("launch", telemetryMode(), "none", func() error {
-			return launchClient(resolved)
-		})
-		return
-	}
-
-	if !isInteractive() {
-		return
-	}
-
-	fmt.Println()
-	var choice string
-	err = huh.NewSelect[string]().
-		Title(fmt.Sprintf("Launch %s now?", p.DisplayName())).
-		Options(
-			huh.NewOption("Yes", "yes"),
-			huh.NewOption("No", "no"),
-		).
-		Value(&choice).
-		WithTheme(navTheme()).
-		Run()
-	if err != nil || choice != "yes" {
-		return
-	}
-
-	fmt.Println()
-	_ = runWithCommandTelemetry("launch", telemetryMode(), "none", func() error {
-		return launchClient(resolved)
-	})
+	offerLaunchCopilot(resolved)
 }

--- a/cli/nav-pilot/internal/cli/interactive.go
+++ b/cli/nav-pilot/internal/cli/interactive.go
@@ -630,7 +630,9 @@ func interactiveRepoInstall(src *Source, scope *InstallScope, flagSource string)
 var promptInstallScopeFn = promptInstallScope
 
 // promptInstallScope asks the user where to install: repo or user home.
-// Returns nil if the user cancels.
+// Returns (nil, nil) only when the user cancels; a prompt that could not run
+// (no usable TTY) returns its error so callers can fall back instead of
+// pretending the user said no.
 func promptInstallScope(targetDir string) (*InstallScope, error) {
 	if !isInteractive() {
 		// Non-interactive: default to repo scope
@@ -647,7 +649,10 @@ func promptInstallScope(targetDir string) (*InstallScope, error) {
 		WithTheme(navTheme()).
 		Run()
 	if err != nil {
-		return nil, nil // user cancelled
+		if errors.Is(err, huh.ErrUserAborted) {
+			return nil, nil // user cancelled
+		}
+		return nil, err
 	}
 
 	switch choice {
@@ -729,20 +734,26 @@ type launchDecision int
 
 const (
 	launchSkipUnavailable    launchDecision = iota // client binary missing: warn, don't launch
+	launchSkipOptedOut                             // auto_launch = false: name the command, don't launch
 	launchSkipQuiet                                // no terminal: do nothing
 	launchGo                                       // launch
 	launchConfirmUnsandboxed                       // warn about the missing sandbox, ask, then launch
 )
 
-// decideLaunch maps the post-install state to a launch decision. sandboxed is
-// false only when the copilot client resolved to the plain, unsandboxed CLI.
-// Without a terminal nothing is ever launched.
-func decideLaunch(available, sandboxed, interactive bool) launchDecision {
+// decideLaunch maps the post-install state to a launch decision. autoLaunch is
+// the resolved auto_launch setting; false means the user opted out and nothing
+// is ever launched or confirmed, only the command to run is printed. sandboxed
+// is false only when the copilot client resolved to the plain, unsandboxed CLI.
+// Without a terminal nothing is ever launched — and nothing is printed either,
+// so scripted runs stay as quiet as they were before the launch warnings.
+func decideLaunch(available, autoLaunch, sandboxed, interactive bool) launchDecision {
 	switch {
-	case !available:
-		return launchSkipUnavailable
 	case !interactive:
 		return launchSkipQuiet
+	case !available:
+		return launchSkipUnavailable
+	case !autoLaunch:
+		return launchSkipOptedOut
 	case sandboxed:
 		return launchGo
 	default:
@@ -751,8 +762,9 @@ func decideLaunch(available, sandboxed, interactive bool) launchDecision {
 }
 
 // offerLaunchCopilot launches the configured agent after install. A healthy
-// setup launches without asking; a missing binary is warned about, and an
-// unsandboxed launch is confirmed interactively.
+// setup launches without asking; a missing binary is warned about, an
+// unsandboxed launch is confirmed interactively, and auto_launch = false
+// prints the command to run instead of launching anything.
 func offerLaunchCopilot(resolved ResolvedConfig) {
 	p, err := providerFor(resolved.Client)
 	if err != nil {
@@ -760,12 +772,17 @@ func offerLaunchCopilot(resolved ResolvedConfig) {
 	}
 
 	sandboxed := true
+	cmdName := resolved.Client // opencode and pi are launched under their own name
 	if resolved.Client == "copilot" {
 		_, name := findCopilotCLI()
 		sandboxed = name == "cplt"
+		cmdName = "cplt"
+		if name != "" {
+			cmdName = name
+		}
 	}
 
-	decision := decideLaunch(p.Available(), sandboxed, isInteractive())
+	decision := decideLaunch(p.Available(), resolved.AutoLaunch, sandboxed, isInteractive())
 	if decision == launchSkipQuiet {
 		return
 	}
@@ -774,17 +791,25 @@ func offerLaunchCopilot(resolved ResolvedConfig) {
 	switch decision {
 	case launchSkipUnavailable:
 		missing := p.DisplayName()
+		// With no client on PATH the copilot provider has no name to display;
+		// cmdName always holds a real command to point at.
+		if missing == "" {
+			missing = cmdName
+		}
 		// opencode needs both opencode and cplt; name whichever is missing.
 		if resolved.Client == "opencode" {
 			if _, err := exec.LookPath("opencode"); err == nil {
 				missing = "cplt"
 			}
 		}
-		fmt.Printf("%s %s was not found on PATH — skipping launch. Run %s to diagnose.\n",
+		fmt.Fprintf(os.Stderr, "%s %s was not found on PATH — skipping launch. Run %s to diagnose.\n",
 			yellow("⚠"), missing, bold("nav-pilot doctor"))
 		return
+	case launchSkipOptedOut:
+		fmt.Println(dim(fmt.Sprintf("Not launching (auto_launch = false). Start it yourself with: %s", cmdName)))
+		return
 	case launchConfirmUnsandboxed:
-		fmt.Printf("%s The cplt sandbox was not found — %s would run unsandboxed.\n",
+		fmt.Fprintf(os.Stderr, "%s The cplt sandbox was not found — %s would run unsandboxed.\n",
 			yellow("⚠"), p.DisplayName())
 		var ok bool
 		if err := huh.NewConfirm().
@@ -798,9 +823,11 @@ func offerLaunchCopilot(resolved ResolvedConfig) {
 	}
 
 	fmt.Printf("%s Launching %s...\n", dim("→"), p.DisplayName())
-	_ = runWithCommandTelemetry("launch", telemetryMode(), "none", func() error {
+	if err := runWithCommandTelemetry("launch", telemetryMode(), "none", func() error {
 		return launchClient(resolved)
-	})
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "%s Launch failed: %v\n", yellow("⚠"), err)
+	}
 }
 
 // offerLaunchCopilotWithAgents is offerLaunchCopilot for callers that have the

--- a/cli/nav-pilot/internal/cli/interactive_test.go
+++ b/cli/nav-pilot/internal/cli/interactive_test.go
@@ -531,22 +531,26 @@ func TestPatchOpenCodeConfig(t *testing.T) {
 
 func TestDecideLaunch(t *testing.T) {
 	tests := []struct {
-		name                              string
-		available, sandboxed, interactive bool
-		want                              launchDecision
+		name                                          string
+		available, autoLaunch, sandboxed, interactive bool
+		want                                          launchDecision
 	}{
-		{"client missing", false, true, true, launchSkipUnavailable},
-		{"client missing wins over no terminal", false, true, false, launchSkipUnavailable},
-		{"no terminal", true, true, false, launchSkipQuiet},
-		{"healthy and interactive launches without asking", true, true, true, launchGo},
-		{"no sandbox, interactive: confirm", true, false, true, launchConfirmUnsandboxed},
-		{"no sandbox, no terminal: nothing", true, false, false, launchSkipQuiet},
+		{"client missing", false, true, true, true, launchSkipUnavailable},
+		{"no terminal wins over a missing client", false, true, true, false, launchSkipQuiet},
+		{"client missing wins over opt-out", false, false, true, true, launchSkipUnavailable},
+		{"no terminal", true, true, true, false, launchSkipQuiet},
+		{"healthy and interactive launches without asking", true, true, true, true, launchGo},
+		{"no sandbox, interactive: confirm", true, true, false, true, launchConfirmUnsandboxed},
+		{"no sandbox, no terminal: nothing", true, true, false, false, launchSkipQuiet},
+		{"opt-out", true, false, true, true, launchSkipOptedOut},
+		{"opt-out wins over the unsandboxed confirmation", true, false, false, true, launchSkipOptedOut},
+		{"no terminal wins over the opt-out notice", true, false, true, false, launchSkipQuiet},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := decideLaunch(tt.available, tt.sandboxed, tt.interactive); got != tt.want {
-				t.Errorf("decideLaunch(%v, %v, %v) = %v, want %v",
-					tt.available, tt.sandboxed, tt.interactive, got, tt.want)
+			if got := decideLaunch(tt.available, tt.autoLaunch, tt.sandboxed, tt.interactive); got != tt.want {
+				t.Errorf("decideLaunch(%v, %v, %v, %v) = %v, want %v",
+					tt.available, tt.autoLaunch, tt.sandboxed, tt.interactive, got, tt.want)
 			}
 		})
 	}

--- a/cli/nav-pilot/internal/cli/interactive_test.go
+++ b/cli/nav-pilot/internal/cli/interactive_test.go
@@ -528,3 +528,26 @@ func TestPatchOpenCodeConfig(t *testing.T) {
 		t.Fatalf("expected error for invalid json")
 	}
 }
+
+func TestDecideLaunch(t *testing.T) {
+	tests := []struct {
+		name                              string
+		available, sandboxed, interactive bool
+		want                              launchDecision
+	}{
+		{"client missing", false, true, true, launchSkipUnavailable},
+		{"client missing wins over no terminal", false, true, false, launchSkipUnavailable},
+		{"no terminal", true, true, false, launchSkipQuiet},
+		{"healthy and interactive launches without asking", true, true, true, launchGo},
+		{"no sandbox, interactive: confirm", true, false, true, launchConfirmUnsandboxed},
+		{"no sandbox, no terminal: nothing", true, false, false, launchSkipQuiet},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := decideLaunch(tt.available, tt.sandboxed, tt.interactive); got != tt.want {
+				t.Errorf("decideLaunch(%v, %v, %v) = %v, want %v",
+					tt.available, tt.sandboxed, tt.interactive, got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/nav-pilot/internal/cli/scope_test.go
+++ b/cli/nav-pilot/internal/cli/scope_test.go
@@ -760,3 +760,66 @@ func TestRun_InstallHonoursPromptedScope(t *testing.T) {
 		t.Errorf("install went somewhere else, %s missing: %v", installed, err)
 	}
 }
+
+// A prompt that cannot open a terminal must not be mistaken for a cancel: the
+// install still lands in the repository, the way it did before the prompt.
+func TestRun_InstallFallsBackToRepoWhenPromptFails(t *testing.T) {
+	isolatedConfig(t)
+	t.Setenv("HOME", t.TempDir())
+	forceInteractive(t)
+	stubResolveSource(t, pakkeSource(t, defaultSourceRepo))
+
+	target := repoTarget(t)
+	t.Chdir(target)
+
+	orig := promptInstallScopeFn
+	t.Cleanup(func() { promptInstallScopeFn = orig })
+	promptInstallScopeFn = func(string) (*InstallScope, error) {
+		return nil, errors.New("huh: could not open a new TTY")
+	}
+
+	if err := run([]string{"install", "grillmester"}); err != nil {
+		t.Fatalf("install grillmester: %v", err)
+	}
+	installed := filepath.Join(target, ".github", "agents", "grillmester.agent.md")
+	if _, err := os.Stat(installed); err != nil {
+		t.Errorf("a failed prompt must still install into the repo, %s missing: %v", installed, err)
+	}
+}
+
+// Outside a git repo the "this repo" answer cannot work, and a prompt type that
+// user scope cannot hold makes the other answer fail — neither is asked about.
+func TestRun_InstallSkipsPromptWhenOnlyOneScopeWorks(t *testing.T) {
+	tests := []struct {
+		name  string
+		args  []string
+		inGit bool
+	}{
+		{"no git repo", []string{"install", "grillmester"}, false},
+		{"prompts cannot live in user scope", []string{"add", "prompt", "grillmester"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isolatedConfig(t)
+			t.Setenv("HOME", t.TempDir())
+			forceInteractive(t)
+			if tt.inGit {
+				t.Chdir(repoTarget(t))
+			} else {
+				t.Chdir(t.TempDir())
+			}
+
+			origResolve := resolveSource
+			t.Cleanup(func() { resolveSource = origResolve })
+			resolveSource = func(ref, sourceRepo string) (*Source, error) {
+				return nil, errStubNoSource
+			}
+
+			asked := stubScopePrompt(t, nil)
+			_ = run(tt.args)
+			if *asked {
+				t.Error("asked a question with only one workable answer")
+			}
+		})
+	}
+}

--- a/cli/nav-pilot/internal/cli/scope_test.go
+++ b/cli/nav-pilot/internal/cli/scope_test.go
@@ -694,6 +694,7 @@ func TestRun_InstallScopePrompt(t *testing.T) {
 		wantPrompt  bool
 	}{
 		{"--user says where already", []string{"install", "--user", "grillmester"}, true, false},
+		{"--repo says where already", []string{"install", "--repo", "grillmester"}, true, false},
 		{"--target says where already", []string{"install", "--target", "TMP", "grillmester"}, true, false},
 		{"non-interactive cannot ask", []string{"install", "grillmester"}, false, false},
 		{"--json must stay scriptable", []string{"install", "grillmester", "--json"}, true, false},
@@ -758,6 +759,69 @@ func TestRun_InstallHonoursPromptedScope(t *testing.T) {
 	installed := filepath.Join(target, ".github", "agents", "grillmester.agent.md")
 	if _, err := os.Stat(installed); err != nil {
 		t.Errorf("install went somewhere else, %s missing: %v", installed, err)
+	}
+}
+
+// --repo is the non-interactive way to answer "this repository", and like the
+// prompted answer it installs into the git root, not the subdirectory we're in.
+func TestRun_InstallRepoFlagUsesGitRoot(t *testing.T) {
+	isolatedConfig(t)
+	t.Setenv("HOME", t.TempDir())
+	forceInteractive(t)
+	stubResolveSource(t, pakkeSource(t, defaultSourceRepo))
+
+	target := repoTarget(t)
+	sub := filepath.Join(target, "cli", "nested")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(sub)
+
+	asked := stubScopePrompt(t, nil)
+	if err := run([]string{"install", "grillmester", "--repo"}); err != nil {
+		t.Fatalf("install grillmester --repo: %v", err)
+	}
+	if *asked {
+		t.Error("--repo already answers where to install")
+	}
+	installed := filepath.Join(target, ".github", "agents", "grillmester.agent.md")
+	if _, err := os.Stat(installed); err != nil {
+		t.Errorf("--repo must install into the git root, %s missing: %v", installed, err)
+	}
+	if _, err := os.Stat(filepath.Join(sub, ".github")); err == nil {
+		t.Error("--repo installed into the subdirectory instead of the git root")
+	}
+}
+
+// --repo picks a scope, so combining it with the other scope flags is a
+// contradiction rather than a silent winner.
+func TestRun_RepoFlagConflicts(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"--repo with --user", []string{"install", "grillmester", "--repo", "--user"}, "--repo and --user are mutually exclusive"},
+		{"--repo with --target", []string{"install", "grillmester", "--repo", "--target", "TMP"}, "--repo and --target are mutually exclusive"},
+		{"--repo on an unscoped command", []string{"init", "--repo"}, `--repo is not supported for "init"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isolatedConfig(t)
+			t.Setenv("HOME", t.TempDir())
+
+			args := append([]string(nil), tt.args...)
+			for i, a := range args {
+				if a == "TMP" {
+					args[i] = repoTarget(t)
+				}
+			}
+
+			err := run(args)
+			if err == nil || err.Error() != tt.want {
+				t.Fatalf("run(%v) error = %v, want %q", args, err, tt.want)
+			}
+		})
 	}
 }
 

--- a/cli/nav-pilot/internal/cli/scope_test.go
+++ b/cli/nav-pilot/internal/cli/scope_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -650,5 +651,112 @@ func TestResolverList_Prompts_RootWinsScope(t *testing.T) {
 	}
 	if strings.Contains(entries[0].AbsPath, ".github") {
 		t.Errorf("root should win: %q", entries[0].AbsPath)
+	}
+}
+
+var errStubNoSource = errors.New("stubbed: no source")
+
+// ─── explicit install asks where to install ──────────────────────────────────
+
+// forceInteractive makes isInteractive() report true deterministically:
+// /dev/null is a character device, which is what isInteractive() checks.
+func forceInteractive(t *testing.T) {
+	t.Helper()
+	t.Setenv("CI", "")
+	t.Setenv("GITHUB_ACTIONS", "")
+	devnull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Skipf("cannot open %s: %v", os.DevNull, err)
+	}
+	orig := os.Stdin
+	os.Stdin = devnull
+	t.Cleanup(func() { os.Stdin = orig; devnull.Close() })
+}
+
+// stubScopePrompt replaces the scope picker and reports whether it was asked.
+func stubScopePrompt(t *testing.T, scope *InstallScope) *bool {
+	t.Helper()
+	orig := promptInstallScopeFn
+	t.Cleanup(func() { promptInstallScopeFn = orig })
+	asked := false
+	promptInstallScopeFn = func(string) (*InstallScope, error) {
+		asked = true
+		return scope, nil
+	}
+	return &asked
+}
+
+func TestRun_InstallScopePrompt(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		interactive bool
+		wantPrompt  bool
+	}{
+		{"--user says where already", []string{"install", "--user", "grillmester"}, true, false},
+		{"--target says where already", []string{"install", "--target", "TMP", "grillmester"}, true, false},
+		{"non-interactive cannot ask", []string{"install", "grillmester"}, false, false},
+		{"--json must stay scriptable", []string{"install", "grillmester", "--json"}, true, false},
+		{"--dry-run installs nothing", []string{"install", "grillmester", "--dry-run"}, true, false},
+		{"bare install is not prompted before dispatch", []string{"install"}, true, false},
+		{"explicit install asks", []string{"install", "grillmester"}, true, true},
+		{"add asks too", []string{"add", "agent", "grillmester"}, true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isolatedConfig(t)
+			t.Setenv("HOME", t.TempDir())
+			if tt.interactive {
+				forceInteractive(t)
+			} else {
+				forceNonInteractive = true
+				t.Cleanup(func() { forceNonInteractive = false })
+			}
+
+			origResolve := resolveSource
+			t.Cleanup(func() { resolveSource = origResolve })
+			resolveSource = func(ref, sourceRepo string) (*Source, error) {
+				return nil, errStubNoSource
+			}
+
+			args := append([]string(nil), tt.args...)
+			for i, a := range args {
+				if a == "TMP" {
+					args[i] = repoTarget(t)
+				}
+			}
+
+			// Cancelling (nil scope) keeps every case a no-op.
+			asked := stubScopePrompt(t, nil)
+			err := run(args)
+			if *asked != tt.wantPrompt {
+				t.Fatalf("prompt asked = %v, want %v (err: %v)", *asked, tt.wantPrompt, err)
+			}
+			if tt.wantPrompt && err != nil {
+				t.Errorf("cancelled scope prompt must exit cleanly, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestRun_InstallHonoursPromptedScope(t *testing.T) {
+	isolatedConfig(t)
+	t.Setenv("HOME", t.TempDir())
+	forceInteractive(t)
+	stubResolveSource(t, pakkeSource(t, defaultSourceRepo))
+
+	target := repoTarget(t)
+	asked := stubScopePrompt(t, ScopeRepo(target))
+
+	if err := run([]string{"install", "grillmester"}); err != nil {
+		t.Fatalf("install grillmester: %v", err)
+	}
+	if !*asked {
+		t.Fatal("explicit install must ask where to install")
+	}
+	installed := filepath.Join(target, ".github", "agents", "grillmester.agent.md")
+	if _, err := os.Stat(installed); err != nil {
+		t.Errorf("install went somewhere else, %s missing: %v", installed, err)
 	}
 }

--- a/cli/nav-pilot/internal/cli/suggest.go
+++ b/cli/nav-pilot/internal/cli/suggest.go
@@ -74,6 +74,7 @@ var knownFlags = []string{
 	"--items",
 	"-F", "--feature",
 	"-u", "--user",
+	"--repo",
 	"-t", "--target",
 	"-r", "--ref",
 	"-s", "--source",

--- a/cli/nav-pilot/internal/domain/domain.go
+++ b/cli/nav-pilot/internal/domain/domain.go
@@ -22,9 +22,8 @@ type Config struct {
 	ContextTier     *string `toml:"context_tier"`
 	AllowAllTools   *bool   `toml:"allow_all_tools"`
 	AskUser         *bool   `toml:"ask_user"`
-	// AutoLaunch is accepted for backwards compatibility only; it no longer
-	// has any effect. Keeping the field stops old config files from failing
-	// the unknown-key check at launch.
+	// AutoLaunch controls whether nav-pilot starts the coding agent by itself
+	// after an install/sync. Defaults to true; false means never launch.
 	AutoLaunch        *bool   `toml:"auto_launch"`
 	LogLevel          *string `toml:"log_level"`
 	OtelLogLevel      *string `toml:"otel_log_level"`
@@ -46,6 +45,7 @@ type ResolvedConfig struct {
 	ContextTier       string // empty = unset
 	AllowAllTools     bool
 	AskUser           bool
+	AutoLaunch        bool     // launch the coding agent automatically after install/sync
 	LogLevel          string   // empty = unset
 	OtelLogLevel      string   // always set; defaults to "none"
 	RtkPromptedClient string   // comma-separated list of clients where the RTK setup was prompted
@@ -66,6 +66,7 @@ type CLIOverrides struct {
 	ContextTier     string
 	AllowAllTools   *bool
 	AskUser         *bool
+	AutoLaunch      *bool
 	LogLevel        string
 	OtelLogLevel    string
 	ExtraArgs       []string

--- a/cli/nav-pilot/internal/domain/domain.go
+++ b/cli/nav-pilot/internal/domain/domain.go
@@ -13,15 +13,18 @@ import (
 // Pointer types are used for optional fields to distinguish "unset" from zero-value,
 // enabling correct per-field precedence in resolve().
 type Config struct {
-	Version           int     `toml:"version"`
-	Client            *string `toml:"client"`
-	Source            *string `toml:"source"`
-	Model             *string `toml:"model"`
-	Mode              *string `toml:"mode"`
-	ReasoningEffort   *string `toml:"reasoning_effort"`
-	ContextTier       *string `toml:"context_tier"`
-	AllowAllTools     *bool   `toml:"allow_all_tools"`
-	AskUser           *bool   `toml:"ask_user"`
+	Version         int     `toml:"version"`
+	Client          *string `toml:"client"`
+	Source          *string `toml:"source"`
+	Model           *string `toml:"model"`
+	Mode            *string `toml:"mode"`
+	ReasoningEffort *string `toml:"reasoning_effort"`
+	ContextTier     *string `toml:"context_tier"`
+	AllowAllTools   *bool   `toml:"allow_all_tools"`
+	AskUser         *bool   `toml:"ask_user"`
+	// AutoLaunch is accepted for backwards compatibility only; it no longer
+	// has any effect. Keeping the field stops old config files from failing
+	// the unknown-key check at launch.
 	AutoLaunch        *bool   `toml:"auto_launch"`
 	LogLevel          *string `toml:"log_level"`
 	OtelLogLevel      *string `toml:"otel_log_level"`
@@ -43,7 +46,6 @@ type ResolvedConfig struct {
 	ContextTier       string // empty = unset
 	AllowAllTools     bool
 	AskUser           bool
-	AutoLaunch        bool     // skip the interactive "Launch X now?" confirmation
 	LogLevel          string   // empty = unset
 	OtelLogLevel      string   // always set; defaults to "none"
 	RtkPromptedClient string   // comma-separated list of clients where the RTK setup was prompted
@@ -64,7 +66,6 @@ type CLIOverrides struct {
 	ContextTier     string
 	AllowAllTools   *bool
 	AskUser         *bool
-	AutoLaunch      *bool
 	LogLevel        string
 	OtelLogLevel    string
 	ExtraArgs       []string

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -177,12 +177,9 @@ nav-pilot config show
 ```
 
 Støttede felt er `client`, `model`, `mode`, `reasoning_effort`, `context_tier`,
-`allow_all_tools`, `ask_user`, `auto_launch` og `log_level`. Du kan overstyre dem per kjøring med
+`allow_all_tools`, `ask_user` og `log_level`. Du kan overstyre dem per kjøring med
 globale flagg som `--client`, `--model`, `--mode`, `--effort`, `--context`,
-`--allow-all-tools`, `--no-ask-user`, `--auto-launch`/`--no-auto-launch` og `--log-level`.
-
-> **Tips:** Sett `auto_launch = true` (eller bruk `--auto-launch`) for å starte
-> cplt/copilot/opencode automatisk uten «Launch X now?»-bekreftelsen.
+`--allow-all-tools`, `--no-ask-user` og `--log-level`.
 
 **Modell per klient:**
 - Copilot: `auto`, `claude-opus-5`, `claude-fable-5`, `claude-sonnet-5`,

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -170,6 +170,7 @@ Metrikkene inkluderer også `execution_context` for å skille organisk bruk fra 
 Du kan lagre standardvalg i `~/.nav-pilot/config.toml`.
 
 ```bash
+nav-pilot config          # interaktiv innstillingsside — alle valg med forklaring
 nav-pilot config init
 nav-pilot config setup
 nav-pilot config show

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -29,8 +29,8 @@ nav-pilot install kotlin-backend
 ```
 
 `install` spør hvor den skal installere — i repoet (`.github/`) eller i hjemmekatalogen
-(`~/.copilot/`). Bruk `--user` eller `--target <mappe>` for å svare på forhånd og hoppe
-over spørsmålet.
+(`~/.copilot/`). Bruk `--repo`, `--user` eller `--target <mappe>` for å svare på forhånd og
+hoppe over spørsmålet.
 
 ## Sandboxing og isolasjon er påkrevd
 

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -28,6 +28,10 @@ nav-pilot
 nav-pilot install kotlin-backend
 ```
 
+`install` spør hvor den skal installere — i repoet (`.github/`) eller i hjemmekatalogen
+(`~/.copilot/`). Bruk `--user` eller `--target <mappe>` for å svare på forhånd og hoppe
+over spørsmålet.
+
 ## Sandboxing og isolasjon er påkrevd
 
 Når du bruker en AI-agent på Nav-utstyr, skal agenten kjøre i en sandbox eller
@@ -177,9 +181,13 @@ nav-pilot config show
 ```
 
 Støttede felt er `client`, `model`, `mode`, `reasoning_effort`, `context_tier`,
-`allow_all_tools`, `ask_user` og `log_level`. Du kan overstyre dem per kjøring med
+`allow_all_tools`, `ask_user`, `auto_launch` og `log_level`. Du kan overstyre dem per kjøring med
 globale flagg som `--client`, `--model`, `--mode`, `--effort`, `--context`,
-`--allow-all-tools`, `--no-ask-user` og `--log-level`.
+`--allow-all-tools`, `--no-ask-user`, `--auto-launch`/`--no-auto-launch` og `--log-level`.
+
+Etter synk/installasjon starter nav-pilot kodeagenten automatisk. Sett
+`auto_launch = false` (eller bruk `--no-auto-launch`) hvis du heller vil starte
+den selv — da skriver nav-pilot bare ut kommandoen du kan kjøre.
 
 **Modell per klient:**
 - Copilot: `auto`, `claude-opus-5`, `claude-fable-5`, `claude-sonnet-5`,


### PR DESCRIPTION
Two changes to `nav-pilot`, both from feedback in the Slack thread.

## Interactive settings page

`nav-pilot config` with no subcommand printed a usage error. On a terminal it now opens a settings page listing every user-facing config key with its current value, where that value comes from (config file, environment or default), and a description of what the key does. Selecting a key edits it: booleans and keys with a fixed set of allowed values get a picker, everything else gets a prefilled input. Submitting an empty value clears the key from the config file. The sandbox setup wizard is reachable from the same list. Without a terminal (scripts, CI) the usage error is unchanged.

`config show` now builds its output from the same key table that drives the page, so value and source labelling cannot drift between the two commands. The output is byte-identical to before.

## Install scope prompt

`nav-pilot install kotlin-backend` (and `nav-pilot add <type> <name>`) wrote to the repository's `.github/` without asking, which surprised people who expected a user-level install. Both now ask the same repo-or-user question the bare interactive flow already asks.

The prompt is skipped when the scope is already explicit (`--user`, `--target`) and for `--json`, `--dry-run` and non-interactive runs, which keep writing to the repository as before. Malformed invocations such as `nav-pilot add agent` still return their usage error rather than opening a picker.

## Testing

`go build ./...`, `go vet ./...`, `go test ./...` and `gofmt -l .` are clean. New tests cover the entry building and key clearing on the settings page, and the scope prompt across all the flag combinations above.

The cplt problems from the same thread are filed separately as navikt/cplt#187, #188 and #189.


## Launch straight after install, and `auto_launch` retired

The "Launch X now?" confirmation after an install is gone. On a terminal a working setup launches the configured agent directly; without a terminal nothing is launched, as before.

Warnings replace it where there is something worth saying:

- client binary missing: nav-pilot says so and points at `nav-pilot doctor`, instead of silently doing nothing. For opencode it names cplt when opencode itself is present, which is the case people actually hit.
- only the plain, unsandboxed copilot CLI on PATH: the launch is called out as unsandboxed and confirmed before it starts.

With no confirmation left to skip, `auto_launch` does nothing, so it is removed from the settings page, `config show`, the `config init` template, the setup wizard and the docs. The TOML field is kept and parsed on purpose — unknown keys are a hard error at launch, so deleting it would stop nav-pilot for everyone who has the key in their config. Those configs get a non-fatal advisory saying it can be deleted, and `--auto-launch` / `--no-auto-launch` are still accepted and ignored so existing aliases keep working.


## After the review

Two reviewers went over the branch adversarially; the findings are fixed in `3cd3d61`.

The important one: retiring `auto_launch` removed the only way to say "never launch an agent at me". It is honoured again with the new meaning — it no longer skips a confirmation, it decides whether nav-pilot launches at all. Default `true`; `auto_launch = false` (or `--no-auto-launch`) prints the command instead of starting anything.

Also fixed:

- `install <name>` with a character-device stdin but no controlling tty (cron, CI without `CI=1`, detached ssh) opened the scope prompt, huh failed, the failure was read as "cancelled" and the command exited 0 having installed nothing. A failed prompt now falls back to the repository scope with a warning; only a real abort cancels.
- The scope question is skipped where one answer is already known to fail: outside a git repository, and for item types user scope cannot hold.
- `config --json` opened the settings page instead of returning the usage error, and a page that could not open a terminal surfaced the raw huh error. Both fall back to the usage error; a genuinely broken config file still reports itself.
- Runs without a terminal are silent again, and the launch warnings that remain go to stderr.
- A failed launch printed `Launching pi...` and then nothing — the error was discarded. `client = pi` without cplt now says so. The missing-client warning also printed an empty name when neither cplt nor copilot was on PATH.
- `writeConfigKey` replaced the first line matching a key, commented or not, so editing a key present both as a template comment and as a hand-added active line defined it twice and left the config unparseable. It prefers the active line now.


## `--repo` and the docs site

The scope question could only be answered up front with `--user` or `--target`, and `--target` also bypasses git-root resolution, so `install <name> --target .` from a subdirectory installs into that subdirectory. `--repo` is the explicit opposite of `--user`: repository scope, git root intact, no question. Mutually exclusive with `--user` and `--target`.

my-copilot needed updating in one place that was genuinely broken: the setup wizard builds a multi-line recipe to paste into a terminal, and its `nav-pilot install <collection>` line would open the scope picker, which then eats the following pasted lines as keystrokes. That command passes `--repo` now. The detail drawer's "I repoet" button had the same problem and gets `--repo` too. The rest is text: `nav-pilot` starts Copilot rather than offering to, `install` asks where to install, and bare `nav-pilot config` is listed as the settings page.

Note on rollout: the site now hands out `--repo`, which older nav-pilot binaries reject as an unknown flag. The site should not be deployed ahead of the CLI release.
