### PR TITLE
feat(nav-pilot): recommend cplt's strict preset and report cplt version skew

### DIFF
--- a/cli/nav-pilot/internal/artifacts/version.go
+++ b/cli/nav-pilot/internal/artifacts/version.go
@@ -12,18 +12,22 @@ func VersionTimestamp(v string) string {
 	return v
 }
 
+// VersionParseable reports whether v carries a comparable date-time prefix.
+// VersionNewer answers false for anything else, so callers that must tell
+// "not newer" apart from "cannot tell" ask this first instead of inventing
+// their own rule.
+func VersionParseable(v string) bool {
+	t := VersionTimestamp(v)
+	return len(t) > 0 && t[0] >= '0' && t[0] <= '9'
+}
+
 // VersionNewer returns true if candidate is a newer version than current.
 // Compares the date-time prefix (YYYY.MM.DD-HHMMSS) lexicographically,
 // which works because the format is zero-padded and fixed-width.
 // Returns false if either version is malformed (e.g. "dev", "").
 func VersionNewer(candidate, current string) bool {
-	ct := VersionTimestamp(candidate)
-	cu := VersionTimestamp(current)
-	if len(ct) == 0 || ct[0] < '0' || ct[0] > '9' {
+	if !VersionParseable(candidate) || !VersionParseable(current) {
 		return false
 	}
-	if len(cu) == 0 || cu[0] < '0' || cu[0] > '9' {
-		return false
-	}
-	return ct > cu
+	return VersionTimestamp(candidate) > VersionTimestamp(current)
 }

--- a/cli/nav-pilot/internal/cli/aliases.go
+++ b/cli/nav-pilot/internal/cli/aliases.go
@@ -192,6 +192,7 @@ type (
 
 var (
 	versionNewer     = artifacts.VersionNewer
+	versionParseable = artifacts.VersionParseable
 	versionTimestamp = artifacts.VersionTimestamp
 )
 

--- a/cli/nav-pilot/internal/cli/config_page.go
+++ b/cli/nav-pilot/internal/cli/config_page.go
@@ -123,8 +123,22 @@ func buildConfigPageEntries(cfg *Config, r ResolvedConfig) []configPageEntry {
 // Sentinel option values; no config key can collide with them.
 const (
 	configPageSandbox = "\x00sandbox"
+	configPagePosture = "\x00posture"
 	configPageDone    = "\x00done"
 )
+
+// cpltPostureLabel renders the security-posture row the way the key rows read:
+// the current value first, and what it should be when it is not that already.
+func cpltPostureLabel(preset string) string {
+	switch {
+	case preset == "":
+		return "cplt security posture   unknown  (could not read it from cplt)"
+	case cpltRecommendStrict(preset):
+		return fmt.Sprintf("cplt security posture   %s  (recommended: %s)", preset, cpltRecommendedPreset)
+	default:
+		return fmt.Sprintf("cplt security posture   %s", preset)
+	}
+}
 
 // errConfigPageUnavailable reports that the settings page never started, e.g.
 // because there is no usable terminal. Callers fall back to their non-
@@ -138,6 +152,10 @@ func cmdConfigPage() error {
 	// a TTY must leave no trace before its caller falls back.
 	rendered := false
 
+	// Reading the preset costs a cplt spawn, so it is read once per page and
+	// refreshed only when the user actually changes it — not on every redraw.
+	preset := cpltSandboxPreset()
+
 	for {
 		cfg, err := readConfig()
 		if err != nil {
@@ -148,15 +166,17 @@ func cmdConfigPage() error {
 
 		descriptions := map[string]string{
 			configPageSandbox: "Runs the cplt sandbox wizard (requires cplt on your PATH).",
+			configPagePosture: "Sets cplt sandbox.preset = strict, which turns on gh_guard, git_guard and forced proxy in one key (requires cplt on your PATH).",
 			configPageDone:    "Leave the settings page.",
 		}
-		opts := make([]huh.Option[string], 0, len(entries)+2)
+		opts := make([]huh.Option[string], 0, len(entries)+3)
 		for _, e := range entries {
 			opts = append(opts, huh.NewOption(e.label(), e.Key))
 			descriptions[e.Key] = e.Description
 		}
 		opts = append(opts,
 			huh.NewOption("Configure cplt sandbox settings…", configPageSandbox),
+			huh.NewOption(cpltPostureLabel(preset), configPagePosture),
 			huh.NewOption("Done", configPageDone),
 		)
 
@@ -190,6 +210,12 @@ func cmdConfigPage() error {
 			// "cplt not on PATH" is a notice, not a reason to leave the page.
 			if err := cmdConfigSandbox(); err != nil {
 				fmt.Printf("%s %v\n", yellow("⚠"), err)
+			}
+		case configPagePosture:
+			if err := cmdConfigStrictPreset(); err != nil {
+				fmt.Printf("%s %v\n", yellow("⚠"), err)
+			} else {
+				preset = cpltSandboxPreset()
 			}
 		default:
 			if err := editConfigKey(choice, resolved); err != nil {

--- a/cli/nav-pilot/internal/cli/config_page_test.go
+++ b/cli/nav-pilot/internal/cli/config_page_test.go
@@ -133,3 +133,18 @@ func TestClearConfigKey(t *testing.T) {
 		t.Errorf("mode still parsed as %q", *cfg.Mode)
 	}
 }
+
+func TestCpltPostureLabel(t *testing.T) {
+	tests := []struct {
+		preset, want string
+	}{
+		{"strict", "cplt security posture   strict"},
+		{"standard", "cplt security posture   standard  (recommended: strict)"},
+		{"", "cplt security posture   unknown  (could not read it from cplt)"},
+	}
+	for _, tc := range tests {
+		if got := cpltPostureLabel(tc.preset); got != tc.want {
+			t.Errorf("cpltPostureLabel(%q) = %q, want %q", tc.preset, got, tc.want)
+		}
+	}
+}

--- a/cli/nav-pilot/internal/cli/config_sandbox.go
+++ b/cli/nav-pilot/internal/cli/config_sandbox.go
@@ -1,23 +1,45 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
+	"strings"
+	"time"
 
 	"github.com/charmbracelet/huh"
 	"github.com/navikt/copilot/cli/nav-pilot/internal/domain"
 	providerpkg "github.com/navikt/copilot/cli/nav-pilot/internal/provider"
 )
 
-// cmdConfigSandbox runs an interactive wizard to configure the cplt sandbox profile.
-func cmdConfigSandbox() error {
+// findCplt locates the cplt binary. The `copilot` binary is only accepted when
+// it really is cplt — plain GitHub Copilot has no `config` subcommand.
+func findCplt() (string, error) {
 	cliPath, cliName := providerpkg.FindCopilotCLI()
 	if cliPath == "" || cliName != "cplt" {
-		return fmt.Errorf("cplt (Copilot Sandbox) is not available on your PATH. This command requires cplt")
+		return "", fmt.Errorf("cplt (Copilot Sandbox) is not available on your PATH. This command requires cplt")
+	}
+	return cliPath, nil
+}
+
+// cpltConfigSet writes one cplt config key.
+func cpltConfigSet(cliPath, key, val string) error {
+	out, err := exec.Command(cliPath, "config", "set", key, val).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to set %s: %v\n%s", key, err, string(out))
+	}
+	return nil
+}
+
+// cmdConfigSandbox runs an interactive wizard to configure the cplt sandbox profile.
+func cmdConfigSandbox() error {
+	cliPath, err := findCplt()
+	if err != nil {
+		return err
 	}
 
 	var choices []string
-	err := huh.NewMultiSelect[string]().
+	err = huh.NewMultiSelect[string]().
 		Title("Configure cplt sandbox relaxations").
 		Description("Select which restrictions to lift for agents running under cplt.").
 		Options(
@@ -43,12 +65,87 @@ func cmdConfigSandbox() error {
 				break
 			}
 		}
-		out, err := exec.Command(cliPath, "config", "set", key, val).CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("failed to set %s: %v\n%s", key, err, string(out))
+		if err := cpltConfigSet(cliPath, key, val); err != nil {
+			return err
 		}
 	}
 
 	fmt.Printf("%s Successfully updated cplt sandbox configuration\n", domain.Green("✓"))
+	return nil
+}
+
+// ─── security posture (sandbox.preset) ───────────────────────────────────────
+
+// cpltRecommendedPreset is the sandbox preset nav-pilot recommends: it turns on
+// gh_guard, git_guard and proxy.forced in one key. Individually set keys still
+// override it, so it is safe to recommend to users who have tuned cplt already.
+const cpltRecommendedPreset = "strict"
+
+// cpltPresets are the values cplt accepts for sandbox.preset. Anything else is
+// treated as unknown rather than guessed at.
+var cpltPresets = []string{"strict", "standard", "permissive", "full-trust"}
+
+// cpltPresetFromConfigGet extracts the preset from `cplt config get
+// sandbox.preset` output: the value is on the first line, and a following
+// annotation line such as "[cplt] (default — not set in config file)" is
+// ignored. An empty or unrecognised value yields "" — unknown, never guessed at.
+func cpltPresetFromConfigGet(out string) string {
+	first, _, _ := strings.Cut(out, "\n")
+	val := strings.TrimSpace(first)
+	if !containsStr(cpltPresets, val) {
+		return ""
+	}
+	return val
+}
+
+// cpltSandboxPreset returns the effective cplt sandbox.preset, or "" when it
+// cannot be determined — no cplt, a failed command, or a value this build does
+// not know. Callers skip their recommendation on "" rather than guessing.
+// A var so tests can stub the process spawn.
+var cpltSandboxPreset = func() string {
+	cliPath, err := findCplt()
+	if err != nil {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, cliPath, "config", "get", "sandbox.preset").Output()
+	if err != nil {
+		return ""
+	}
+	return cpltPresetFromConfigGet(string(out))
+}
+
+// cpltRecommendStrict reports whether nav-pilot should nudge the user towards
+// the strict preset. An unknown preset is left alone.
+func cpltRecommendStrict(preset string) bool {
+	return preset != "" && preset != cpltRecommendedPreset
+}
+
+// cmdConfigStrictPreset asks for confirmation and sets sandbox.preset = strict.
+// cplt config is personal: nav-pilot never sets it silently.
+func cmdConfigStrictPreset() error {
+	cliPath, err := findCplt()
+	if err != nil {
+		return err
+	}
+
+	var ok bool
+	if err := huh.NewConfirm().
+		Title("Set cplt sandbox.preset = strict?").
+		Description("Turns on gh_guard, git_guard and forced proxy in one key. Keys you set yourself still win.").
+		Value(&ok).
+		WithTheme(navTheme()).
+		Run(); err != nil {
+		return fmt.Errorf("prompt cancelled: %w", err)
+	}
+	if !ok {
+		return nil
+	}
+
+	if err := cpltConfigSet(cliPath, "sandbox.preset", cpltRecommendedPreset); err != nil {
+		return err
+	}
+	fmt.Printf("%s cplt sandbox.preset = %s\n", domain.Green("✓"), cpltRecommendedPreset)
 	return nil
 }

--- a/cli/nav-pilot/internal/cli/config_sandbox_test.go
+++ b/cli/nav-pilot/internal/cli/config_sandbox_test.go
@@ -1,0 +1,41 @@
+package cli
+
+import "testing"
+
+func TestCpltPresetFromConfigGet(t *testing.T) {
+	tests := []struct {
+		name, out, want string
+	}{
+		{"value with annotation", "standard\n[cplt] (default — not set in config file)\n", "standard"},
+		{"strict", "strict\n[cplt] (set in config file)\n", "strict"},
+		{"bare value", "permissive\n", "permissive"},
+		{"padded", "  full-trust  \n", "full-trust"},
+		{"empty (command failed, nothing on stdout)", "", ""},
+		{"only whitespace", "\n\n", ""},
+		{"unknown value", "paranoid\n", ""},
+		{"error text", "[cplt] unknown config key 'sandbox.preset'\n", ""},
+	}
+	for _, tc := range tests {
+		if got := cpltPresetFromConfigGet(tc.out); got != tc.want {
+			t.Errorf("%s: cpltPresetFromConfigGet(%q) = %q, want %q", tc.name, tc.out, got, tc.want)
+		}
+	}
+}
+
+func TestCpltRecommendStrict(t *testing.T) {
+	tests := []struct {
+		preset string
+		want   bool
+	}{
+		{"strict", false},
+		{"standard", true},
+		{"permissive", true},
+		{"full-trust", true},
+		{"", false}, // unknown: skip the recommendation rather than guess
+	}
+	for _, tc := range tests {
+		if got := cpltRecommendStrict(tc.preset); got != tc.want {
+			t.Errorf("cpltRecommendStrict(%q) = %v, want %v", tc.preset, got, tc.want)
+		}
+	}
+}

--- a/cli/nav-pilot/internal/cli/doctor.go
+++ b/cli/nav-pilot/internal/cli/doctor.go
@@ -115,6 +115,33 @@ func cmdDoctor() error {
 		}
 		fmt.Printf("      %s Binary found: %s (%s)\n", green("✓"), cpltPath, version)
 
+		// Version skew is warn-only: nav-pilot never downloads or upgrades cplt,
+		// and a slow or offline GitHub must not fail the health check.
+		installed := parseCpltVersion(version)
+		switch latest, lerr := latestCpltVersion(); {
+		case lerr != nil || latest == "":
+			fmt.Printf("      %s Could not check for a newer cplt release\n", dim("-"))
+		case versionNewer(latest, installed):
+			fmt.Printf("      %s cplt %s is out of date (latest: %s)\n", yellow("⚠"), installed, latest)
+			fmt.Printf("          %s Run %s\n", yellow("Solution:"), bold("brew upgrade navikt/tap/cplt"))
+		default:
+			fmt.Printf("      %s cplt is up to date\n", green("✓"))
+		}
+
+		// Security posture. A recommendation, not a failure — and an unknown
+		// preset is skipped rather than guessed at.
+		preset := cpltSandboxPreset()
+		switch {
+		case preset == "":
+			// cplt could not tell us; nothing to recommend.
+		case cpltRecommendStrict(preset):
+			fmt.Printf("      %s Sandbox preset is %q (recommended: %q — turns on gh_guard, git_guard and forced proxy)\n",
+				yellow("⚠"), preset, cpltRecommendedPreset)
+			fmt.Printf("          %s Run %s\n", yellow("Solution:"), bold("cplt config set sandbox.preset strict"))
+		default:
+			fmt.Printf("      %s Sandbox preset is %s\n", green("✓"), preset)
+		}
+
 		// The persona is pinned by nav-pilot itself, not by user configuration:
 		// BuildCopilotArgs unconditionally emits `cplt --agent copilot --
 		// --agent nav-pilot` on every launch. There is nothing to check and

--- a/cli/nav-pilot/internal/cli/doctor.go
+++ b/cli/nav-pilot/internal/cli/doctor.go
@@ -1,13 +1,11 @@
 package cli
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/BurntSushi/toml"
 	providerpkg "github.com/navikt/copilot/cli/nav-pilot/internal/provider"
@@ -97,8 +95,6 @@ func cmdDoctor() error {
 
 	// 3. Client Agents
 	fmt.Printf("[i] Client Agents\n")
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
 
 	// copilot (cplt)
 	fmt.Printf("    • copilot (cplt)\n")
@@ -108,7 +104,7 @@ func cmdDoctor() error {
 		fmt.Printf("      %s Binary not found on PATH\n", red("[✗]"))
 		fmt.Printf("          %s Install cplt via Homebrew: %s\n", red("Solution:"), bold("brew install navikt/tap/cplt"))
 	} else {
-		versionOut, err := exec.CommandContext(ctx, cpltPath, "--version").Output()
+		versionOut, err := runBounded(cpltPath, "--version")
 		version := strings.TrimSpace(string(versionOut))
 		if err != nil {
 			version = "unknown"
@@ -116,16 +112,18 @@ func cmdDoctor() error {
 		fmt.Printf("      %s Binary found: %s (%s)\n", green("✓"), cpltPath, version)
 
 		// Version skew is warn-only: nav-pilot never downloads or upgrades cplt,
-		// and a slow or offline GitHub must not fail the health check.
+		// and a slow or offline GitHub must not fail the health check. An
+		// unreadable installed version reports unknown, never "up to date".
 		installed := parseCpltVersion(version)
-		switch latest, lerr := latestCpltVersion(); {
-		case lerr != nil || latest == "":
-			fmt.Printf("      %s Could not check for a newer cplt release\n", dim("-"))
-		case versionNewer(latest, installed):
+		latest, lerr := latestCpltVersion()
+		switch classifyCpltSkew(installed, latest, lerr) {
+		case cpltVersionBehind:
 			fmt.Printf("      %s cplt %s is out of date (latest: %s)\n", yellow("⚠"), installed, latest)
 			fmt.Printf("          %s Run %s\n", yellow("Solution:"), bold("brew upgrade navikt/tap/cplt"))
-		default:
+		case cpltVersionCurrent:
 			fmt.Printf("      %s cplt is up to date\n", green("✓"))
+		default:
+			fmt.Printf("      %s Could not check for a newer cplt release\n", dim("-"))
 		}
 
 		// Security posture. A recommendation, not a failure — and an unknown
@@ -196,12 +194,21 @@ func cmdDoctor() error {
 	// 4. Project Security
 	fmt.Printf("[i] Project Security (.cplt.toml)\n")
 	if cpltPath != "" {
-		cfgOut, _ := exec.CommandContext(ctx, cpltPath, "config", "show").CombinedOutput()
-		if strings.Contains(string(cfgOut), "pending approval") || strings.Contains(string(cfgOut), "pending") {
+		// Its own deadline: an earlier slow check must not be able to starve
+		// this one into an empty read, which would print a false "trusted".
+		cfgOut, cfgErr := runBoundedCombined(cpltPath, "config", "show")
+		switch {
+		case strings.Contains(string(cfgOut), "pending"):
 			hasErrors = true
 			fmt.Printf("    %s Pending permissions detected!\n", red("[✗]"))
 			fmt.Printf("        %s Run %s in this directory to approve new sandbox rules.\n", red("Solution:"), bold("cplt trust"))
-		} else {
+		case cfgErr != nil:
+			// Unreadable config is unknown, not trusted: never print a green
+			// tick for rules we failed to look at.
+			hasErrors = true
+			fmt.Printf("    %s Could not read cplt config (%v)\n", yellow("⚠"), cfgErr)
+			fmt.Printf("        %s Run %s in this directory to check for pending sandbox rules.\n", yellow("Solution:"), bold("cplt trust"))
+		default:
 			if _, err := os.Stat(".cplt.toml"); err == nil {
 				fmt.Printf("    %s .cplt.toml rules are trusted\n", green("✓"))
 			} else {

--- a/cli/nav-pilot/internal/cli/update.go
+++ b/cli/nav-pilot/internal/cli/update.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -20,6 +21,9 @@ import (
 var (
 	releasesAPI = "https://api.github.com/repos/navikt/copilot/releases"
 	downloadURL = "https://github.com/navikt/copilot/releases/download"
+
+	// cplt ships from its own repo, with its own release train and unprefixed tags.
+	cpltReleasesAPI = "https://api.github.com/repos/navikt/cplt/releases"
 )
 
 // httpClient is the client used for all HTTP requests. Overridable in tests.
@@ -47,9 +51,13 @@ func cmdUpdate() error {
 // from "successfully updated" and avoid re-executing when nothing changed.
 func doUpdate() (updated bool, err error) {
 	if isBrewManaged() {
+		formulae := "navikt/tap/nav-pilot"
+		if cpltBehind() {
+			formulae += " navikt/tap/cplt"
+		}
 		fmt.Println("nav-pilot is managed by Homebrew.")
 		fmt.Println()
-		fmt.Println("  brew upgrade navikt/tap/nav-pilot")
+		fmt.Printf("  brew upgrade %s\n", formulae)
 		return false, nil
 	}
 
@@ -144,7 +152,14 @@ func isBrewManaged() bool {
 // Returns the raw version (matching the build-injected format, e.g. "2026.04.13-170138-abc1234")
 // and the full tag (e.g. "nav-pilot/2026.04.13-170138-abc1234").
 func fetchLatestVersion(ctx context.Context) (ver string, tag string, err error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", releasesAPI+"?per_page=20", nil)
+	return fetchLatestRelease(ctx, releasesAPI, "nav-pilot/")
+}
+
+// fetchLatestRelease returns the newest release from a GitHub releases API whose
+// tag carries prefix (empty prefix = the newest release, for repos that do not
+// prefix their tags). Returns the version (tag minus prefix) and the full tag.
+func fetchLatestRelease(ctx context.Context, api, prefix string) (ver string, tag string, err error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", api+"?per_page=20", nil)
 	if err != nil {
 		return "", "", err
 	}
@@ -169,14 +184,54 @@ func fetchLatestVersion(ctx context.Context) (ver string, tag string, err error)
 	}
 
 	for _, rel := range releases {
-		if strings.HasPrefix(rel.TagName, "nav-pilot/") {
+		if strings.HasPrefix(rel.TagName, prefix) {
 			tag = rel.TagName
-			ver = strings.TrimPrefix(tag, "nav-pilot/")
+			ver = strings.TrimPrefix(tag, prefix)
 			return ver, tag, nil
 		}
 	}
 
-	return "", "", fmt.Errorf("no nav-pilot release found")
+	return "", "", fmt.Errorf("no release found with tag prefix %q", prefix)
+}
+
+// latestCpltVersion returns the newest published cplt version. The short
+// timeout keeps a slow or unreachable GitHub from stalling doctor or upgrade —
+// callers treat an error as "could not check", never as "outdated".
+// A var so tests can stub it without a network call.
+var latestCpltVersion = func() (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ver, _, err := fetchLatestRelease(ctx, cpltReleasesAPI, "")
+	return ver, err
+}
+
+// parseCpltVersion pulls the bare version out of `cplt --version` output, which
+// reads "cplt 2026.08.24-153138-0d1d66d".
+func parseCpltVersion(out string) string {
+	fields := strings.Fields(out)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[len(fields)-1]
+}
+
+// cpltBehind reports whether the installed cplt is older than the latest cplt
+// release. Everything uncertain — no cplt, no network, an unparseable version —
+// answers false: nav-pilot stays quiet rather than guessing.
+func cpltBehind() bool {
+	cliPath, err := findCplt()
+	if err != nil {
+		return false
+	}
+	out, err := exec.Command(cliPath, "--version").Output()
+	if err != nil {
+		return false
+	}
+	latest, err := latestCpltVersion()
+	if err != nil {
+		return false
+	}
+	return versionNewer(latest, parseCpltVersion(string(out)))
 }
 
 func httpGet(url string) ([]byte, error) {

--- a/cli/nav-pilot/internal/cli/update.go
+++ b/cli/nav-pilot/internal/cli/update.go
@@ -51,12 +51,14 @@ func cmdUpdate() error {
 // from "successfully updated" and avoid re-executing when nothing changed.
 func doUpdate() (updated bool, err error) {
 	if isBrewManaged() {
+		// Print first, then check cplt: the cplt lookup can take seconds, and
+		// the "managed by Homebrew" line used to be instant.
+		fmt.Println("nav-pilot is managed by Homebrew.")
+		fmt.Println()
 		formulae := "navikt/tap/nav-pilot"
 		if cpltBehind() {
 			formulae += " navikt/tap/cplt"
 		}
-		fmt.Println("nav-pilot is managed by Homebrew.")
-		fmt.Println()
 		fmt.Printf("  brew upgrade %s\n", formulae)
 		return false, nil
 	}
@@ -159,18 +161,22 @@ func fetchLatestVersion(ctx context.Context) (ver string, tag string, err error)
 // tag carries prefix (empty prefix = the newest release, for repos that do not
 // prefix their tags). Returns the version (tag minus prefix) and the full tag.
 func fetchLatestRelease(ctx context.Context, api, prefix string) (ver string, tag string, err error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", api+"?per_page=20", nil)
+	token := os.Getenv("GITHUB_TOKEN")
+	resp, err := releasesRequest(ctx, api, token)
 	if err != nil {
 		return "", "", err
 	}
 
-	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return "", "", err
+	// A GITHUB_TOKEN scoped for packages (but not for api.github.com) answers
+	// 401/403 here and would kill release checks for good. The releases API is
+	// public, so retry once anonymously. The authenticated attempt stays first
+	// for its higher rate limit.
+	if token != "" && (resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden) {
+		resp.Body.Close()
+		resp, err = releasesRequest(ctx, api, "")
+		if err != nil {
+			return "", "", err
+		}
 	}
 	defer resp.Body.Close()
 
@@ -194,6 +200,19 @@ func fetchLatestRelease(ctx context.Context, api, prefix string) (ver string, ta
 	return "", "", fmt.Errorf("no release found with tag prefix %q", prefix)
 }
 
+// releasesRequest issues one GET against a GitHub releases API, authenticated
+// when token is non-empty.
+func releasesRequest(ctx context.Context, api, token string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", api+"?per_page=20", nil)
+	if err != nil {
+		return nil, err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return httpClient.Do(req)
+}
+
 // latestCpltVersion returns the newest published cplt version. The short
 // timeout keeps a slow or unreachable GitHub from stalling doctor or upgrade —
 // callers treat an error as "could not check", never as "outdated".
@@ -205,33 +224,83 @@ var latestCpltVersion = func() (string, error) {
 	return ver, err
 }
 
+// cpltCommandTimeout bounds every cplt process spawn. Each spawn gets its own
+// deadline: no check may share a wall clock with an unrelated one.
+const cpltCommandTimeout = 2 * time.Second
+
+// runBounded runs a command with its own deadline and returns its stdout.
+func runBounded(name string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), cpltCommandTimeout)
+	defer cancel()
+	return exec.CommandContext(ctx, name, args...).Output()
+}
+
+// runBoundedCombined is runBounded, but keeps stderr — for commands whose
+// interesting output is not reliably on stdout.
+func runBoundedCombined(name string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), cpltCommandTimeout)
+	defer cancel()
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
 // parseCpltVersion pulls the bare version out of `cplt --version` output, which
-// reads "cplt 2026.08.24-153138-0d1d66d".
+// reads "cplt 2026.08.24-153138-0d1d66d". Anything that is not a comparable
+// version ("unknown", "dev", a future format) yields "" — unknown, so callers
+// cannot mistake it for "up to date".
 func parseCpltVersion(out string) string {
 	fields := strings.Fields(out)
 	if len(fields) == 0 {
 		return ""
 	}
-	return fields[len(fields)-1]
+	v := fields[len(fields)-1]
+	if !versionParseable(v) {
+		return ""
+	}
+	return v
+}
+
+// cpltSkew is the three-way outcome of the cplt version-skew check.
+type cpltSkew int
+
+const (
+	cpltVersionUnknown cpltSkew = iota // could not tell — never report as current
+	cpltVersionCurrent
+	cpltVersionBehind
+)
+
+// classifyCpltSkew compares the installed cplt version against the latest
+// release. A failed lookup or a version neither side can parse is unknown, not
+// current: a security-relevant check must never go green on missing data.
+func classifyCpltSkew(installed, latest string, lookupErr error) cpltSkew {
+	if lookupErr != nil || !versionParseable(latest) || !versionParseable(installed) {
+		return cpltVersionUnknown
+	}
+	if versionNewer(latest, installed) {
+		return cpltVersionBehind
+	}
+	return cpltVersionCurrent
+}
+
+// cpltVersionSkew reads the installed cplt version and compares it to the
+// latest release. Everything uncertain — no cplt, no network, an unparseable
+// version — is cpltVersionUnknown.
+func cpltVersionSkew() cpltSkew {
+	cliPath, err := findCplt()
+	if err != nil {
+		return cpltVersionUnknown
+	}
+	out, err := runBounded(cliPath, "--version")
+	if err != nil {
+		return cpltVersionUnknown
+	}
+	latest, lerr := latestCpltVersion()
+	return classifyCpltSkew(parseCpltVersion(string(out)), latest, lerr)
 }
 
 // cpltBehind reports whether the installed cplt is older than the latest cplt
-// release. Everything uncertain — no cplt, no network, an unparseable version —
-// answers false: nav-pilot stays quiet rather than guessing.
+// release. Uncertainty answers false: nav-pilot stays quiet rather than guessing.
 func cpltBehind() bool {
-	cliPath, err := findCplt()
-	if err != nil {
-		return false
-	}
-	out, err := exec.Command(cliPath, "--version").Output()
-	if err != nil {
-		return false
-	}
-	latest, err := latestCpltVersion()
-	if err != nil {
-		return false
-	}
-	return versionNewer(latest, parseCpltVersion(string(out)))
+	return cpltVersionSkew() == cpltVersionBehind
 }
 
 func httpGet(url string) ([]byte, error) {

--- a/cli/nav-pilot/internal/cli/update_test.go
+++ b/cli/nav-pilot/internal/cli/update_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"net/http"
@@ -136,4 +137,60 @@ func TestRun_UpdateCommand(t *testing.T) {
 		t.Fatal("update command not wired up in main.go")
 	}
 	// Will get a network error or version mismatch, that's fine
+}
+
+func TestFetchLatestRelease_UnprefixedTags(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[
+			{"tag_name": "2026.08.26-201133-2e78d25"},
+			{"tag_name": "2026.08.24-153138-0d1d66d"}
+		]`)
+	}))
+	defer srv.Close()
+
+	origClient := httpClient
+	httpClient = srv.Client()
+	defer func() { httpClient = origClient }()
+
+	// cplt tags carry no prefix, so the newest release wins outright.
+	ver, tag, err := fetchLatestRelease(context.Background(), srv.URL, "")
+	if err != nil {
+		t.Fatalf("fetchLatestRelease: %v", err)
+	}
+	if ver != "2026.08.26-201133-2e78d25" || tag != ver {
+		t.Errorf("got ver=%q tag=%q, want both %q", ver, tag, "2026.08.26-201133-2e78d25")
+	}
+}
+
+func TestParseCpltVersion(t *testing.T) {
+	tests := []struct{ out, want string }{
+		{"cplt 2026.08.24-153138-0d1d66d", "2026.08.24-153138-0d1d66d"},
+		{"cplt 2026.08.24-153138-0d1d66d\n", "2026.08.24-153138-0d1d66d"},
+		{"unknown", "unknown"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		if got := parseCpltVersion(tc.out); got != tc.want {
+			t.Errorf("parseCpltVersion(%q) = %q, want %q", tc.out, got, tc.want)
+		}
+	}
+}
+
+func TestCpltVersionSkew(t *testing.T) {
+	const latest = "2026.08.26-201133-2e78d25"
+	tests := []struct {
+		name, versionOut string
+		wantBehind       bool
+	}{
+		{"older", "cplt 2026.08.24-153138-0d1d66d", true},
+		{"same", "cplt " + latest, false},
+		{"newer (local build)", "cplt 2026.09.01-090000-aaaaaaa", false},
+		{"unparseable version output", "unknown", false},
+	}
+	for _, tc := range tests {
+		if got := versionNewer(latest, parseCpltVersion(tc.versionOut)); got != tc.wantBehind {
+			t.Errorf("%s: behind = %v, want %v", tc.name, got, tc.wantBehind)
+		}
+	}
 }

--- a/cli/nav-pilot/internal/cli/update_test.go
+++ b/cli/nav-pilot/internal/cli/update_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -167,7 +168,8 @@ func TestParseCpltVersion(t *testing.T) {
 	tests := []struct{ out, want string }{
 		{"cplt 2026.08.24-153138-0d1d66d", "2026.08.24-153138-0d1d66d"},
 		{"cplt 2026.08.24-153138-0d1d66d\n", "2026.08.24-153138-0d1d66d"},
-		{"unknown", "unknown"},
+		{"cplt dev", ""},
+		{"unknown", ""},
 		{"", ""},
 	}
 	for _, tc := range tests {
@@ -180,17 +182,78 @@ func TestParseCpltVersion(t *testing.T) {
 func TestCpltVersionSkew(t *testing.T) {
 	const latest = "2026.08.26-201133-2e78d25"
 	tests := []struct {
-		name, versionOut string
-		wantBehind       bool
+		name, versionOut, latest string
+		lookupErr                error
+		want                     cpltSkew
 	}{
-		{"older", "cplt 2026.08.24-153138-0d1d66d", true},
-		{"same", "cplt " + latest, false},
-		{"newer (local build)", "cplt 2026.09.01-090000-aaaaaaa", false},
-		{"unparseable version output", "unknown", false},
+		{"older", "cplt 2026.08.24-153138-0d1d66d", latest, nil, cpltVersionBehind},
+		{"same", "cplt " + latest, latest, nil, cpltVersionCurrent},
+		{"newer (local build)", "cplt 2026.09.01-090000-aaaaaaa", latest, nil, cpltVersionCurrent},
+		// An unreadable installed version must never read as up to date.
+		{"unparseable version output", "unknown", latest, nil, cpltVersionUnknown},
+		{"dev build", "cplt dev", latest, nil, cpltVersionUnknown},
+		{"lookup failed", "cplt " + latest, "", errors.New("no network"), cpltVersionUnknown},
+		{"empty latest", "cplt " + latest, "", nil, cpltVersionUnknown},
 	}
 	for _, tc := range tests {
-		if got := versionNewer(latest, parseCpltVersion(tc.versionOut)); got != tc.wantBehind {
-			t.Errorf("%s: behind = %v, want %v", tc.name, got, tc.wantBehind)
+		got := classifyCpltSkew(parseCpltVersion(tc.versionOut), tc.latest, tc.lookupErr)
+		if got != tc.want {
+			t.Errorf("%s: classifyCpltSkew = %v, want %v", tc.name, got, tc.want)
 		}
+	}
+}
+
+// A GITHUB_TOKEN that is valid for packages but not for api.github.com answers
+// 401 here; the releases API is public, so the check must fall back to an
+// anonymous request instead of going dark for good.
+func TestFetchLatestRelease_RetriesAnonymouslyOn401(t *testing.T) {
+	var attempts []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts = append(attempts, r.Header.Get("Authorization"))
+		if r.Header.Get("Authorization") != "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[{"tag_name": "2026.08.26-201133-2e78d25"}]`)
+	}))
+	defer srv.Close()
+
+	origClient := httpClient
+	httpClient = srv.Client()
+	defer func() { httpClient = origClient }()
+	t.Setenv("GITHUB_TOKEN", "packages-only-token")
+
+	ver, _, err := fetchLatestRelease(context.Background(), srv.URL, "")
+	if err != nil {
+		t.Fatalf("fetchLatestRelease: %v", err)
+	}
+	if ver != "2026.08.26-201133-2e78d25" {
+		t.Errorf("ver = %q, want the release from the anonymous retry", ver)
+	}
+	if len(attempts) != 2 || attempts[0] == "" || attempts[1] != "" {
+		t.Errorf("attempts = %q, want an authenticated request followed by an anonymous one", attempts)
+	}
+}
+
+// Without a token there is nothing to retry: a 401 stays an error.
+func TestFetchLatestRelease_NoRetryWithoutToken(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	origClient := httpClient
+	httpClient = srv.Client()
+	defer func() { httpClient = origClient }()
+	t.Setenv("GITHUB_TOKEN", "")
+
+	if _, _, err := fetchLatestRelease(context.Background(), srv.URL, ""); err == nil {
+		t.Fatal("fetchLatestRelease = nil error, want a failure")
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1", calls)
 	}
 }

--- a/cli/nav-pilot/internal/provider/copilot_launch.go
+++ b/cli/nav-pilot/internal/provider/copilot_launch.go
@@ -37,8 +37,12 @@ func FindCopilotCLI() (path, name string) {
 
 // isCplt checks if a binary is actually cplt (Copilot Sandbox) by inspecting
 // its version output. Returns true if the binary identifies as cplt/sandbox.
+// The spawn is bounded: FindCopilotCLI runs it on every launch path where a
+// plain `copilot` binary is on PATH, and a hanging binary must not hang us.
 func isCplt(binPath string) bool {
-	out, err := exec.Command(binPath, "--version").CombinedOutput()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, binPath, "--version").CombinedOutput()
 	if err != nil {
 		return false
 	}

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -47,6 +47,25 @@ til Nav-utstyret.
 Les [kortversjonen av kravet](https://ki-utvikling.nav.no/nyheter/sandboxing-er-pakrevd-pa-nav-utstyr)
 for en lenke du kan dele med andre.
 
+### Sikkerhetsnivå og versjon i cplt
+
+`nav-pilot doctor` sjekker sikkerhetsnivået til cplt og anbefaler
+`sandbox.preset = strict`. Det presetet slår på `gh_guard`, `git_guard` og
+tvungen proxy i én nøkkel, og nøkler du har satt selv gjelder fortsatt foran
+presetet. cplt-config er personlig, så nav-pilot setter den aldri stilltiende —
+du velger selv, enten med
+
+```bash
+cplt config set sandbox.preset strict
+```
+
+eller ved å velge raden `cplt security posture` på innstillingssiden
+(`nav-pilot config`), som spør før den setter nøkkelen.
+
+`nav-pilot doctor` sier også fra når cplt selv er utdatert, og foreslår
+`brew upgrade navikt/tap/cplt`. nav-pilot laster aldri ned eller oppgraderer
+cplt for deg, og hvis GitHub ikke svarer, hopper den bare over versjonssjekken.
+
 ## Klienter
 
 nav-pilot støtter tre kodingsagenter (`client`-feltet i konfig):


### PR DESCRIPTION
Closes part of #422. nav-pilot requires cplt but has never had an opinion about how cplt itself is configured, and it only ever checked its own version.

## Security posture

The issue lists four guard keys to recommend individually. cplt has since gained `sandbox.preset`, whose `strict` value turns on `gh_guard`, `git_guard` and the forced proxy in one key — and keys the user sets themselves still override it. So this recommends the one key instead of the four.

- `nav-pilot doctor` reads the effective preset and, when it is not `strict`, says so with `cplt config set sandbox.preset strict` as the fix. It is a recommendation, not a failure — the health check still passes.
- The settings page gets a row showing the current value (`cplt security posture   standard  (recommended: strict)`) that sets `strict` after a confirmation.
- nav-pilot never writes it silently, and a preset it does not recognise is left alone rather than guessed at.

## Version skew

`doctor` compares the installed cplt against the latest `navikt/cplt` release and reports when it is behind, and the Homebrew upgrade line becomes `brew upgrade navikt/tap/nav-pilot navikt/tap/cplt` when cplt is out of date too.

Warn-only: nav-pilot does not download or install cplt, so there is no second SHA256/SLSA path to maintain. Everything uncertain — no cplt, no network, an unparseable version — stays quiet instead of guessing, and the lookup has a 5s timeout so a slow or offline GitHub cannot stall `doctor` or `upgrade`.

## Not in this PR

The issue's option C (nav-pilot generating and maintaining a `~/.config/cplt/config.toml` template) — one recommended key reachable from both `doctor` and the settings page covers the acceptance criteria without nav-pilot owning a file cplt already owns.

## Testing

`mise run nav-pilot:check` (build, test, vet, staticcheck, shellcheck, bats) passes. New tests cover the `cplt config get` output parsing, the recommend-or-not decision, the version comparison, and the release lookup against a stubbed HTTP client. Verified by hand against a real cplt install: `doctor` reports `Sandbox preset is "standard"` with the fix line, and degrades to `Could not check for a newer cplt release` without network.


## After the review

A Fable reviewer went over the branch adversarially; the findings are fixed in `026aad3`.

The worst one was not in the new feature but in what it broke: `doctor` built one 2-second context at the top of its client section and reused it for `cplt config show` in the Project Security check far below. The release lookup added in front of it can spend five seconds, so on a slow or black-holed network the deadline was gone by the time the security check ran — the command was killed, its output came back empty, the `pending` test found nothing, and `doctor` printed that the `.cplt.toml` rules are trusted for rules that may be waiting for approval. Every external call carries its own deadline now, and an unreadable config is reported as unreadable instead of passing.

Also fixed:

- The version check went green on missing data: a failed `cplt --version` became `"unknown"`, which compares as "not newer", which printed `✓ cplt is up to date`. Skew is a three-way answer now — behind, current, unknown — and anything unparseable is unknown.
- `cplt --version` and the `copilot --version` probe in `isCplt` had no deadline, so a hung binary could hang `nav-pilot upgrade` indefinitely. Both are bounded, and the Homebrew branch prints its message before checking cplt rather than after.
- The release lookup attached `GITHUB_TOKEN` unconditionally. A token scoped for packages but not for `api.github.com` answers 401, which made the check fail on every run for those users — nav-pilot's own update check included, since it shares the code. A 401/403 on an authenticated request is retried once anonymously.
- The tests exercised only the `versionNewer(parseCpltVersion(...))` composition, and one case enshrined the exact input behind the false "up to date". They run the real decision function now, plus the anonymous-retry path.
