### PR TITLE
feat(agents): flytt research og fire prompt-maler til GPT-5.6 Luna

### DIFF
--- a/agents/research.agent.md
+++ b/agents/research.agent.md
@@ -1,7 +1,7 @@
 ---
 name: research-agent
 description: Utforsker kodebaser, undersøker problemer og samler kontekst før implementering
-model: GPT-5.3-Codex
+model: GPT-5.6 Luna
 tools:
   - read
   - search

--- a/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
+++ b/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
@@ -167,7 +167,7 @@
       "displayName": "@research-agent",
       "description": "Utforsker kodebaser, undersøker problemer og samler kontekst før implementering",
       "filePath": "agents/research.agent.md",
-      "contentHash": "9c7d4bd4590a7cf973cd7a199c90a9173da87bf31e13f6cdde54ea7a15f72d7b",
+      "contentHash": "57973bb865dfdd9de5f023351b72280e61afe794e96ee87b6607c98fb8970009",
       "useCases": [
         "Creating .nais/app.yaml manifests",
         "Azure AD integration",
@@ -495,7 +495,7 @@
         "infrastructure"
       ],
       "filePath": "prompts/golang-service.prompt.md",
-      "contentHash": "42a507250b011dbd7947a4729bcaf4baf8a9c8d6a72ba0904153051ee8939bf4",
+      "contentHash": "6b0b8487f8cc481e1632f2888e331e2cda331a0bbd0c6a3c3f2682967741aab7",
       "installUrl": "vscode:chat-prompt/install?url=https://raw.githubusercontent.com/navikt/copilot/main/prompts/golang-service.prompt.md",
       "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/prompts/golang-service.prompt.md"
     },
@@ -521,7 +521,7 @@
       "displayName": "#ktor-endpoint",
       "description": "Generer ein Ktor-rute med autentisering, validering og feilhåndtering",
       "filePath": "prompts/ktor-endpoint.prompt.md",
-      "contentHash": "e5a24e1b9e9bc398ffbd697757c2974d7ea60ee3adf2ab38b3163f3729d4b469",
+      "contentHash": "78a11bb6d225b6646f2588f5b3efa69126f47826d490ca0cdcb32d0b94adfa93",
       "installUrl": "vscode:chat-prompt/install?url=https://raw.githubusercontent.com/navikt/copilot/main/prompts/ktor-endpoint.prompt.md",
       "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/prompts/ktor-endpoint.prompt.md"
     },
@@ -553,7 +553,7 @@
         "react"
       ],
       "filePath": "prompts/nextjs-api-route.prompt.md",
-      "contentHash": "691c380aa1e47757211de51ca1b54ca2ff72e8a8e78de1b05acb9c4d29353d2a",
+      "contentHash": "5f65db6b410ea3e63988772a1af8fcacec54c13daafc91339ee304a32c698053",
       "installUrl": "vscode:chat-prompt/install?url=https://raw.githubusercontent.com/navikt/copilot/main/prompts/nextjs-api-route.prompt.md",
       "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/prompts/nextjs-api-route.prompt.md"
     },
@@ -569,7 +569,7 @@
         "infrastructure"
       ],
       "filePath": "prompts/spring-boot-endpoint.prompt.md",
-      "contentHash": "3e68aab2f5cbe4027b7b11faf928d1f179a6a2882f8d5c6358707caf28c98894",
+      "contentHash": "82404ec13b5fd880203d06fed3e98965bcee18ac205fd8b86bc56b8036e04f71",
       "installUrl": "vscode:chat-prompt/install?url=https://raw.githubusercontent.com/navikt/copilot/main/prompts/spring-boot-endpoint.prompt.md",
       "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/prompts/spring-boot-endpoint.prompt.md"
     }

--- a/apps/my-copilot/src/lib/copilot-manifest.json
+++ b/apps/my-copilot/src/lib/copilot-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-08-28T16:38:53.220Z",
+  "generatedAt": "2026-08-31T06:20:53.714Z",
   "items": [
     {
       "id": "accessibility-agent",
@@ -367,7 +367,7 @@
       "domain": "general",
       "filePath": ".github/agents/research.agent.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/agents/research.agent.md",
-      "contentHash": "9c7d4bd4590a7cf973cd7a199c90a9173da87bf31e13f6cdde54ea7a15f72d7b",
+      "contentHash": "57973bb865dfdd9de5f023351b72280e61afe794e96ee87b6607c98fb8970009",
       "installUrl": "/install/agent?url=vscode%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fagents%2Fresearch.agent.md",
       "insidersInstallUrl": "/install/agent?url=vscode-insiders%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fagents%2Fresearch.agent.md",
       "tools": [
@@ -391,7 +391,7 @@
         "io.github.navikt/github-mcp/list_tags",
         "io.github.navikt/github-mcp/list_branches"
       ],
-      "model": ["GPT-5.3-Codex"],
+      "model": ["GPT-5.6 Luna"],
       "agentReferences": ["aksel-agent", "kafka-agent", "security-champion-agent"],
       "tags": ["research", "analysis", "codebase-exploration"],
       "examples": [
@@ -811,11 +811,11 @@
       "domain": "general",
       "filePath": ".github/prompts/golang-service.prompt.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/prompts/golang-service.prompt.md",
-      "contentHash": "42a507250b011dbd7947a4729bcaf4baf8a9c8d6a72ba0904153051ee8939bf4",
+      "contentHash": "6b0b8487f8cc481e1632f2888e331e2cda331a0bbd0c6a3c3f2682967741aab7",
       "installUrl": "/install/prompt?url=vscode%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fprompts%2Fgolang-service.prompt.md",
       "insidersInstallUrl": "/install/prompt?url=vscode-insiders%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fprompts%2Fgolang-service.prompt.md",
       "invocation": "#golang-service",
-      "model": ["Claude Haiku 4.5"],
+      "model": ["GPT-5.6 Luna"],
       "collections": ["fullstack", "platform"]
     },
     {
@@ -843,11 +843,11 @@
       "domain": "general",
       "filePath": ".github/prompts/ktor-endpoint.prompt.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/prompts/ktor-endpoint.prompt.md",
-      "contentHash": "e5a24e1b9e9bc398ffbd697757c2974d7ea60ee3adf2ab38b3163f3729d4b469",
+      "contentHash": "78a11bb6d225b6646f2588f5b3efa69126f47826d490ca0cdcb32d0b94adfa93",
       "installUrl": "/install/prompt?url=vscode%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fprompts%2Fktor-endpoint.prompt.md",
       "insidersInstallUrl": "/install/prompt?url=vscode-insiders%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fprompts%2Fktor-endpoint.prompt.md",
       "invocation": "#ktor-endpoint",
-      "model": ["Claude Haiku 4.5"],
+      "model": ["GPT-5.6 Luna"],
       "collections": ["fullstack", "kotlin-backend"]
     },
     {
@@ -875,11 +875,11 @@
       "domain": "frontend",
       "filePath": ".github/prompts/nextjs-api-route.prompt.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/prompts/nextjs-api-route.prompt.md",
-      "contentHash": "691c380aa1e47757211de51ca1b54ca2ff72e8a8e78de1b05acb9c4d29353d2a",
+      "contentHash": "5f65db6b410ea3e63988772a1af8fcacec54c13daafc91339ee304a32c698053",
       "installUrl": "/install/prompt?url=vscode%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fprompts%2Fnextjs-api-route.prompt.md",
       "insidersInstallUrl": "/install/prompt?url=vscode-insiders%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fprompts%2Fnextjs-api-route.prompt.md",
       "invocation": "#nextjs-api-route",
-      "model": ["Claude Haiku 4.5"],
+      "model": ["GPT-5.6 Luna"],
       "tags": ["nextjs", "api-route", "app-router", "scaffold"],
       "examples": ["#api-route Lag en API-route for å hente brukerdata fra BigQuery"],
       "collections": ["fullstack", "nextjs-frontend"]
@@ -892,11 +892,11 @@
       "domain": "backend",
       "filePath": ".github/prompts/spring-boot-endpoint.prompt.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/prompts/spring-boot-endpoint.prompt.md",
-      "contentHash": "3e68aab2f5cbe4027b7b11faf928d1f179a6a2882f8d5c6358707caf28c98894",
+      "contentHash": "82404ec13b5fd880203d06fed3e98965bcee18ac205fd8b86bc56b8036e04f71",
       "installUrl": "/install/prompt?url=vscode%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fprompts%2Fspring-boot-endpoint.prompt.md",
       "insidersInstallUrl": "/install/prompt?url=vscode-insiders%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fprompts%2Fspring-boot-endpoint.prompt.md",
       "invocation": "#spring-boot-endpoint",
-      "model": ["Claude Haiku 4.5"],
+      "model": ["GPT-5.6 Luna"],
       "tags": ["spring-boot", "kotlin", "rest", "endpoint", "scaffold"],
       "examples": ["#spring-boot-endpoint Lag et CRUD-endepunkt for vedtak med PostgreSQL"],
       "collections": ["fullstack", "kotlin-backend"]

--- a/cli/nav-pilot/internal/domain/domain_test.go
+++ b/cli/nav-pilot/internal/domain/domain_test.go
@@ -404,9 +404,20 @@ func TestOpenCodeModelForLabel(t *testing.T) {
 // table: a display name nobody recognises materializes without a model line, so
 // a typo would silently disable per-agent model selection for that agent.
 func TestAgentFrontmatterModelsAreKnown(t *testing.T) {
-	files, err := filepath.Glob(filepath.Join("..", "..", "..", "..", "agents", "*.agent.md"))
-	if err != nil || len(files) == 0 {
-		t.Skip("agents/ not reachable from this checkout")
+	root := filepath.Join("..", "..", "..", "..")
+	var files []string
+	for _, pat := range []string{
+		filepath.Join(root, "agents", "*.agent.md"),
+		filepath.Join(root, "prompts", "*.prompt.md"),
+	} {
+		found, err := filepath.Glob(pat)
+		if err != nil {
+			t.Fatalf("globbing %s: %v", pat, err)
+		}
+		files = append(files, found...)
+	}
+	if len(files) == 0 {
+		t.Skip("agents/ and prompts/ not reachable from this checkout")
 	}
 	re := regexp.MustCompile(`(?m)^model:\s*(.+?)\s*$`)
 	for _, f := range files {

--- a/docs/modellvalg.md
+++ b/docs/modellvalg.md
@@ -15,7 +15,7 @@ De fleste agenter og prompts har et eksplisitt `model:`-felt i YAML-frontmatter.
 | `@security-champion` | Claude Opus 4.6 | Sikkerhetskritiske vurderinger krever høyeste presisjon |
 | `@code-review` | GPT-5.3-Codex | Sterkest på kodeforståelse og terminal-oppgaver |
 | `@kafka` | GPT-5.3-Codex | Teknisk presis på hendelsesdrevne mønstre |
-| `@research` | GPT-5.3-Codex | Effektiv på bred kodebase-søk og oppsummering |
+| `@research` | GPT-5.6 Luna | Leser og søker uten å skrive kode, og Luna koster omtrent en tiendedel av Codex |
 | `@rust` | GPT-5.3-Codex | Terminal-Bench-leder for kompilert kode |
 | `@aksel` | Claude Sonnet 4.6 | Sterk på komponentstruktur og designsystem-konvensjoner |
 | `@accessibility` | Claude Sonnet 4.6 | God på WCAG-tolkning og semantisk HTML |
@@ -28,14 +28,64 @@ De fleste agenter og prompts har et eksplisitt `model:`-felt i YAML-frontmatter.
 | `kafka-topic` | GPT-5.3-Codex | Konsistent med kafka-agenten |
 | `nais-manifest` | GPT-5.3-Codex | God på infrastruktur og YAML-konfigurasjon |
 | `aksel-component` | Gemini 3.6 Flash | Rask og billig for scaffolding av Aksel-komponenter |
-| `ktor-endpoint` | Claude Haiku 4.5 | Enkel strukturert mal, trenger ikke tung modell |
-| `nextjs-api-route` | Claude Haiku 4.5 | Enkel strukturert mal |
-| `spring-boot-endpoint` | Claude Haiku 4.5 | Enkel strukturert mal |
-| `golang-service` | Claude Haiku 4.5 | Enkel strukturert mal |
+| `ktor-endpoint` | GPT-5.6 Luna | Enkel strukturert mal, trenger ikke tung modell |
+| `nextjs-api-route` | GPT-5.6 Luna | Enkel strukturert mal |
+| `spring-boot-endpoint` | GPT-5.6 Luna | Enkel strukturert mal |
+| `golang-service` | GPT-5.6 Luna | Enkel strukturert mal |
+
+## Grunnlaget for Luna-byttene (august 2026)
+
+Golden-prompt-harnessen kjørte nav-pilot-personaen mot Claude Sonnet 4.6,
+GPT-5.6 Sol, GPT-5.6 Luna og GPT-5.6 Terra på samme oppgave. Tall, metode og
+forbehold står i
+[benchmarken og beslutningene fra august 2026](nav-pilot-benchmark-og-beslutninger-2026-08.md).
+Kortversjonen: ingen av modellene skilte seg signifikant fra Claude Sonnet 4.6
+på den ene påkrevde påstanden som ble målt. Målingen viser altså ikke at Luna
+er tryggere, den viser at kandidatene ikke lot seg skille med dette utvalget.
+Når sikkerhet ikke skiller dem, avgjør kostnad.
+
+Blandet pris under forutsetter **10 input-tokens per output-token. Det er et
+anslag, ikke noe vi har målt**, og forholdet varierer med oppgaven.
+
+| Modell | Input | Output | Blandet $/1M ved 10:1 (anslag) |
+|--------|-------|--------|-------------------------------|
+| GPT-5.6 Luna | $0.20 | $1.20 | 0,29 |
+| Claude Haiku 4.5 | $1.00 | $5.00 | 1,36 |
+| GPT-5.3-Codex | $1.75 | $14.00 | 2,86 |
+| Claude Sonnet 4.6 | $3.00 | $15.00 | 4,09 |
+
+### Hva som flyttes
+
+- `@research` går fra GPT-5.3-Codex til GPT-5.6 Luna. Agenten er lesetilgang
+  alene: verktøylista er `read`, `search`, `web` og lesende GitHub-MCP-kall,
+  uten `execute`, `edit` eller `runSubagent`. Den samler inn og oppsummerer,
+  den skriver ikke kode. Luna ligger omtrent 90 prosent under Codex blandet.
+- De fire malpromptene som sto på Claude Haiku 4.5, går til Luna:
+  `ktor-endpoint`, `nextjs-api-route`, `spring-boot-endpoint` og
+  `golang-service`. Alle fyller ut en fast mal. Luna er omtrent en femtedel av
+  Haiku 4.5 blandet, og omtrent en fjortendedel av Sonnet 4.6.
+
+### Hva som ikke flyttes hit
+
+- `@code-review` og `@accessibility` står igjen på henholdsvis GPT-5.3-Codex og
+  Claude Sonnet 4.6. De ble opprinnelig foreslått til Luna som lesende
+  mønsteranvendere, men det stemmer ikke: `@code-review` har `execute`, og
+  `@accessibility` har `execute`, `edit` og `runSubagent`. De kjører altså
+  kommandoer, skriver filer og starter underagenter. GitHub plasserer Luna i
+  Lightweight-klassen, og målingen dekket bare nav-pilot-personaen, aldri en
+  verktøytung agent. Byttet er derfor ubelagt og måles separat.
+- `@forfatter` beholder Claude Sonnet 4.6. Jobben er å skille bokmål fra
+  nynorsk og luke ut norske AI-markører. Målingen sier ingenting om det, og
+  gevinsten er nær null mot en kjent nedside.
+- Resten av GPT-5.3-Codex-pinningene står urørt. Å flytte dem er en egen
+  beslutning som denne målingen ikke gir grunnlag for.
 
 ## Tilgjengelige modeller og bruksområder
 
-Hele modellflåten, ikke bare de som er pinnet i agenter.
+Hele modellflåten, ikke bare de som er pinnet i agenter. Prisene under er
+GitHubs listepriser slik de sto **30. august 2026**, og speiler
+`apps/my-copilot/src/lib/model-pricing.ts`. De endrer seg uten varsel, så
+tallene her har et tidsstempel og ikke evig gyldighet.
 
 | Modell | Kategori | Input | Output | Best for |
 |--------|----------|-------|--------|----------|
@@ -102,6 +152,7 @@ Slik ser navnekonvensjonene i `model:`-feltet ut i dag:
 | `Claude Opus 5` | Mellomrom | Verifisert (GitHub changelog / Anthropic, 24. juli 2026). API-ID `claude-opus-5` |
 | `Gemini 3.5 Flash` | Mellomrom | Fungerer |
 | `Gemini 3.6 Flash` | Mellomrom | Antatt, ikke verifisert i praksis |
-| `GPT-5.6 Terra` | Mellomrom | Antatt, ikke verifisert i praksis |
+| `GPT-5.6 Luna` | Mellomrom | Verifisert gjennom golden-prompt-kjøringene (august 2026) |
+| `GPT-5.6 Terra` | Mellomrom | Verifisert gjennom golden-prompt-kjøringene, men ikke pinnet |
 
 Frem til en modell er verifisert i praksis, merkes den som «Antatt» og bør ikke brukes i produksjonspinning.

--- a/prompts/golang-service.prompt.md
+++ b/prompts/golang-service.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: golang-service
 description: Scaffold ein Go HTTP-teneste med NAIS-mønster, pgx, sqlc og slog
-model: Claude Haiku 4.5
+model: GPT-5.6 Luna
 ---
 
 # Go NAIS Service

--- a/prompts/ktor-endpoint.prompt.md
+++ b/prompts/ktor-endpoint.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: ktor-endpoint
 description: Generer ein Ktor-rute med autentisering, validering og feilhåndtering
-model: Claude Haiku 4.5
+model: GPT-5.6 Luna
 ---
 
 # Ktor Endpoint

--- a/prompts/nextjs-api-route.prompt.md
+++ b/prompts/nextjs-api-route.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: nextjs-api-route
 description: Scaffold en Next.js App Router API-rute med validering, feilhåndtering, auth og test
-model: Claude Haiku 4.5
+model: GPT-5.6 Luna
 ---
 
 # Next.js API Route

--- a/prompts/spring-boot-endpoint.prompt.md
+++ b/prompts/spring-boot-endpoint.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: spring-boot-endpoint
 description: Scaffold et Spring Boot REST-endepunkt med Controller, Service, Repository, Test og Nais-konfig
-model: Claude Haiku 4.5
+model: GPT-5.6 Luna
 ---
 
 # Spring Boot Endpoint


### PR DESCRIPTION
Fem pinninger som hviler på permanent pris. Delt ut fra en større endring fordi de ni opprinnelige pinningene ikke deler risikoprofil.

## Hva som flytter

`@research-agent` fra GPT-5.3-Codex, og fire prompt-maler fra Claude Haiku 4.5: `ktor-endpoint`, `nextjs-api-route`, `spring-boot-endpoint` og `golang-service`. Verifisert at det er nøyaktig fire Haiku-maler; `aksel-component`, `kafka-topic` og `nais-manifest` er urørt.

## Hvorfor disse er trygge å lande nå

**Prisen er permanent.** Luna står til $0,20/$1,20 uten kampanjemarkør, og GitHubs prisside har nøyaktig to fotnoter, Sol og Gemini Flash. Ingen utløpsdato.

**`@research-agent` er faktisk read-only.** Verktøylista er read, search og web. Den samler og oppsummerer, den skriver ikke.

**Målingen skiller ikke modellene.** Fire modeller, rundt 195 kjøringer, på om personaen reiser de påkrevde blindsonene. Ingen av dem skiller seg signifikant fra dagens modell (Fisher p=1,00 for Luna). Det er derfor prisen avgjør, og det står slik i `modellvalg.md` framfor å påstå at Luna er tryggere.

Besparelsen er rundt 90 prosent mot Codex for research, og omtrent en femtedel av Haiku 4.5 for malene. Blandet 10:1, som er et anslag og merket som det.

## Hva som med vilje ikke er med

`@code-review` og `@accessibility-agent` stod i den opprinnelige endringen og er holdt tilbake.

Jeg begrunnet dem som read-only mønsteragenter. Det stemmer ikke. `code-review` har `execute`. `accessibility` har `execute`, `edit` og `runSubagent`, altså kan den kjøre kommandoer, skrive filer og starte underagenter.

Målingen som begrunnet Luna kjørte bare nav-pilot-personaen, aldri en verktøytung agent. OpenAI beskriver dessuten Luna som tilsvarende nano-nivået i tidligere GPT-5-familier. De to byttene er altså ubelagte, ikke utrygge, og det er forskjell. Harnesset utvides nå til å kunne måle dem.

`docs/modellvalg.md` noterer hvorfor de er holdt.

## Rettelser underveis

Den opprinnelige grenen skrev «under en femtedel av Claude Haiku 4.5». Luna blander til 0,2909 mot Haikus 1,3636, altså 21,3 prosent. Skrevet om til «omtrent en femtedel».

Testen `TestAgentFrontmatterModelsAreKnown` globbet bare `agents/*.agent.md`, så prompt-frontmatter aldri gikk gjennom modellmapperen. Den globber nå `prompts/*.prompt.md` også, hvilket er grunnen til at den fanger disse fire.

`scripts/lint-skills.sh`, `scripts/lint-collections.sh`, `mise run docs:check` og `mise run nav-pilot:check` er grønne. Manifester er regenerert med `mise run generate`, ikke håndredigert.