### PR TITLE
feat(nav-pilot): launch Copilot and OpenCode from a staged Tier 2 payload

### DIFF
--- a/cli/nav-pilot/internal/cli/agentpakke.go
+++ b/cli/nav-pilot/internal/cli/agentpakke.go
@@ -33,13 +33,35 @@ func attachPakke(src *Source) error {
 			src.Pakke = nil
 			return nil
 		}
-		return fmt.Errorf("%s ships an agentpakke manifest (%s) that this nav-pilot cannot use:\n  %v\n\nNothing was installed. Fix the manifest in the source repo, or run %s to list every finding",
+		return &unusableManifestError{msg: fmt.Sprintf("%s ships an agentpakke manifest (%s) that this nav-pilot cannot use:\n  %v\n\nNothing was installed. Fix the manifest in the source repo, or run %s to list every finding",
 			sourceLabelFor(src), agentpakke.ManifestPath, err,
-			bold("nav-pilot validate --source "+sourceLabelFor(src)))
+			bold("nav-pilot validate --source "+sourceLabelFor(src)))}
 	}
 	src.Pakke = m
 	return nil
 }
+
+// errUnusableManifest is the sentinel behind every attachPakke validation
+// failure — a non-conforming manifest, an unsupported contractVersion, a
+// nav-pilot too old for the pakke's minimum version.
+//
+// It exists so callers that degrade gracefully on a *resolve* failure (being
+// offline, a repo name that no longer exists) can still fail closed on a
+// manifest failure, which arrives through the same error return. Without it
+// the day a pakke adopts contract major 2, every older nav-pilot would quietly
+// drop to the built-in default instead of saying "upgrade".
+//
+// This mirrors agentpakke.ErrNoManifest, the package's other errors.Is
+// sentinel: manifest present but broken, versus manifest absent.
+var errUnusableManifest = errors.New("unusable agentpakke manifest")
+
+// unusableManifestError carries attachPakke's user-facing message — which
+// already says everything — while errors.Is can see errUnusableManifest behind
+// it. Wrapping with %w would prefix the sentinel's text onto that message.
+type unusableManifestError struct{ msg string }
+
+func (e *unusableManifestError) Error() string { return e.msg }
+func (e *unusableManifestError) Unwrap() error { return errUnusableManifest }
 
 // pakkeFor returns the manifest that governs an install from this source: the
 // one the source ships, or the legacy adapter naming the collection being

--- a/cli/nav-pilot/internal/cli/cli.go
+++ b/cli/nav-pilot/internal/cli/cli.go
@@ -271,6 +271,17 @@ func run(args []string) error {
 					return fmt.Errorf("--context %q is not valid (allowed: %s)", v, strings.Join(validContextTiers, ", "))
 				}
 				cliOverrides.ContextTier = v
+			case "--payload-context":
+				// The agentpakke payload context (G3) — distinct from
+				// --context above, which is Copilot's long-context tier.
+				// Context ids are open-ended per the contract's
+				// ignore-unknown rule, so the value is validated against the
+				// manifest at launch, not against a fixed set here.
+				if i+1 >= len(args) {
+					return fmt.Errorf("--payload-context requires a value")
+				}
+				i++
+				cliOverrides.PayloadContext = args[i]
 			case "--log-level":
 				if i+1 >= len(args) {
 					return fmt.Errorf("--log-level requires a value")

--- a/cli/nav-pilot/internal/cli/config.go
+++ b/cli/nav-pilot/internal/cli/config.go
@@ -299,6 +299,9 @@ func resolve(file *Config, cli CLIOverrides) ResolvedConfig {
 	if cli.Source != "" {
 		r.Source = cli.Source
 	}
+	if cli.PayloadContext != "" {
+		r.PayloadContext = cli.PayloadContext
+	}
 	if cli.Model != "" {
 		r.Model = cli.Model
 	}

--- a/cli/nav-pilot/internal/cli/interactive.go
+++ b/cli/nav-pilot/internal/cli/interactive.go
@@ -722,11 +722,56 @@ func installedAgents(state *StateFile) []string {
 }
 
 func launchClient(resolved ResolvedConfig) error {
+	return launchClientConfirming(resolved, false)
+}
+
+// launchClientConfirming is launchClient with the missing-sandbox
+// confirmation, which only the post-install interactive flow asks for.
+//
+// The question is asked here rather than by the caller because "would run
+// unsandboxed" is only true on the legacy path: a Tier 2 launch requires cplt
+// and refuses without it (fail-closed), and which of the two applies is not
+// known until tryPakkeLaunch has resolved the source and read the tier. Asking
+// first produced a confirmed "yes" that was then refused.
+func launchClientConfirming(resolved ResolvedConfig, confirmUnsandboxed bool) error {
+	handled, err := tryPakkeLaunch(resolved)
+	if err != nil {
+		return err
+	}
+	if handled {
+		return nil
+	}
+	if confirmUnsandboxed && !confirmUnsandboxedLaunch(resolved.Client) {
+		return nil
+	}
 	p, err := providerFor(resolved.Client)
 	if err != nil {
 		return err
 	}
 	return p.Launch(resolved)
+}
+
+// confirmUnsandboxedLaunch warns that cplt is missing and asks whether to
+// launch the client anyway. It reports whether the user agreed.
+func confirmUnsandboxedLaunch(client string) bool {
+	name := client
+	if p, err := providerFor(client); err == nil && p.DisplayName() != "" {
+		name = p.DisplayName()
+	}
+	fmt.Fprintf(os.Stderr, "%s The cplt sandbox was not found — %s would run unsandboxed.\n",
+		yellow("⚠"), name)
+	var ok bool
+	if err := huh.NewConfirm().
+		Title("Launch without the cplt sandbox?").
+		Value(&ok).
+		WithTheme(navTheme()).
+		Run(); err != nil {
+		return false
+	}
+	if ok {
+		fmt.Println()
+	}
+	return ok
 }
 
 // launchDecision is what offerLaunchCopilot should do about launching.
@@ -808,23 +853,15 @@ func offerLaunchCopilot(resolved ResolvedConfig) {
 	case launchSkipOptedOut:
 		fmt.Println(dim(fmt.Sprintf("Not launching (auto_launch = false). Start it yourself with: %s", cmdName)))
 		return
-	case launchConfirmUnsandboxed:
-		fmt.Fprintf(os.Stderr, "%s The cplt sandbox was not found — %s would run unsandboxed.\n",
-			yellow("⚠"), p.DisplayName())
-		var ok bool
-		if err := huh.NewConfirm().
-			Title("Launch without the cplt sandbox?").
-			Value(&ok).
-			WithTheme(navTheme()).
-			Run(); err != nil || !ok {
-			return
-		}
-		fmt.Println()
 	}
+
+	// The missing-sandbox confirmation is deferred into the launch itself: see
+	// launchClientConfirming.
+	confirmUnsandboxed := decision == launchConfirmUnsandboxed
 
 	fmt.Printf("%s Launching %s...\n", dim("→"), p.DisplayName())
 	if err := runWithCommandTelemetry("launch", telemetryMode(), "none", func() error {
-		return launchClient(resolved)
+		return launchClientConfirming(resolved, confirmUnsandboxed)
 	}); err != nil {
 		fmt.Fprintf(os.Stderr, "%s Launch failed: %v\n", yellow("⚠"), err)
 	}

--- a/cli/nav-pilot/internal/cli/pakke_launch.go
+++ b/cli/nav-pilot/internal/cli/pakke_launch.go
@@ -1,0 +1,145 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
+	providerpkg "github.com/navikt/copilot/cli/nav-pilot/internal/provider"
+)
+
+// stagedMaxAge is how long a staged payload tree may survive its launch before
+// the next staged launch sweeps it. A tree is normally removed when the client
+// exits; anything older than this was left behind by a crash.
+//
+// ponytail: naive age heuristic. A session running longer than a day would have
+// its config swept out from under it — visible at the next config read, not
+// unsafe. Upgrade to owner-pid files only if that turns out to happen.
+const stagedMaxAge = 24 * time.Hour
+
+// stagedRoot is where verified Tier 2 payloads are staged: ~/.nav-pilot/staged,
+// a sibling of config.toml. It follows configPath(), so NAV_PILOT_CONFIG
+// relocates it too.
+func stagedRoot() string {
+	return filepath.Join(filepath.Dir(configPath()), "staged")
+}
+
+// tryPakkeLaunch runs the Tier 2 (payload) launch path when — and only when —
+// the resolved source ships an agentpakke manifest that declares pre-built
+// payloads for the client being launched. It reports whether it handled the
+// launch; (false, nil) means the caller should launch the legacy way.
+//
+// The first check is the no-regression gate: with no source selected (the
+// default for every user who has never run `config set source` or passed
+// --source) it returns immediately, having resolved nothing, read nothing, and
+// left the active agentpakke on the built-in default.
+func tryPakkeLaunch(resolved ResolvedConfig) (bool, error) {
+	if resolved.Source == "" {
+		return false, payloadContextUnsupported(resolved, defaultSourceRepo)
+	}
+
+	// The CLI's source funnel: applies source precedence and attaches the
+	// schema-validated manifest.
+	//
+	// A resolve failure lands *before* the tier gate, so nothing yet says this
+	// launch is Tier 2 — the source may well declare no payloads at all. Being
+	// offline, or having a stale repo name in config, must therefore not block
+	// a launch that worked before Tier 2 staging existed: warn and take the
+	// legacy path, as EnsureOpenCodeNavContext has always done. Fail-closed
+	// starts at the tier gate below, where the payload is known.
+	src, err := resolveSource("", resolved.Source)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s Could not resolve source %s: %v — launching without agentpakke context.\n",
+			yellow("⚠"), resolved.Source, err)
+		return false, payloadContextUnsupported(resolved, resolved.Source)
+	}
+
+	if src.Pakke == nil || src.Pakke.Tier(resolved.Client) != agentpakke.TierPayload {
+		// Manifest-less or Tier 1: exactly today's path, built-in default
+		// agentpakke still active.
+		src.Cleanup()
+		return false, payloadContextUnsupported(resolved, resolved.Source)
+	}
+
+	pakke := src.Pakke
+	context := resolved.PayloadContext
+	if context == "" {
+		context = pakke.DefaultContext(resolved.Client)
+	}
+	payload, ok := pakke.Payload(resolved.Client, context)
+	if !ok {
+		src.Cleanup()
+		return true, fmt.Errorf("agentpakke %q declares no %q payload for %s (declared contexts: %s)",
+			pakke.Name, context, resolved.Client, strings.Join(declaredContexts(pakke, resolved.Client), ", "))
+	}
+
+	root := stagedRoot()
+	// Best-effort sweep of trees a crashed session left behind. It costs one
+	// directory read on a path that is about to do far more I/O than that.
+	_ = agentpakke.GCStaged(root, stagedMaxAge)
+
+	stagedDir, stageErr := agentpakke.StagePayload(
+		filepath.Join(src.Dir, filepath.FromSlash(payload.Path)),
+		filepath.Join(src.Dir, filepath.FromSlash(payload.ManifestPath())),
+		root)
+	// The staged tree carries its own manifest, so the checkout — which may be
+	// a temp clone — is no longer needed either way.
+	src.Cleanup()
+	if stageErr != nil {
+		// Fail-closed (G2): a Tier 2 launch never falls back to the legacy path.
+		return true, fmt.Errorf("staging the %q payload of agentpakke %q for %s: %w",
+			context, pakke.Name, resolved.Client, stageErr)
+	}
+	defer func() {
+		// A tree that survives is verified config left on disk; say so, and
+		// let the 24h sweep pick it up.
+		if err := agentpakke.CleanupStaged(stagedDir); err != nil {
+			fmt.Fprintf(os.Stderr, "%s %v\n", yellow("⚠"), err)
+		}
+	}()
+
+	// The only SetActivePakke call site: past the tier gate the manifest is
+	// known to declare this client, which is the invariant provider.PrimaryAgent
+	// relies on.
+	providerpkg.SetActivePakke(pakke)
+
+	staged := providerpkg.StagedLaunch{Dir: stagedDir, PakkeName: pakke.Name, Context: context}
+	switch resolved.Client {
+	case "opencode":
+		return true, providerpkg.LaunchOpenCodeStaged(resolved, staged)
+	case "copilot":
+		return true, providerpkg.LaunchCopilotStaged(resolved, staged)
+	default:
+		return true, fmt.Errorf("agentpakke %q declares payloads for %s, but this nav-pilot cannot launch staged payloads for that client",
+			pakke.Name, resolved.Client)
+	}
+}
+
+// payloadContextUnsupported turns an explicit --payload-context into an error
+// when the launch resolves to the legacy path. Ignoring the flag silently would
+// mask what the user asked for, the same policy unknown config keys get.
+func payloadContextUnsupported(resolved ResolvedConfig, label string) error {
+	if resolved.PayloadContext == "" {
+		return nil
+	}
+	return fmt.Errorf("--payload-context requires an agentpakke with pre-built payloads; source %s declares none for client %s",
+		label, resolved.Client)
+}
+
+// declaredContexts lists a client's payload context ids, sorted.
+func declaredContexts(m *agentpakke.Manifest, client string) []string {
+	entry, ok := m.Client(client)
+	if !ok {
+		return nil
+	}
+	ids := make([]string, 0, len(entry.Payloads))
+	for id := range entry.Payloads {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}

--- a/cli/nav-pilot/internal/cli/pakke_launch.go
+++ b/cli/nav-pilot/internal/cli/pakke_launch.go
@@ -232,7 +232,22 @@ func cachedTier(source, client string) (int, bool) {
 		return agentpakke.TierUnknown, false
 	}
 	entry, ok := cache[tierCacheKey(source, client)]
-	if !ok || time.Since(entry.LearnedAt) > tierCacheTTL {
+	if !ok {
+		return agentpakke.TierUnknown, false
+	}
+	// Well-formed JSON is not a trustworthy answer. A tier no nav-pilot writes
+	// (a hand-edited file, or a future binary with other tier semantics) would
+	// be neither TierPayload nor a known legacy tier, and the launch would skip
+	// the resolve and run legacy for a source that declares a payload. A
+	// learnedAt in the future — clock stepped back, or skew when it was written
+	// — makes the age negative, so the entry would outlive the TTL until
+	// wall-clock catches up. Both resolve normally, exactly like a corrupt file.
+	switch entry.Tier {
+	case agentpakke.TierUnknown, agentpakke.TierLayout, agentpakke.TierPayload:
+	default:
+		return agentpakke.TierUnknown, false
+	}
+	if age := time.Since(entry.LearnedAt); age < 0 || age > tierCacheTTL {
 		return agentpakke.TierUnknown, false
 	}
 	return entry.Tier, true

--- a/cli/nav-pilot/internal/cli/pakke_launch.go
+++ b/cli/nav-pilot/internal/cli/pakke_launch.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -45,20 +47,49 @@ func tryPakkeLaunch(resolved ResolvedConfig) (bool, error) {
 	// The CLI's source funnel: applies source precedence and attaches the
 	// schema-validated manifest.
 	//
-	// A resolve failure lands *before* the tier gate, so nothing yet says this
+	// A *fetch* failure lands before the tier gate, so nothing yet says this
 	// launch is Tier 2 — the source may well declare no payloads at all. Being
 	// offline, or having a stale repo name in config, must therefore not block
 	// a launch that worked before Tier 2 staging existed: warn and take the
-	// legacy path, as EnsureOpenCodeNavContext has always done. Fail-closed
-	// starts at the tier gate below, where the payload is known.
+	// legacy path, as EnsureOpenCodeNavContext has always done.
+	//
+	// A manifest-validation failure arrives through the same error return but
+	// is the opposite case: the source was fetched, and what it ships says this
+	// nav-pilot must not run it (attachPakke's fail-closed rule, A3). Degrading
+	// there would inject the user's own ~/.copilot into a launch the pakke
+	// author never sanctioned, behind a stderr warning the client TUI wipes off
+	// the screen — and would silently strand every older binary the day a pakke
+	// adopts contract major 2. errUnusableManifest separates the two.
+	// Resolving a repo-shaped source clones it. A Tier 1 or manifest-less
+	// source has nothing to stage, so before this PR that launch never touched
+	// the source at all; without a memory it would now clone on every launch to
+	// re-learn an answer it already had. A remembered non-payload tier skips
+	// the clone and takes exactly the legacy path.
+	//
+	// --payload-context is exempt on purpose: it asks about payloads the
+	// manifest declares, which only the manifest can answer.
+	if resolved.PayloadContext == "" {
+		if tier, ok := cachedTier(resolved.Source, resolved.Client); ok && tier != agentpakke.TierPayload {
+			return false, nil
+		}
+	}
+
 	src, err := resolveSource("", resolved.Source)
 	if err != nil {
+		if errors.Is(err, errUnusableManifest) {
+			return true, err
+		}
 		fmt.Fprintf(os.Stderr, "%s Could not resolve source %s: %v — launching without agentpakke context.\n",
 			yellow("⚠"), resolved.Source, err)
 		return false, payloadContextUnsupported(resolved, resolved.Source)
 	}
 
-	if src.Pakke == nil || src.Pakke.Tier(resolved.Client) != agentpakke.TierPayload {
+	tier := agentpakke.TierUnknown
+	if src.Pakke != nil {
+		tier = src.Pakke.Tier(resolved.Client)
+	}
+	rememberTier(resolved.Source, resolved.Client, tier)
+	if tier != agentpakke.TierPayload {
 		// Manifest-less or Tier 1: exactly today's path, built-in default
 		// agentpakke still active.
 		src.Cleanup()
@@ -142,4 +173,90 @@ func declaredContexts(m *agentpakke.Manifest, client string) []string {
 	}
 	sort.Strings(ids)
 	return ids
+}
+
+// ─── tier memory ─────────────────────────────────────────────────────────────
+//
+// The launch path caches a *decision* — which tier a source declares for a
+// client, and when that was learned — never content. A miss, a stale entry, an
+// unreadable or corrupt file all mean "resolve the source as usual"; none of
+// them may be read as "assume legacy".
+
+// tierCacheTTL bounds how long a remembered tier is trusted. A pakke that
+// changes tier — Tier 1 adopting payloads, or dropping them — must be picked up
+// without the user knowing a cache exists, and six hours means at worst one
+// working day's delay while a burst of launches costs a single clone.
+//
+// ponytail: like stagedMaxAge, an arbitrary-but-bounded number, not a measured
+// one. Nothing was timed to pick it; it is short enough that a stale answer
+// self-corrects the same day and long enough that a normal day's launches do
+// not re-clone. Shorten it if tier changes turn out to need faster pickup.
+const tierCacheTTL = 6 * time.Hour
+
+// tierCachePath is ~/.nav-pilot/tier-cache.json, a sibling of config.toml and
+// of stagedRoot(). It is nav-pilot's own state, not an OS cache directory that
+// may be swept between launches; NAV_PILOT_CONFIG relocates it too.
+func tierCachePath() string {
+	return filepath.Join(filepath.Dir(configPath()), "tier-cache.json")
+}
+
+type tierCacheEntry struct {
+	Tier      int       `json:"tier"`
+	LearnedAt time.Time `json:"learnedAt"`
+}
+
+// tierCacheKey names the source as well as the client, so changing `source`
+// asks a question this cache has never been asked before rather than inheriting
+// the old source's answer.
+func tierCacheKey(source, client string) string { return source + "\x00" + client }
+
+// tierCacheable reports whether a source is worth remembering. Only repo-shaped
+// sources are: an absolute path resolves with a stat and no clone, so there is
+// nothing to save, and a developer editing the manifest in their own checkout
+// must see the change on the next launch.
+func tierCacheable(source string) bool {
+	return source != "" && !filepath.IsAbs(source)
+}
+
+// cachedTier returns a remembered tier and whether it may be trusted.
+func cachedTier(source, client string) (int, bool) {
+	if !tierCacheable(source) {
+		return agentpakke.TierUnknown, false
+	}
+	data, err := os.ReadFile(tierCachePath())
+	if err != nil {
+		return agentpakke.TierUnknown, false
+	}
+	var cache map[string]tierCacheEntry
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return agentpakke.TierUnknown, false
+	}
+	entry, ok := cache[tierCacheKey(source, client)]
+	if !ok || time.Since(entry.LearnedAt) > tierCacheTTL {
+		return agentpakke.TierUnknown, false
+	}
+	return entry.Tier, true
+}
+
+// rememberTier records what a resolve just learned. Every failure is silent: a
+// cache that cannot be written costs a clone next launch and nothing else.
+func rememberTier(source, client string, tier int) {
+	if !tierCacheable(source) {
+		return
+	}
+	cache := map[string]tierCacheEntry{}
+	if data, err := os.ReadFile(tierCachePath()); err == nil {
+		if err := json.Unmarshal(data, &cache); err != nil {
+			cache = map[string]tierCacheEntry{}
+		}
+	}
+	cache[tierCacheKey(source, client)] = tierCacheEntry{Tier: tier, LearnedAt: time.Now()}
+	data, err := json.Marshal(cache)
+	if err != nil {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(tierCachePath()), 0o755); err != nil {
+		return
+	}
+	_ = os.WriteFile(tierCachePath(), data, 0o644)
 }

--- a/cli/nav-pilot/internal/cli/pakke_launch_test.go
+++ b/cli/nav-pilot/internal/cli/pakke_launch_test.go
@@ -1,0 +1,272 @@
+package cli
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	providerpkg "github.com/navikt/copilot/cli/nav-pilot/internal/provider"
+)
+
+// A Tier 2 agentpakke: payload-bearing client entries, no layout. Shaped like
+// grillmester's manifest at the pinned reference SHA.
+const tier2LaunchManifestJSON = `{
+  "contractVersion": "1",
+  "name": "grillmester",
+  "description": "Grillmester agentpakke",
+  "clients": {
+    "copilot": {
+      "primaryAgents": ["grillmester", "barista"],
+      "defaultModel": "inherit",
+      "defaultContext": "full",
+      "payloads": {
+        "full": {"path": "plugin"},
+        "focused": {"path": "targets/copilot-cli-focused-v1"}
+      }
+    }
+  }
+}`
+
+// failingResolveSource installs a source funnel that fails the test if it is
+// called at all — the no-source gate must not resolve anything.
+func failingResolveSource(t *testing.T) {
+	t.Helper()
+	orig := resolveSource
+	t.Cleanup(func() { resolveSource = orig })
+	resolveSource = func(ref, sourceRepo string) (*Source, error) {
+		t.Fatalf("resolveSource must not be called: launch resolved no source (ref=%q, source=%q)", ref, sourceRepo)
+		return nil, nil
+	}
+}
+
+// assertDefaultPakkeActive pins that a launch left the built-in agentpakke in
+// place, so personas and model defaults are exactly today's.
+func assertDefaultPakkeActive(t *testing.T) {
+	t.Helper()
+	if got := providerpkg.PrimaryAgent("copilot"); got != "nav-pilot" {
+		t.Errorf("active agentpakke changed: PrimaryAgent(copilot) = %q, want nav-pilot", got)
+	}
+}
+
+// TestTryPakkeLaunchNoRegression is the no-regression table: every population
+// that exists today must take the legacy path, with nothing resolved, nothing
+// staged, and the built-in agentpakke still active.
+func TestTryPakkeLaunchNoRegression(t *testing.T) {
+	t.Run("no source at all", func(t *testing.T) {
+		isolatedConfig(t)
+		t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
+		failingResolveSource(t)
+
+		handled, err := tryPakkeLaunch(ResolvedConfig{Client: "copilot"})
+		if handled || err != nil {
+			t.Errorf("tryPakkeLaunch(no source) = (%v, %v), want (false, nil)", handled, err)
+		}
+		assertDefaultPakkeActive(t)
+	})
+
+	t.Run("custom source, manifest-less repo", func(t *testing.T) {
+		isolatedConfig(t)
+		t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
+		src := &Source{Dir: legacySourceTree(t), SHA: "abc1234", Version: "dev", Repo: "navikt/other"}
+		if err := attachPakke(src); err != nil {
+			t.Fatalf("attachPakke: %v", err)
+		}
+		stubResolveSource(t, src)
+
+		handled, err := tryPakkeLaunch(ResolvedConfig{Client: "copilot", Source: "navikt/other"})
+		if handled || err != nil {
+			t.Errorf("tryPakkeLaunch(manifest-less source) = (%v, %v), want (false, nil)", handled, err)
+		}
+		assertDefaultPakkeActive(t)
+	})
+
+	t.Run("custom source, Tier 1 manifest", func(t *testing.T) {
+		isolatedConfig(t)
+		t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
+		stubResolveSource(t, pakkeSource(t, "navikt/grillmester"))
+
+		handled, err := tryPakkeLaunch(ResolvedConfig{Client: "copilot", Source: "navikt/grillmester"})
+		if handled || err != nil {
+			t.Errorf("tryPakkeLaunch(Tier 1 source) = (%v, %v), want (false, nil)", handled, err)
+		}
+		assertDefaultPakkeActive(t)
+	})
+
+	t.Run("Tier 2 for another client stays on the legacy path", func(t *testing.T) {
+		isolatedConfig(t)
+		t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
+		stubResolveSource(t, tier2Source(t))
+
+		// The fixture declares payloads for copilot only.
+		handled, err := tryPakkeLaunch(ResolvedConfig{Client: "opencode", Source: "navikt/grillmester"})
+		if handled || err != nil {
+			t.Errorf("tryPakkeLaunch(opencode, copilot-only payloads) = (%v, %v), want (false, nil)", handled, err)
+		}
+		assertDefaultPakkeActive(t)
+	})
+}
+
+// tier2Source builds a resolved, Tier 2 manifest-bearing source.
+func tier2Source(t *testing.T) *Source {
+	t.Helper()
+	src := &Source{Dir: pakkeSourceTree(t, tier2LaunchManifestJSON), SHA: "def5678", Version: "dev", Repo: "navikt/grillmester"}
+	if err := attachPakke(src); err != nil {
+		t.Fatalf("attachPakke on the Tier 2 fixture: %v", err)
+	}
+	if src.Pakke == nil {
+		t.Fatal("Tier 2 fixture attached no manifest")
+	}
+	return src
+}
+
+// TestPayloadContextOnLegacyPath: an explicit --payload-context that cannot
+// mean anything is an error, never a silent no-op.
+func TestPayloadContextOnLegacyPath(t *testing.T) {
+	t.Run("no source", func(t *testing.T) {
+		isolatedConfig(t)
+		failingResolveSource(t)
+
+		_, err := tryPakkeLaunch(ResolvedConfig{Client: "copilot", PayloadContext: "focused"})
+		if err == nil {
+			t.Fatal("--payload-context without an agentpakke must be an error")
+		}
+		if !strings.Contains(err.Error(), "--payload-context") || !strings.Contains(err.Error(), defaultSourceRepo) {
+			t.Errorf("error should name the flag and the source, got: %v", err)
+		}
+	})
+
+	t.Run("Tier 1 source", func(t *testing.T) {
+		isolatedConfig(t)
+		stubResolveSource(t, pakkeSource(t, "navikt/grillmester"))
+
+		_, err := tryPakkeLaunch(ResolvedConfig{Client: "copilot", Source: "navikt/grillmester", PayloadContext: "focused"})
+		if err == nil {
+			t.Fatal("--payload-context against a Tier 1 agentpakke must be an error")
+		}
+		if !strings.Contains(err.Error(), "navikt/grillmester") || !strings.Contains(err.Error(), "copilot") {
+			t.Errorf("error should name the source and the client, got: %v", err)
+		}
+	})
+}
+
+// TestPayloadContextUnknown: an unknown context lists what the manifest does
+// declare, sorted.
+func TestPayloadContextUnknown(t *testing.T) {
+	isolatedConfig(t)
+	t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
+	stubResolveSource(t, tier2Source(t))
+
+	handled, err := tryPakkeLaunch(ResolvedConfig{Client: "copilot", Source: "navikt/grillmester", PayloadContext: "tiny"})
+	if !handled || err == nil {
+		t.Fatalf("tryPakkeLaunch(unknown context) = (%v, %v), want (true, error)", handled, err)
+	}
+	if !strings.Contains(err.Error(), "declared contexts: focused, full") {
+		t.Errorf("error should list the declared contexts sorted, got: %v", err)
+	}
+	assertDefaultPakkeActive(t)
+}
+
+// TestPayloadContextSelection pins G3's defaulting: with no flag the manifest's
+// defaultContext is staged, and the flag overrides it. Both fixtures point at
+// payload paths that carry no payload manifest, so staging fails — after the
+// context has been selected, which is what the wrapped error names.
+func TestPayloadContextSelection(t *testing.T) {
+	tests := []struct {
+		name        string
+		flag        string
+		wantContext string
+	}{
+		{name: "defaults to the manifest's defaultContext", wantContext: "full"},
+		{name: "the flag overrides it", flag: "focused", wantContext: "focused"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isolatedConfig(t)
+			t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
+			stubResolveSource(t, tier2Source(t))
+
+			handled, err := tryPakkeLaunch(ResolvedConfig{
+				Client: "copilot", Source: "navikt/grillmester", PayloadContext: tt.flag,
+			})
+			if !handled || err == nil {
+				t.Fatalf("tryPakkeLaunch = (%v, %v), want (true, staging error)", handled, err)
+			}
+			want := `staging the "` + tt.wantContext + `" payload`
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error should report %s, got: %v", want, err)
+			}
+			// Fail-closed: a Tier 2 launch that could not stage never falls
+			// back to the legacy launch.
+			assertDefaultPakkeActive(t)
+		})
+	}
+}
+
+// TestStagedRootFollowsConfig keeps staged trees inside nav-pilot's own home,
+// and out of the developer's when tests redirect the config.
+func TestStagedRootFollowsConfig(t *testing.T) {
+	cfg := isolatedConfig(t)
+	if got, want := stagedRoot(), filepath.Join(filepath.Dir(cfg), "staged"); got != want {
+		t.Errorf("stagedRoot() = %q, want %q", got, want)
+	}
+}
+
+// TestUnresolvableSourceFallsBackToLegacy pins that a source that cannot be
+// resolved — offline, or a repo name that no longer exists — does not block the
+// launch. The tier is unknown at that point, so the launch may well be one that
+// worked before Tier 2 staging existed; it degrades to the legacy path with one
+// warning, the way EnsureOpenCodeNavContext always has.
+func TestUnresolvableSourceFallsBackToLegacy(t *testing.T) {
+	isolatedConfig(t)
+	t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
+
+	orig := resolveSource
+	t.Cleanup(func() { resolveSource = orig })
+	resolveSource = func(string, string) (*Source, error) {
+		return nil, errors.New("dial tcp: no route to host")
+	}
+
+	origStderr := os.Stderr
+	r, w, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatalf("os.Pipe: %v", pipeErr)
+	}
+	os.Stderr = w
+
+	handled, err := tryPakkeLaunch(ResolvedConfig{Client: "copilot", Source: "navikt/copilot"})
+
+	w.Close()
+	os.Stderr = origStderr
+	var stderr strings.Builder
+	io.Copy(&stderr, r)
+
+	if handled || err != nil {
+		t.Errorf("tryPakkeLaunch(unresolvable source) = (%v, %v), want (false, nil) — the legacy path", handled, err)
+	}
+	if !strings.Contains(stderr.String(), "navikt/copilot") {
+		t.Errorf("warning should name the source, got: %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "no route to host") {
+		t.Errorf("warning should name the reason, got: %q", stderr.String())
+	}
+	assertDefaultPakkeActive(t)
+}
+
+// TestTier2LaunchIsNotOfferedUnsandboxed pins the flow fix: a Tier 2 launch is
+// refused before the "Launch without the cplt sandbox?" question is asked, so
+// the user is never talked into a confirmation that is then overruled. If the
+// prompt still ran it would fail without a terminal and return nil.
+func TestTier2LaunchIsNotOfferedUnsandboxed(t *testing.T) {
+	isolatedConfig(t)
+	t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
+	stubResolveSource(t, tier2Source(t))
+
+	err := launchClientConfirming(
+		ResolvedConfig{Client: "copilot", Source: "navikt/grillmester"}, true)
+	if err == nil {
+		t.Fatal("a Tier 2 launch must fail rather than reach the unsandboxed confirmation")
+	}
+}

--- a/cli/nav-pilot/internal/cli/pakke_launch_test.go
+++ b/cli/nav-pilot/internal/cli/pakke_launch_test.go
@@ -1,12 +1,14 @@
 package cli
 
 import (
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	providerpkg "github.com/navikt/copilot/cli/nav-pilot/internal/provider"
 )
@@ -268,5 +270,229 @@ func TestTier2LaunchIsNotOfferedUnsandboxed(t *testing.T) {
 		ResolvedConfig{Client: "copilot", Source: "navikt/grillmester"}, true)
 	if err == nil {
 		t.Fatal("a Tier 2 launch must fail rather than reach the unsandboxed confirmation")
+	}
+}
+
+// contractMajor2ManifestJSON is a manifest on a contract major this nav-pilot
+// does not implement — the case that makes the difference between the two
+// failure modes matter: every older binary must be told to upgrade, not
+// silently dropped to the built-in default.
+const contractMajor2ManifestJSON = `{
+  "contractVersion": "2",
+  "name": "grillmester",
+  "description": "Grillmester agentpakke",
+  "clients": {"copilot": {"primaryAgents": ["grillmester"]}}
+}`
+
+// stubResolveSourceAttaching installs a source funnel that runs the real
+// attachPakke over a fixture tree, so its error reaches tryPakkeLaunch exactly
+// as the production funnel delivers it (aliases.go: resolveSource returns
+// attachPakkeOrCleanup's error verbatim).
+func stubResolveSourceAttaching(t *testing.T, dir, repo string) {
+	t.Helper()
+	orig := resolveSource
+	t.Cleanup(func() { resolveSource = orig })
+	resolveSource = func(string, string) (*Source, error) {
+		src := &Source{Dir: dir, SHA: "def5678", Version: "dev", Repo: repo}
+		return src, attachPakke(src)
+	}
+}
+
+// TestUnusableManifestAbortsLaunch is the other half of
+// TestUnresolvableSourceFallsBackToLegacy: a source that was fetched fine but
+// ships a manifest this nav-pilot cannot use must abort the launch with the
+// real message, not warn and take the legacy path with the user's own
+// ~/.copilot injected.
+func TestUnusableManifestAbortsLaunch(t *testing.T) {
+	isolatedConfig(t)
+	t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
+	stubResolveSourceAttaching(t, pakkeSourceTree(t, contractMajor2ManifestJSON), "navikt/grillmester")
+
+	handled, err := tryPakkeLaunch(ResolvedConfig{Client: "copilot", Source: "navikt/grillmester"})
+	if !handled || err == nil {
+		t.Fatalf("tryPakkeLaunch(unusable manifest) = (%v, %v), want (true, error) — the launch must abort", handled, err)
+	}
+	if !errors.Is(err, errUnusableManifest) {
+		t.Errorf("error should carry errUnusableManifest, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "contractVersion") {
+		t.Errorf("error should name the manifest problem, got: %v", err)
+	}
+	assertDefaultPakkeActive(t)
+}
+
+// TestUnusableManifestIsNotCached: a launch that aborted before the tier gate
+// learned no tier, so it must not leave an answer behind for the next launch.
+func TestUnusableManifestIsNotCached(t *testing.T) {
+	isolatedConfig(t)
+	t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
+	stubResolveSourceAttaching(t, pakkeSourceTree(t, contractMajor2ManifestJSON), "navikt/grillmester")
+
+	if _, err := tryPakkeLaunch(ResolvedConfig{Client: "copilot", Source: "navikt/grillmester"}); err == nil {
+		t.Fatal("setup: the unusable manifest must fail the launch")
+	}
+	if tier, ok := cachedTier("navikt/grillmester", "copilot"); ok {
+		t.Errorf("a failed manifest validation cached tier %d; it must leave the cache untouched", tier)
+	}
+}
+
+// ─── tier memory ─────────────────────────────────────────────────────────────
+
+// countingResolveSource installs a source funnel that hands out a prepared
+// checkout and counts how often it was asked, so a test can pin that a launch
+// resolved nothing.
+func countingResolveSource(t *testing.T, src *Source) *int {
+	t.Helper()
+	calls := 0
+	orig := resolveSource
+	t.Cleanup(func() { resolveSource = orig })
+	resolveSource = func(string, string) (*Source, error) {
+		calls++
+		return src, nil
+	}
+	return &calls
+}
+
+// tier1Launch runs a Tier 1 launch and fails the test if it did not take the
+// legacy path.
+func tier1Launch(t *testing.T, source string) {
+	t.Helper()
+	handled, err := tryPakkeLaunch(ResolvedConfig{Client: "copilot", Source: source})
+	if handled || err != nil {
+		t.Fatalf("tryPakkeLaunch(Tier 1) = (%v, %v), want (false, nil)", handled, err)
+	}
+}
+
+// TestTierCacheSkipsSecondResolve: resolving a repo-shaped source clones it.
+// Once a launch has learned that a source is not Tier 2, the next launch must
+// take the legacy path without cloning again to re-learn it.
+func TestTierCacheSkipsSecondResolve(t *testing.T) {
+	isolatedConfig(t)
+	t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
+	calls := countingResolveSource(t, pakkeSource(t, "navikt/grillmester"))
+
+	tier1Launch(t, "navikt/grillmester")
+	tier1Launch(t, "navikt/grillmester")
+
+	if *calls != 1 {
+		t.Errorf("resolveSource called %d times, want 1 — the second launch must reuse the remembered tier", *calls)
+	}
+	assertDefaultPakkeActive(t)
+}
+
+// TestTierCacheExpires: a pakke that changes tier has to be picked up without
+// the user knowing a cache exists, so an entry older than tierCacheTTL is not
+// trusted.
+func TestTierCacheExpires(t *testing.T) {
+	isolatedConfig(t)
+	t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
+	calls := countingResolveSource(t, pakkeSource(t, "navikt/grillmester"))
+
+	tier1Launch(t, "navikt/grillmester")
+	ageTierCache(t, tierCacheTTL+time.Minute)
+	tier1Launch(t, "navikt/grillmester")
+
+	if *calls != 2 {
+		t.Errorf("resolveSource called %d times, want 2 — an expired entry must resolve again", *calls)
+	}
+}
+
+// ageTierCache backdates every entry in the cache file by d.
+func ageTierCache(t *testing.T, d time.Duration) {
+	t.Helper()
+	data, err := os.ReadFile(tierCachePath())
+	if err != nil {
+		t.Fatalf("reading the tier cache: %v", err)
+	}
+	var cache map[string]tierCacheEntry
+	if err := json.Unmarshal(data, &cache); err != nil {
+		t.Fatalf("parsing the tier cache: %v", err)
+	}
+	if len(cache) == 0 {
+		t.Fatal("the tier cache is empty; nothing was remembered")
+	}
+	for k, e := range cache {
+		e.LearnedAt = e.LearnedAt.Add(-d)
+		cache[k] = e
+	}
+	data, err = json.Marshal(cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tierCachePath(), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestTierCacheKeyedBySource: changing `source` asks a question the cache has
+// never been asked, so the new source is resolved rather than inheriting the
+// old one's answer.
+func TestTierCacheKeyedBySource(t *testing.T) {
+	isolatedConfig(t)
+	t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
+	calls := countingResolveSource(t, pakkeSource(t, "navikt/grillmester"))
+
+	tier1Launch(t, "navikt/grillmester")
+	tier1Launch(t, "navikt/other-pakke")
+
+	if *calls != 2 {
+		t.Errorf("resolveSource called %d times, want 2 — a different source must resolve", *calls)
+	}
+}
+
+// TestTierCacheCorruptFileResolves: an unreadable cache degrades to a normal
+// resolve. It must never be an error, and never a legacy assumption.
+func TestTierCacheCorruptFileResolves(t *testing.T) {
+	isolatedConfig(t)
+	t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
+	src := tier2Source(t)
+	calls := countingResolveSource(t, src)
+
+	if err := os.MkdirAll(filepath.Dir(tierCachePath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tierCachePath(), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A Tier 2 source: had the corrupt file been read as "legacy", this would
+	// have returned (false, nil) without resolving anything.
+	handled, err := tryPakkeLaunch(ResolvedConfig{Client: "copilot", Source: "navikt/grillmester"})
+	if !handled || err == nil {
+		t.Fatalf("tryPakkeLaunch over a corrupt cache = (%v, %v), want (true, staging error)", handled, err)
+	}
+	if *calls != 1 {
+		t.Errorf("resolveSource called %d times, want 1 — a corrupt cache must resolve normally", *calls)
+	}
+}
+
+// TestPayloadContextAlwaysResolves: --payload-context asks about payloads only
+// the manifest declares, so it must resolve even when the cache holds a
+// non-payload answer for the same source.
+func TestPayloadContextAlwaysResolves(t *testing.T) {
+	isolatedConfig(t)
+	t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
+	calls := countingResolveSource(t, pakkeSource(t, "navikt/grillmester"))
+
+	tier1Launch(t, "navikt/grillmester")
+
+	_, err := tryPakkeLaunch(ResolvedConfig{
+		Client: "copilot", Source: "navikt/grillmester", PayloadContext: "focused",
+	})
+	if err == nil {
+		t.Fatal("--payload-context against a Tier 1 agentpakke must be an error")
+	}
+	if *calls != 2 {
+		t.Errorf("resolveSource called %d times, want 2 — --payload-context must always resolve", *calls)
+	}
+}
+
+// TestTierCacheLivesWithNavPilotState keeps the remembered decision next to
+// config.toml and the staged trees, not in an OS cache directory that may be
+// swept between launches.
+func TestTierCacheLivesWithNavPilotState(t *testing.T) {
+	cfg := isolatedConfig(t)
+	if got, want := tierCachePath(), filepath.Join(filepath.Dir(cfg), "tier-cache.json"); got != want {
+		t.Errorf("tierCachePath() = %q, want %q", got, want)
 	}
 }

--- a/cli/nav-pilot/internal/cli/pakke_launch_test.go
+++ b/cli/nav-pilot/internal/cli/pakke_launch_test.go
@@ -466,6 +466,61 @@ func TestTierCacheCorruptFileResolves(t *testing.T) {
 	}
 }
 
+// TestTierCacheRejectsUnknownTier: a well-formed entry can still hold a tier
+// no nav-pilot writes. Trusting it would skip the resolve for a source that
+// declares a payload and run legacy with the user's own ~/.copilot, which is
+// exactly the "assume legacy" this cache may never produce.
+func TestTierCacheRejectsUnknownTier(t *testing.T) {
+	isolatedConfig(t)
+	t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
+	calls := countingResolveSource(t, tier2Source(t))
+
+	writeTierCache(t, map[string]tierCacheEntry{
+		tierCacheKey("navikt/grillmester", "copilot"): {Tier: 99, LearnedAt: time.Now()},
+	})
+
+	handled, err := tryPakkeLaunch(ResolvedConfig{Client: "copilot", Source: "navikt/grillmester"})
+	if !handled || err == nil {
+		t.Fatalf("tryPakkeLaunch over a nonsense tier = (%v, %v), want (true, staging error) — the Tier 2 source must be resolved", handled, err)
+	}
+	if *calls != 1 {
+		t.Errorf("resolveSource called %d times, want 1 — an unknown tier must resolve normally", *calls)
+	}
+}
+
+// TestTierCacheRejectsFutureEntry: a learnedAt in the future (clock stepped
+// back, or skewed when the entry was written) makes the age negative, so a
+// plain "older than the TTL?" test would trust the entry until wall-clock
+// catches up. Out of range is out of range in both directions.
+func TestTierCacheRejectsFutureEntry(t *testing.T) {
+	isolatedConfig(t)
+	t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
+	calls := countingResolveSource(t, pakkeSource(t, "navikt/grillmester"))
+
+	tier1Launch(t, "navikt/grillmester")
+	ageTierCache(t, -(tierCacheTTL + time.Hour)) // forward, not back
+	tier1Launch(t, "navikt/grillmester")
+
+	if *calls != 2 {
+		t.Errorf("resolveSource called %d times, want 2 — an entry learned in the future must resolve again", *calls)
+	}
+}
+
+// writeTierCache replaces the tier cache file with exactly these entries.
+func writeTierCache(t *testing.T, cache map[string]tierCacheEntry) {
+	t.Helper()
+	data, err := json.Marshal(cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(tierCachePath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tierCachePath(), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // TestPayloadContextAlwaysResolves: --payload-context asks about payloads only
 // the manifest declares, so it must resolve even when the cache holds a
 // non-payload answer for the same source.

--- a/cli/nav-pilot/internal/domain/domain.go
+++ b/cli/nav-pilot/internal/domain/domain.go
@@ -38,7 +38,12 @@ type ResolvedConfig struct {
 	Client string
 	// Source is the agentpakke content source: a git repo "owner/name" or an
 	// absolute path. Empty means the built-in default (navikt/copilot).
-	Source            string
+	Source string
+	// PayloadContext selects which Tier 2 payload context an agentpakke
+	// launch stages ("full", "focused", …). Empty means the context the
+	// manifest declares as default. Unrelated to ContextTier, which is
+	// Copilot's own long-context setting; the two coexist on one command line.
+	PayloadContext    string
 	Model             string // empty = use agent default
 	Mode              string
 	ReasoningEffort   string // empty = unset
@@ -59,7 +64,11 @@ type CLIOverrides struct {
 	Client string
 	// Source is the --source flag value (agentpakke repo "owner/name" or an
 	// absolute path). It takes precedence over the config file's source key.
-	Source          string
+	Source string
+	// PayloadContext is the --payload-context flag value (Tier 2 payload
+	// context id). It has no config-file key: the persistent default is the
+	// agentpakke manifest's defaultContext.
+	PayloadContext  string
 	Model           string
 	Mode            string
 	ReasoningEffort string

--- a/cli/nav-pilot/internal/provider/copilot_launch.go
+++ b/cli/nav-pilot/internal/provider/copilot_launch.go
@@ -80,6 +80,21 @@ func BuildCopilotArgs(cliName string, resolved domain.ResolvedConfig) []string {
 	if resolved.Model != "" {
 		args = append(args, "--model", resolved.Model)
 	}
+	args = append(args, copilotResolvedFlags(resolved)...)
+	if cliName == "cplt" {
+		cpltArgs := append([]string{"--agent", "copilot", "--"}, args...)
+		return append(cpltArgs, resolved.ExtraArgs...)
+	}
+	return append(args, resolved.ExtraArgs...)
+}
+
+// copilotResolvedFlags returns the copilot CLI flags that follow the persona
+// and model: the resolved-config tail shared by the legacy launch
+// ([BuildCopilotArgs]) and the staged Tier 2 launch
+// (buildStagedCopilotSpec). Order and emit conditions are pinned by
+// golden_launch_test.go — do not reorder.
+func copilotResolvedFlags(resolved domain.ResolvedConfig) []string {
+	var args []string
 	if resolved.Mode != "" && resolved.Mode != "default" {
 		args = append(args, "--mode", resolved.Mode)
 	}
@@ -98,11 +113,7 @@ func BuildCopilotArgs(cliName string, resolved domain.ResolvedConfig) []string {
 	if resolved.LogLevel != "" {
 		args = append(args, "--log-level", resolved.LogLevel)
 	}
-	if cliName == "cplt" {
-		cpltArgs := append([]string{"--agent", "copilot", "--"}, args...)
-		return append(cpltArgs, resolved.ExtraArgs...)
-	}
-	return append(args, resolved.ExtraArgs...)
+	return args
 }
 
 // LaunchCopilotResolved launches the Copilot CLI with the resolved launch config.
@@ -194,7 +205,19 @@ func PrintModelAvailabilityHint(model string) {
 // COPILOT_CUSTOM_INSTRUCTIONS_DIRS if user-scope customizations exist
 // (instructions and/or agents), and OTEL_LOG_LEVEL if otelLogLevel is set.
 func CopilotEnv(otelLogLevel string) []string {
+	return copilotEnv(otelLogLevel, true)
+}
+
+// copilotEnv is CopilotEnv with the user-instructions injection made optional.
+// injectUserInstructions is false for a staged Tier 2 launch, which must not
+// mix the user's own ~/.copilot content into a third-party pakke's session; an
+// exported COPILOT_CUSTOM_INSTRUCTIONS_DIRS is still inherited untouched from
+// os.Environ(), as the reference launcher does.
+func copilotEnv(otelLogLevel string, injectUserInstructions bool) []string {
 	copilotDir := userCopilotDir()
+	if !injectUserInstructions {
+		copilotDir = ""
+	}
 	env := os.Environ()
 	key := "COPILOT_CUSTOM_INSTRUCTIONS_DIRS"
 	if copilotDir != "" {

--- a/cli/nav-pilot/internal/provider/cplt.go
+++ b/cli/nav-pilot/internal/provider/cplt.go
@@ -19,6 +19,11 @@ type cpltLaunch struct {
 	// agent is the cplt --agent value selecting which agent to sandbox
 	// (e.g. "copilot", "opencode", "pi").
 	agent string
+	// noAudit emits cplt's --no-audit ahead of "--agent", as the reference
+	// launcher does (grillmester.py line 663). Set by staged Tier 2 launches
+	// only; false for every legacy launch, which keeps their argument vectors
+	// byte-identical (golden_launch_test.go, cplt_test.go).
+	noAudit bool
 	// cpltArgs are cplt-level flags placed between "--agent <agent>" and the
 	// "--" separator (e.g. --allow-read, --pass-env). Empty for every legacy
 	// launch, which keeps their argument vectors byte-identical
@@ -35,11 +40,17 @@ type cpltLaunch struct {
 }
 
 // cpltArgv is the argument vector launchViaCplt passes to cplt:
-// `--agent <agent> [cpltArgs...] -- [agentArgs...]`. Pure, so the vector is
-// testable without launching anything. With no cpltArgs it is byte-identical
-// to what every legacy launch produced before Tier 2 staging existed.
+// `[--no-audit] --agent <agent> [cpltArgs...] -- [agentArgs...]`. Pure, so the
+// vector is testable without launching anything. With noAudit false and no
+// cpltArgs it is byte-identical to what every legacy launch produced before
+// Tier 2 staging existed.
 func cpltArgv(spec cpltLaunch) []string {
-	args := append([]string{"--agent", spec.agent}, spec.cpltArgs...)
+	var args []string
+	if spec.noAudit {
+		args = append(args, "--no-audit")
+	}
+	args = append(args, "--agent", spec.agent)
+	args = append(args, spec.cpltArgs...)
 	args = append(args, "--")
 	return append(args, spec.agentArgs...)
 }

--- a/cli/nav-pilot/internal/provider/cplt.go
+++ b/cli/nav-pilot/internal/provider/cplt.go
@@ -19,6 +19,11 @@ type cpltLaunch struct {
 	// agent is the cplt --agent value selecting which agent to sandbox
 	// (e.g. "copilot", "opencode", "pi").
 	agent string
+	// cpltArgs are cplt-level flags placed between "--agent <agent>" and the
+	// "--" separator (e.g. --allow-read, --pass-env). Empty for every legacy
+	// launch, which keeps their argument vectors byte-identical
+	// (golden_launch_test.go, cplt_test.go).
+	cpltArgs []string
 	// agentArgs are forwarded to the agent process after the "--" separator.
 	agentArgs []string
 	// env is the process environment. nil inherits the parent environment.
@@ -27,6 +32,16 @@ type cpltLaunch struct {
 	displayName string
 	// messageSuffix is appended to the "Launching …" line (e.g. nav-context summary).
 	messageSuffix string
+}
+
+// cpltArgv is the argument vector launchViaCplt passes to cplt:
+// `--agent <agent> [cpltArgs...] -- [agentArgs...]`. Pure, so the vector is
+// testable without launching anything. With no cpltArgs it is byte-identical
+// to what every legacy launch produced before Tier 2 staging existed.
+func cpltArgv(spec cpltLaunch) []string {
+	args := append([]string{"--agent", spec.agent}, spec.cpltArgs...)
+	args = append(args, "--")
+	return append(args, spec.agentArgs...)
 }
 
 // launchViaCplt runs the given client agent inside the cplt sandbox, wiring
@@ -39,7 +54,7 @@ func launchViaCplt(spec cpltLaunch) error {
 		return fmt.Errorf("cplt not found in PATH — nav-pilot launches clients inside the cplt sandbox; install cplt to launch %s", spec.displayName)
 	}
 
-	args := append([]string{"--agent", spec.agent, "--"}, spec.agentArgs...)
+	args := cpltArgv(spec)
 
 	fmt.Printf("Launching %s via %s%s...\n\n",
 		domain.Bold(spec.displayName), domain.Bold("cplt sandbox"), spec.messageSuffix)

--- a/cli/nav-pilot/internal/provider/pakke.go
+++ b/cli/nav-pilot/internal/provider/pakke.go
@@ -10,20 +10,32 @@ import (
 // [SetVersion]: a process-wide seam set once, at startup or before a launch.
 // A nil manifest restores the built-in default.
 //
+// Invariant callers must uphold: only set a manifest that declares the client
+// about to be launched or materialized. WP3's single call site (the staged
+// launch branch in internal/cli) satisfies it by construction — it sets the
+// pakke only after Tier(client) == TierPayload, which requires a declared
+// entry, and schemas/agentpakke-v1.json requires primaryAgents (line 49) with
+// "minItems": 1 (line 56) on every declared client entry, checked by
+// agentpakke.Load before a manifest is ever attached to a source. That is what lets
+// [PrimaryAgent] be a pure manifest read with no fallback.
+//
 // The manifest itself is held by internal/source, the lowest package both this
 // one and internal/artifacts import — artifacts materializes agent frontmatter
 // from the same declarations and cannot import provider.
 func SetActivePakke(m *agentpakke.Manifest) { source.SetActivePakke(m) }
 
 // PrimaryAgent returns the persona a client launches by default: the first
-// primary agent the active agentpakke declares for it. An agentpakke that
-// declares none for the client falls back to the built-in default's, so a
-// launch never passes an empty --agent.
+// primary agent the active agentpakke declares for it.
+//
+// It returns "" exactly when the active agentpakke declares no entry for the
+// client — there is no fallback to the built-in default's persona, which would
+// inject Nav's nav-pilot persona into a foreign agentpakke's launch while
+// materialization (artifacts/export.go:317) correctly demoted it to a
+// subagent. Launch paths never observe the empty string: the built-in default
+// declares every known client, and the staged path only sets a pakke that
+// declares the client it is launching (see [SetActivePakke]).
 func PrimaryAgent(client string) string {
 	agents := source.ActivePakke().PrimaryAgents(client)
-	if len(agents) == 0 {
-		agents = agentpakke.Default().PrimaryAgents(client)
-	}
 	if len(agents) == 0 {
 		return ""
 	}
@@ -33,8 +45,17 @@ func PrimaryAgent(client string) string {
 // openCodeDefaultModel returns the model an opencode launch falls back to when
 // the user pins none: the active agentpakke's declaration, or the built-in
 // default when it pins nothing.
+//
+// [agentpakke.InheritModel] counts as pinning nothing: consumers of this
+// function (ToOpenCodeModel, the setup label) need a concrete model id, and
+// "inherit" means "whatever the client would use anyway". The staged launch
+// path does not call this at all — it reads the declaration directly and omits
+// --model entirely for inherit. Cosmetic residue: `config setup` run with an
+// inherit-pakke active labels the built-in id "Nav default"; no M2 flow sets a
+// pakke before setup, so nothing reaches it today.
 func openCodeDefaultModel() string {
-	if model := source.ActivePakke().DefaultModel("opencode"); model != "" {
+	model := source.ActivePakke().DefaultModel("opencode")
+	if model != "" && model != agentpakke.InheritModel {
 		return model
 	}
 	return OpenCodeDefaultModel

--- a/cli/nav-pilot/internal/provider/pakke_test.go
+++ b/cli/nav-pilot/internal/provider/pakke_test.go
@@ -19,8 +19,10 @@ func TestSetActivePakke(t *testing.T) {
 		Clients: map[string]agentpakke.ClientEntry{
 			"copilot":  {PrimaryAgents: []string{"grillmester"}},
 			"opencode": {PrimaryAgents: []string{"grillmester", "sous"}, DefaultModel: "github-copilot/claude-opus-5"},
-			// No primaryAgents: falls back to the built-in default rather than
-			// launching with an empty --agent.
+			// No primaryAgents. There is no fallback to the built-in
+			// default's persona (WP3): the manifest is authoritative, and
+			// schemas/agentpakke-v1.json makes this shape unrepresentable in a
+			// loaded manifest anyway (primaryAgents is required, minItems 1).
 			"pi": {},
 		},
 	})
@@ -31,8 +33,8 @@ func TestSetActivePakke(t *testing.T) {
 	if got := PrimaryAgent("opencode"); got != "grillmester" {
 		t.Errorf("PrimaryAgent(opencode) = %q, want grillmester (first primary)", got)
 	}
-	if got := PrimaryAgent("pi"); got != "nav-pilot" {
-		t.Errorf("PrimaryAgent(pi) = %q, want the built-in fallback nav-pilot", got)
+	if got := PrimaryAgent("pi"); got != "" {
+		t.Errorf("PrimaryAgent(pi) = %q, want \"\" — no fallback to the built-in persona", got)
 	}
 	if got := ToOpenCodeModel(""); got != "github-copilot/claude-opus-5" {
 		t.Errorf("ToOpenCodeModel(\"\") = %q, want the active pakke's default model", got)

--- a/cli/nav-pilot/internal/provider/provider.go
+++ b/cli/nav-pilot/internal/provider/provider.go
@@ -223,8 +223,14 @@ func (openCodeProvider) Available() bool {
 }
 
 func (openCodeProvider) Launch(r domain.ResolvedConfig) error { return LaunchOpenCode(r) }
-func (openCodeProvider) DefaultModel() string                 { return OpenCodeDefaultModel }
-func (openCodeProvider) KnownModels() []domain.ModelChoice    { return knownOpenCodeModels }
+
+// DefaultModel reports the model an opencode launch falls back to, read from
+// the active agentpakke — the same source the launch fallback reads, so the
+// "Nav default" label in `config setup` and the model actually launched can
+// never disagree.
+func (openCodeProvider) DefaultModel() string { return openCodeDefaultModel() }
+
+func (openCodeProvider) KnownModels() []domain.ModelChoice { return knownOpenCodeModels }
 
 func (openCodeProvider) ValidateModel(model string) error {
 	if err := domain.ValidateModelValue(model); err != nil {

--- a/cli/nav-pilot/internal/provider/staged_launch.go
+++ b/cli/nav-pilot/internal/provider/staged_launch.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"slices"
+	"strings"
 
 	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
 	"github.com/navikt/copilot/cli/nav-pilot/internal/domain"
@@ -120,6 +121,46 @@ func openCodeClientArgs(bind, forwarded []string) []string {
 	}
 }
 
+// containsOption reports whether an argument vector carries an option, in
+// either the "--opt value" or "--opt=value" spelling. Transcribed from the
+// reference launcher's _contains_option (grillmester.py lines 602-603 at
+// 3573b93cc8b7568516117263562d073cae9ee7fc).
+func containsOption(args []string, option string) bool {
+	return slices.ContainsFunc(args, func(a string) bool {
+		return a == option || strings.HasPrefix(a, option+"=")
+	})
+}
+
+// rejectReservedClientArgs refuses client arguments that a Tier 2 launch owns.
+// Transcribed from the reference launcher's _reject_reserved_arguments
+// (grillmester.py lines 633-643):
+//
+//	line 633-636  client --agent
+//	line 637-640  client --project-dir
+//	line 641-643  copilot --plugin-dir
+//
+// These select what the session actually runs, and on this path that is fixed
+// by the digest-verified payload: a forwarded --plugin-dir would append an
+// unverified plugin directory to a verified session. The reference's cplt-side
+// checks (lines 613-632) have no counterpart here — nav-pilot builds its cplt
+// argument vector itself and forwards nothing of the user's into it.
+//
+// Refused, not dropped: the user typed it and deserves to be told why it did
+// not take effect. Only the staged path is guarded; the legacy path has no
+// verified payload to protect.
+func rejectReservedClientArgs(client, pakkeName string, args []string) error {
+	reserved := []string{"--agent", "--project-dir"}
+	if client == "copilot" {
+		reserved = append(reserved, "--plugin-dir")
+	}
+	for _, option := range reserved {
+		if containsOption(args, option) {
+			return fmt.Errorf("%s is owned by agentpakke %q's verified payload and cannot be passed to %s after --", option, pakkeName, client)
+		}
+	}
+	return nil
+}
+
 // stagedPrimaryAgent returns the persona a staged launch starts, failing loudly
 // rather than passing an empty --agent if a future call site sets a pakke that
 // does not declare the client (see [SetActivePakke]'s invariant).
@@ -136,6 +177,9 @@ func stagedPrimaryAgent(client, pakkeName string) (string, error) {
 // OPENCODE_CONFIG_DIR pointing at the same payload, and --pass-env for it, with
 // the client receiving --agent <agent>.
 func buildStagedOpenCodeSpec(r domain.ResolvedConfig, s StagedLaunch) (cpltLaunch, error) {
+	if err := rejectReservedClientArgs("opencode", s.PakkeName, r.ExtraArgs); err != nil {
+		return cpltLaunch{}, err
+	}
 	primary, err := stagedPrimaryAgent("opencode", s.PakkeName)
 	if err != nil {
 		return cpltLaunch{}, err
@@ -172,6 +216,9 @@ func buildStagedOpenCodeSpec(r domain.ResolvedConfig, s StagedLaunch) (cpltLaunc
 // <plugin> on the cplt side, and --plugin-dir <plugin> before
 // --agent <pakke>:<agent> on the client side.
 func buildStagedCopilotSpec(r domain.ResolvedConfig, s StagedLaunch) (cpltLaunch, error) {
+	if err := rejectReservedClientArgs("copilot", s.PakkeName, r.ExtraArgs); err != nil {
+		return cpltLaunch{}, err
+	}
 	primary, err := stagedPrimaryAgent("copilot", s.PakkeName)
 	if err != nil {
 		return cpltLaunch{}, err

--- a/cli/nav-pilot/internal/provider/staged_launch.go
+++ b/cli/nav-pilot/internal/provider/staged_launch.go
@@ -26,7 +26,7 @@ import (
 //
 // --no-audit (line 663) is adopted, in the reference's position: first in the
 // cplt vector, before --agent. It was first read as launcher policy; team eSyfo
-// corrected that (#458, comment 5437575432): at the cplt baseline grillmester
+// corrected that (#437, comment 5437575432): at the cplt baseline grillmester
 // v0.3.0 is tested against, cplt's parent-side audit can execute
 // repository-controlled Git helpers *outside* the sandbox, so a staged launch
 // without it is less isolated than the launcher it is meant to be equivalent

--- a/cli/nav-pilot/internal/provider/staged_launch.go
+++ b/cli/nav-pilot/internal/provider/staged_launch.go
@@ -22,9 +22,22 @@ import (
 //
 // The invocation shape is transcribed from the reference launcher, grillmester
 // at 3573b93cc8b7568516117263562d073cae9ee7fc, scripts/grillmester.py
-// build_launch_command (lines 647-689). Two of its cplt flags are launcher
-// policy rather than payload contract and are deliberately not adopted:
-// --no-audit (line 663) and --project-dir (lines 666-667).
+// build_launch_command (lines 647-689).
+//
+// --no-audit (line 663) is adopted, in the reference's position: first in the
+// cplt vector, before --agent. It was first read as launcher policy; team eSyfo
+// corrected that (#458, comment 5437575432): at the cplt baseline grillmester
+// v0.3.0 is tested against, cplt's parent-side audit can execute
+// repository-controlled Git helpers *outside* the sandbox, so a staged launch
+// without it is less isolated than the launcher it is meant to be equivalent
+// to. Dropping it again requires evidence that a reviewed cplt baseline fixes
+// that behaviour, plus a cplt minimum-version gate that enforces the baseline —
+// not the flag looking redundant.
+//
+// --project-dir (lines 666-667) stays omitted: nav-pilot treats the working
+// directory as the project scope. No launch path sets cmd.Dir, so cplt and the
+// client inherit the user's cwd, which is what the reference passes explicitly.
+// eSyfo accept the omission on exactly that condition.
 //
 // Note on provenance: the reference launcher does not stage — it points cplt at
 // the payload in place inside its immutable Homebrew bundle. The
@@ -173,7 +186,8 @@ func stagedPrimaryAgent(client, pakkeName string) (string, error) {
 }
 
 // buildStagedOpenCodeSpec builds the cplt invocation for a staged opencode
-// launch. Reference: grillmester.py lines 668-677 — --allow-read <payload>,
+// launch. Reference: grillmester.py line 663 — --no-audit — and lines 668-677
+// — --allow-read <payload>,
 // OPENCODE_CONFIG_DIR pointing at the same payload, and --pass-env for it, with
 // the client receiving --agent <agent>.
 func buildStagedOpenCodeSpec(r domain.ResolvedConfig, s StagedLaunch) (cpltLaunch, error) {
@@ -203,6 +217,7 @@ func buildStagedOpenCodeSpec(r domain.ResolvedConfig, s StagedLaunch) (cpltLaunc
 
 	return cpltLaunch{
 		agent:         "opencode",
+		noAudit:       true,
 		cpltArgs:      []string{"--allow-read", s.Dir, "--pass-env", "OPENCODE_CONFIG_DIR"},
 		agentArgs:     agentArgs,
 		env:           env,
@@ -212,8 +227,9 @@ func buildStagedOpenCodeSpec(r domain.ResolvedConfig, s StagedLaunch) (cpltLaunc
 }
 
 // buildStagedCopilotSpec builds the cplt invocation for a staged copilot
-// launch. Reference: grillmester.py lines 668-669 and 679-685 — --allow-read
-// <plugin> on the cplt side, and --plugin-dir <plugin> before
+// launch. Reference: grillmester.py line 663 and lines 668-669 and 679-685 —
+// --no-audit and --allow-read <plugin> on the cplt side, and
+// --plugin-dir <plugin> before
 // --agent <pakke>:<agent> on the client side.
 func buildStagedCopilotSpec(r domain.ResolvedConfig, s StagedLaunch) (cpltLaunch, error) {
 	if err := rejectReservedClientArgs("copilot", s.PakkeName, r.ExtraArgs); err != nil {
@@ -235,6 +251,7 @@ func buildStagedCopilotSpec(r domain.ResolvedConfig, s StagedLaunch) (cpltLaunch
 
 	return cpltLaunch{
 		agent:         "copilot",
+		noAudit:       true,
 		cpltArgs:      []string{"--allow-read", s.Dir},
 		agentArgs:     agentArgs,
 		env:           copilotEnv(r.OtelLogLevel, pakkeAcceptsUserContext("copilot")),

--- a/cli/nav-pilot/internal/provider/staged_launch.go
+++ b/cli/nav-pilot/internal/provider/staged_launch.go
@@ -1,0 +1,236 @@
+package provider
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"slices"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
+	"github.com/navikt/copilot/cli/nav-pilot/internal/domain"
+	"github.com/navikt/copilot/cli/nav-pilot/internal/source"
+	"github.com/navikt/copilot/cli/nav-pilot/internal/telemetry"
+)
+
+// Tier 2 (payload) launch.
+//
+// A Tier 2 agentpakke ships pre-built, digest-pinned client configuration
+// instead of content nav-pilot materializes. internal/cli stages that payload
+// into a private tree (agentpakke.StagePayload) and hands the verified
+// directory here; these builders turn it into a cplt invocation.
+//
+// The invocation shape is transcribed from the reference launcher, grillmester
+// at 3573b93cc8b7568516117263562d073cae9ee7fc, scripts/grillmester.py
+// build_launch_command (lines 647-689). Two of its cplt flags are launcher
+// policy rather than payload contract and are deliberately not adopted:
+// --no-audit (line 663) and --project-dir (lines 666-667).
+//
+// Note on provenance: the reference launcher does not stage — it points cplt at
+// the payload in place inside its immutable Homebrew bundle. The
+// verify -> copy -> re-verify sequence nav-pilot uses comes from the same
+// project's local mode (scripts/grillmester_local.py, _materialize_opencode_config).
+// nav-pilot has to stage because its source may be a temp clone with umask
+// modes rather than the manifest's.
+//
+// G2: nothing on this path writes to the user's shared client configuration.
+// The staged opencode launch deliberately skips EnsureOpenCodeNavContext and
+// EnsureOpenCodeOTelConfig — both write into ~/.config/opencode — and never
+// edits the payload either, whose bytes are digest-bound. OTel still travels as
+// environment variables, which is not config mutation.
+
+// StagedLaunch is the verified payload tree a Tier 2 launch runs against.
+type StagedLaunch struct {
+	// Dir is the staged payload directory. It is what cplt is allowed to read
+	// and what the client is pointed at.
+	Dir string
+	// PakkeName is the agentpakke identity, used to plugin-qualify the copilot
+	// persona (<pakke>:<agent>).
+	PakkeName string
+	// Context is the payload context id ("full", "focused", …), for the
+	// launch message only.
+	Context string
+}
+
+// suffix names the agentpakke and context in the "Launching …" line.
+func (s StagedLaunch) suffix() string {
+	return fmt.Sprintf(" with agentpakke %s (%s)", domain.Bold(s.PakkeName), s.Context)
+}
+
+// pakkeDeclaredModel returns the active agentpakke's model declaration for a
+// client, or "" when it declares none or declares [agentpakke.InheritModel]
+// (F1). "inherit" means no --model flag at all, which is also what the
+// reference launcher passes: build_launch_command forwards no model.
+func pakkeDeclaredModel(client string) string {
+	model := source.ActivePakke().DefaultModel(client)
+	if model == agentpakke.InheritModel {
+		return ""
+	}
+	return model
+}
+
+// pakkeAcceptsUserContext reports whether the agentpakke declares that it
+// accepts the user's own client customizations (~/.copilot instructions and
+// agents) being mixed into its session.
+//
+// No manifest field carries that declaration yet — the proposal is
+// `acceptsUserContext` on the client entry, see #437, which needs the contract
+// owners' agreement before it goes into schemas/agentpakke-v1.json. Absent a
+// declaration nothing is mixed in: a third-party pakke's session must not
+// silently receive Nav content its author never tested against. When the field
+// lands this becomes a one-line read of the manifest, like pakkeDeclaredModel:
+//
+//	return source.ActivePakke().AcceptsUserContext(client)
+func pakkeAcceptsUserContext(client string) bool {
+	return false
+}
+
+// openCodeSubcommands are opencode's own subcommands, transcribed from the
+// reference launcher's OPENCODE_COMMANDS (grillmester.py lines 37-63). A
+// forwarded argument vector starting with one of these is not a session entry
+// point, so no --agent may be bound to it.
+var openCodeSubcommands = map[string]bool{
+	"acp": true, "agent": true, "attach": true, "auth": true, "completion": true,
+	"db": true, "debug": true, "export": true, "github": true, "import": true,
+	"mcp": true, "models": true, "plugin": true, "plug": true, "pr": true,
+	"providers": true, "run": true, "serve": true, "session": true, "stats": true,
+	"uninstall": true, "upgrade": true, "web": true,
+}
+
+// openCodeClientArgs binds the agent selection only to opencode entry points
+// that accept it. Transcribed from the reference launcher's
+// _opencode_client_arguments (grillmester.py lines 692-704):
+//
+//	line 698-699  no forwarded arguments      -> <bind>
+//	line 700-701  "run" ...                   -> run <bind> ...
+//	line 702-703  another opencode subcommand -> forwarded unchanged, no --agent
+//	line 704      anything else               -> <bind> ...
+//
+// bind is "--agent <agent>" plus the resolved --model, which is only meaningful
+// wherever --agent is; the reference forwards no model at all.
+func openCodeClientArgs(bind, forwarded []string) []string {
+	switch {
+	case len(forwarded) == 0:
+		return bind
+	case forwarded[0] == "run":
+		return append(append([]string{"run"}, bind...), forwarded[1:]...)
+	case openCodeSubcommands[forwarded[0]]:
+		return slices.Clone(forwarded)
+	default:
+		return append(slices.Clone(bind), forwarded...)
+	}
+}
+
+// stagedPrimaryAgent returns the persona a staged launch starts, failing loudly
+// rather than passing an empty --agent if a future call site sets a pakke that
+// does not declare the client (see [SetActivePakke]'s invariant).
+func stagedPrimaryAgent(client, pakkeName string) (string, error) {
+	agent := PrimaryAgent(client)
+	if agent == "" {
+		return "", fmt.Errorf("agentpakke %q declares no primary agent for %s — it cannot be launched", pakkeName, client)
+	}
+	return agent, nil
+}
+
+// buildStagedOpenCodeSpec builds the cplt invocation for a staged opencode
+// launch. Reference: grillmester.py lines 668-677 — --allow-read <payload>,
+// OPENCODE_CONFIG_DIR pointing at the same payload, and --pass-env for it, with
+// the client receiving --agent <agent>.
+func buildStagedOpenCodeSpec(r domain.ResolvedConfig, s StagedLaunch) (cpltLaunch, error) {
+	primary, err := stagedPrimaryAgent("opencode", s.PakkeName)
+	if err != nil {
+		return cpltLaunch{}, err
+	}
+
+	env, _ := telemetry.ApplyOpenCodeOTelEnv(os.Environ(), cliVersion)
+	env, _ = telemetry.SetEnvValue(env, "OPENCODE_CONFIG_DIR", s.Dir)
+
+	agent := primary
+	if r.Mode == "plan" {
+		// opencode's built-in read-only planning agent, as on the legacy path.
+		agent = "plan"
+	}
+	bind := []string{"--agent", agent}
+	if r.Model != "" {
+		bind = append(bind, "--model", ToOpenCodeModel(r.Model))
+	} else if model := pakkeDeclaredModel("opencode"); model != "" {
+		bind = append(bind, "--model", model)
+	}
+	agentArgs := openCodeClientArgs(bind, r.ExtraArgs)
+
+	return cpltLaunch{
+		agent:         "opencode",
+		cpltArgs:      []string{"--allow-read", s.Dir, "--pass-env", "OPENCODE_CONFIG_DIR"},
+		agentArgs:     agentArgs,
+		env:           env,
+		displayName:   "opencode",
+		messageSuffix: s.suffix(),
+	}, nil
+}
+
+// buildStagedCopilotSpec builds the cplt invocation for a staged copilot
+// launch. Reference: grillmester.py lines 668-669 and 679-685 — --allow-read
+// <plugin> on the cplt side, and --plugin-dir <plugin> before
+// --agent <pakke>:<agent> on the client side.
+func buildStagedCopilotSpec(r domain.ResolvedConfig, s StagedLaunch) (cpltLaunch, error) {
+	primary, err := stagedPrimaryAgent("copilot", s.PakkeName)
+	if err != nil {
+		return cpltLaunch{}, err
+	}
+
+	agentArgs := []string{"--plugin-dir", s.Dir, "--agent", s.PakkeName + ":" + primary}
+	agentArgs = append(agentArgs, copilotResolvedFlags(r)...)
+	if r.Model != "" {
+		agentArgs = append(agentArgs, "--model", r.Model)
+	} else if model := pakkeDeclaredModel("copilot"); model != "" {
+		agentArgs = append(agentArgs, "--model", model)
+	}
+	agentArgs = append(agentArgs, r.ExtraArgs...)
+
+	return cpltLaunch{
+		agent:         "copilot",
+		cpltArgs:      []string{"--allow-read", s.Dir},
+		agentArgs:     agentArgs,
+		env:           copilotEnv(r.OtelLogLevel, pakkeAcceptsUserContext("copilot")),
+		displayName:   CLIDisplayName("cplt"),
+		messageSuffix: s.suffix(),
+	}, nil
+}
+
+// LaunchOpenCodeStaged launches opencode against a staged Tier 2 payload.
+func LaunchOpenCodeStaged(r domain.ResolvedConfig, s StagedLaunch) error {
+	if _, err := exec.LookPath("opencode"); err != nil {
+		return fmt.Errorf("opencode not found in PATH — install it first: https://opencode.ai")
+	}
+	spec, err := buildStagedOpenCodeSpec(r, s)
+	if err != nil {
+		return err
+	}
+	for _, msg := range OpenCodeUnsupportedConfigWarnings(r) {
+		fmt.Fprintf(os.Stderr, "%s %s\n", domain.Yellow("⚠"), msg)
+	}
+	return launchViaCplt(spec)
+}
+
+// LaunchCopilotStaged launches copilot against a staged Tier 2 payload.
+//
+// cplt is required here even though the legacy copilot path still accepts a
+// plain copilot binary: a payload launch is defined by the sandbox flags
+// (--allow-read over the staged tree), and running it unsandboxed is not the
+// contract anyone reviewed. There is no fallback and no confirmation prompt.
+func LaunchCopilotStaged(r domain.ResolvedConfig, s StagedLaunch) error {
+	if _, name := FindCopilotCLI(); name != "cplt" {
+		telemetryRecorder.RecordLaunchError("copilot", "client_not_found")
+		return fmt.Errorf(
+			"launching agentpakke %q requires the cplt sandbox, which is not in PATH.\n"+
+				"A Tier 2 agentpakke ships pre-built payloads that nav-pilot only hands to a sandboxed client.\n\n"+
+				"  Install it: %s",
+			s.PakkeName, domain.Bold("brew install navikt/tap/cplt"))
+	}
+	spec, err := buildStagedCopilotSpec(r, s)
+	if err != nil {
+		return err
+	}
+	PrintCpltSandboxHint()
+	PrintModelAvailabilityHint(r.Model)
+	return launchViaCplt(spec)
+}

--- a/cli/nav-pilot/internal/provider/staged_launch_test.go
+++ b/cli/nav-pilot/internal/provider/staged_launch_test.go
@@ -62,6 +62,7 @@ func buildStagedSpec(t *testing.T, client string, r domain.ResolvedConfig, s Sta
 // at 3573b93cc8b7568516117263562d073cae9ee7fc, scripts/grillmester.py
 // build_launch_command:
 //
+//	line 663       --no-audit, first in the cplt vector, before --agent
 //	line 664-665   cplt --agent <client>
 //	line 668-669   --allow-read <payload>   (payload = plugin for copilot,
 //	               opencode_target for opencode; both clients read exactly the
@@ -76,10 +77,10 @@ func buildStagedSpec(t *testing.T, client string, r domain.ResolvedConfig, s Sta
 //	line 704       opencode client args, anything else: --agent <agent> …
 //	line 679-684   copilot client args: --plugin-dir <plugin> --agent grillmester:<agent>
 //
-// Not adopted, deliberately: --no-audit (line 663) and --project-dir (lines
-// 666-667), which are launcher policy rather than payload contract. No --model
-// either: the fixture declares "inherit", and the reference forwards no model
-// at all.
+// Not adopted, deliberately: --project-dir (lines 666-667) — nav-pilot treats
+// the working directory as the project scope, which is what the client inherits
+// anyway. No --model either: the fixture declares "inherit", and the reference
+// forwards no model at all.
 func TestStagedLaunchSpecs(t *testing.T) {
 	SetActivePakke(stagedFixturePakke())
 	t.Cleanup(func() { SetActivePakke(nil) })
@@ -181,6 +182,12 @@ func TestStagedLaunchSpecs(t *testing.T) {
 			}
 			if !slices.Equal(spec.cpltArgs, tt.wantCpltArgs) {
 				t.Errorf("cpltArgs\n got: %q\nwant: %q", spec.cpltArgs, tt.wantCpltArgs)
+			}
+			// Reference line 663: every staged launch leads with --no-audit,
+			// before --agent, because cplt's parent-side audit can execute
+			// repository-controlled Git helpers outside the sandbox.
+			if argv := cpltArgv(spec); len(argv) == 0 || argv[0] != "--no-audit" {
+				t.Errorf("cplt vector must lead with --no-audit\n got: %q", argv)
 			}
 			if !slices.Equal(spec.agentArgs, tt.wantAgentArgs) {
 				t.Errorf("agentArgs\n got: %q\nwant: %q", spec.agentArgs, tt.wantAgentArgs)

--- a/cli/nav-pilot/internal/provider/staged_launch_test.go
+++ b/cli/nav-pilot/internal/provider/staged_launch_test.go
@@ -1,0 +1,487 @@
+package provider
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
+	"github.com/navikt/copilot/cli/nav-pilot/internal/domain"
+	"github.com/navikt/copilot/cli/nav-pilot/internal/telemetry"
+)
+
+// stagedFixturePakke mirrors the shape of grillmester's manifest at the pinned
+// reference SHA 3573b93cc8b7568516117263562d073cae9ee7fc: both clients declare
+// the same primaries, defaultModel "inherit", defaultContext "full", and two
+// payload contexts. WP6 replaces the fixture with the vendored real manifest.
+func stagedFixturePakke() *agentpakke.Manifest {
+	entry := func() agentpakke.ClientEntry {
+		return agentpakke.ClientEntry{
+			PrimaryAgents:  []string{"grillmester", "barista", "designer", "doctor-who"},
+			DefaultModel:   agentpakke.InheritModel,
+			DefaultContext: "full",
+			Payloads: map[string]agentpakke.Payload{
+				"full":    {Path: "plugin"},
+				"focused": {Path: "targets/copilot-cli-focused-v1"},
+			},
+		}
+	}
+	return &agentpakke.Manifest{
+		ContractVersion: "1",
+		Name:            "grillmester",
+		Clients: map[string]agentpakke.ClientEntry{
+			"copilot":  entry(),
+			"opencode": entry(),
+		},
+	}
+}
+
+func buildStagedSpec(t *testing.T, client string, r domain.ResolvedConfig, s StagedLaunch) cpltLaunch {
+	t.Helper()
+	var (
+		spec cpltLaunch
+		err  error
+	)
+	if client == "opencode" {
+		spec, err = buildStagedOpenCodeSpec(r, s)
+	} else {
+		spec, err = buildStagedCopilotSpec(r, s)
+	}
+	if err != nil {
+		t.Fatalf("building staged %s spec: %v", client, err)
+	}
+	return spec
+}
+
+// TestStagedLaunchSpecs is the four-scenario invocation table: the two clients
+// times the two payload contexts a Tier 2 agentpakke declares.
+//
+// Every expected value is transcribed from the reference launcher, grillmester
+// at 3573b93cc8b7568516117263562d073cae9ee7fc, scripts/grillmester.py
+// build_launch_command:
+//
+//	line 664-665   cplt --agent <client>
+//	line 668-669   --allow-read <payload>   (payload = plugin for copilot,
+//	               opencode_target for opencode; both clients read exactly the
+//	               one staged tree)
+//	line 673       OPENCODE_CONFIG_DIR=<payload>       (opencode only)
+//	line 674       --pass-env OPENCODE_CONFIG_DIR      (opencode only)
+//	line 687       the "--" separator
+//	line 698-699   opencode client args, no forwarded arguments: --agent <agent>
+//	line 700-701   opencode client args, "run …": run --agent <agent> …
+//	line 702-703   opencode client args, another opencode subcommand: forwarded
+//	               unchanged, with no --agent bound to it
+//	line 704       opencode client args, anything else: --agent <agent> …
+//	line 679-684   copilot client args: --plugin-dir <plugin> --agent grillmester:<agent>
+//
+// Not adopted, deliberately: --no-audit (line 663) and --project-dir (lines
+// 666-667), which are launcher policy rather than payload contract. No --model
+// either: the fixture declares "inherit", and the reference forwards no model
+// at all.
+func TestStagedLaunchSpecs(t *testing.T) {
+	SetActivePakke(stagedFixturePakke())
+	t.Cleanup(func() { SetActivePakke(nil) })
+
+	fullDir := filepath.Join(t.TempDir(), "grillmester-copilot-full-abc123")
+	focusedDir := filepath.Join(t.TempDir(), "grillmester-opencode-focused-def456")
+
+	tests := []struct {
+		name          string
+		client        string
+		staged        StagedLaunch
+		extraArgs     []string
+		wantCpltAgent string
+		wantCpltArgs  []string
+		wantAgentArgs []string
+		wantConfigDir string // OPENCODE_CONFIG_DIR, "" when it must be unset
+	}{
+		{
+			name:          "copilot/full",
+			client:        "copilot",
+			staged:        StagedLaunch{Dir: fullDir, PakkeName: "grillmester", Context: "full"},
+			wantCpltAgent: "copilot",
+			wantCpltArgs:  []string{"--allow-read", fullDir},
+			wantAgentArgs: []string{"--plugin-dir", fullDir, "--agent", "grillmester:grillmester"},
+		},
+		{
+			name:          "copilot/focused",
+			client:        "copilot",
+			staged:        StagedLaunch{Dir: focusedDir, PakkeName: "grillmester", Context: "focused"},
+			wantCpltAgent: "copilot",
+			wantCpltArgs:  []string{"--allow-read", focusedDir},
+			wantAgentArgs: []string{"--plugin-dir", focusedDir, "--agent", "grillmester:grillmester"},
+		},
+		{
+			name:          "opencode/full",
+			client:        "opencode",
+			staged:        StagedLaunch{Dir: fullDir, PakkeName: "grillmester", Context: "full"},
+			wantCpltAgent: "opencode",
+			wantCpltArgs:  []string{"--allow-read", fullDir, "--pass-env", "OPENCODE_CONFIG_DIR"},
+			wantAgentArgs: []string{"--agent", "grillmester"},
+			wantConfigDir: fullDir,
+		},
+		{
+			name:          "opencode/focused",
+			client:        "opencode",
+			staged:        StagedLaunch{Dir: focusedDir, PakkeName: "grillmester", Context: "focused"},
+			wantCpltAgent: "opencode",
+			wantCpltArgs:  []string{"--allow-read", focusedDir, "--pass-env", "OPENCODE_CONFIG_DIR"},
+			wantAgentArgs: []string{"--agent", "grillmester"},
+			wantConfigDir: focusedDir,
+		},
+		{
+			// Reference lines 700-701: "run" keeps its leading position and the
+			// agent is bound after it.
+			name:          "opencode/run reorders the agent binding",
+			client:        "opencode",
+			staged:        StagedLaunch{Dir: fullDir, PakkeName: "grillmester", Context: "full"},
+			extraArgs:     []string{"run", "hi"},
+			wantCpltAgent: "opencode",
+			wantCpltArgs:  []string{"--allow-read", fullDir, "--pass-env", "OPENCODE_CONFIG_DIR"},
+			wantAgentArgs: []string{"run", "--agent", "grillmester", "hi"},
+			wantConfigDir: fullDir,
+		},
+		{
+			// Reference lines 702-703: a bare opencode subcommand is not a
+			// session entry point, so no --agent may be bound to it.
+			name:          "opencode/subcommand takes no agent binding",
+			client:        "opencode",
+			staged:        StagedLaunch{Dir: fullDir, PakkeName: "grillmester", Context: "full"},
+			extraArgs:     []string{"auth", "login"},
+			wantCpltAgent: "opencode",
+			wantCpltArgs:  []string{"--allow-read", fullDir, "--pass-env", "OPENCODE_CONFIG_DIR"},
+			wantAgentArgs: []string{"auth", "login"},
+			wantConfigDir: fullDir,
+		},
+		{
+			// Reference line 704: anything that is not a subcommand is session
+			// arguments, which follow the agent binding.
+			name:          "opencode/flags follow the agent binding",
+			client:        "opencode",
+			staged:        StagedLaunch{Dir: fullDir, PakkeName: "grillmester", Context: "full"},
+			extraArgs:     []string{"--port", "4096"},
+			wantCpltAgent: "opencode",
+			wantCpltArgs:  []string{"--allow-read", fullDir, "--pass-env", "OPENCODE_CONFIG_DIR"},
+			wantAgentArgs: []string{"--agent", "grillmester", "--port", "4096"},
+			wantConfigDir: fullDir,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// AskUser: true keeps the copilot flag tail empty, so the vector is
+			// exactly the reference shape; the tail itself is pinned below.
+			r := domain.ResolvedConfig{Client: tt.client, AskUser: true, ExtraArgs: tt.extraArgs}
+			spec := buildStagedSpec(t, tt.client, r, tt.staged)
+
+			if spec.agent != tt.wantCpltAgent {
+				t.Errorf("cplt --agent = %q, want %q", spec.agent, tt.wantCpltAgent)
+			}
+			if !slices.Equal(spec.cpltArgs, tt.wantCpltArgs) {
+				t.Errorf("cpltArgs\n got: %q\nwant: %q", spec.cpltArgs, tt.wantCpltArgs)
+			}
+			if !slices.Equal(spec.agentArgs, tt.wantAgentArgs) {
+				t.Errorf("agentArgs\n got: %q\nwant: %q", spec.agentArgs, tt.wantAgentArgs)
+			}
+			if got := telemetry.LookupEnvValue(spec.env, "OPENCODE_CONFIG_DIR"); got != tt.wantConfigDir {
+				t.Errorf("OPENCODE_CONFIG_DIR = %q, want %q", got, tt.wantConfigDir)
+			}
+			if !strings.Contains(spec.messageSuffix, tt.staged.Context) {
+				t.Errorf("message suffix %q should name the payload context", spec.messageSuffix)
+			}
+		})
+	}
+}
+
+// TestStagedLaunchModel pins the F1 manifest-default-model half: "inherit"
+// forwards no --model (as the reference does), a concrete manifest default is
+// forwarded, and a user pin always wins.
+func TestStagedLaunchModel(t *testing.T) {
+	t.Cleanup(func() { SetActivePakke(nil) })
+	staged := StagedLaunch{Dir: "/staged/x", PakkeName: "grillmester", Context: "full"}
+
+	concrete := func(model string) *agentpakke.Manifest {
+		m := stagedFixturePakke()
+		for id, entry := range m.Clients {
+			entry.DefaultModel = model
+			m.Clients[id] = entry
+		}
+		return m
+	}
+
+	tests := []struct {
+		name       string
+		pakke      *agentpakke.Manifest
+		userModel  string
+		wantOpen   []string
+		wantCopilo []string
+	}{
+		{
+			name:       "inherit forwards no model",
+			pakke:      stagedFixturePakke(),
+			wantOpen:   []string{"--agent", "grillmester"},
+			wantCopilo: []string{"--plugin-dir", staged.Dir, "--agent", "grillmester:grillmester"},
+		},
+		{
+			name:       "manifest default model is forwarded",
+			pakke:      concrete("github-copilot/claude-opus-5"),
+			wantOpen:   []string{"--agent", "grillmester", "--model", "github-copilot/claude-opus-5"},
+			wantCopilo: []string{"--plugin-dir", staged.Dir, "--agent", "grillmester:grillmester", "--model", "github-copilot/claude-opus-5"},
+		},
+		{
+			name:       "user pin wins over the manifest default",
+			pakke:      concrete("github-copilot/claude-opus-5"),
+			userModel:  "gpt-5.5",
+			wantOpen:   []string{"--agent", "grillmester", "--model", "github-copilot/gpt-5.5"},
+			wantCopilo: []string{"--plugin-dir", staged.Dir, "--agent", "grillmester:grillmester", "--model", "gpt-5.5"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetActivePakke(tt.pakke)
+			r := domain.ResolvedConfig{AskUser: true, Model: tt.userModel}
+
+			if got := buildStagedSpec(t, "opencode", r, staged).agentArgs; !slices.Equal(got, tt.wantOpen) {
+				t.Errorf("opencode agentArgs\n got: %q\nwant: %q", got, tt.wantOpen)
+			}
+			if got := buildStagedSpec(t, "copilot", r, staged).agentArgs; !slices.Equal(got, tt.wantCopilo) {
+				t.Errorf("copilot agentArgs\n got: %q\nwant: %q", got, tt.wantCopilo)
+			}
+		})
+	}
+}
+
+// TestStagedLaunchForwardsResolvedConfig pins the rest of each client's tail:
+// copilot reuses the shared resolved-flag helper (the same one BuildCopilotArgs
+// emits, so the golden legacy vectors stay valid), opencode keeps mapping plan
+// mode to its built-in plan agent, and both append ExtraArgs last.
+func TestStagedLaunchForwardsResolvedConfig(t *testing.T) {
+	SetActivePakke(stagedFixturePakke())
+	t.Cleanup(func() { SetActivePakke(nil) })
+	staged := StagedLaunch{Dir: "/staged/x", PakkeName: "grillmester", Context: "full"}
+
+	r := domain.ResolvedConfig{
+		Mode:            "autopilot",
+		ReasoningEffort: "high",
+		ContextTier:     "large",
+		AllowAllTools:   true,
+		AskUser:         false,
+		LogLevel:        "debug",
+		ExtraArgs:       []string{"-p", "hei"},
+	}
+	want := []string{
+		"--plugin-dir", staged.Dir,
+		"--agent", "grillmester:grillmester",
+		"--mode", "autopilot",
+		"--effort", "high",
+		"--context", "large",
+		"--allow-all-tools",
+		"--no-ask-user",
+		"--log-level", "debug",
+		"-p", "hei",
+	}
+	if got := buildStagedSpec(t, "copilot", r, staged).agentArgs; !slices.Equal(got, want) {
+		t.Errorf("copilot agentArgs\n got: %q\nwant: %q", got, want)
+	}
+
+	plan := domain.ResolvedConfig{Mode: "plan", AskUser: true, ExtraArgs: []string{"--foo"}}
+	wantPlan := []string{"--agent", "plan", "--foo"}
+	if got := buildStagedSpec(t, "opencode", plan, staged).agentArgs; !slices.Equal(got, wantPlan) {
+		t.Errorf("opencode agentArgs (plan mode)\n got: %q\nwant: %q", got, wantPlan)
+	}
+}
+
+// TestStagedCopilotRequiresCplt pins the decision that a staged copilot launch
+// never falls back to a plain, unsandboxed copilot binary.
+func TestStagedCopilotRequiresCplt(t *testing.T) {
+	SetActivePakke(stagedFixturePakke())
+	t.Cleanup(func() { SetActivePakke(nil) })
+
+	// A PATH with a plain `copilot` that is not cplt: the legacy path would
+	// launch it, the staged path must refuse.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "copilot"), []byte("#!/bin/sh\necho copilot 1.2.3\n"), 0o755); err != nil {
+		t.Fatalf("writing fake copilot: %v", err)
+	}
+	t.Setenv("PATH", dir)
+
+	err := LaunchCopilotStaged(domain.ResolvedConfig{Client: "copilot", AskUser: true},
+		StagedLaunch{Dir: dir, PakkeName: "grillmester", Context: "full"})
+	if err == nil {
+		t.Fatal("LaunchCopilotStaged must refuse to launch without cplt")
+	}
+	if !strings.Contains(err.Error(), "brew install navikt/tap/cplt") {
+		t.Errorf("error should name the install command, got: %v", err)
+	}
+}
+
+// TestStagedSpecRequiresDeclaredPrimary covers call-site drift: a pakke that
+// does not declare the client fails loudly instead of passing --agent "".
+func TestStagedSpecRequiresDeclaredPrimary(t *testing.T) {
+	t.Cleanup(func() { SetActivePakke(nil) })
+	SetActivePakke(&agentpakke.Manifest{Name: "empty", Clients: map[string]agentpakke.ClientEntry{}})
+
+	staged := StagedLaunch{Dir: "/staged/x", PakkeName: "empty", Context: "full"}
+	if _, err := buildStagedCopilotSpec(domain.ResolvedConfig{}, staged); err == nil {
+		t.Error("buildStagedCopilotSpec must fail when the pakke declares no copilot primary")
+	}
+	if _, err := buildStagedOpenCodeSpec(domain.ResolvedConfig{}, staged); err == nil {
+		t.Error("buildStagedOpenCodeSpec must fail when the pakke declares no opencode primary")
+	}
+}
+
+// TestStagedOpenCodeLeavesSharedConfigAlone is the G2 no-regression pin: the
+// staged opencode path must not read-modify-write the user's shared
+// ~/.config/opencode/opencode.json the way LaunchOpenCode does via
+// EnsureOpenCodeOTelConfig / EnsureOpenCodeNavContext.
+func TestStagedOpenCodeLeavesSharedConfigAlone(t *testing.T) {
+	SetActivePakke(stagedFixturePakke())
+	t.Cleanup(func() { SetActivePakke(nil) })
+
+	configDir := t.TempDir()
+	sentinelPath := filepath.Join(configDir, "opencode.json")
+	sentinel := []byte(`{"theme":"mine"}`)
+	if err := os.WriteFile(sentinelPath, sentinel, 0o600); err != nil {
+		t.Fatalf("writing sentinel config: %v", err)
+	}
+	ConfigPathOverride = sentinelPath
+	NavContextDirOverride = configDir
+	t.Cleanup(func() { ConfigPathOverride, NavContextDirOverride = "", "" })
+
+	staged := StagedLaunch{Dir: t.TempDir(), PakkeName: "grillmester", Context: "full"}
+	buildStagedSpec(t, "opencode", domain.ResolvedConfig{Client: "opencode"}, staged)
+
+	// The launcher too, all the way to the exec. A PATH carrying opencode but
+	// no cplt gets it past its own lookup — which is where the legacy path does
+	// its config work — and stops it at launchViaCplt instead.
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "opencode"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("writing fake opencode: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+	if err := LaunchOpenCodeStaged(domain.ResolvedConfig{Client: "opencode"}, staged); err == nil {
+		t.Fatal("LaunchOpenCodeStaged should fail without cplt on PATH")
+	}
+
+	got, err := os.ReadFile(sentinelPath)
+	if err != nil {
+		t.Fatalf("reading sentinel config back: %v", err)
+	}
+	if string(got) != string(sentinel) {
+		t.Errorf("staged launch modified the shared opencode config:\n got: %s\nwant: %s", got, sentinel)
+	}
+
+	// And it must not create the file when the user has none.
+	absent := filepath.Join(t.TempDir(), "nested", "opencode.json")
+	ConfigPathOverride = absent
+	buildStagedSpec(t, "opencode", domain.ResolvedConfig{Client: "opencode"}, staged)
+	if _, err := os.Stat(absent); !os.IsNotExist(err) {
+		t.Errorf("staged launch created %s; it must never touch the shared config", absent)
+	}
+}
+
+// TestGoldenCpltArgvWithoutCpltArgs pins that the new pre-"--" slot is inert
+// for every legacy launch: with no cpltArgs, cplt receives exactly today's
+// vector.
+func TestGoldenCpltArgvWithoutCpltArgs(t *testing.T) {
+	spec := cpltLaunch{agent: "opencode", agentArgs: OpenCodeArgs(domain.ResolvedConfig{})}
+	want := []string{"--agent", "opencode", "--", "--model", "github-copilot/auto", "--agent", "nav-pilot"}
+	if got := cpltArgv(spec); !slices.Equal(got, want) {
+		t.Errorf("cpltArgv\n got: %q\nwant: %q", got, want)
+	}
+
+	pi := cpltLaunch{agent: "pi"}
+	wantPi := []string{"--agent", "pi", "--"}
+	if got := cpltArgv(pi); !slices.Equal(got, wantPi) {
+		t.Errorf("cpltArgv(pi)\n got: %q\nwant: %q", got, wantPi)
+	}
+}
+
+// TestOpenCodeDefaultModelFollowsPakke covers the WP2 review finding that the
+// provider's advertised default and the launch fallback could disagree.
+func TestOpenCodeDefaultModelFollowsPakke(t *testing.T) {
+	t.Cleanup(func() { SetActivePakke(nil) })
+
+	SetActivePakke(&agentpakke.Manifest{
+		Name:    "grillmester",
+		Clients: map[string]agentpakke.ClientEntry{"opencode": {PrimaryAgents: []string{"grillmester"}, DefaultModel: "github-copilot/claude-opus-5"}},
+	})
+	if got := (openCodeProvider{}).DefaultModel(); got != "github-copilot/claude-opus-5" {
+		t.Errorf("DefaultModel() = %q, want the active pakke's declaration", got)
+	}
+
+	SetActivePakke(&agentpakke.Manifest{
+		Name:    "grillmester",
+		Clients: map[string]agentpakke.ClientEntry{"opencode": {PrimaryAgents: []string{"grillmester"}, DefaultModel: agentpakke.InheritModel}},
+	})
+	if got := (openCodeProvider{}).DefaultModel(); got != OpenCodeDefaultModel {
+		t.Errorf("DefaultModel() under an inherit pakke = %q, want the built-in %q", got, OpenCodeDefaultModel)
+	}
+	if got := ToOpenCodeModel(""); got != OpenCodeDefaultModel {
+		t.Errorf("ToOpenCodeModel(\"\") under an inherit pakke = %q, want the built-in %q", got, OpenCodeDefaultModel)
+	}
+}
+
+// TestGoldenCpltArgvWithCpltArgs pins the assembled vector when cpltArgs is
+// non-empty: the sandbox flags belong *before* the "--" separator, where cplt
+// reads them, and the client arguments after it. Without this the separator
+// could drift past the sandbox grant and hand --allow-read to the client.
+func TestGoldenCpltArgvWithCpltArgs(t *testing.T) {
+	spec := cpltLaunch{
+		agent:     "opencode",
+		cpltArgs:  []string{"--allow-read", "/staged/x", "--pass-env", "OPENCODE_CONFIG_DIR"},
+		agentArgs: []string{"--agent", "grillmester", "-p", "hei"},
+	}
+	want := []string{
+		"--agent", "opencode",
+		"--allow-read", "/staged/x",
+		"--pass-env", "OPENCODE_CONFIG_DIR",
+		"--",
+		"--agent", "grillmester", "-p", "hei",
+	}
+	if got := cpltArgv(spec); !slices.Equal(got, want) {
+		t.Errorf("cpltArgv\n got: %q\nwant: %q", got, want)
+	}
+
+	// And with no agent arguments the separator is still the last element, so
+	// the sandbox flags cannot slide behind it.
+	copilot := cpltLaunch{agent: "copilot", cpltArgs: []string{"--allow-read", "/staged/x"}}
+	wantCopilot := []string{"--agent", "copilot", "--allow-read", "/staged/x", "--"}
+	if got := cpltArgv(copilot); !slices.Equal(got, wantCopilot) {
+		t.Errorf("cpltArgv(copilot)\n got: %q\nwant: %q", got, wantCopilot)
+	}
+}
+
+// TestStagedCopilotDoesNotInjectUserInstructions pins that a staged Tier 2
+// session is not silently given the user's own ~/.copilot content: the pakke
+// author never tested against it, and no manifest field declares that the pakke
+// accepts it (see pakkeAcceptsUserContext). The legacy launch still injects it.
+func TestStagedCopilotDoesNotInjectUserInstructions(t *testing.T) {
+	SetActivePakke(stagedFixturePakke())
+	t.Cleanup(func() { SetActivePakke(nil) })
+
+	home := t.TempDir()
+	instructions := filepath.Join(home, ".copilot", ".github", "instructions")
+	if err := os.MkdirAll(instructions, 0o755); err != nil {
+		t.Fatalf("creating user instructions: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(instructions, "nav.instructions.md"), []byte("# nav\n"), 0o600); err != nil {
+		t.Fatalf("writing user instruction: %v", err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("COPILOT_CUSTOM_INSTRUCTIONS_DIRS", "")
+
+	const key = "COPILOT_CUSTOM_INSTRUCTIONS_DIRS"
+	if got := telemetry.LookupEnvValue(CopilotEnv(""), key); got == "" {
+		t.Fatalf("precondition: the legacy copilot launch should inject %s for this HOME", key)
+	}
+
+	staged := StagedLaunch{Dir: t.TempDir(), PakkeName: "grillmester", Context: "full"}
+	spec := buildStagedSpec(t, "copilot", domain.ResolvedConfig{Client: "copilot", AskUser: true}, staged)
+	if got := telemetry.LookupEnvValue(spec.env, key); got != "" {
+		t.Errorf("staged copilot launch injected %s = %q; a pakke gets the user's own context only when it declares that it accepts it", key, got)
+	}
+}

--- a/cli/nav-pilot/internal/provider/staged_launch_test.go
+++ b/cli/nav-pilot/internal/provider/staged_launch_test.go
@@ -485,3 +485,78 @@ func TestStagedCopilotDoesNotInjectUserInstructions(t *testing.T) {
 		t.Errorf("staged copilot launch injected %s = %q; a pakke gets the user's own context only when it declares that it accepts it", key, got)
 	}
 }
+
+// TestStagedLaunchRejectsReservedClientArguments pins the guard transcribed
+// from the reference launcher's _reject_reserved_arguments (grillmester.py
+// lines 633-643 at 3573b93cc8b7568516117263562d073cae9ee7fc):
+//
+//	line 633-636  client --agent        both clients
+//	line 637-640  client --project-dir  both clients
+//	line 641-643  client --plugin-dir   copilot only
+//
+// These select what the session runs, which on a Tier 2 launch is fixed by the
+// digest-verified payload. Without the guard,
+// `nav-pilot --client copilot -- --plugin-dir /tmp/unverified` appends an
+// unverified plugin directory to a verified session.
+//
+// Both spellings the reference accepts are covered: "--opt value" and
+// "--opt=value" (_contains_option, lines 602-603).
+func TestStagedLaunchRejectsReservedClientArguments(t *testing.T) {
+	SetActivePakke(stagedFixturePakke())
+	t.Cleanup(func() { SetActivePakke(nil) })
+
+	staged := StagedLaunch{Dir: t.TempDir(), PakkeName: "grillmester", Context: "full"}
+
+	tests := []struct {
+		name      string
+		client    string
+		extraArgs []string
+		wantErr   string
+	}{
+		{name: "copilot --agent", client: "copilot", extraArgs: []string{"--agent", "other"}, wantErr: "--agent"},
+		{name: "copilot --agent=", client: "copilot", extraArgs: []string{"--agent=other"}, wantErr: "--agent"},
+		{name: "copilot --project-dir", client: "copilot", extraArgs: []string{"--project-dir", "/tmp"}, wantErr: "--project-dir"},
+		{name: "copilot --plugin-dir", client: "copilot", extraArgs: []string{"--plugin-dir", "/tmp/unverified"}, wantErr: "--plugin-dir"},
+		{name: "copilot --plugin-dir=", client: "copilot", extraArgs: []string{"--plugin-dir=/tmp/unverified"}, wantErr: "--plugin-dir"},
+		{name: "opencode --agent", client: "opencode", extraArgs: []string{"--agent", "other"}, wantErr: "--agent"},
+		{name: "opencode --project-dir", client: "opencode", extraArgs: []string{"--project-dir", "/tmp"}, wantErr: "--project-dir"},
+		// Even behind an opencode subcommand, which openCodeClientArgs
+		// forwards unchanged: the reference rejects before it dispatches.
+		{name: "opencode run --agent", client: "opencode", extraArgs: []string{"run", "--agent", "other"}, wantErr: "--agent"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := domain.ResolvedConfig{Client: tt.client, ExtraArgs: tt.extraArgs}
+			var err error
+			if tt.client == "opencode" {
+				_, err = buildStagedOpenCodeSpec(r, staged)
+			} else {
+				_, err = buildStagedCopilotSpec(r, staged)
+			}
+			if err == nil {
+				t.Fatalf("%v must be refused, not silently accepted", tt.extraArgs)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error should name %s, got: %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+// TestOpenCodeAcceptsPluginDir: --plugin-dir is a copilot flag, so the
+// per-client rule of the reference (line 641, `client == "copilot"`) must not
+// be flattened into a single list for both clients.
+func TestOpenCodeAcceptsPluginDir(t *testing.T) {
+	SetActivePakke(stagedFixturePakke())
+	t.Cleanup(func() { SetActivePakke(nil) })
+
+	staged := StagedLaunch{Dir: t.TempDir(), PakkeName: "grillmester", Context: "full"}
+	spec, err := buildStagedOpenCodeSpec(
+		domain.ResolvedConfig{Client: "opencode", ExtraArgs: []string{"--plugin-dir", "/tmp/x"}}, staged)
+	if err != nil {
+		t.Fatalf("opencode --plugin-dir is not reserved: %v", err)
+	}
+	if !slices.Contains(spec.agentArgs, "--plugin-dir") {
+		t.Errorf("forwarded argument dropped: %v", spec.agentArgs)
+	}
+}

--- a/docs/README.agentpakke.md
+++ b/docs/README.agentpakke.md
@@ -254,13 +254,31 @@ Et eksplisitt `--source` er overstyringen — da har brukeren sagt hvilken kilde
 
 Stiformede kilder sammenlignes symlink-oppløst, så en symlink og checkouten bak den regnes som samme kilde.
 
+## Slik starter brukerne klienten fra en Tier 2-pakke
+
+Peker kilden på en agentpakke som deklarerer `payloads` for klienten, verifiserer og stager nav-pilot payloaden ved hver launch og peker klienten på det stagede treet:
+
+```bash
+nav-pilot --client copilot                                # konteksten manifestet setter som standard
+nav-pilot --client copilot --payload-context focused      # en annen deklarert kontekst
+```
+
+- **`--payload-context <id>`** velger kontekst. Uten flagget brukes `defaultContext` fra klientoppføringa (`full` når feltet mangler). En kontekst pakka ikke deklarerer gir en feil som lister opp de som finnes. Det er ingen config-nøkkel for dette: den varige standarden er manifestets eget felt.
+- **`--payload-context` er ikke `--context`.** Sistnevnte er Copilots long-context-nivå og er uendret; de to er ortogonale og kan stå på samme kommandolinje.
+- **Verifisering før hver launch.** Payloaden sjekkes mot payload-manifestet (digest og modus), kopieres til et privat tre under `~/.nav-pilot/staged/`, og re-verifiseres eksakt der. Feiler noe av dette, starter ingenting — en Tier 2-launch faller aldri tilbake på Tier 1-veien.
+- **Det stagede treet slettes når klienten avslutter.** Rester etter en krasjet økt ryddes av neste staged launch (eldre enn 24 timer).
+- **opencode** startes med `OPENCODE_CONFIG_DIR` mot det stagede treet. Den delte `~/.config/opencode/opencode.json` verken leses eller skrives på denne veien; OTel går fortsatt som miljøvariabler.
+- **copilot** startes med `--plugin-dir <staged>` og personaen kvalifisert med pakkenavnet: `--agent <pakke>:<agent>`.
+- **cplt er påkrevd.** En staged launch gir klienten et verifisert tre inne i sandkassen; uten cplt starter ingenting (`brew install navikt/tap/cplt`).
+- **Modell:** `defaultModel: "inherit"` sender ingen `--model` i det hele tatt. En konkret verdi sendes med. En modell brukeren har pinnet selv vinner over begge.
+
 ## Begrensninger i dag
 
 Dette er statusen i milepæl 1. Alt under er kjent og planlagt, ikke feil:
 
-- **Tier 2 kan valideres, men ikke installeres.** En agentpakke uten `layout` der klientene har `payloads` validerer fint, men install avvises med sin egen begrunnelse: payload-staging kommer i en senere release (M2). En pakke som skal installeres i dag må ha Tier 1-innhold.
+- **Tier 2 kan startes, men ikke installeres.** Staged launch er live (se [Slik starter brukerne klienten fra en Tier 2-pakke](#slik-starter-brukerne-klienten-fra-en-tier-2-pakke)): en pakke uten `layout` kan velges som kilde og startes direkte. `nav-pilot install` avvises fortsatt med sin egen begrunnelse — install av Tier 2 kommer i en senere release. En pakke som skal *installeres* i dag må ha Tier 1-innhold.
 - **`policies` og `profiles` parses og sti-sjekkes, men materialiseres ikke.** nav-pilot skriver hverken opencode-permissions eller launch-profiler ut fra manifestet ennå (M3).
-- **Persona, modell og launch leser fortsatt Nav-defaults.** `primaryAgents`, `defaultModel`, `defaultContext` og `compatibility` valideres, men kallstedene i `internal/provider` og `internal/source` er ennå hardkodet. De flyttes over til manifestet i M2. En agentpakke bør deklarere feltene riktig nå, slik at oppførselen blir riktig når koden begynner å lese dem.
+- **`compatibility` valideres, men håndheves ikke.** `primaryAgents`, `defaultModel` og `defaultContext` leses nå av launch og materialisering, men klientversjonsområdet sjekkes ikke mot klienten som faktisk er installert.
 - **`nav-pilot export opencode` støtter bare kanoniske stier.** Export leser `agents/`, `skills/`, `instructions/` og `prompts/` direkte. En agentpakke som legger innholdet et annet sted avvises av export med en forklaring, framfor å skrive et tomt `.opencode/`-tre.
 - **Ferskhetssjekken i rot-TUI-en beskriver bare standardkilden.** Scope som ikke kommer fra `navikt/copilot` hoppes over der, fordi release-feeden til nav-pilot bare sier noe om standardkilden.
 - **`provenance` verifiseres ikke.** Feltet er metadata; nav-pilot sjekker ikke digest mot innholdet.

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -204,6 +204,12 @@ Støttede felt er `client`, `model`, `mode`, `reasoning_effort`, `context_tier`,
 globale flagg som `--client`, `--model`, `--mode`, `--effort`, `--context`,
 `--allow-all-tools`, `--no-ask-user`, `--auto-launch`/`--no-auto-launch` og `--log-level`.
 
+`--payload-context <id>` gjelder bare kilder som er en agentpakke med ferdigbygde
+payloads, og velger hvilken kontekst som stages ved launch. Den har ingen config-nøkkel
+— standarden er `defaultContext` i pakkas manifest — og er ikke det samme som
+`--context`, som fortsatt er Copilots long-context-nivå. Se
+[README.agentpakke.md](README.agentpakke.md).
+
 Etter synk/installasjon starter nav-pilot kodeagenten automatisk. Sett
 `auto_launch = false` (eller bruk `--no-auto-launch`) hvis du heller vil starte
 den selv — da skriver nav-pilot bare ut kommandoen du kan kjøre.

--- a/docs/agentpakke-beslutninger.md
+++ b/docs/agentpakke-beslutninger.md
@@ -45,7 +45,7 @@ Avvikene er få og hver enkelt er begrunnet i koden der sjekken gjøres. Sammend
 | Ingen pin av `target`-navn | `payload.go`, `PayloadManifest.Target` | Digestkjeden |
 | `O_NOFOLLOW`/`O_NONBLOCK` + fstat på deskriptoren (referansen har ingen av delene) | `payload.go`, `openPayloadFile` | — (strengere enn referansen) |
 | Kopiering styres av manifestets `files`, ikke av en walk av kildetreet | `stage.go`, filhode | — (strengere enn referansen) |
-| `--no-audit` og `--project-dir` tas ikke i bruk | `staged_launch.go`, filhode | — (launcher-policy, ikke payload-kontrakt) |
+| `--project-dir` tas ikke i bruk (`--no-audit` tas i bruk, se [§2.5](#25-flagg-fra-referansen)) | `staged_launch.go`, filhode | Arbeidskatalogen *er* prosjektomfanget — ingen launch-sti setter `cmd.Dir` |
 
 ### 2.1 Modesjekk på kilden: subset pluss exec-bit
 
@@ -69,14 +69,14 @@ Referansen sjekker payload-manifestets `target` mot en hardkodet liste over sine
 
 Referansen kopierer med `shutil.copytree(symlinks=True)` — den walker kilden. nav-pilot kopierer fra manifestets `files`-map: manifestet, ikke katalogen, er autoriteten på hva payloaden inneholder. En fil som smugles inn i kilden mellom verifisering og staging blir dermed aldri kopiert, framfor å bli kopiert og så avvist. I tillegg re-hashes hver fil *mens* den skrives, slik at vinduet mellom kildeverifiseringen og lesingen som kopierer bytene er lukket (`stage.go`, filhode og `stageFile`).
 
-### 2.5 Flagg vi ikke tar i bruk
+### 2.5 Flagg fra referansen
 
-Fra referansens `build_launch_command` (`scripts/grillmester.py`, linje 647–689) utelates to cplt-flagg med vilje, som launcher-policy snarere enn payload-kontrakt:
+Fra referansens `build_launch_command` (`scripts/grillmester.py`, linje 647–689) tar vi ett av de to cplt-flaggene i bruk og utelater ett:
 
-- **`--no-audit`** (linje 663) — referansen dokumenterer det selv som en cplt-versjonsspesifikk workaround.
-- **`--project-dir`** (linje 666–667) — nav-pilot starter i arbeidskatalogen.
+- **`--no-audit`** (linje 663) — **tas i bruk** på den stagede stien, på referansens plass: først i cplt-vektoren, før `--agent`. Vi leste det først som launcher-policy og en versjonsspesifikk workaround, og utelot det. Team eSyfo korrigerte det i svaret på G4-spørsmålet ([kommentar i #437](https://github.com/navikt/copilot/issues/437#issuecomment-5437575432)): på cplt-baselinen grillmester v0.3.0 er testet mot, kan cplts parent-side audit kjøre repo-kontrollerte Git-hjelpere *utenfor* sandboxen. Uten flagget er en staget Tier 2-launch dårligere isolert enn launcheren den skal være ekvivalent med. Å fjerne det igjen krever dokumentasjon på at en gjennomgått cplt-baseline retter oppførselen, pluss en minimumsversjonssperre som håndhever den — ikke at flagget ser overflødig ut.
+- **`--project-dir`** (linje 666–667) — **utelates fortsatt**. nav-pilot starter i arbeidskatalogen: ingen launch-sti setter `cmd.Dir`, så cplt og klienten arver brukerens cwd. eSyfo aksepterer utelatelsen på nøyaktig det vilkåret, og at differansetestene asserterer oppførselen.
 
-Begge er meldt til Team eSyfo som del av det åpne G4-spørsmålet om «equivalent invocation» ([§5.2](#52-grensen-for-equivalent-invocation-g4--eier-team-esyfo)). Til det er besvart, er dette vår beslutning, ikke en avtale.
+Beslutningen om `--no-audit` er altså endret, og den er Team eSyfos ([§5.2](#52-grensen-for-equivalent-invocation-g4--eier-team-esyfo), [§8](#8-der-kildene-er-uenige)); den om `--project-dir` er vår, nå med eSyfos aksept.
 
 ### 2.6 Annet vi ikke speiler
 
@@ -146,7 +146,7 @@ Referanselauncheren når `focused` bare gjennom `grillmester local` (loopback, m
 
 ### 5.2 Grensen for «equivalent invocation» (G4) — eier: Team eSyfo
 
-Vi planlegger å assertere config-plassering, persona inkludert `<pakke>:<agent>`-kvalifiseringen, modellhåndtering, `--pass-env OPENCODE_CONFIG_DIR`, `--allow-read <staged>` og cplt-agentvalg. Vi tar ikke i bruk `--no-audit` eller `--project-dir` ([§2.5](#25-flagg-vi-ikke-tar-i-bruk)), normaliserer modes ved staging ([§2.1](#21-modesjekk-på-kilden-subset-pluss-exec-bit)), og hopper over `.gitignore`-pre-seedingen ([§2.6](#26-annet-vi-ikke-speiler)). Spørsmålet til eSyfo er om noen av dem er bærende for deres guardrail-historie. Stilt samme sted som 5.1.
+Vi planlegger å assertere config-plassering, persona inkludert `<pakke>:<agent>`-kvalifiseringen, modellhåndtering, `--pass-env OPENCODE_CONFIG_DIR`, `--allow-read <staged>` og cplt-agentvalg. Vi tar i bruk `--no-audit` og utelater fortsatt `--project-dir` ([§2.5](#25-flagg-fra-referansen)), normaliserer modes ved staging ([§2.1](#21-modesjekk-på-kilden-subset-pluss-exec-bit)), og hopper over `.gitignore`-pre-seedingen ([§2.6](#26-annet-vi-ikke-speiler)). Spørsmålet til eSyfo var om noen av dem er bærende for deres guardrail-historie. **Besvart for flaggene:** `--no-audit` er bærende og tas i bruk, `--project-dir` kan utelates så lenge arbeidskatalogen er prosjektomfanget ([kommentar i #437](https://github.com/navikt/copilot/issues/437#issuecomment-5437575432)). Resten av G4-ordlyden er fortsatt stilt samme sted som 5.1.
 
 ### 5.3 Skal en pakke kunne be om brukerens egen kontekst? — eier: nav-pilot
 
@@ -186,6 +186,7 @@ Tre valg var tatt uten at begrunnelsen fantes i kode, plan eller issue. De er sk
 - **Rekkefølgen på cplt-argumentene for opencode.** WP3-planen skrev `--pass-env` før `--allow-read`; referansen sender dem motsatt, og koden følger referansen ([§4](#4-launch-beslutningene)).
 - **Brukerens egne Copilot-instruksjoner.** #457 gjenbrukte `CopilotEnv` som den var, slik at brukerens `~/.copilot`-innhold ble blandet inn i en Tier 2-økt. #458 snur det: ingenting injiseres, og valget er samlet i ett kall ([§4](#4-launch-beslutningene), [§5.3](#53-skal-en-pakke-kunne-be-om-brukerens-egen-kontekst--eier-nav-pilot)). WP3-planens klassifisering av dette som «launcher policy» er dermed forlatt.
 - **Hva en resolve-feil gjør.** #457-teksten kaller den en akseptert regresjon for copilot-brukere med egen kilde; koden i #458 advarer og faller tilbake til legacy-stien, og #457-framstillingen var feil på to punkter ([§4](#4-launch-beslutningene)).
+- **`--no-audit` som launcher-policy.** #458 og en tidligere §2.5 klassifiserte flagget som launcher-policy vi ikke tok i bruk, med referansens egen kommentar som kilde. Team eSyfo svarte at det er bærende ved den testede cplt-baselinen ([kommentar i #437](https://github.com/navikt/copilot/issues/437#issuecomment-5437575432)). Deres svar gjelder: den stagede stien sender `--no-audit`, og vår klassifisering er forlatt ([§2.5](#25-flagg-fra-referansen)).
 - **Omstokking av opencode-argumenter.** WP3-planen kuttet referansens `_opencode_client_arguments` som «legges inn hvis noen melder fra». #458 implementerer den ([§4](#4-launch-beslutningene)); planen er utdatert på dette punktet.
 
 ## Se også


### PR DESCRIPTION
Replaces #457, whose branch was stacked on #456 and could not be retargeted after that merged. Same work plus the fixes from its review.

WP3b of the M2 plan for #437: **G2**'s launch half, **G3**, **C4**, and the manifest-default-model half of **F1**. With staging in place (#456), this points the client at the staged tree instead of at the user's shared configuration.

For OpenCode: `OPENCODE_CONFIG_DIR` at the staged path, forwarded through cplt with `--pass-env`, plus `--allow-read`. For Copilot CLI: `--plugin-dir` and the plugin-qualified persona the pakke declares. The argument and environment shapes — including OpenCode's subcommand handling, where the reference reorders for `run` and passes bare subcommands through without `--agent` — are transcribed from the reference launcher at the pinned commit, with line numbers cited in the tests.

## Decisions worth reviewing

- **Staged Copilot requires cplt.** The reference requires it, the payload is untrusted third-party configuration, and falling back to an unsandboxed client would quietly drop the isolation the payload was staged for. No fallback, no prompt. The "launch without the sandbox?" confirmation now happens only once a launch is known to be legacy, so nobody is asked to confirm a launch that is about to be refused.
- **A staged session does not inherit the user's own Copilot instructions.** The reference passes the environment untouched, and a pakke should see the context its author tested against rather than whatever sits in `~/.copilot`. Whether a pakke opts into that mixing is a manifest question — the decision point is a single call so the field is a one-line change once it exists, and the schema is deliberately unchanged here. Raised with Team eSyfo in #437.
- **The context flag is `--payload-context`**, since `--context` already names the Copilot context tier, defaulting to the manifest's declared context.

## Correcting the regression claim from #457

That PR said an unresolvable source only affected the copilot path because OpenCode already cloned per launch. That was wrong twice over: legacy OpenCode clones the *state-recorded* repo rather than the configured source, and its failure is a warning that lets the launch proceed. The new resolve was fatal for both clients, so an offline user with any `source` set — including `navikt/copilot` typed explicitly, which counts as custom — could not launch at all.

Fixed rather than documented: a resolve failure now warns and runs the legacy path. Fail-closed applies past the tier gate, where we know we are staging a payload — not to the lookup that tells us whether we are.

## No regression

Unreachable without a loaded manifest declaring payloads for the client being launched. No source, no manifest, Tier 1, and Tier 2-without-this-client all take the legacy path, each pinned — the no-source case with a `resolveSource` stub that fails the test if called at all.

The shared `~/.config/opencode/opencode.json` is asserted byte-unchanged, by a test that now runs the launcher far enough to reach where the legacy path would write it (the previous version stopped short and would not have caught a write reintroduced there). With no staged arguments the cplt argv is byte-identical to before, now pinned with non-empty staged arguments too — the previous tests would have passed with `--allow-read` moved after the `--` separator, where cplt would have handed the sandbox read grant to the client instead.

## Testing

`mise run nav-pilot:check` passes on current main. Every fix from the review was mutation-checked.
