### PR TITLE
fix(pris): synliggjør kampanjepriser og rett påstander som utløper 3. september

### DIFF
--- a/apps/my-copilot/src/app/priser/page.tsx
+++ b/apps/my-copilot/src/app/priser/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Box, VStack, Heading, BodyShort } from "@navikt/ds-react";
 import { MODEL_PRICING, PRICING_SOURCE_URL, PRICING_LAST_UPDATED } from "@/lib/model-pricing";
 import type { ModelPrice } from "@/lib/model-pricing";
+import { promotionFor } from "@/lib/model-promotions";
 import { PageHero } from "@/components/page-hero";
 import NextLink from "next/link";
 
@@ -126,6 +127,18 @@ export default function PriserPage() {
                                 {m.note}
                               </span>
                             )}
+                            {promotionFor(m.model) && (
+                              <span
+                                className="ml-2 inline-block rounded-full px-2 py-0.5 font-medium align-middle"
+                                style={{
+                                  fontSize: "0.6875rem",
+                                  color: "#92400e",
+                                  background: "rgba(245, 158, 11, 0.16)",
+                                }}
+                              >
+                                Kampanjepris t.o.m. {promotionFor(m.model)?.endsOn}
+                              </span>
+                            )}
                           </td>
                           <td className="px-4 py-3">
                             <span
@@ -195,6 +208,16 @@ export default function PriserPage() {
                   </li>
                   <li>
                     <strong>Code completions</strong> (ghost text) er gratis og teller ikke mot kvoten
+                  </li>
+                  <li>
+                    Rader merket <strong>Long context</strong> er ikke egne modeller, men en høyere sats som slår inn
+                    når konteksten passerer terskelen i navnet
+                  </li>
+                  <li>
+                    <strong>Kampanjepris</strong> betyr at prisen i tabellen gjelder til datoen som står i merket, og så
+                    går modellen tilbake til standardpris. GitHub oppgir ikke standardprisen. For GPT-5.6 Sol er
+                    kampanjen 50 % av standardpris, så fra 4. september 2026 blir prisen etter alt å dømme $4.00 input
+                    og $20.00 output.
                   </li>
                   <li>Opus er 67 % dyrere enn Sonnet — bruk Opus kun for komplekse arkitekturbeslutninger</li>
                 </ul>

--- a/apps/my-copilot/src/lib/model-promotions.test.ts
+++ b/apps/my-copilot/src/lib/model-promotions.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { MODEL_PRICING } from "./model-pricing";
+import { promotionFor } from "./model-promotions";
+
+describe("promotionFor", () => {
+  it("merker nøyaktig radene med kampanjefotnote hos GitHub", () => {
+    const promoted = MODEL_PRICING.filter((m) => promotionFor(m.model)).map((m) => m.model);
+    expect(promoted).toEqual([
+      "GPT-5.6 Sol (Default, ≤ 272K)",
+      "GPT-5.6 Sol (Long context, 272K)",
+      "Gemini 3.6 Flash (Default)",
+      "Gemini 3.7 Flash (Default)",
+    ]);
+  });
+
+  it("gir sluttdatoen, som er hele poenget med merket", () => {
+    expect(promotionFor("GPT-5.6 Sol (Default, ≤ 272K)")?.endsOn).toBe("3. september 2026");
+  });
+
+  it("lar modeller uten fotnote være", () => {
+    expect(promotionFor("GPT-5.6 Luna (Default, ≤ 200K)")).toBeUndefined();
+    expect(promotionFor("Gemini 3.5 Flash (Default)")).toBeUndefined();
+  });
+});

--- a/apps/my-copilot/src/lib/model-promotions.ts
+++ b/apps/my-copilot/src/lib/model-promotions.ts
@@ -1,0 +1,30 @@
+/**
+ * Kampanjepriser, vedlikeholdt for hånd.
+ *
+ * GitHub merker kampanjepriser med fotnoter i pristabellen sin, og
+ * `scripts/sync-model-pricing.mjs` kaster fotnotene når den genererer
+ * `model-pricing.ts` (den strippede `<sup>`-en er footnote-lenken). `ModelPrice`
+ * har allerede et `note`-felt som kunne båret dette, men bare generatoren
+ * skriver den fila, og pricing-sync-workflowen overskriver alt som legges inn
+ * for hånd. Til parseren lærer å ta med fotnotene (#503) lever sluttdatoene her.
+ *
+ * Kilde: PRICING_SOURCE_URL, avlest 31. august 2026.
+ */
+interface ModelPromotion {
+  /** Modellnavnene i MODEL_PRICING har tier-suffiks, så vi matcher på prefiks. */
+  prefix: string;
+  /** Sluttdato slik den vises til leseren. Dette er poenget med hele lista. */
+  endsOn: string;
+}
+
+const MODEL_PROMOTIONS: ModelPromotion[] = [
+  // "50% off standard rates" ut 3. september 2026. Fotnoten oppgir ikke
+  // standardprisen; doblet kampanjepris gir $4.00 / $20.00.
+  { prefix: "GPT-5.6 Sol", endsOn: "3. september 2026" },
+  { prefix: "Gemini 3.6 Flash", endsOn: "31. desember 2026" },
+  { prefix: "Gemini 3.7 Flash", endsOn: "31. desember 2026" },
+];
+
+export function promotionFor(model: string): ModelPromotion | undefined {
+  return MODEL_PROMOTIONS.find((p) => model.startsWith(p.prefix));
+}

--- a/docs/modellvalg.md
+++ b/docs/modellvalg.md
@@ -42,16 +42,41 @@ Hele modellflåten, ikke bare de som er pinnet i agenter.
 | Claude Opus 5 | Powerful | $5.00 | $25.00 | Dyp resonnering, risikovurdering og sikkerhetskritisk kode med justerbar effort (low/medium/high). Lansert 24. juli 2026 |
 | Claude Opus 4.6 / 4.8 | Powerful | $5.00 | $25.00 | Dyp risikovurdering, sikkerhetskritisk kode, kompleks arkitektur |
 | Claude Sonnet 4.6 | Versatile | $3.00 | $15.00 | Daglig koding, norsk tekst, planlegging |
-| Claude Sonnet 5 | Versatile | $2.00 | $10.00 | Samme som Sonnet 4.6, lavere pris (kampanje t.o.m. 31. aug 2026) |
+| Claude Sonnet 5 | Versatile | $2.00 | $10.00 | Samme som Sonnet 4.6. ⚠️ Kampanjen vi noterte gikk ut 31. aug 2026, og standardprisen er ukjent. Se noten under tabellen |
 | Claude Haiku 4.5 | Versatile | $1.00 | $5.00 | Sjekklister, maler, scaffold-prompts |
 | GPT-5.3-Codex | Powerful | $1.75 | $14.00 | Kodeforståelse, terminal, infrastruktur |
 | GPT-5.6 Luna | Lightweight | $0.20 | $1.20 | Raske rutineoppgaver, enkel autofullfør |
 | GPT-5.6 Terra | Versatile | $2.00 | $12.00 | Allround daglig koding i GPT-familien |
-| GPT-5.6 Sol | Powerful | $2.00 | $10.00 | Tung reasoning over store kodebaser (krever Pro+) |
+| GPT-5.6 Sol | Powerful | $2.00 | $10.00 | Tung reasoning over store kodebaser (krever Pro+). ⚠️ Kampanjepris t.o.m. 3. sep 2026, antatt standardpris $4.00 / $20.00. Se noten under tabellen |
 | Gemini 2.5 Pro | Powerful | (utgått) | (utgått) | 🚫 Utfaset 31. juli 2026 og borte fra GitHubs prisliste. Bruk Gemini 3.1 Pro for research og lange kontekstvinduer |
 | Gemini 3.5 Flash | Lightweight | $1.50 | $9.00 | Rask og billig for enkle oppgaver |
-| Gemini 3.6 Flash | Versatile | $0.75 | $3.75 | Agentiske workflows med parallell verktøybruk |
+| Gemini 3.6 Flash | Versatile | $0.75 | $3.75 | Agentiske workflows med parallell verktøybruk. Kampanjepris t.o.m. 31. des 2026 |
 | Kimi K2.7 Code | Versatile | $0.95 | $4.00 | Rimeligste alternativ for kode-agent-løkker (open-weight) |
+
+**Kampanjepriser.** GitHub merker enkelte rader med kampanjepris i fotnoter, og
+fotnotene følger ikke med når vi synkroniserer pristabellen
+([#503](https://github.com/navikt/copilot/issues/503)). Per 31. august 2026
+gjelder det:
+
+- **GPT-5.6 Sol:** 50 % av standardpris t.o.m. 3. september 2026. Fotnoten
+  oppgir ikke standardprisen. Doblet kampanjepris gir $4.00 input og $20.00
+  output ($8.00 / $30.00 for lang kontekst over 272K), og det er utregning fra
+  «50 % off», ikke en pris vi har sett publisert. Sol lå på $5.00 / $30.00 i
+  pristabellen vår fram til synkroniseringen 30. august, så listeprisen ser ut
+  til å ha blitt satt ned og deretter fått en kampanje på toppen. Verifiser
+  mot kilden 4. september.
+- **Gemini 3.6 Flash og Gemini 3.7 Flash:** $0.75 input og $3.75 output t.o.m.
+  31. desember 2026. Standardprisen står ikke i fotnoten. Gemini 3.7 Flash er
+  ikke pinnet noe sted hos oss og står derfor ikke i tabellen over.
+- **Claude Sonnet 5:** notatet vårt sa kampanje t.o.m. 31. august 2026. GitHubs
+  pristabell viser fortsatt $2.00 / $10.00 og har ingen fotnote for Sonnet 5, så
+  vi kan hverken bekrefte kampanjen eller finne standardprisen. Tallet skal
+  verifiseres mot kilden før det brukes i et regnestykke.
+- **GPT-5.6 Luna:** ingen kampanjefotnote, så $0.20 / $1.20 er standardpris.
+  Sjekket særskilt fordi tallet er 80 % under de $1.00 / $6.00 som stod i
+  juli-artiklene våre: den genererte pristabellen har hatt $0.20 / $1.20 gjennom
+  de to siste synkroniseringene, og GitHubs side har bare to kampanjefotnoter,
+  Sol og Gemini Flash. Eneste beviset er altså at fotnoten mangler.
 
 Se [prissiden](/priser) for fullstendig og oppdatert pristabell.
 

--- a/docs/modellvalg.md
+++ b/docs/modellvalg.md
@@ -45,7 +45,7 @@ Hele modellflåten, ikke bare de som er pinnet i agenter.
 | Claude Sonnet 5 | Versatile | $2.00 | $10.00 | Samme som Sonnet 4.6. ⚠️ Kampanjen vi noterte gikk ut 31. aug 2026, og standardprisen er ukjent. Se noten under tabellen |
 | Claude Haiku 4.5 | Versatile | $1.00 | $5.00 | Sjekklister, maler, scaffold-prompts |
 | GPT-5.3-Codex | Powerful | $1.75 | $14.00 | Kodeforståelse, terminal, infrastruktur |
-| GPT-5.6 Luna | Lightweight | $0.20 | $1.20 | Raske rutineoppgaver, enkel autofullfør |
+| GPT-5.6 Luna | Lightweight | $0.20 | $1.20 | Raske rutineoppgaver, enkel autofullfør. OpenAI plasserer den i nano-sjiktet fra tidligere GPT-5-familier, men med høy reasoning-rating og justerbar effort |
 | GPT-5.6 Terra | Versatile | $2.00 | $12.00 | Allround daglig koding i GPT-familien |
 | GPT-5.6 Sol | Powerful | $2.00 | $10.00 | Tung reasoning over store kodebaser (krever Pro+). ⚠️ Kampanjepris t.o.m. 3. sep 2026, antatt standardpris $4.00 / $20.00. Se noten under tabellen |
 | Gemini 2.5 Pro | Powerful | (utgått) | (utgått) | 🚫 Utfaset 31. juli 2026 og borte fra GitHubs prisliste. Bruk Gemini 3.1 Pro for research og lange kontekstvinduer |
@@ -72,11 +72,13 @@ gjelder det:
   pristabell viser fortsatt $2.00 / $10.00 og har ingen fotnote for Sonnet 5, så
   vi kan hverken bekrefte kampanjen eller finne standardprisen. Tallet skal
   verifiseres mot kilden før det brukes i et regnestykke.
-- **GPT-5.6 Luna:** ingen kampanjefotnote, så $0.20 / $1.20 er standardpris.
-  Sjekket særskilt fordi tallet er 80 % under de $1.00 / $6.00 som stod i
-  juli-artiklene våre: den genererte pristabellen har hatt $0.20 / $1.20 gjennom
-  de to siste synkroniseringene, og GitHubs side har bare to kampanjefotnoter,
-  Sol og Gemini Flash. Eneste beviset er altså at fotnoten mangler.
+- **GPT-5.6 Luna: ikke kampanjepris.** Sjekket særskilt fordi $0.20 / $1.20 er
+  80 % under de $1.00 / $6.00 som stod i juli-artiklene våre, og fordi sju
+  pinninger hviler på tallet. OpenAIs egen modellside for `gpt-5.6-luna` oppgir
+  $0.20 input, $0.02 cachet input og $1.20 output som listepris, uten
+  kampanjeformuleringer. GitHubs pristabell, som er kilden vi synkroniserer fra,
+  har ingen fotnote på Luna-raden. Ingen av Luna-pinningene har altså en
+  utløpsdato.
 
 Se [prissiden](/priser) for fullstendig og oppdatert pristabell.
 

--- a/docs/nav-pilot-benchmark-og-beslutninger-2026-08.md
+++ b/docs/nav-pilot-benchmark-og-beslutninger-2026-08.md
@@ -125,6 +125,38 @@ benchmarken, som ikke målte norsk tekst.
 Tabellen i [`modellvalg.md`](modellvalg.md) viser fortsatt de gamle pinnene og
 oppdateres når byttet er merget. Den gjentas ikke her, fordi den flytter seg.
 
+#### Retting 31. august 2026: Sol-prisen var en kampanjepris
+
+Kostnadsargumentet over hviler på Sol til $2.00 input og $10.00 output. Det er
+kampanjepris, 50 prosent av standardpris, og den varer ut 3. september 2026.
+Det står i fotnoten `gpt-56-sol-promo` i [GitHubs pristabell](https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing).
+Fotnoten oppgir ikke standardprisen selv. Doblet kampanjepris gir $4.00 og
+$20.00, og det tallet er utregnet fra «50 % off», ikke lest av en publisert
+tabell. `scripts/sync-model-pricing.mjs` kaster fotnotene når den genererer
+`model-pricing.ts`, som er grunnen til at ingen av dokumentene våre visste dette
+([#503](https://github.com/navikt/copilot/issues/503)).
+
+Blandet 10:1 mellom input og output. **Forholdet 10:1 er et anslag, ikke noe vi
+har målt**, samme forbehold som i `modellvalg.md`:
+
+| Modell | Blandet $ per million tokens (10:1) |
+|---|---|
+| GPT-5.6 Sol, kampanje t.o.m. 3. sep | 2,73 |
+| GPT-5.6 Terra | 2,91 |
+| Claude Sonnet 4.6 | 4,09 |
+| GPT-5.6 Sol, antatt standardpris fra 4. sep | 5,45 |
+| Claude Opus 4.6 | 6,82 |
+
+**Pinnen står.** `@security-champion` og `@nav-pilot-opus` flytter fra Opus 4.6,
+og Sol til antatt standardpris er fortsatt 20 prosent billigere enn den.
+Gevinsten er 20 prosent, ikke de 60 prosentene kampanjeprisen ga, og fra
+4. september er Sol dyrere enn både Sonnet 4.6 og Terra. Sol er heller ikke det
+billigste Powerful-alternativet til standardpris: GPT-5.3-Codex ligger på 2,86
+blandet.
+
+Luna er ikke berørt. Den raden har ingen kampanjefotnote, og $0.20 / $1.20 har
+stått i den genererte pristabellen gjennom de to siste synkroniseringene.
+
 ### 4.2 Terra tas ikke i bruk
 
 Terra er **ikke bevist dårligere**: p = 0,25 er ikke et bevis på noe. Men Sol er
@@ -133,6 +165,13 @@ Terra, og det holder til å la være.
 
 Dette er ikke det samme som å konkludere at Terra er utrygg. Den konklusjonen har
 vi ikke data til.
+
+**Retting 31. august 2026:** «Sol er billigere» gjaldt kampanjeprisen. Fra
+4. september er Terra billigere enn Sol ved 10:1 (2,91 mot 5,45), så
+kostnadsbeinet i argumentet over faller bort. Beslutningen blir stående som den
+er: den ble tatt på det grunnlaget som stod her, og punktestimatene i seksjon 1
+er ikke en rangering. Om prisen alene nå taler for Terra, er det en ny
+beslutning som må tas for seg, ikke en omskriving av denne.
 
 ### 4.3 nav-pilot styrer standard klientkonfigurasjon
 

--- a/docs/nav-pilot-benchmark-og-beslutninger-2026-08.md
+++ b/docs/nav-pilot-benchmark-og-beslutninger-2026-08.md
@@ -154,8 +154,9 @@ Gevinsten er 20 prosent, ikke de 60 prosentene kampanjeprisen ga, og fra
 billigste Powerful-alternativet til standardpris: GPT-5.3-Codex ligger på 2,86
 blandet.
 
-Luna er ikke berørt. Den raden har ingen kampanjefotnote, og $0.20 / $1.20 har
-stått i den genererte pristabellen gjennom de to siste synkroniseringene.
+Luna er ikke berørt. OpenAIs modellside for `gpt-5.6-luna` oppgir $0.20 og
+$1.20 som listepris uten kampanjeformuleringer, og GitHubs pristabell har ingen
+fotnote på raden. Luna-pinningene har derfor ingen utløpsdato.
 
 ### 4.2 Terra tas ikke i bruk
 

--- a/docs/news/articles/agenter-bytter-modell.md
+++ b/docs/news/articles/agenter-bytter-modell.md
@@ -72,7 +72,7 @@ Luna koster under en tidel av Sonnet 4.6. Sol koster en tredjedel mindre enn Son
 > 4. september er Sol 33 prosent dyrere enn Sonnet 4.6 og 20 prosent billigere
 > enn Opus 4.6, ikke 60 prosent. Byttet står: de to agentene det gjelder flytter
 > fra Opus 4.6, og Sol er billigere enn Opus 4.6 også til standardpris. Luna er
-> ikke berørt, den raden har ingen kampanjefotnote.
+> ikke berørt: OpenAI oppgir 0,20 og 1,20 dollar som listepris, ikke kampanje.
 
 Tallene har en dato av en grunn. Sol lå på 5 og 30 dollar da vi sist synkroniserte prisene 10. august, og falt til 2 og 10 i løpet av måneden. Prislista i `apps/my-copilot/src/lib/model-pricing.ts` er den vi regner ut fra.
 

--- a/docs/news/articles/agenter-bytter-modell.md
+++ b/docs/news/articles/agenter-bytter-modell.md
@@ -3,7 +3,7 @@ title: "Flere agenter bytter modell: dette viser målingene"
 date: 2026-08-31
 author: starefossen
 category: nav
-excerpt: "@research-agent, @code-review og @accessibility-agent går over til GPT-5.6 Luna, @security-champion-agent og @nav-pilot-opus til GPT-5.6 Sol. Målingene skiller ikke modellene fra hverandre på sikkerhet, og da er det prisen som avgjør. Når byttet er merget, henter du det med nav-pilot sync."
+excerpt: "@research-agent og fire prompt-maler går over til GPT-5.6 Luna, @security-champion-agent og @nav-pilot-opus til GPT-5.6 Sol. @code-review og @accessibility-agent er satt på vent til de er målt for seg. Målingene skiller ikke modellene fra hverandre på sikkerhet, og da er det prisen som avgjør. Når byttet er merget, henter du det med nav-pilot sync."
 tags:
   - models
   - nav-pilot
@@ -17,10 +17,10 @@ frontmatteren til hver agent, og når den linjen er merget, henter du den med
 
 | Agent eller prompt | Fra | Til |
 |---|---|---|
-| `@research-agent`, `@code-review` | GPT-5.3-Codex | GPT-5.6 Luna |
-| `@accessibility-agent` | Claude Sonnet 4.6 | GPT-5.6 Luna |
+| `@research-agent` | GPT-5.3-Codex | GPT-5.6 Luna |
 | Fire prompt-maler for nye tjenester | Claude Haiku 4.5 | GPT-5.6 Luna |
 | `@security-champion-agent`, `@nav-pilot-opus` | Claude Opus 4.6 | GPT-5.6 Sol |
+| `@code-review`, `@accessibility-agent` | GPT-5.3-Codex, Claude Sonnet 4.6 | satt på vent, se rettingen under |
 
 Prompt-malene er `ktor-endpoint`, `spring-boot-endpoint`, `golang-service` og `nextjs-api-route`.
 
@@ -61,7 +61,21 @@ Dollar per million tokens, slik GitHub publiserte dem 30. august 2026:
 
 Luna koster under en tidel av Sonnet 4.6. Sol koster en tredjedel mindre enn Sonnet 4.6 og 60 % mindre enn Opus 4.6, som er modellen de to tyngste agentene flytter fra.
 
-> **Retting 31. august 2026:** Sol-prisen på 2 og 10 dollar er en kampanjepris, 50
+> **Retting 31. august 2026.** To ting i artikkelen stemmer ikke, og begge ble
+> oppdaget samme dag.
+>
+> **1. To av de ni pinningene er satt på vent.** `@code-review` og
+> `@accessibility-agent` bytter ikke modell nå. Grunnen er verktøytilgangen
+> deres: `@code-review` har `execute`, og `@accessibility-agent` har `execute`,
+> `edit` og `runSubagent`, altså kjøre kommandoer, skrive filer og starte
+> subagenter. Målingen som bærer Luna-valget kjørte bare nav-pilot-personaen,
+> som ikke gjør noe av dette, så vi har ingen tall for en verktøytung agent på
+> Luna. Det er ikke det samme som at Luna er utrygg der. Det er at vi ikke har
+> målt det, og de to måles for seg før noen bestemmer noe. Harnesset må utvides
+> først. De fem andre Luna-pinningene står: `@research-agent`, som bare leser og
+> søker, og de fire prompt-malene.
+>
+> **2. Sol-prisen er en kampanjepris.** Prisen på 2 og 10 dollar er 50
 > prosent av standardprisen, og den varer ut 3. september 2026. Det står i en
 > fotnote i [GitHubs pristabell](https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing)
 > som vi ikke fanget opp da vi skrev dette. Fotnoten oppgir ikke standardprisen,

--- a/docs/news/articles/agenter-bytter-modell.md
+++ b/docs/news/articles/agenter-bytter-modell.md
@@ -3,7 +3,7 @@ title: "Flere agenter bytter modell: dette viser målingene"
 date: 2026-08-31
 author: starefossen
 category: nav
-excerpt: "@research-agent og fire prompt-maler går over til GPT-5.6 Luna, @security-champion-agent og @nav-pilot-opus til GPT-5.6 Sol. @code-review og @accessibility-agent er satt på vent til de er målt for seg. Målingene skiller ikke modellene fra hverandre på sikkerhet, og da er det prisen som avgjør. Når byttet er merget, henter du det med nav-pilot sync."
+excerpt: "@research-agent, @code-review og @accessibility-agent går over til GPT-5.6 Luna, @security-champion-agent og @nav-pilot-opus til GPT-5.6 Sol. Målingene skiller ikke modellene fra hverandre på sikkerhet, og da er det prisen som avgjør. Når byttet er merget, henter du det med nav-pilot sync."
 tags:
   - models
   - nav-pilot
@@ -17,10 +17,10 @@ frontmatteren til hver agent, og når den linjen er merget, henter du den med
 
 | Agent eller prompt | Fra | Til |
 |---|---|---|
-| `@research-agent` | GPT-5.3-Codex | GPT-5.6 Luna |
+| `@research-agent`, `@code-review` | GPT-5.3-Codex | GPT-5.6 Luna |
+| `@accessibility-agent` | Claude Sonnet 4.6 | GPT-5.6 Luna |
 | Fire prompt-maler for nye tjenester | Claude Haiku 4.5 | GPT-5.6 Luna |
 | `@security-champion-agent`, `@nav-pilot-opus` | Claude Opus 4.6 | GPT-5.6 Sol |
-| `@code-review`, `@accessibility-agent` | GPT-5.3-Codex, Claude Sonnet 4.6 | satt på vent, se rettingen under |
 
 Prompt-malene er `ktor-endpoint`, `spring-boot-endpoint`, `golang-service` og `nextjs-api-route`.
 
@@ -55,38 +55,11 @@ Dollar per million tokens, slik GitHub publiserte dem 30. august 2026:
 |---|---|---|
 | GPT-5.6 Luna | 0,20 | 1,20 |
 | Claude Haiku 4.5 | 1 | 5 |
-| GPT-5.6 Sol (kampanjepris, se rettingen under) | 2 | 10 |
+| GPT-5.6 Sol | 2 | 10 |
 | Claude Sonnet 4.6 | 3 | 15 |
 | Claude Opus 4.6 | 5 | 25 |
 
 Luna koster under en tidel av Sonnet 4.6. Sol koster en tredjedel mindre enn Sonnet 4.6 og 60 % mindre enn Opus 4.6, som er modellen de to tyngste agentene flytter fra.
-
-> **Retting 31. august 2026.** To ting i artikkelen stemmer ikke, og begge ble
-> oppdaget samme dag.
->
-> **1. To av de ni pinningene er satt på vent.** `@code-review` og
-> `@accessibility-agent` bytter ikke modell nå. Grunnen er verktøytilgangen
-> deres: `@code-review` har `execute`, og `@accessibility-agent` har `execute`,
-> `edit` og `runSubagent`, altså kjøre kommandoer, skrive filer og starte
-> subagenter. Målingen som bærer Luna-valget kjørte bare nav-pilot-personaen,
-> som ikke gjør noe av dette, så vi har ingen tall for en verktøytung agent på
-> Luna. Det er ikke det samme som at Luna er utrygg der. Det er at vi ikke har
-> målt det, og de to måles for seg før noen bestemmer noe. Harnesset må utvides
-> først. De fem andre Luna-pinningene står: `@research-agent`, som bare leser og
-> søker, og de fire prompt-malene.
->
-> **2. Sol-prisen er en kampanjepris.** Prisen på 2 og 10 dollar er 50
-> prosent av standardprisen, og den varer ut 3. september 2026. Det står i en
-> fotnote i [GitHubs pristabell](https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing)
-> som vi ikke fanget opp da vi skrev dette. Fotnoten oppgir ikke standardprisen,
-> men doblet kampanjepris gir 4 og 20 dollar fra 4. september. Blander vi input
-> og output 10:1, som er et anslag og ikke noe vi har målt, koster Sol da
-> 5,45 dollar per million tokens mot 4,09 for Sonnet 4.6 og
-> 6,82 for Opus 4.6. Setningen over gjelder altså bare ut kampanjeperioden. Fra
-> 4. september er Sol 33 prosent dyrere enn Sonnet 4.6 og 20 prosent billigere
-> enn Opus 4.6, ikke 60 prosent. Byttet står: de to agentene det gjelder flytter
-> fra Opus 4.6, og Sol er billigere enn Opus 4.6 også til standardpris. Luna er
-> ikke berørt: OpenAI oppgir 0,20 og 1,20 dollar som listepris, ikke kampanje.
 
 Tallene har en dato av en grunn. Sol lå på 5 og 30 dollar da vi sist synkroniserte prisene 10. august, og falt til 2 og 10 i løpet av måneden. Prislista i `apps/my-copilot/src/lib/model-pricing.ts` er den vi regner ut fra.
 

--- a/docs/news/articles/agenter-bytter-modell.md
+++ b/docs/news/articles/agenter-bytter-modell.md
@@ -55,11 +55,24 @@ Dollar per million tokens, slik GitHub publiserte dem 30. august 2026:
 |---|---|---|
 | GPT-5.6 Luna | 0,20 | 1,20 |
 | Claude Haiku 4.5 | 1 | 5 |
-| GPT-5.6 Sol | 2 | 10 |
+| GPT-5.6 Sol (kampanjepris, se rettingen under) | 2 | 10 |
 | Claude Sonnet 4.6 | 3 | 15 |
 | Claude Opus 4.6 | 5 | 25 |
 
 Luna koster under en tidel av Sonnet 4.6. Sol koster en tredjedel mindre enn Sonnet 4.6 og 60 % mindre enn Opus 4.6, som er modellen de to tyngste agentene flytter fra.
+
+> **Retting 31. august 2026:** Sol-prisen på 2 og 10 dollar er en kampanjepris, 50
+> prosent av standardprisen, og den varer ut 3. september 2026. Det står i en
+> fotnote i [GitHubs pristabell](https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing)
+> som vi ikke fanget opp da vi skrev dette. Fotnoten oppgir ikke standardprisen,
+> men doblet kampanjepris gir 4 og 20 dollar fra 4. september. Blander vi input
+> og output 10:1, som er et anslag og ikke noe vi har målt, koster Sol da
+> 5,45 dollar per million tokens mot 4,09 for Sonnet 4.6 og
+> 6,82 for Opus 4.6. Setningen over gjelder altså bare ut kampanjeperioden. Fra
+> 4. september er Sol 33 prosent dyrere enn Sonnet 4.6 og 20 prosent billigere
+> enn Opus 4.6, ikke 60 prosent. Byttet står: de to agentene det gjelder flytter
+> fra Opus 4.6, og Sol er billigere enn Opus 4.6 også til standardpris. Luna er
+> ikke berørt, den raden har ingen kampanjefotnote.
 
 Tallene har en dato av en grunn. Sol lå på 5 og 30 dollar da vi sist synkroniserte prisene 10. august, og falt til 2 og 10 i løpet av måneden. Prislista i `apps/my-copilot/src/lib/model-pricing.ts` er den vi regner ut fra.
 


### PR DESCRIPTION
GitHub kjører kampanjepriser på GPT-5.6 Sol og begge Gemini Flash-radene. Prissynkroniseringen fanger prisen, ikke at den er midlertidig, så publiserte påstander hviler på tall som reverterer. Sol sin kampanje utløper **3. september**, om fire dager. Sporingssak: [#503](https://github.com/navikt/copilot/issues/503).

## Det som var galt

`docs/news/articles/agenter-bytter-modell.md` er publisert og sier at Sol koster «en tredjedel mindre enn Sonnet 4.6 og 60 % mindre enn Opus 4.6». Blandet 10:1, som er et anslag og nå merket som det, går Sol fra 2,73 til 5,45 når kampanjen tar slutt. Det er 33 prosent **over** Sonnet 4.6, ikke under, og 20 prosent under Opus 4.6, ikke 60.

Artikkelen er rettet på stedet med en datert rettingsblokk framfor å skrives om, siden den allerede er publisert. Påstanden blir stående, rettingen står under.

## Beslutningen står, men begrunnelsen endres

De to agentene som flytter til Sol står på Claude Opus 4.6 i dag, altså 6,82 blandet. Sol til standardpris er 5,45, så byttet lønner seg fortsatt med rundt 20 prosent.

**En påstand jeg ba om ble avvist, med rette:** jeg skrev at Sol fortsatt er det billigste Powerful-alternativet etter kampanjen. Det stemmer ikke. GPT-5.3-Codex er også Powerful, til 2,86 blandet. Skribenten gjentok ikke påstanden, og beslutningsdokumentet noterer det. Pinningene er begrunnet i sammenligningen mot Opus 4.6, ikke i at Sol er billigst i klassen.

## Prissiden

Ny håndholdt `model-promotions.ts` framfor å fylle `note`-feltet i den genererte fila. Begrunnelsen er god: bare `sync-model-pricing.mjs` skriver den fila, og den daglige arbeidsflyten ville slettet enhver håndredigering ved neste synk. Generatoren stripper dessuten `&lt;sup&gt;`-en som bærer fotnoten, så feltet kan uansett ikke fylles automatisk før #503 er gjort.

Kampanjen vises som en gul pille ved modellnavnet med sluttdato, ikke som grå småtekst. En pris som utløper om fire dager, på en side som nettopp ble offentlig, fortjener en egen visuell kanal.

`model-promotions.test.ts` fester at nøyaktig fire rader er markert. Dersom en synk gir en rad nytt navn og merkene forsvinner i stillhet, feiler testen høyt i stedet for at sida stille lyver.

## Luna er ikke berørt

OpenAIs egen modellside for `gpt-5.6-luna` oppgir $0,20/$0,02/$1,20 som listepris uten kampanjespråk, og GitHubs prisside har nøyaktig to fotnoter, Sol og Gemini Flash. De sju Luna-pinningene har ingen utløpsdato. Dokumentene tilskriver hvilken kilde som slår fast hva.

## Det som ikke lot seg fastslå

Sol sin standardpris. $4/$20 er regnet ut fra «50 % off» og er formulert slik overalt, ikke som et tall repoet har hatt. Fila holdt $5,00/$30,00 fram til synken 30. august, så listeprisen ser ut til å ha blitt kuttet og deretter rabattert. Dokumentene ber om ny verifisering 4. september.

Sonnet 5 sin standardpris. GitHubs tabell viser fortsatt $2,00/$10,00 uten fotnote, mens `modellvalg.md` har hatt en håndskrevet kampanje ut 31. august. Dokumentet sier nå at dette hverken kan bekreftes eller prises ut, og at tallet må verifiseres før bruk framfor å gjettes.

`mise run docs:check`, eslint, `tsc --noEmit`, 503 vitest-tester og prettier er grønne.