### PR TITLE
feat(auth): one-shot token broker for cplt (follow-up to #424)

### DIFF
--- a/cli/nav-pilot/internal/provider/auth_broker.go
+++ b/cli/nav-pilot/internal/provider/auth_broker.go
@@ -1,0 +1,197 @@
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const maxBrokerTokenSize = 8 * 1024
+
+// tokenBroker is a one-shot Unix-domain-socket server. It accepts exactly one
+// client connection, sends the token, reads an ACK, then closes. The token
+// buffer is zeroized after sending.
+//
+// Security properties:
+//   - The socket is created in a mode-0700 temporary directory owned by the
+//     current user, so other users cannot reach it.
+//   - The token is never written to disk; it travels only through the socket.
+//   - The server accepts only one connection; subsequent attempts are rejected.
+//   - Zeroizing the buffer reduces the window during which the token is in
+//     memory, though it is not a hard security boundary against agents running
+//     as the same UID.
+type tokenBroker struct {
+	socketPath string
+	listener   net.Listener
+	mu         sync.Mutex
+	served     bool
+}
+
+// newTokenBroker creates a Unix-socket server in a private temp directory and
+// starts listening. Call Serve to block until one client is handled (or timeout),
+// then call Close to clean up.
+func newTokenBroker() (*tokenBroker, error) {
+	dir, err := os.MkdirTemp("", "nav-pilot-auth-*")
+	if err != nil {
+		return nil, fmt.Errorf("token broker: could not create socket dir: %w", err)
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, fmt.Errorf("token broker: could not secure socket dir: %w", err)
+	}
+
+	socketPath := filepath.Join(dir, "token.sock")
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, fmt.Errorf("token broker: could not listen on socket: %w", err)
+	}
+
+	return &tokenBroker{
+		socketPath: socketPath,
+		listener:   ln,
+	}, nil
+}
+
+// SocketPath returns the path to the Unix socket. Pass this to the sandboxed
+// process via an environment variable so the gh-wrapper can connect.
+func (b *tokenBroker) SocketPath() string {
+	return b.socketPath
+}
+
+// Serve waits for exactly one client connection, sends token, reads the "ok\n"
+// ACK, then returns. If the timeout elapses before a client connects, it returns
+// an error. The token slice is zeroized before Serve returns.
+func (b *tokenBroker) Serve(token []byte, timeout time.Duration) error {
+	defer zeroize(token)
+
+	if len(token) == 0 {
+		return errors.New("token broker: token must not be empty")
+	}
+	if len(token) > maxBrokerTokenSize {
+		return fmt.Errorf("token broker: token exceeds maximum size of %d bytes", maxBrokerTokenSize)
+	}
+
+	if ul, ok := b.listener.(*net.UnixListener); ok {
+		if err := ul.SetDeadline(time.Now().Add(timeout)); err != nil {
+			return fmt.Errorf("token broker: could not set deadline: %w", err)
+		}
+	}
+
+	conn, err := b.listener.Accept()
+	if err != nil {
+		return fmt.Errorf("token broker: no client connected within %s: %w", timeout, err)
+	}
+	// Stop listening immediately after the first connection to keep the broker one-shot.
+	_ = b.listener.Close()
+	defer conn.Close()
+	b.mu.Lock()
+	if b.served {
+		b.mu.Unlock()
+		return errors.New("token broker: already served one client; refusing second connection")
+	}
+	b.served = true
+	b.mu.Unlock()
+
+	// Write token followed by newline so the reader knows where it ends.
+	// Use an explicit allocation to avoid append mutating token's backing array.
+	payload := make([]byte, len(token)+1)
+	copy(payload, token)
+	payload[len(token)] = '\n'
+	// Wipe the copy unconditionally: a failed or partial write must not leave
+	// the token sitting in heap memory until GC.
+	defer zeroize(payload)
+	if err := writeAll(conn, payload); err != nil {
+		return fmt.Errorf("token broker: failed to send token: %w", err)
+	}
+
+	// Read ACK from client ("ok\n"). Set a short read deadline.
+	if tc, ok := conn.(*net.UnixConn); ok {
+		_ = tc.SetReadDeadline(time.Now().Add(2 * time.Second))
+	}
+	ack := make([]byte, 3)
+	n, _ := io.ReadAtLeast(conn, ack, 1)
+	_ = n // ACK is best-effort; we already sent the token.
+
+	return nil
+}
+
+// Close closes the listener and removes the socket directory.
+func (b *tokenBroker) Close() {
+	_ = b.listener.Close()
+	_ = os.RemoveAll(filepath.Dir(b.socketPath))
+}
+
+// ReadFromBroker connects to the broker socket, reads the token line, sends ACK,
+// and returns the token. Used by the gh-wrapper / tests to consume the broker.
+func ReadFromBroker(socketPath string, timeout time.Duration) ([]byte, error) {
+	conn, err := net.DialTimeout("unix", socketPath, timeout)
+	if err != nil {
+		return nil, fmt.Errorf("broker client: could not connect to %s: %w", socketPath, err)
+	}
+	defer conn.Close()
+
+	if tc, ok := conn.(*net.UnixConn); ok {
+		_ = tc.SetReadDeadline(time.Now().Add(timeout))
+	}
+
+	// Read until newline.
+	var buf []byte
+	oneByte := make([]byte, 1)
+	for {
+		n, err := conn.Read(oneByte)
+		if n > 0 {
+			if oneByte[0] == '\n' {
+				break
+			}
+			if len(buf) >= maxBrokerTokenSize {
+				return nil, fmt.Errorf("broker client: token exceeds maximum size of %d bytes", maxBrokerTokenSize)
+			}
+			buf = append(buf, oneByte[0])
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil, errors.New("broker client: stream closed before token terminator")
+			}
+			return nil, fmt.Errorf("broker client: read error: %w", err)
+		}
+	}
+
+	// Send ACK.
+	_, _ = conn.Write([]byte("ok\n"))
+
+	if len(buf) == 0 {
+		return nil, errors.New("broker client: received empty token")
+	}
+	return buf, nil
+}
+
+// zeroize overwrites a byte slice with zeros to reduce the window during which
+// a token is held in memory.
+func zeroize(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+func writeAll(w io.Writer, payload []byte) error {
+	total := 0
+	for total < len(payload) {
+		n, err := w.Write(payload[total:])
+		if n > 0 {
+			total += n
+		}
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return io.ErrShortWrite
+		}
+	}
+	return nil
+}

--- a/cli/nav-pilot/internal/provider/auth_broker_test.go
+++ b/cli/nav-pilot/internal/provider/auth_broker_test.go
@@ -1,0 +1,516 @@
+package provider
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTokenBroker_OneShotServe(t *testing.T) {
+	b, err := newTokenBroker()
+	if err != nil {
+		t.Skipf("skipping: Unix socket unavailable in this environment: %v", err)
+	}
+	defer b.Close()
+
+	token := []byte("ghu_brokertest")
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- b.Serve(token, 2*time.Second)
+	}()
+
+	got, err := ReadFromBroker(b.SocketPath(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("ReadFromBroker: %v", err)
+	}
+	if string(got) != "ghu_brokertest" {
+		t.Errorf("got token %q, want %q", got, "ghu_brokertest")
+	}
+
+	if err := <-errCh; err != nil {
+		t.Errorf("Serve returned error: %v", err)
+	}
+}
+
+func TestTokenBroker_ZeroizesAfterServe(t *testing.T) {
+	b, err := newTokenBroker()
+	if err != nil {
+		t.Skipf("skipping: Unix socket unavailable in this environment: %v", err)
+	}
+	defer b.Close()
+
+	token := []byte("ghu_zeroize_me")
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- b.Serve(token, 2*time.Second)
+	}()
+
+	_, err = ReadFromBroker(b.SocketPath(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("ReadFromBroker: %v", err)
+	}
+	<-errCh
+
+	// After Serve returns, the original token slice should be zeroized.
+	for i, b := range token {
+		if b != 0 {
+			t.Errorf("token[%d] = %d, want 0 (not zeroized)", i, b)
+		}
+	}
+}
+
+func TestTokenBroker_Timeout(t *testing.T) {
+	b, err := newTokenBroker()
+	if err != nil {
+		t.Skipf("skipping: Unix socket unavailable in this environment: %v", err)
+	}
+	defer b.Close()
+
+	// Very short timeout — no client connects.
+	err = b.Serve([]byte("ghu_timeout"), 50*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error when no client connects")
+	}
+}
+
+func TestTokenBroker_RejectsOversizedToken(t *testing.T) {
+	b, err := newTokenBroker()
+	if err != nil {
+		t.Skipf("skipping: Unix socket unavailable in this environment: %v", err)
+	}
+	defer b.Close()
+
+	token := make([]byte, maxBrokerTokenSize+1)
+	for i := range token {
+		token[i] = 'a'
+	}
+
+	err = b.Serve(token, 50*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected oversized token to be rejected")
+	}
+	if got := err.Error(); got == "" || !strings.Contains(got, "exceeds maximum size") {
+		t.Fatalf("expected max-size error, got %v", err)
+	}
+	for i, b := range token {
+		if b != 0 {
+			t.Fatalf("token[%d] = %d, want 0", i, b)
+		}
+	}
+}
+
+func TestTokenBroker_AcceptsTokenAtExactSizeLimit(t *testing.T) {
+	b, err := newTokenBroker()
+	if err != nil {
+		t.Skipf("skipping: Unix socket unavailable in this environment: %v", err)
+	}
+	defer b.Close()
+
+	token := bytes.Repeat([]byte("a"), maxBrokerTokenSize)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- b.Serve(token, 2*time.Second)
+	}()
+
+	got, err := ReadFromBroker(b.SocketPath(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("ReadFromBroker: %v", err)
+	}
+	if len(got) != maxBrokerTokenSize {
+		t.Fatalf("token size = %d, want %d", len(got), maxBrokerTokenSize)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("Serve returned error: %v", err)
+	}
+}
+
+func TestTokenBroker_RejectsEmptyToken(t *testing.T) {
+	b, err := newTokenBroker()
+	if err != nil {
+		t.Skipf("skipping: Unix socket unavailable in this environment: %v", err)
+	}
+	defer b.Close()
+
+	err = b.Serve([]byte{}, 50*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected empty token to be rejected")
+	}
+	if !strings.Contains(err.Error(), "must not be empty") {
+		t.Fatalf("expected empty-token validation error, got: %v", err)
+	}
+}
+
+func TestTokenBroker_SocketPermissions(t *testing.T) {
+	b, err := newTokenBroker()
+	if err != nil {
+		t.Skipf("skipping: Unix socket unavailable in this environment: %v", err)
+	}
+	defer b.Close()
+
+	// The parent directory should be mode 0700.
+	socketDir := filepath.Dir(b.SocketPath())
+	info, err := os.Stat(socketDir)
+	if err != nil {
+		t.Skipf("cannot stat socket dir: %v", err)
+	}
+	perm := info.Mode().Perm()
+	if perm != 0o700 {
+		t.Errorf("socket dir permissions = %04o, want 0700", perm)
+	}
+}
+
+func TestTokenBroker_Cleanup(t *testing.T) {
+	b, err := newTokenBroker()
+	if err != nil {
+		t.Skipf("skipping: Unix socket unavailable in this environment: %v", err)
+	}
+	socketPath := b.SocketPath()
+	b.Close()
+
+	if _, err := os.Stat(socketPath); !os.IsNotExist(err) {
+		t.Error("expected socket path to be removed after Close()")
+	}
+}
+
+func TestReadFromBroker_NoServer(t *testing.T) {
+	_, err := ReadFromBroker("/tmp/nav-pilot-nonexistent-test.sock", 100*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error connecting to non-existent socket")
+	}
+}
+
+func TestReadFromBroker_RejectsTruncatedToken(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix sockets are not supported on windows")
+	}
+
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "truncated.sock")
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Skipf("unix socket unavailable in this environment: %v", err)
+	}
+	defer ln.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		conn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			done <- acceptErr
+			return
+		}
+		defer conn.Close()
+		_, writeErr := conn.Write([]byte("ghu_truncated_no_newline"))
+		done <- writeErr
+	}()
+
+	_, err = ReadFromBroker(socketPath, time.Second)
+	if err == nil {
+		_ = ln.Close()
+		t.Fatal("expected error for truncated token without newline terminator")
+	}
+
+	select {
+	case gorErr := <-done:
+		if gorErr != nil && !errors.Is(gorErr, net.ErrClosed) {
+			t.Fatalf("unexpected server goroutine error: %v", gorErr)
+		}
+	case <-time.After(time.Second):
+		_ = ln.Close()
+		t.Fatal("timed out waiting for server goroutine to finish")
+	}
+}
+
+func TestReadFromBroker_TokenSplitAcrossReads_Succeeds(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix sockets are not supported on windows")
+	}
+
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "split.sock")
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Skipf("unix socket unavailable in this environment: %v", err)
+	}
+	defer ln.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		conn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			done <- acceptErr
+			return
+		}
+		defer conn.Close()
+
+		chunks := []string{"ghu_", "split_", "token", "\n"}
+		for _, c := range chunks {
+			if _, writeErr := conn.Write([]byte(c)); writeErr != nil {
+				done <- writeErr
+				return
+			}
+		}
+		done <- nil
+	}()
+
+	got, err := ReadFromBroker(socketPath, time.Second)
+	if err != nil {
+		t.Fatalf("ReadFromBroker returned error: %v", err)
+	}
+	if string(got) != "ghu_split_token" {
+		t.Fatalf("got token %q, want %q", got, "ghu_split_token")
+	}
+
+	select {
+	case gorErr := <-done:
+		if gorErr != nil && !errors.Is(gorErr, net.ErrClosed) {
+			t.Fatalf("unexpected server goroutine error: %v", gorErr)
+		}
+	case <-time.After(time.Second):
+		_ = ln.Close()
+		t.Fatal("timed out waiting for server goroutine to finish")
+	}
+}
+
+func TestReadFromBroker_EmptyConnection_Fails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix sockets are not supported on windows")
+	}
+
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "empty.sock")
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Skipf("unix socket unavailable in this environment: %v", err)
+	}
+	defer ln.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		conn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			done <- acceptErr
+			return
+		}
+		_ = conn.Close()
+		done <- nil
+	}()
+
+	_, err = ReadFromBroker(socketPath, time.Second)
+	if err == nil {
+		t.Fatal("expected error for empty connection")
+	}
+	if !strings.Contains(err.Error(), "stream closed before token terminator") {
+		t.Fatalf("expected EOF-before-terminator error, got: %v", err)
+	}
+
+	select {
+	case gorErr := <-done:
+		if gorErr != nil && !errors.Is(gorErr, net.ErrClosed) {
+			t.Fatalf("unexpected server goroutine error: %v", gorErr)
+		}
+	case <-time.After(time.Second):
+		_ = ln.Close()
+		t.Fatal("timed out waiting for server goroutine to finish")
+	}
+}
+
+func TestReadFromBroker_RejectsOversizedToken(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix sockets are not supported on windows")
+	}
+
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "oversized.sock")
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Skipf("unix socket unavailable in this environment: %v", err)
+	}
+	defer ln.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		conn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			done <- acceptErr
+			return
+		}
+		defer conn.Close()
+
+		payload := make([]byte, maxBrokerTokenSize+1)
+		for i := range payload {
+			payload[i] = 'a'
+		}
+		_, writeErr := conn.Write(payload)
+		done <- writeErr
+	}()
+
+	_, err = ReadFromBroker(socketPath, time.Second)
+	if err == nil {
+		_ = ln.Close()
+		t.Fatal("expected error for oversized token")
+	}
+	if got := err.Error(); got == "" {
+		t.Fatal("expected a non-empty error")
+	}
+
+	select {
+	case gorErr := <-done:
+		if gorErr != nil && !errors.Is(gorErr, net.ErrClosed) {
+			t.Fatalf("unexpected server goroutine error: %v", gorErr)
+		}
+	case <-time.After(time.Second):
+		_ = ln.Close()
+		t.Fatal("timed out waiting for server goroutine to finish")
+	}
+}
+
+func TestReadFromBroker_UnexpectedReadError_Fails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix sockets are not supported on windows")
+	}
+
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "read-timeout.sock")
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Skipf("unix socket unavailable in this environment: %v", err)
+	}
+	defer ln.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		conn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			done <- acceptErr
+			return
+		}
+		defer conn.Close()
+		// Keep the connection open without sending data so the client read deadline expires.
+		time.Sleep(250 * time.Millisecond)
+		done <- nil
+	}()
+
+	_, err = ReadFromBroker(socketPath, 50*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected read error when server does not send token data")
+	}
+	if !strings.Contains(err.Error(), "broker client: read error") {
+		t.Fatalf("expected read-error wrapper, got: %v", err)
+	}
+
+	select {
+	case gorErr := <-done:
+		if gorErr != nil && !errors.Is(gorErr, net.ErrClosed) {
+			t.Fatalf("unexpected server goroutine error: %v", gorErr)
+		}
+	case <-time.After(time.Second):
+		_ = ln.Close()
+		t.Fatal("timed out waiting for server goroutine to finish")
+	}
+}
+
+type chunkWriter struct {
+	buf   bytes.Buffer
+	chunk int
+}
+
+func (w *chunkWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	n := w.chunk
+	if n <= 0 || n > len(p) {
+		n = len(p)
+	}
+	_, _ = w.buf.Write(p[:n])
+	return n, nil
+}
+
+type failAfterCallsWriter struct {
+	buf        bytes.Buffer
+	chunk      int
+	call       int
+	failOnCall int
+	err        error
+}
+
+func (w *failAfterCallsWriter) Write(p []byte) (int, error) {
+	w.call++
+	if w.call == w.failOnCall {
+		return 0, w.err
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+	n := w.chunk
+	if n <= 0 || n > len(p) {
+		n = len(p)
+	}
+	_, _ = w.buf.Write(p[:n])
+	return n, nil
+}
+
+type zeroProgressWriter struct{}
+
+func (zeroProgressWriter) Write(_ []byte) (int, error) {
+	return 0, nil
+}
+
+func TestWriteAll_PartialWrites(t *testing.T) {
+	payload := []byte("ghu_partial_write_token")
+	w := &chunkWriter{chunk: 3}
+
+	if err := writeAll(w, payload); err != nil {
+		t.Fatalf("writeAll returned error: %v", err)
+	}
+	if got := w.buf.String(); got != string(payload) {
+		t.Fatalf("written payload = %q, want %q", got, string(payload))
+	}
+}
+
+func TestWriteAll_ErrorAfterPartialWrite(t *testing.T) {
+	payload := []byte("ghu_partial_then_error")
+	wantErr := errors.New("boom")
+	w := &failAfterCallsWriter{
+		chunk:      4,
+		failOnCall: 3,
+		err:        wantErr,
+	}
+
+	err := writeAll(w, payload)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("writeAll error = %v, want %v", err, wantErr)
+	}
+	if got := w.buf.String(); got == "" {
+		t.Fatal("expected partial payload to be written before failure")
+	}
+	if got := w.buf.String(); got == string(payload) {
+		t.Fatal("expected truncated payload on write failure, got full payload")
+	}
+}
+
+func TestWriteAll_ZeroProgressReturnsShortWrite(t *testing.T) {
+	payload := []byte("ghu_no_progress")
+	err := writeAll(zeroProgressWriter{}, payload)
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("writeAll error = %v, want %v", err, io.ErrShortWrite)
+	}
+}
+
+func TestZeroize(t *testing.T) {
+	buf := []byte("sensitive-token-data")
+	zeroize(buf)
+	for i, b := range buf {
+		if b != 0 {
+			t.Errorf("buf[%d] = %d, want 0", i, b)
+		}
+	}
+}


### PR DESCRIPTION
Draft. **Blocked on a `navikt/cplt` change** — do not review for merge yet.

Closes #477 when complete.

## What this is

#424 shipped Copilot token pre-extraction + `GH_TOKEN` injection for `cplt` launches. It originally also carried a one-shot Unix-socket token broker (`auth_broker.go` + tests). The broker had no production caller and cannot get one until cplt can read a token from a socket, so it was removed from #424 (commit `8f6d089`) and parked here.

This PR restores that code verbatim (including the zeroize-on-error fix) as the starting point. **Nothing is wired into a launch path.**

## Remaining work (see #477)

- `navikt/cplt`: a `gh` wrapper that reads the token from the broker socket (socket path passed via env), and dropping blanket `Keychain: allowed` from the copilot sandbox profile
- nav-pilot: start the broker before `cplt`, pass the socket path, serve one client; use it from both `LaunchCopilotResolved` and `LaunchCopilotStaged`, gated on a cplt version check, falling back to `GH_TOKEN` injection on older cplt
- `SECURITY.md`: replace the "Future work" note with the real description
- re-review the broker against the live integration, not just as restored code

## Status

`go build` / `go vet` / broker tests pass on top of `main`.