### PR TITLE
fix(ci): allowlist nav-pilots modellmanifest på main

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -33,3 +33,18 @@ description = "Prosa i copilot-instructions.md matchet av generic-api-key"
 condition = "AND"
 paths = ['''\.github/copilot-instructions\.md''']
 regexes = ['''billing/seat/SAML''']
+
+# Falsk positiv: modellmanifestet i nav-pilot har et felt som heter "key",
+# og generic-api-key-regelen slår ut på feltnavnet kombinert med entropien
+# i verdien. Verdien er profilnøkkelen fra mise, altså en slug av typen
+# "qwen3.6-35b-a3b-optiq" som også står i filnavn og i CLI-utskrift.
+# Filen genereres av 'mise run model-manifest' og inneholder kun modell-id,
+# minnekrav og MLX_-parametre. Ingen hemmeligheter kan ligge der: nav-pilot
+# avviser parameternøkler som ikke matcher ^MLX_[A-Z0-9_]+$, og modell-id-er
+# fra publishere utenfor tillatelseslisten.
+[[allowlists]]
+description = "Profilnøkkel i nav-pilots modellmanifest, ikke en API-nøkkel"
+condition = "AND"
+regexTarget = "line"
+paths = ['''cli/nav-pilot/internal/local/models\.json''']
+regexes = ['''"key":\s*"[a-z0-9][a-z0-9.\-]*"''']


### PR DESCRIPTION
Alle PR-er mot `main` feiler på gitleaks nå. Denne retter det.

## Hva som skjer

Gitleaks-jobben i `ci.yaml` henter hele historikken (`fetch-depth: 0`) og kjører `gitleaks git .`, altså en skann av alt den kan se. Men konfigurasjonen den bruker er `.gitleaks.toml` fra grenen som er sjekket ut.

`local-inference` ([#483](https://github.com/navikt/copilot/pull/483)) la til `cli/nav-pilot/internal/local/models.json` og allowlist-regelen som dekker den, i samme gren. Regelen finnes bare der.

Derfor: en gren ut fra `main` ser commitene fra local-inference i den hentede historikken, mangler regelen, og feiler. `local-inference` selv er grønn fordi den bærer regelen sin. Det forklarer hvorfor #483 er grønn mens #482 og #486 er røde på nøyaktig samme funn.

## Hva denne gjør

Kopierer regelen uendret til `main`, med begrunnelsen sin. Ingenting annet.

Funnet er en dokumentert falsk positiv. Feltet heter `key`, og verdien er en profilslug fra mise (`qwen3.6-35b-a3b-optiq`) som også står i filnavn og CLI-utskrift. Filen genereres av `mise run model-manifest` og kan bare inneholde modell-id, minnekrav og `MLX_`-parametre: nav-pilot avviser parameternøkler som ikke matcher `^MLX_[A-Z0-9_]+$`.

Regelen er smal: én sti, ett regex, `condition = "AND"`.

## Hva denne ikke gjør

Rører ikke skanneomfanget. At konfigurasjon og historikk kan komme fra ulike grener er en reell svakhet i jobben, og en gren kan i prinsippet stilne et funn for alle andre ved å legge til sin egen allowlist. Å endre dekningen til en sikkerhetskontroll fortjener sin egen vurdering, og bør ikke skje som sidegevinst av en opplåsing.