### PR TITLE
feat(agents): flytt security-champion og nav-pilot-opus til GPT-5.6 Sol

### DIFF
--- a/agents/nav-pilot-opus.agent.md
+++ b/agents/nav-pilot-opus.agent.md
@@ -1,7 +1,7 @@
 ---
 name: nav-pilot-opus
 description: Dyp analyse for høyrisiko planlegging, arkitekturvalg og kritisk review i Nav-prosjekter
-model: Claude Opus 4.6
+model: GPT-5.6 Sol
 tools:
   - execute
   - read

--- a/agents/security-champion.agent.md
+++ b/agents/security-champion.agent.md
@@ -1,7 +1,7 @@
 ---
 name: security-champion-agent
 description: Navs sikkerhetsarkitektur, trusselmodellering, compliance og sikkerhetspraksis
-model: Claude Opus 4.6
+model: GPT-5.6 Sol
 tools:
   - execute
   - read

--- a/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
+++ b/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
@@ -119,7 +119,7 @@
       "displayName": "@nav-pilot-opus",
       "description": "Dyp analyse for høyrisiko planlegging, arkitekturvalg og kritisk review i Nav-prosjekter",
       "filePath": "agents/nav-pilot-opus.agent.md",
-      "contentHash": "19b8f598f0672fce5cd0d6b5151695754b117f074951f2a84886533dd1b7c36a",
+      "contentHash": "30ac4257c5a30df0b6ca6c8524881e7095af48d7c2ce73179f5eca58742c8e2e",
       "useCases": [
         "Network policies",
         "Secrets management",
@@ -221,7 +221,7 @@
         "vulnerability"
       ],
       "filePath": "agents/security-champion.agent.md",
-      "contentHash": "160b9c9cc7263b409e2dc9878eb69d8269e3f3a402811ae75913ccf3ff0c1e36",
+      "contentHash": "a209e3ce5d93746d09abdafe3d5aa91adc3eae51790dc1ac7bbf46d01708df92",
       "useCases": [
         "Creating .nais/app.yaml manifests",
         "Azure AD integration",

--- a/apps/my-copilot/src/lib/copilot-manifest.json
+++ b/apps/my-copilot/src/lib/copilot-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-08-28T16:38:53.220Z",
+  "generatedAt": "2026-08-31T06:23:03.942Z",
   "items": [
     {
       "id": "accessibility-agent",
@@ -256,7 +256,7 @@
       "domain": "general",
       "filePath": ".github/agents/nav-pilot-opus.agent.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/agents/nav-pilot-opus.agent.md",
-      "contentHash": "19b8f598f0672fce5cd0d6b5151695754b117f074951f2a84886533dd1b7c36a",
+      "contentHash": "30ac4257c5a30df0b6ca6c8524881e7095af48d7c2ce73179f5eca58742c8e2e",
       "installUrl": "/install/agent?url=vscode%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fagents%2Fnav-pilot-opus.agent.md",
       "insidersInstallUrl": "/install/agent?url=vscode-insiders%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fagents%2Fnav-pilot-opus.agent.md",
       "tools": [
@@ -279,7 +279,7 @@
         "io.github.navikt/github-mcp/get_latest_release",
         "io.github.navikt/github-mcp/list_releases"
       ],
-      "model": ["Claude Opus 4.6"],
+      "model": ["GPT-5.6 Sol"],
       "tags": ["planning", "architecture", "review", "security", "nav-pilot"],
       "examples": [
         {
@@ -442,7 +442,7 @@
       "domain": "general",
       "filePath": ".github/agents/security-champion.agent.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/agents/security-champion.agent.md",
-      "contentHash": "160b9c9cc7263b409e2dc9878eb69d8269e3f3a402811ae75913ccf3ff0c1e36",
+      "contentHash": "a209e3ce5d93746d09abdafe3d5aa91adc3eae51790dc1ac7bbf46d01708df92",
       "installUrl": "/install/agent?url=vscode%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fagents%2Fsecurity-champion.agent.md",
       "insidersInstallUrl": "/install/agent?url=vscode-insiders%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fagents%2Fsecurity-champion.agent.md",
       "tools": [
@@ -469,7 +469,7 @@
         "io.github.navikt/github-mcp/list_tags",
         "io.github.navikt/github-mcp/list_branches"
       ],
-      "model": ["Claude Opus 4.6"],
+      "model": ["GPT-5.6 Sol"],
       "tags": ["security", "compliance", "gdpr", "threat-modeling"],
       "examples": [
         {

--- a/docs/modellvalg.md
+++ b/docs/modellvalg.md
@@ -11,8 +11,8 @@ De fleste agenter og prompts har et eksplisitt `model:`-felt i YAML-frontmatter.
 | Agent | Modell | Begrunnelse |
 |-------|--------|-------------|
 | `@nav-pilot` | Klientens standardmodell | Orkestratoren pinnes ikke; den arver modellen brukeren allerede kjører i klienten |
-| `@nav-pilot-opus` | Claude Opus 4.6 | Dypest resonnering for høy-risiko beslutninger |
-| `@security-champion` | Claude Opus 4.6 | Sikkerhetskritiske vurderinger krever høyeste presisjon |
+| `@nav-pilot-opus` | GPT-5.6 Sol | Tung resonnering for høy-risiko beslutninger, billigere enn Opus 4.6 på begge akser |
+| `@security-champion` | GPT-5.6 Sol | Sikkerhetskritiske vurderinger, uten målbart tap mot Opus 4.6 |
 | `@code-review` | GPT-5.3-Codex | Sterkest på kodeforståelse og terminal-oppgaver |
 | `@kafka` | GPT-5.3-Codex | Teknisk presis på hendelsesdrevne mønstre |
 | `@research` | GPT-5.3-Codex | Effektiv på bred kodebase-søk og oppsummering |
@@ -47,13 +47,64 @@ Hele modellflåten, ikke bare de som er pinnet i agenter.
 | GPT-5.3-Codex | Powerful | $1.75 | $14.00 | Kodeforståelse, terminal, infrastruktur |
 | GPT-5.6 Luna | Lightweight | $0.20 | $1.20 | Raske rutineoppgaver, enkel autofullfør |
 | GPT-5.6 Terra | Versatile | $2.00 | $12.00 | Allround daglig koding i GPT-familien |
-| GPT-5.6 Sol | Powerful | $2.00 | $10.00 | Tung reasoning over store kodebaser (krever Pro+) |
+| GPT-5.6 Sol | Powerful | $2.00 | $10.00 | Tung reasoning over store kodebaser (krever Pro+). **Kampanjepris, 50 prosent avslag t.o.m. 3. september 2026.** Full pris blir da $4.00 / $20.00 |
 | Gemini 2.5 Pro | Powerful | (utgått) | (utgått) | 🚫 Utfaset 31. juli 2026 og borte fra GitHubs prisliste. Bruk Gemini 3.1 Pro for research og lange kontekstvinduer |
 | Gemini 3.5 Flash | Lightweight | $1.50 | $9.00 | Rask og billig for enkle oppgaver |
 | Gemini 3.6 Flash | Versatile | $0.75 | $3.75 | Agentiske workflows med parallell verktøybruk |
 | Kimi K2.7 Code | Versatile | $0.95 | $4.00 | Rimeligste alternativ for kode-agent-løkker (open-weight) |
 
 Se [prissiden](/priser) for fullstendig og oppdatert pristabell.
+
+## Grunnlaget for Sol-byttet (august 2026)
+
+`@security-champion` og `@nav-pilot-opus` går fra Claude Opus 4.6 til GPT-5.6
+Sol. Golden-prompt-harnessen kjørte nav-pilot-personaen mot fire modeller, og
+Sol skilte seg ikke signifikant fra Claude Sonnet 4.6 på den ene påkrevde
+påstanden som ble målt. Tall, metode og forbehold står i
+[benchmarken og beslutningene fra august 2026](nav-pilot-benchmark-og-beslutninger-2026-08.md).
+Målingen viser ikke at Sol er tryggere enn de andre, bare at kandidatene ikke
+lot seg skille med dette utvalget. Når sikkerhet ikke skiller dem, avgjør
+kostnad.
+
+### Prisen er en kampanjepris
+
+GitHub oppgir i en fotnote på prissiden (anker
+`#user-content-fn-gpt-56-sol-promo`) at GPT-5.6 Sol ligger på **50 prosent
+avslag til og med 3. september 2026**. Kampanjeprisen for standardvinduet er
+$2.00 input og $10.00 output, som er tallene i tabellen over. Full pris er
+dermed $4.00 og $20.00. **Det tallet er regnet ut fra fotnoten, ikke en pris
+GitHub har oppgitt direkte, og ikke en pris dette repoet har hatt liggende.**
+
+Sammenlikningen under er blandet pris per million tokens ved **10 input-tokens
+per output-token. Forholdet er et anslag, ikke noe vi har målt**, og varierer
+med oppgaven.
+
+| Modell | Input | Output | Blandet $/1M ved 10:1 (anslag) |
+|--------|-------|--------|-------------------------------|
+| GPT-5.6 Sol, kampanje t.o.m. 3. sep 2026 | $2.00 | $10.00 | 2,73 |
+| Claude Sonnet 4.6 | $3.00 | $15.00 | 4,09 |
+| GPT-5.6 Sol, full pris | $4.00 | $20.00 | 5,45 |
+| Claude Opus 4.6 | $5.00 | $25.00 | 6,82 |
+
+### Hva byttet faktisk sparer
+
+Den riktige sammenlikningen er mot Claude Opus 4.6, som er modellen disse to
+agentene kjører på i dag. Sol er billigere enn Opus 4.6 på begge akser både med
+og uten kampanje: $2.00 mot $5.00 og $10.00 mot $25.00 nå, og $4.00 mot $5.00
+og $20.00 mot $25.00 etter 3. september. Det er omtrent 20 prosent billigere på
+begge akser når kampanjen er over, og gevinsten overlever altså kampanjeslutt.
+
+Mot Claude Sonnet 4.6 er bildet et annet, og det skal ikke brukes som
+begrunnelse. Til kampanjepris ligger Sol 33 prosent under Sonnet 4.6 blandet,
+men til full pris ligger Sol 33 prosent **over**. Sonnet 4.6 er heller ikke
+modellen disse agentene erstatter.
+
+Sol er ikke det billigste Powerful-alternativet. Til full pris ligger både
+GPT-5.3-Codex (2,86 blandet) og Gemini 3.1 Pro (2,91 blandet) under. Valget av
+Sol hviler på at den er nærmeste erstatter for Opus 4.6 i resonneringssjiktet
+og målte likt med de andre kandidatene, ikke på at den er billigst i klassen.
+
+Merk at Sol krever Copilot Pro+ eller høyere plan.
 
 ## Kriterier for å bytte modell
 
@@ -79,7 +130,7 @@ Regnestykket ser bort fra cachet input, der Codex ligger på $0.175 mot Terras $
 
 ## Sjekkliste for nye modeller
 
-> **Notat (24. juli 2026):** Claude Opus 5 (`claude-opus-5`) er lansert av Anthropic og er kandidat til å erstatte Opus 4.6-pinningene på `@nav-pilot-opus` og `@security-champion`. Listeprisen er identisk med Opus 4.8 ($5.00/$25.00), og Anthropic oppgir vesentlig sterkere resonnering (mer enn dobling av Opus 4.8 på Frontier-Bench v0.1). Et bytte skal gjennom sjekklisten under før pinningene endres. Foreløpig beholdes Opus 4.6. Utrullingen i Copilot er gradvis (GA for Pro+/Max/Business/Enterprise 24. juli), så modellen kan mangle i model picker en periode.
+> **Notat (24. juli 2026, oppdatert 30. august 2026):** Claude Opus 5 (`claude-opus-5`) er lansert av Anthropic og var kandidat til å erstatte Opus 4.6-pinningene på `@nav-pilot-opus` og `@security-champion`. Listeprisen er identisk med Opus 4.8 ($5.00/$25.00), og Anthropic oppgir vesentlig sterkere resonnering (mer enn dobling av Opus 4.8 på Frontier-Bench v0.1). Begge agentene står nå på GPT-5.6 Sol, som er billigere enn Opus 4.6 på begge akser også etter at kampanjeprisen løper ut 3. september 2026. Opus 5 er fortsatt aktuell hvis en måling viser at den tyngre resonneringen er verdt prisforskjellen, men den er ikke testet mot vår egen golden-prompt. Utrullingen i Copilot er gradvis (GA for Pro+/Max/Business/Enterprise 24. juli), så modellen kan mangle i model picker en periode.
 
 Når nye modeller slås på (som nå med Claude Opus 5, GPT-5.6-familien, Kimi K2.7 og Gemini 3.6 Flash):
 
@@ -99,6 +150,7 @@ Slik ser navnekonvensjonene i `model:`-feltet ut i dag:
 | `GPT-5.3-Codex` | Bindestrek mellom versjon og variant | Fungerer |
 | `Claude Sonnet 4.6` | Mellomrom | Fungerer |
 | `Claude Opus 4.6` | Mellomrom | Fungerer |
+| `GPT-5.6 Sol` | Mellomrom | Verifisert gjennom golden-prompt-kjøringene (august 2026) |
 | `Claude Opus 5` | Mellomrom | Verifisert (GitHub changelog / Anthropic, 24. juli 2026). API-ID `claude-opus-5` |
 | `Gemini 3.5 Flash` | Mellomrom | Fungerer |
 | `Gemini 3.6 Flash` | Mellomrom | Antatt, ikke verifisert i praksis |


### PR DESCRIPTION
To pinninger som hviler på kampanjepris. Skilt ut fra Luna-pinningene i [#506](https://github.com/navikt/copilot/pull/506) nettopp fordi risikoprofilen er en annen.

## Kampanjen utløper 3. september

GPT-5.6 Sol står til 50 prosent rabatt til og med 3. september 2026, per fotnote på GitHubs prisside (anker `#user-content-fn-gpt-56-sol-promo`). Kampanjeprisen er $2,00 inn og $10,00 ut, så standardprisen blir $4,00 og $20,00.

**Det tallet er regnet ut fra «50 % off», ikke hentet fra kilden.** Repoet har aldri holdt $4/$20, og dokumentet sier det slik framfor å presentere det som et kjent tall. Fila holdt $5,00/$30,00 fram til synken 30. august, så listeprisen ser ut til å ha blitt kuttet og deretter rabattert.

## Byttet lønner seg likevel, men ikke slik jeg først skrev

Begge agentene står på Claude Opus 4.6 i dag. Blandet 10:1, som er et anslag:

| | blandet |
|---|---|
| GPT-5.6 Sol, kampanje | 2,73 |
| GPT-5.6 Sol, standard | 5,45 |
| Claude Opus 4.6 | 6,82 |

Sol er billigere enn Opus 4.6 på begge akser, før og etter kampanjen. Rundt 20 prosent etter.

**En påstand jeg ba om ble avvist, med rette.** Jeg skrev at Sol fortsatt er det billigste Powerful-alternativet etter kampanjen. Det stemmer ikke: GPT-5.3-Codex blander til 2,86 og Gemini 3.1 Pro til 2,91, begge under Sol. Dokumentet sier i stedet at Sol er den nærmeste erstatningen for Opus 4.6 i resonneringsklassen, ikke den billigste i klassen.

Om noen vil bytte disse to til noe rimeligere enn Sol, er det en ny beslutning på et annet grunnlag enn denne.

## Grunnlaget

Samme måling som Luna-pinningene: ingen av de fire modellene skiller seg signifikant fra dagens (Fisher p=1,00 for Sol, 1/50 mot 2/50). Målingen viste ikke at Sol er tryggere, den viste at utvalget ikke kan skille dem.

## Etter 3. september

Prisen bør verifiseres på nytt. Sporingssak [#503](https://github.com/navikt/copilot/issues/503) beskriver hvorfor ingenting i repoet oppdager at en kampanje tar slutt: synkroniseringen fanger prisen, ikke varigheten.

Alle fire sjekkene er grønne, manifester regenerert.