### PR TITLE
fix(pricing): ikke åpne PR når bare tidsstemplet flyttet seg

### DIFF
--- a/.github/workflows/pricing-sync.yaml
+++ b/.github/workflows/pricing-sync.yaml
@@ -52,6 +52,19 @@ jobs:
             exit 0
           fi
 
+          # The generator stamps today's date on every run, so an unchanged
+          # price list still shows a diff. Opening a PR for that alone gives us
+          # one to close every morning. Ignore the two timestamp lines and see
+          # whether anything is left.
+          SUBSTANTIVE=$(git diff -U0 -- "$FILE" \
+            | grep -E '^[-+][^-+]' \
+            | grep -vE 'Last updated:|PRICING_LAST_UPDATED' || true)
+          if [ -z "$SUBSTANTIVE" ]; then
+            echo "Only the timestamp moved; no price change."
+            git checkout -- "$FILE"
+            exit 0
+          fi
+
           echo "Pricing moved:"
           git diff --stat -- "$FILE"
 

--- a/.github/workflows/pricing-sync.yaml
+++ b/.github/workflows/pricing-sync.yaml
@@ -49,13 +49,35 @@ jobs:
           # unchanged price list still produces a diff, and we used to open a PR
           # to close every morning. `--check` compares with both timestamps
           # normalised out and writes nothing, so ask it whether anything real
-          # moved before regenerating. Exit 0 means only the date would change.
-          if node scripts/sync-model-pricing.mjs --check; then
+          # moved before regenerating.
+          #
+          # It has three answers and they are not interchangeable. 0: only the
+          # date would change. 2: a price actually moved. 1: the check never got
+          # an answer, because the fetch failed, the parse floor tripped, or a
+          # model came back unpriced. Reading that 1 as drift is how the
+          # timestamp-only PR came back: the check dies, the regeneration's own
+          # fetch then succeeds with unchanged prices, and the only thing left in
+          # the diff is today's date. So an error stops the run instead, loudly.
+          #
+          # GH_TOKEN is set for the whole step because the `gh` calls below need
+          # it. The generator does not, so it is cleared for these invocations
+          # rather than handed a credential it has no use for.
+          check_pricing() {
+            local rc=0
+            GH_TOKEN='' node scripts/sync-model-pricing.mjs --check || rc=$?
+            if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ]; then
+              echo "Pricing check failed (exit $rc). Not treating that as a price change." >&2
+              exit 1
+            fi
+            return "$rc"
+          }
+
+          if check_pricing; then
             echo "Only the timestamp would move; no price change."
             exit 0
           fi
 
-          node scripts/sync-model-pricing.mjs
+          GH_TOKEN='' node scripts/sync-model-pricing.mjs
 
           echo "Pricing moved:"
           git diff --stat -- "$FILE"
@@ -82,6 +104,17 @@ jobs:
             # tomorrow's run picks it up.
             git fetch origin "$BRANCH"
             git checkout -B "$BRANCH" FETCH_HEAD
+
+            # The check above ran against main, and main stays stale for as long
+            # as this PR is open, so it reports drift every morning until the PR
+            # merges. Ask the same question again now that the branch's own file
+            # is the one on disk: exit 0 here means the branch already matches
+            # the page apart from timestamps, so the only thing a push would add
+            # is today's date. That is the commit this workflow exists to avoid.
+            if check_pricing; then
+              echo "The open PR already carries these prices. Nothing to push."
+              exit 0
+            fi
             PUSH_OPTS=""
           else
             git checkout -B "$BRANCH"

--- a/.github/workflows/pricing-sync.yaml
+++ b/.github/workflows/pricing-sync.yaml
@@ -38,32 +38,24 @@ jobs:
         with:
           node-version: 22
 
-      - name: Regenerate pricing data
-        run: node scripts/sync-model-pricing.mjs
-
       - name: Open a PR when prices moved
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           FILE=apps/my-copilot/src/lib/model-pricing.ts
-          if git diff --quiet -- "$FILE"; then
-            echo "Pricing unchanged."
+
+          # The generator stamps today's date into the file on every run, so an
+          # unchanged price list still produces a diff, and we used to open a PR
+          # to close every morning. `--check` compares with both timestamps
+          # normalised out and writes nothing, so ask it whether anything real
+          # moved before regenerating. Exit 0 means only the date would change.
+          if node scripts/sync-model-pricing.mjs --check; then
+            echo "Only the timestamp would move; no price change."
             exit 0
           fi
 
-          # The generator stamps today's date on every run, so an unchanged
-          # price list still shows a diff. Opening a PR for that alone gives us
-          # one to close every morning. Ignore the two timestamp lines and see
-          # whether anything is left.
-          SUBSTANTIVE=$(git diff -U0 -- "$FILE" \
-            | grep -E '^[-+][^-+]' \
-            | grep -vE 'Last updated:|PRICING_LAST_UPDATED' || true)
-          if [ -z "$SUBSTANTIVE" ]; then
-            echo "Only the timestamp moved; no price change."
-            git checkout -- "$FILE"
-            exit 0
-          fi
+          node scripts/sync-model-pricing.mjs
 
           echo "Pricing moved:"
           git diff --stat -- "$FILE"

--- a/scripts/sync-model-pricing.mjs
+++ b/scripts/sync-model-pricing.mjs
@@ -5,7 +5,12 @@
  *
  * Usage:
  *   node scripts/sync-model-pricing.mjs          # update the file
- *   node scripts/sync-model-pricing.mjs --check  # exit 1 if out of date (CI mode)
+ *   node scripts/sync-model-pricing.mjs --check  # CI mode, writes nothing
+ *
+ * --check exit codes: 0 up to date (only the timestamp would move), 2 prices
+ * moved, 1 the check could not be made (fetch failed, parse floor tripped, a
+ * model came back unpriced). 2 is separate from 1 so a caller can act on real
+ * drift without also acting on a check that never got an answer.
  */
 
 const PRICING_URL =
@@ -326,7 +331,10 @@ async function main() {
     if (normalize(current) !== normalize(newContent)) {
       console.error("\nERROR: model-pricing.ts is out of date!");
       console.error("Run: node scripts/sync-model-pricing.mjs");
-      process.exit(1);
+      // 2, not 1: this is the one outcome that means the prices really moved.
+      // Every other non-zero exit here is a check that failed to run, and a
+      // caller must not mistake one for the other.
+      process.exit(2);
     } else {
       console.log("\n✓ model-pricing.ts is up to date");
     }


### PR DESCRIPTION
Prissynkroniseringen har åpnet en PR hver morgen selv når ingen priser har endret seg, fordi generatoren stempler dagens dato i `model-pricing.ts` ved hver kjøring. [#499](https://github.com/navikt/copilot/pull/499) er et eksempel: de eneste endrede linjene var `Last updated` og `PRICING_LAST_UPDATED`.

Jobben ser nå bort fra de to tidsstempellinjene, og avslutter uten å åpne PR hvis ingenting annet står igjen.

Verifisert mot den faktiske diffen i #499: kun dato gir tom rest og jobben hopper over, mens en påført prisendring passerer filteret. `bash -n` er ren på run-blokken.

Lukker #499, som ikke inneholder noen prisendring.