### PR TITLE
refactor(nav-pilot): read personas from the active agentpakke manifest

### DIFF
--- a/cli/nav-pilot/internal/artifacts/export.go
+++ b/cli/nav-pilot/internal/artifacts/export.go
@@ -314,7 +314,8 @@ func transformAgent(data []byte, name string) []byte {
 		description = "Nav agent"
 	}
 
-	newFM := source.BuildAgentFrontmatter(description, source.OpenCodeAgentMode(name))
+	mode := source.OpenCodeAgentMode(name, source.ActivePakke().PrimaryAgents("opencode"))
+	newFM := source.BuildAgentFrontmatter(description, mode)
 	return source.Reassemble(newFM, body)
 }
 

--- a/cli/nav-pilot/internal/artifacts/golden_agent_test.go
+++ b/cli/nav-pilot/internal/artifacts/golden_agent_test.go
@@ -1,0 +1,80 @@
+package artifacts
+
+import (
+	"strings"
+	"testing"
+)
+
+// Golden materialization test (C3).
+//
+// transformAgent's output is the exact bytes that land in
+// ~/.config/opencode/agents/<name>.md on every opencode launch, so this pins
+// them byte for byte across the primary/subagent split. The data-driven
+// persona refactor (C1/C2) must keep these identical; if a case here has to
+// change, a real materialized file changed and that is a regression.
+
+func TestGoldenTransformAgent(t *testing.T) {
+	const input = `---
+name: %NAME%
+description: Plan and build Nav applications
+tools:
+  - execute
+  - read
+---
+
+You are %NAME%.
+`
+
+	tests := []struct {
+		name  string
+		agent string
+		want  string
+	}{
+		{
+			name:  "nav-pilot is primary",
+			agent: "nav-pilot",
+			want: `---
+description: Plan and build Nav applications
+mode: primary
+---
+
+
+You are nav-pilot.
+`,
+		},
+		{
+			name:  "nav-pilot-opus is primary",
+			agent: "nav-pilot-opus",
+			want: `---
+description: Plan and build Nav applications
+mode: primary
+---
+
+
+You are nav-pilot-opus.
+`,
+		},
+		{
+			name:  "every other agent is a subagent",
+			agent: "aksel-ekspert",
+			want: `---
+description: Plan and build Nav applications
+mode: subagent
+---
+
+
+You are aksel-ekspert.
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := []byte(strings.ReplaceAll(input, "%NAME%", tt.agent))
+			got := string(transformAgent(src, tt.agent))
+			if got != tt.want {
+				t.Errorf("transformAgent(%q)\n got: %q\nwant: %q", tt.agent, got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/nav-pilot/internal/cli/doctor.go
+++ b/cli/nav-pilot/internal/cli/doctor.go
@@ -149,7 +149,7 @@ func cmdDoctor() error {
 		// no such key, so the check always failed and pointed users at
 		// `cplt config set copilot.agent_name nav-pilot` — a key that has never
 		// existed in cplt, which rejects it with "unknown config key" (#406).
-		fmt.Printf("      %s Agent pinned to %s at launch\n", green("✓"), providerpkg.CopilotAgentPersona)
+		fmt.Printf("      %s Agent pinned to %s at launch\n", green("✓"), providerpkg.PrimaryAgent("copilot"))
 	}
 
 	// opencode

--- a/cli/nav-pilot/internal/provider/copilot_launch.go
+++ b/cli/nav-pilot/internal/provider/copilot_launch.go
@@ -14,11 +14,6 @@ import (
 	telemetrypkg "github.com/navikt/copilot/cli/nav-pilot/internal/telemetry"
 )
 
-// CopilotAgentPersona is the Copilot CLI custom-agent persona that loads
-// Nav's instructions and context. This is distinct from resolved.Client,
-// which selects the launcher (copilot vs opencode vs pi).
-const CopilotAgentPersona = "nav-pilot"
-
 // FindCopilotCLI returns the path to cplt or copilot CLI.
 // Prefers cplt (unambiguous GitHub Copilot CLI).
 // If the "copilot" binary is actually cplt (aliased), it's treated as cplt.
@@ -74,12 +69,14 @@ func copilotAgentArgs(agent string) []string {
 // agent on PATH (e.g. opencode) is never picked, then forward the copilot
 // persona + flags after the "--" separator.
 //
-// Note: the forwarded --agent is always the nav-pilot persona; resolved.Client
-// selects the launcher and is consumed by launchClient before reaching here.
+// Note: the forwarded --agent is always the active agentpakke's copilot
+// persona; resolved.Client selects the launcher and is consumed by
+// launchClient before reaching here.
 func BuildCopilotArgs(cliName string, resolved domain.ResolvedConfig) []string {
+	persona := PrimaryAgent("copilot")
 	var args []string
-	args = append(args, "--agent", CopilotAgentPersona)
-	args = append(args, copilotAgentArgs(CopilotAgentPersona)...)
+	args = append(args, "--agent", persona)
+	args = append(args, copilotAgentArgs(persona)...)
 	if resolved.Model != "" {
 		args = append(args, "--model", resolved.Model)
 	}
@@ -123,7 +120,7 @@ func LaunchCopilotResolved(resolved domain.ResolvedConfig) error {
 	PrintModelAvailabilityHint(resolved.Model)
 	args := BuildCopilotArgs(cliName, resolved)
 	displayName := CLIDisplayName(cliName)
-	fmt.Printf("Launching %s with agent %s...\n\n", domain.Bold(displayName), domain.Bold(CopilotAgentPersona))
+	fmt.Printf("Launching %s with agent %s...\n\n", domain.Bold(displayName), domain.Bold(PrimaryAgent("copilot")))
 	cmd := exec.Command(cliPath, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/cli/nav-pilot/internal/provider/golden_launch_test.go
+++ b/cli/nav-pilot/internal/provider/golden_launch_test.go
@@ -1,0 +1,195 @@
+package provider
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/domain"
+)
+
+// Golden launch-argument tests (C3).
+//
+// These pin the exact argument vectors nav-pilot passes to the clients today,
+// byte for byte. They exist so the data-driven persona refactor (C1/C2) is
+// provably a no-op for every existing user: if any of these vectors changes,
+// some real launch changed, and the change is a regression until proven
+// otherwise. They must never be "updated to match" a refactor.
+
+func TestGoldenBuildCopilotArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		cliName  string
+		resolved domain.ResolvedConfig
+		want     []string
+	}{
+		{
+			name:    "cplt/zero config",
+			cliName: "cplt",
+			// AskUser is false in a zero ResolvedConfig, hence --no-ask-user.
+			resolved: domain.ResolvedConfig{},
+			want:     []string{"--agent", "copilot", "--", "--agent", "nav-pilot", "--no-ask-user"},
+		},
+		{
+			name:     "cplt/ask user",
+			cliName:  "cplt",
+			resolved: domain.ResolvedConfig{AskUser: true},
+			want:     []string{"--agent", "copilot", "--", "--agent", "nav-pilot"},
+		},
+		{
+			name:    "cplt/every field set",
+			cliName: "cplt",
+			resolved: domain.ResolvedConfig{
+				Client:          "copilot",
+				Model:           "claude-opus-5",
+				Mode:            "autopilot",
+				ReasoningEffort: "high",
+				ContextTier:     "large",
+				AllowAllTools:   true,
+				AskUser:         true,
+				LogLevel:        "debug",
+				ExtraArgs:       []string{"-p", "hei"},
+			},
+			want: []string{
+				"--agent", "copilot", "--",
+				"--agent", "nav-pilot",
+				"--model", "claude-opus-5",
+				"--mode", "autopilot",
+				"--effort", "high",
+				"--context", "large",
+				"--allow-all-tools",
+				"--log-level", "debug",
+				"-p", "hei",
+			},
+		},
+		{
+			name:    "cplt/default mode and context tier are omitted",
+			cliName: "cplt",
+			resolved: domain.ResolvedConfig{
+				Mode:        "default",
+				ContextTier: "default",
+				AskUser:     true,
+			},
+			want: []string{"--agent", "copilot", "--", "--agent", "nav-pilot"},
+		},
+		{
+			name:     "copilot/zero config",
+			cliName:  "copilot",
+			resolved: domain.ResolvedConfig{},
+			want:     []string{"--agent", "nav-pilot", "--no-ask-user"},
+		},
+		{
+			name:    "copilot/every field set",
+			cliName: "copilot",
+			resolved: domain.ResolvedConfig{
+				Model:           "gpt-5.5",
+				Mode:            "plan",
+				ReasoningEffort: "low",
+				ContextTier:     "small",
+				AllowAllTools:   true,
+				AskUser:         false,
+				LogLevel:        "error",
+				ExtraArgs:       []string{"--foo"},
+			},
+			want: []string{
+				"--agent", "nav-pilot",
+				"--model", "gpt-5.5",
+				"--mode", "plan",
+				"--effort", "low",
+				"--context", "small",
+				"--allow-all-tools",
+				"--no-ask-user",
+				"--log-level", "error",
+				"--foo",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildCopilotArgs(tt.cliName, tt.resolved)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("BuildCopilotArgs(%q, %+v)\n got: %q\nwant: %q", tt.cliName, tt.resolved, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGoldenOpenCodeArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		resolved domain.ResolvedConfig
+		want     []string
+	}{
+		{
+			name:     "zero config",
+			resolved: domain.ResolvedConfig{},
+			want:     []string{"--model", "github-copilot/auto", "--agent", "nav-pilot"},
+		},
+		{
+			name:     "explicit auto model",
+			resolved: domain.ResolvedConfig{Model: "auto"},
+			want:     []string{"--model", "github-copilot/auto", "--agent", "nav-pilot"},
+		},
+		{
+			name:     "bare copilot model id gains the provider prefix",
+			resolved: domain.ResolvedConfig{Model: "claude-sonnet-4.6"},
+			want:     []string{"--model", "github-copilot/claude-sonnet-4.6", "--agent", "nav-pilot"},
+		},
+		{
+			name:     "provider-qualified model passes through",
+			resolved: domain.ResolvedConfig{Model: "anthropic/claude-opus-5"},
+			want:     []string{"--model", "anthropic/claude-opus-5", "--agent", "nav-pilot"},
+		},
+		{
+			name:     "plan mode selects opencode's built-in plan agent",
+			resolved: domain.ResolvedConfig{Mode: "plan"},
+			want:     []string{"--model", "github-copilot/auto", "--agent", "plan"},
+		},
+		{
+			name: "every field set",
+			resolved: domain.ResolvedConfig{
+				Model:           "claude-opus-5",
+				Mode:            "autopilot",
+				ReasoningEffort: "high",
+				ContextTier:     "large",
+				AllowAllTools:   true,
+				AskUser:         true,
+				LogLevel:        "debug",
+				ExtraArgs:       []string{"--ignored"},
+			},
+			want: []string{
+				"--model", "github-copilot/claude-opus-5",
+				"--agent", "nav-pilot",
+				"--variant", "high",
+				"--dangerously-skip-permissions",
+				"--log-level", "DEBUG",
+			},
+		},
+		{
+			name:     "warning log level maps to WARN",
+			resolved: domain.ResolvedConfig{LogLevel: "warning"},
+			want:     []string{"--model", "github-copilot/auto", "--agent", "nav-pilot", "--log-level", "WARN"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := OpenCodeArgs(tt.resolved)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("OpenCodeArgs(%+v)\n got: %q\nwant: %q", tt.resolved, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGoldenOpenCodeLaunchAgent pins the cplt agent opencode is launched under,
+// alongside the client args above: together they are the full opencode
+// invocation LaunchOpenCode builds.
+func TestGoldenOpenCodeLaunchAgent(t *testing.T) {
+	if got := (openCodeProvider{}).DefaultModel(); got != "github-copilot/auto" {
+		t.Errorf("opencode DefaultModel() = %q, want %q", got, "github-copilot/auto")
+	}
+	if got := ToOpenCodeModel(""); got != "github-copilot/auto" {
+		t.Errorf("ToOpenCodeModel(\"\") = %q, want %q", got, "github-copilot/auto")
+	}
+}

--- a/cli/nav-pilot/internal/provider/opencode_launch.go
+++ b/cli/nav-pilot/internal/provider/opencode_launch.go
@@ -106,7 +106,7 @@ func OpenCodeArgs(resolved domain.ResolvedConfig) []string {
 	} else {
 		// Launch the materialized Nav primary agent so the session starts with
 		// Nav's persona and context (parity with the copilot client persona).
-		args = append(args, "--agent", OpenCodeAgentPersona)
+		args = append(args, "--agent", PrimaryAgent("opencode"))
 	}
 	if resolved.ReasoningEffort != "" {
 		args = append(args, "--variant", resolved.ReasoningEffort)

--- a/cli/nav-pilot/internal/provider/pakke.go
+++ b/cli/nav-pilot/internal/provider/pakke.go
@@ -1,0 +1,41 @@
+package provider
+
+import (
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
+	"github.com/navikt/copilot/cli/nav-pilot/internal/source"
+)
+
+// SetActivePakke sets the agentpakke that launch and materialization read
+// their persona, primary-agent allowlist, and model defaults from. It mirrors
+// [SetVersion]: a process-wide seam set once, at startup or before a launch.
+// A nil manifest restores the built-in default.
+//
+// The manifest itself is held by internal/source, the lowest package both this
+// one and internal/artifacts import — artifacts materializes agent frontmatter
+// from the same declarations and cannot import provider.
+func SetActivePakke(m *agentpakke.Manifest) { source.SetActivePakke(m) }
+
+// PrimaryAgent returns the persona a client launches by default: the first
+// primary agent the active agentpakke declares for it. An agentpakke that
+// declares none for the client falls back to the built-in default's, so a
+// launch never passes an empty --agent.
+func PrimaryAgent(client string) string {
+	agents := source.ActivePakke().PrimaryAgents(client)
+	if len(agents) == 0 {
+		agents = agentpakke.Default().PrimaryAgents(client)
+	}
+	if len(agents) == 0 {
+		return ""
+	}
+	return agents[0]
+}
+
+// openCodeDefaultModel returns the model an opencode launch falls back to when
+// the user pins none: the active agentpakke's declaration, or the built-in
+// default when it pins nothing.
+func openCodeDefaultModel() string {
+	if model := source.ActivePakke().DefaultModel("opencode"); model != "" {
+		return model
+	}
+	return OpenCodeDefaultModel
+}

--- a/cli/nav-pilot/internal/provider/pakke_test.go
+++ b/cli/nav-pilot/internal/provider/pakke_test.go
@@ -1,0 +1,51 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
+	"github.com/navikt/copilot/cli/nav-pilot/internal/domain"
+)
+
+func TestSetActivePakke(t *testing.T) {
+	t.Cleanup(func() { SetActivePakke(nil) })
+
+	if got := PrimaryAgent("copilot"); got != "nav-pilot" {
+		t.Fatalf("default PrimaryAgent(copilot) = %q, want nav-pilot", got)
+	}
+
+	SetActivePakke(&agentpakke.Manifest{
+		Name: "grillmester",
+		Clients: map[string]agentpakke.ClientEntry{
+			"copilot":  {PrimaryAgents: []string{"grillmester"}},
+			"opencode": {PrimaryAgents: []string{"grillmester", "sous"}, DefaultModel: "github-copilot/claude-opus-5"},
+			// No primaryAgents: falls back to the built-in default rather than
+			// launching with an empty --agent.
+			"pi": {},
+		},
+	})
+
+	if got := PrimaryAgent("copilot"); got != "grillmester" {
+		t.Errorf("PrimaryAgent(copilot) = %q, want grillmester", got)
+	}
+	if got := PrimaryAgent("opencode"); got != "grillmester" {
+		t.Errorf("PrimaryAgent(opencode) = %q, want grillmester (first primary)", got)
+	}
+	if got := PrimaryAgent("pi"); got != "nav-pilot" {
+		t.Errorf("PrimaryAgent(pi) = %q, want the built-in fallback nav-pilot", got)
+	}
+	if got := ToOpenCodeModel(""); got != "github-copilot/claude-opus-5" {
+		t.Errorf("ToOpenCodeModel(\"\") = %q, want the active pakke's default model", got)
+	}
+	if got := OpenCodeArgs(domain.ResolvedConfig{}); got[3] != "grillmester" {
+		t.Errorf("OpenCodeArgs persona = %q, want grillmester", got[3])
+	}
+
+	SetActivePakke(nil)
+	if got := PrimaryAgent("copilot"); got != "nav-pilot" {
+		t.Errorf("after SetActivePakke(nil): PrimaryAgent(copilot) = %q, want nav-pilot", got)
+	}
+	if got := ToOpenCodeModel(""); got != OpenCodeDefaultModel {
+		t.Errorf("after SetActivePakke(nil): ToOpenCodeModel(\"\") = %q, want %q", got, OpenCodeDefaultModel)
+	}
+}

--- a/cli/nav-pilot/internal/provider/provider.go
+++ b/cli/nav-pilot/internal/provider/provider.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
 	"github.com/navikt/copilot/cli/nav-pilot/internal/artifacts"
 	"github.com/navikt/copilot/cli/nav-pilot/internal/domain"
 	"github.com/navikt/copilot/cli/nav-pilot/internal/source"
@@ -56,11 +57,12 @@ type Provider interface {
 // Copilot provider, so the model id uses the github-copilot/<id> form.
 // Prefer Copilot Auto so default routing can follow the current
 // cost/quality frontier instead of a historically pinned model.
-const OpenCodeDefaultModel = "github-copilot/auto"
-
-// OpenCodeAgentPersona is the materialized opencode primary agent that loads
-// Nav's context and persona. Mirrors CopilotAgentPersona for the copilot client.
-const OpenCodeAgentPersona = "nav-pilot"
+// The value is the built-in agentpakke's declaration, so the model id is
+// written down in exactly one place (internal/agentpakke's legacy adapter).
+// It anchors the curated model list and the advisory messages; the model a
+// launch actually falls back to comes from the active agentpakke, via
+// openCodeDefaultModel.
+var OpenCodeDefaultModel = agentpakke.Default().DefaultModel("opencode")
 
 // openCodeProviderPrefix is the opencode provider that cplt authenticates
 // opencode against. Bare Copilot-style model ids are mapped under it.
@@ -114,7 +116,7 @@ var knownOpenCodeModels = func() []domain.ModelChoice {
 func ToOpenCodeModel(model string) string {
 	model = strings.TrimSpace(model)
 	if model == "" || model == "auto" {
-		return OpenCodeDefaultModel
+		return openCodeDefaultModel()
 	}
 	if strings.Contains(model, "/") {
 		return model

--- a/cli/nav-pilot/internal/source/frontmatter.go
+++ b/cli/nav-pilot/internal/source/frontmatter.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"bytes"
+	"slices"
 	"strings"
 )
 
@@ -165,21 +166,15 @@ func ExtractFrontmatterValue(fm []byte, key string) (string, bool) {
 	return "", false
 }
 
-// openCodePrimaryAgents are the materialized agent names that opencode should
-// treat as primary agents — i.e. selectable in the Tab/switch_agent picker and
-// launchable via `opencode --agent <name>`. Every other Nav agent is exported
-// as a subagent (invoked via @mention or delegated to by a primary agent),
-// matching the @agent usage in their metadata examples.
-var openCodePrimaryAgents = map[string]bool{
-	"nav-pilot":      true,
-	"nav-pilot-opus": true,
-}
-
 // OpenCodeAgentMode returns the opencode agent mode ("primary" or "subagent")
-// for a materialized agent of the given name. Primary agents appear in the
-// opencode agent selector and can be launched with `--agent <name>`.
-func OpenCodeAgentMode(name string) string {
-	if openCodePrimaryAgents[name] {
+// for a materialized agent of the given name. primaries is the agentpakke's
+// primary-agent set for opencode: those agents are selectable in the
+// Tab/switch_agent picker and launchable via `opencode --agent <name>`. Every
+// other Nav agent materializes as a subagent (invoked via @mention or
+// delegated to by a primary agent), matching the @agent usage in their
+// metadata examples.
+func OpenCodeAgentMode(name string, primaries []string) string {
+	if slices.Contains(primaries, name) {
 		return "primary"
 	}
 	return "subagent"

--- a/cli/nav-pilot/internal/source/frontmatter_test.go
+++ b/cli/nav-pilot/internal/source/frontmatter_test.go
@@ -271,8 +271,9 @@ func TestOpenCodeAgentMode(t *testing.T) {
 		{"research", "subagent"},
 		{"", "subagent"},
 	}
+	primaries := ActivePakke().PrimaryAgents("opencode")
 	for _, tt := range tests {
-		if got := OpenCodeAgentMode(tt.name); got != tt.want {
+		if got := OpenCodeAgentMode(tt.name, primaries); got != tt.want {
 			t.Errorf("OpenCodeAgentMode(%q) = %q, want %q", tt.name, got, tt.want)
 		}
 	}

--- a/cli/nav-pilot/internal/source/source.go
+++ b/cli/nav-pilot/internal/source/source.go
@@ -17,6 +17,30 @@ import (
 // file's source key names one.
 const DefaultRepo = "navikt/copilot"
 
+// activePakke is the agentpakke whose declarations — launch persona, opencode
+// primary-agent allowlist, model defaults — drive launch and materialization.
+// It defaults to the in-memory legacy adapter, so no default path reads a file
+// to learn them.
+//
+// It is held here rather than in internal/provider because internal/artifacts
+// needs the same declarations when it materializes agent frontmatter, and
+// artifacts cannot import provider. [provider.SetActivePakke] is the seam
+// callers use.
+var activePakke = agentpakke.Default()
+
+// SetActivePakke sets the agentpakke read by launch and materialization. A nil
+// manifest restores the built-in default. Call it through
+// provider.SetActivePakke.
+func SetActivePakke(m *agentpakke.Manifest) {
+	if m == nil {
+		m = agentpakke.Default()
+	}
+	activePakke = m
+}
+
+// ActivePakke returns the active agentpakke. Never nil.
+func ActivePakke() *agentpakke.Manifest { return activePakke }
+
 // Source holds a resolved source directory and optional temp dir to clean up.
 type Source struct {
 	Dir     string


### PR DESCRIPTION
Work package 2 of the M2 plan for #437, closing requirements **C1**, **C2** and **C3**. Independent of #454 — the two touch disjoint packages.

The persona names and the OpenCode primary-agent allowlist were written down as constants in several places. A Tier 2 pakke declares its own, so they have to come from the active manifest instead.

**Behaviour is unchanged for everyone.** The active manifest defaults to the in-memory `Default()` literal, which carries exactly the names the constants did, and no default path gained file I/O — `ActivePakke()` is a var read, not a load.

## The C3 gate

The golden tests were written first, against unmodified code, and did not change through the refactor:

- `BuildCopilotArgs` full argument vectors across six configurations, on both the `cplt` and plain-`copilot` paths — persona, flag order, the `--agent copilot --` prefix, where `ExtraArgs` land.
- The OpenCode argument and model construction across seven configurations.
- The byte-exact frontmatter `transformAgent` emits for a primary agent, a second primary and a subagent, blank-line quirks included.

This is the code every existing launch flows through, and merging to main releases to all users, so the tests were mutation-checked: renaming the persona in `Default()` fails all six copilot vectors, six of seven opencode vectors (the plan-mode case correctly unaffected), and the frontmatter goldens; changing the default model fails the model assertions.

## One design note

The active-pakke state lives in `internal/source`, not `internal/provider` where the plan sketched it. `internal/artifacts` needs the same declarations for materialized frontmatter and cannot import provider; `internal/source` is the lowest package both already import. The provider seam stays where the plan put it and delegates to it.

After this, the persona names appear once in non-test code: in the `Default()` literal they came from.

## Testing

`mise run nav-pilot:check` passes.
