### PR TITLE
docs(modellvalg): rett tre overdrevne påstander om Sol-byttet

### DIFF
--- a/docs/modellvalg.md
+++ b/docs/modellvalg.md
@@ -11,7 +11,7 @@ De fleste agenter og prompts har et eksplisitt `model:`-felt i YAML-frontmatter.
 | Agent | Modell | Begrunnelse |
 |-------|--------|-------------|
 | `@nav-pilot` | Klientens standardmodell | Orkestratoren pinnes ikke; den arver modellen brukeren allerede kjører i klienten |
-| `@nav-pilot-opus` | GPT-5.6 Sol | Tung resonnering for høy-risiko beslutninger. Billigere enn Opus 4.6 på begge akser under 272K kontekst, dyrere over. Agenten er ikke målt mot Opus 4.6 |
+| `@nav-pilot-opus` | GPT-5.6 Sol | Tung resonnering for høy-risiko beslutninger. Billigere enn Opus 4.6 på begge akser under 272K kontekst; over 272K også billigere til kampanjepris, men dyrere til antatt standardpris etter 3. sep 2026. Agenten er ikke målt mot Opus 4.6 |
 | `@security-champion` | GPT-5.6 Sol | Sikkerhetskritiske vurderinger. Agenten er ikke målt mot Opus 4.6 eller mot noen annen modell. Byttet hviler på pris |
 | `@code-review` | GPT-5.3-Codex | Sterkest på kodeforståelse og terminal-oppgaver |
 | `@kafka` | GPT-5.3-Codex | Teknisk presis på hendelsesdrevne mønstre |
@@ -228,7 +228,7 @@ Regnestykket ser bort fra cachet input, der Codex ligger på $0.175 mot Terras $
 
 ## Sjekkliste for nye modeller
 
-> **Notat (24. juli 2026, oppdatert 30. august 2026):** Claude Opus 5 (`claude-opus-5`) er lansert av Anthropic og var kandidat til å erstatte Opus 4.6-pinningene på `@nav-pilot-opus` og `@security-champion`. Listeprisen er identisk med Opus 4.8 ($5.00/$25.00), og Anthropic oppgir vesentlig sterkere resonnering (mer enn dobling av Opus 4.8 på Frontier-Bench v0.1). Begge agentene står nå på GPT-5.6 Sol, som er billigere enn Opus 4.6 på begge akser under 272K kontekst også etter at kampanjeprisen løper ut 3. september 2026; over 272K er Sol til antatt standardpris dyrere enn Opus 4.6 på begge akser. Opus 5 er fortsatt aktuell hvis en måling viser at den tyngre resonneringen er verdt prisforskjellen, men den er ikke testet mot vår egen golden-prompt. Utrullingen i Copilot er gradvis (GA for Pro+/Max/Business/Enterprise 24. juli), så modellen kan mangle i model picker en periode.
+> **Notat (24. juli 2026, oppdatert 31. august 2026):** Claude Opus 5 (`claude-opus-5`) er lansert av Anthropic og var kandidat til å erstatte Opus 4.6-pinningene på `@nav-pilot-opus` og `@security-champion`. Listeprisen er identisk med Opus 4.8 ($5.00/$25.00), og Anthropic oppgir vesentlig sterkere resonnering (mer enn dobling av Opus 4.8 på Frontier-Bench v0.1). Begge agentene står nå på GPT-5.6 Sol, som er billigere enn Opus 4.6 på begge akser under 272K kontekst også etter at kampanjeprisen løper ut 3. september 2026; over 272K er Sol til antatt standardpris dyrere enn Opus 4.6 på begge akser. Opus 5 er fortsatt aktuell hvis en måling viser at den tyngre resonneringen er verdt prisforskjellen, men den er ikke testet mot vår egen golden-prompt. Utrullingen i Copilot er gradvis (GA for Pro+/Max/Business/Enterprise 24. juli), så modellen kan mangle i model picker en periode.
 
 Når nye modeller slås på (som nå med Claude Opus 5, GPT-5.6-familien, Kimi K2.7 og Gemini 3.6 Flash):
 

--- a/docs/modellvalg.md
+++ b/docs/modellvalg.md
@@ -11,8 +11,8 @@ De fleste agenter og prompts har et eksplisitt `model:`-felt i YAML-frontmatter.
 | Agent | Modell | Begrunnelse |
 |-------|--------|-------------|
 | `@nav-pilot` | Klientens standardmodell | Orkestratoren pinnes ikke; den arver modellen brukeren allerede kjører i klienten |
-| `@nav-pilot-opus` | GPT-5.6 Sol | Tung resonnering for høy-risiko beslutninger, billigere enn Opus 4.6 på begge akser |
-| `@security-champion` | GPT-5.6 Sol | Sikkerhetskritiske vurderinger, uten målbart tap mot Opus 4.6 |
+| `@nav-pilot-opus` | GPT-5.6 Sol | Tung resonnering for høy-risiko beslutninger. Billigere enn Opus 4.6 på begge akser under 272K kontekst, dyrere over. Agenten er ikke målt mot Opus 4.6 |
+| `@security-champion` | GPT-5.6 Sol | Sikkerhetskritiske vurderinger. Agenten er ikke målt mot Opus 4.6 eller mot noen annen modell. Byttet hviler på pris |
 | `@code-review` | GPT-5.3-Codex | Sterkest på kodeforståelse og terminal-oppgaver |
 | `@kafka` | GPT-5.3-Codex | Teknisk presis på hendelsesdrevne mønstre |
 | `@research` | GPT-5.6 Luna | Leser og søker uten å skrive kode, og Luna koster omtrent en tiendedel av Codex |
@@ -135,13 +135,17 @@ Se [prissiden](/priser) for fullstendig og oppdatert pristabell.
 ## Grunnlaget for Sol-byttet (august 2026)
 
 `@security-champion` og `@nav-pilot-opus` går fra Claude Opus 4.6 til GPT-5.6
-Sol. Golden-prompt-harnessen kjørte nav-pilot-personaen mot fire modeller, og
-Sol skilte seg ikke signifikant fra Claude Sonnet 4.6 på den ene påkrevde
-påstanden som ble målt. Tall, metode og forbehold står i
+Sol. **Byttet hviler på pris. Disse to agentene er ikke målt mot noen modell,
+heller ikke mot den de flytter fra.**
+
+Golden-prompt-harnessen kjørte nav-pilot-personaen mot Claude Sonnet 4.6,
+GPT-5.6 Sol, GPT-5.6 Luna og GPT-5.6 Terra. Opus 4.6, modellen disse to
+agentene faktisk kjører på i dag, var ikke med i målingen, og harnessen tester
+personaen til `nav-pilot`, ikke `@security-champion` og ikke `@nav-pilot-opus`.
+Det som ble målt er én regex-påstand på én prompt, og der skilte Sol seg ikke
+fra Claude Sonnet 4.6 (Fisher p = 1,00). Det betyr umulig å skille, ikke
+likeverdig. Tall, metode og forbehold står i
 [benchmarken og beslutningene fra august 2026](nav-pilot-benchmark-og-beslutninger-2026-08.md).
-Målingen viser ikke at Sol er tryggere enn de andre, bare at kandidatene ikke
-lot seg skille med dette utvalget. Når sikkerhet ikke skiller dem, avgjør
-kostnad.
 
 ### Prisen er en kampanjepris
 
@@ -166,20 +170,37 @@ med oppgaven.
 ### Hva byttet faktisk sparer
 
 Den riktige sammenlikningen er mot Claude Opus 4.6, som er modellen disse to
-agentene kjører på i dag. Sol er billigere enn Opus 4.6 på begge akser både med
-og uten kampanje: $2.00 mot $5.00 og $10.00 mot $25.00 nå, og $4.00 mot $5.00
-og $20.00 mot $25.00 etter 3. september. Det er omtrent 20 prosent billigere på
-begge akser når kampanjen er over, og gevinsten overlever altså kampanjeslutt.
+agentene kjører på i dag. **Under 272K kontekst** er Sol billigere enn Opus 4.6
+på begge akser både med og uten kampanje: $2.00 mot $5.00 og $10.00 mot $25.00
+nå, og $4.00 mot $5.00 og $20.00 mot $25.00 etter 3. september. Det er omtrent
+20 prosent billigere på begge akser når kampanjen er over, og den delen av
+gevinsten overlever kampanjeslutt.
+
+**Over 272K snur det.** Sol har et eget prisnivå for lang kontekst, Opus 4.6 har
+ikke det og koster $5.00 / $25.00 uansett kontekstlengde. Til kampanjepris
+ligger Sol fortsatt under ($4.00 mot $5.00 og $15.00 mot $25.00), men til antatt
+standardpris, $8.00 / $30.00 (se noten om kampanjepriser over), er Sol dyrere
+enn Opus 4.6 på begge akser. Begge disse to agentene er pitchet mot tung
+resonnering over store kodebaser, altså nettopp arbeidslasten som oftest krysser
+272K. Prisgevinsten gjelder korte kontekster, ikke lange.
 
 Mot Claude Sonnet 4.6 er bildet et annet, og det skal ikke brukes som
 begrunnelse. Til kampanjepris ligger Sol 33 prosent under Sonnet 4.6 blandet,
 men til full pris ligger Sol 33 prosent **over**. Sonnet 4.6 er heller ikke
 modellen disse agentene erstatter.
 
-Sol er ikke det billigste Powerful-alternativet. Til full pris ligger både
-GPT-5.3-Codex (2,86 blandet) og Gemini 3.1 Pro (2,91 blandet) under. Valget av
-Sol hviler på at den er nærmeste erstatter for Opus 4.6 i resonneringssjiktet
-og målte likt med de andre kandidatene, ikke på at den er billigst i klassen.
+### Kostnadsregelen peker ikke på Sol
+
+Regelen «når sikkerhet ikke skiller dem, avgjør kostnad» velger ikke Sol. Til
+antatt standardpris ligger Sol på 5,45 blandet, mens GPT-5.3-Codex ligger på
+2,86 og Gemini 3.1 Pro på 2,91. Begge er Powerful-modeller, og begge er
+billigere enn Sol. Fulgt bokstavelig peker regelen på en av dem, ikke på Sol.
+
+Sol er valgt fordi den er nærmeste erstatter for Opus 4.6 i resonneringssjiktet.
+**Det er en vurdering, ikke en måling.** Vi har ingen tall som viser at Sol
+resonnerer bedre enn GPT-5.3-Codex eller Gemini 3.1 Pro på oppgavene disse to
+agentene gjør, og ingen som viser at den holder Opus 4.6-nivået. Argumentet er
+ubelagt, og skal leses som det.
 
 Merk at Sol krever Copilot Pro+ eller høyere plan.
 
@@ -207,7 +228,7 @@ Regnestykket ser bort fra cachet input, der Codex ligger på $0.175 mot Terras $
 
 ## Sjekkliste for nye modeller
 
-> **Notat (24. juli 2026, oppdatert 30. august 2026):** Claude Opus 5 (`claude-opus-5`) er lansert av Anthropic og var kandidat til å erstatte Opus 4.6-pinningene på `@nav-pilot-opus` og `@security-champion`. Listeprisen er identisk med Opus 4.8 ($5.00/$25.00), og Anthropic oppgir vesentlig sterkere resonnering (mer enn dobling av Opus 4.8 på Frontier-Bench v0.1). Begge agentene står nå på GPT-5.6 Sol, som er billigere enn Opus 4.6 på begge akser også etter at kampanjeprisen løper ut 3. september 2026. Opus 5 er fortsatt aktuell hvis en måling viser at den tyngre resonneringen er verdt prisforskjellen, men den er ikke testet mot vår egen golden-prompt. Utrullingen i Copilot er gradvis (GA for Pro+/Max/Business/Enterprise 24. juli), så modellen kan mangle i model picker en periode.
+> **Notat (24. juli 2026, oppdatert 30. august 2026):** Claude Opus 5 (`claude-opus-5`) er lansert av Anthropic og var kandidat til å erstatte Opus 4.6-pinningene på `@nav-pilot-opus` og `@security-champion`. Listeprisen er identisk med Opus 4.8 ($5.00/$25.00), og Anthropic oppgir vesentlig sterkere resonnering (mer enn dobling av Opus 4.8 på Frontier-Bench v0.1). Begge agentene står nå på GPT-5.6 Sol, som er billigere enn Opus 4.6 på begge akser under 272K kontekst også etter at kampanjeprisen løper ut 3. september 2026; over 272K er Sol til antatt standardpris dyrere enn Opus 4.6 på begge akser. Opus 5 er fortsatt aktuell hvis en måling viser at den tyngre resonneringen er verdt prisforskjellen, men den er ikke testet mot vår egen golden-prompt. Utrullingen i Copilot er gradvis (GA for Pro+/Max/Business/Enterprise 24. juli), så modellen kan mangle i model picker en periode.
 
 Når nye modeller slås på (som nå med Claude Opus 5, GPT-5.6-familien, Kimi K2.7 og Gemini 3.6 Flash):
 

--- a/docs/news/articles/agenter-bytter-modell.md
+++ b/docs/news/articles/agenter-bytter-modell.md
@@ -18,7 +18,9 @@ Vi bytter modellene bak flere av Copilot-konfigurasjonene i nav-pilot basert på
 | `@research-agent` | GPT-5.3-Codex | GPT-5.6 Luna |
 | Fire prompt-maler for nye tjenester | Claude Haiku 4.5 | GPT-5.6 Luna |
 | `@security-champion-agent`, `@nav-pilot-opus` | Claude Opus 4.6 | GPT-5.6 Sol |
-| `@code-review`, `@accessibility-agent` | GPT-5.3-Codex, Claude Sonnet 4.6 | satt på vent, se rettingen under |
+| `@code-review`, `@accessibility-agent` | GPT-5.3-Codex, Claude Sonnet 4.6 | satt på vent |
+
+`@code-review` og `@accessibility-agent` venter fordi de kjører kommandoer, skriver filer og starter subagenter, og det har vi ikke målt noen av de nye modellene på. De to måles for seg.
 
 `@forfatter` blir stående på Claude Sonnet 4.6. Jobben omfatter norsk tekst, og vi har ingen måling som sier at en annen modell gjør den like godt.
 
@@ -39,6 +41,8 @@ Fishers eksakte test mot Claude gir p = 1,00 for Sol, p = 1,00 for Luna og p = 0
 
 Målingen sier altså ikke at de nye modellene er tryggere. Den sier at vi ikke klarer å skille dem fra den vi kjører i dag. Det er nettopp derfor prisen får avgjøre.
 
+Claude Opus 4.6 var ikke med i målingen. For `@security-champion-agent` og `@nav-pilot-opus`, som flytter fra den, hviler byttet på prisen alene.
+
 ## Blindsonen bommer alle modellene på
 
 Alle de fire modellene overser personvernblindsonen. Tre av modellene bommer med noen få prosent, Terra 11,1 prosent, og modellen vi kjører i dag er blant dem som bommer. Det er ikke et modellproblem, og ikke noe modellbytte fikser for oss dessverre. Vi følger det som en bug i instruksjonene til agenten selv.
@@ -51,53 +55,16 @@ Pris (USD) per million tokens, slik GitHub publiserte dem 30. august 2026:
 |---|---|---|
 | GPT-5.6 Luna | 0,20 | 1,20 |
 | Claude Haiku 4.5 | 1 | 5 |
-| GPT-5.6 Sol (kampanjepris, se rettingen under) | 2 | 10 |
+| GPT-5.6 Sol (kampanjepris ut 3. september 2026) | 2 | 10 |
 | Claude Sonnet 4.6 | 3 | 15 |
 | Claude Opus 4.6 | 5 | 25 |
 
-Luna koster under en tidel av Sonnet 4.6. Sol koster en tredjedel mindre enn Sonnet 4.6 og 60 % mindre enn Opus 4.6, som er modellen de to tyngste agentene flytter fra.
-
-> **Retting 31. august 2026.** Tre ting i artikkelen stemmer ikke, og alle ble
-> oppdaget samme dag.
->
-> **1. To av de ni pinningene er satt på vent.** `@code-review` og
-> `@accessibility-agent` bytter ikke modell nå. Grunnen er verktøytilgangen
-> deres: `@code-review` har `execute`, og `@accessibility-agent` har `execute`,
-> `edit` og `runSubagent`, altså kjøre kommandoer, skrive filer og starte
-> subagenter. Målingen som bærer Luna-valget kjørte bare nav-pilot-konfigurasjonen,
-> som ikke bruker verktøy i det hele tatt, så vi har ingen tall for en
-> verktøytung agent på Luna. Det er ikke det samme som at Luna er utrygg der.
-> Det er at vi ikke har målt det, og de to måles for seg før noen bestemmer noe.
-> Harnesset må utvides først. De fem andre Luna-pinningene står:
-> `@research-agent`, som bare leser og søker, og de fire prompt-malene.
->
-> **2. Sol-prisen er en kampanjepris.** Prisen på 2 og 10 dollar er 50 prosent
-> av standardprisen, og den varer ut 3. september 2026. Det står i en fotnote i
-> [GitHubs pristabell](https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing#user-content-fn-gpt-56-sol-promo)
-> som vi ikke fanget opp da vi skrev dette. Fotnoten oppgir ikke standardprisen,
-> men doblet kampanjepris gir 4 og 20 dollar fra 4. september. Det tallet er
-> regnet ut fra «50 % off», ikke lest av en publisert prisliste. Blander vi
-> input og output 10:1, som er et anslag og ikke noe vi har målt, koster Sol da
-> 5,45 dollar per million tokens mot 2,73 i dag. Sol går dermed fra en tredjedel
-> billigere enn Sonnet 4.6 (4,09) til en tredjedel dyrere. Mot Opus 4.6 (6,82),
-> som er modellen de to agentene faktisk kjører i dag, går den fra 60 prosent
-> billigere til rundt 20 prosent billigere. Beslutningen står, det er
-> regnestykket som endrer seg. Luna er ikke berørt: OpenAIs egen modellside
-> oppgir 0,20 og 1,20 dollar som listepris, og GitHub har ingen fotnote på
-> Luna-raden. Gemini Flash-radene er også kampanjepris, ut 31. desember 2026.
->
-> **3. Opus 4.6 var ikke med i målingen.** Tabellen over sammenlikner fire
-> modeller, og Opus 4.6, som `@security-champion-agent` og `@nav-pilot-opus`
-> faktisk kjører på, er ikke en av dem. Harnesset kjørte dessuten
-> nav-pilot-konfigurasjonen, ikke disse to agentene. Vi har altså ingen måling
-> som sier at Sol holder nivået til Opus 4.6 for dem, og byttet hviler på prisen
-> alene. Prisgevinsten gjelder i tillegg bare kontekster under 272K tokens: Sol
-> har et eget prisnivå for lang kontekst, Opus 4.6 har ikke det, og over 272K er
-> Sol til antatt standardpris (8 og 30 dollar) dyrere enn Opus 4.6 på begge
-> akser.
+Luna koster under en tidel av Sonnet 4.6. Sol-prisen er en kampanjepris; fra 4. september er den 4 og 20 dollar, og da ligger Sol rundt 20 prosent under Opus 4.6, som er modellen de to tyngste agentene flytter fra. Den gevinsten gjelder kontekster under 272K tokens. Over 272K koster Sol 8 og 30 dollar og er dyrere enn Opus 4.6.
 
 Tallene har en dato av en grunn. Sol lå på 5 og 30 dollar da vi sist synkroniserte prisene 10. august, og falt til 2 og 10 i løpet av måneden. Prislista i `apps/my-copilot/src/lib/model-pricing.ts` er den vi regner ut fra.
 
 ## Hvis en agent svarer dårligere
 
 Si fra i [#github-copilot](https://nav-it.slack.com/archives/C055TNXBM17). Modellvalget står i metadaten til hver agent, så det er én linje å sette tilbake hvis det skulle være behov.
+
+*Rettet 31. august 2026: Sol-prisen og hva målingen faktisk dekker.*

--- a/docs/news/articles/agenter-bytter-modell.md
+++ b/docs/news/articles/agenter-bytter-modell.md
@@ -1,9 +1,9 @@
 ---
-title: "Flere agenter bytter modell: dette viser målingene"
+title: "Flere agenter bytter modell: hva målingene viser, og hva de ikke dekker"
 date: 2026-08-31
 author: starefossen
 category: nav
-excerpt: "@research-agent og fire prompt-maler går over til GPT-5.6 Luna, @security-champion-agent og @nav-pilot-opus til GPT-5.6 Sol. @code-review og @accessibility-agent er satt på vent til de er målt for seg. Målingene skiller ikke modellene fra hverandre på sikkerhet og kvalitet, og da er det prisen som avgjør. nav-pilot tilbyr oppdateringen neste gang du starter den."
+excerpt: "@research-agent og fire prompt-maler går over til GPT-5.6 Luna, @security-champion-agent og @nav-pilot-opus til GPT-5.6 Sol. @code-review og @accessibility-agent er satt på vent til de er målt for seg. Målingene skiller ikke modellene på sikkerhet og kvalitet, og Opus 4.6 var ikke med i dem, så Sol-byttet hviler på pris. nav-pilot tilbyr oppdateringen neste gang du starter den."
 tags:
   - models
   - nav-pilot
@@ -59,7 +59,7 @@ Pris (USD) per million tokens, slik GitHub publiserte dem 30. august 2026:
 | Claude Sonnet 4.6 | 3 | 15 |
 | Claude Opus 4.6 | 5 | 25 |
 
-Luna koster under en tidel av Sonnet 4.6. Sol-prisen er en kampanjepris; fra 4. september er den 4 og 20 dollar, og da ligger Sol rundt 20 prosent under Opus 4.6, som er modellen de to tyngste agentene flytter fra. Den gevinsten gjelder kontekster under 272K tokens. Over 272K koster Sol 8 og 30 dollar og er dyrere enn Opus 4.6.
+Luna koster under en tidel av Sonnet 4.6. Sol-prisen er en kampanjepris, og GitHub oppgir bare «50 % avslag», ikke standardprisen, så prisene etter kampanjen er våre anslag. Fra 4. september blir Sol trolig 4 og 20 dollar, rundt 20 prosent under Opus 4.6, som er modellen de to tyngste agentene flytter fra. Den gevinsten gjelder kontekster under 272K tokens. Over 272K koster Sol nå 4 og 15, også under Opus 4.6, men trolig 8 og 30 etter kampanjen, og da dyrere.
 
 Tallene har en dato av en grunn. Sol lå på 5 og 30 dollar da vi sist synkroniserte prisene 10. august, og falt til 2 og 10 i løpet av måneden. Prislista i `apps/my-copilot/src/lib/model-pricing.ts` er den vi regner ut fra.
 

--- a/docs/news/articles/agenter-bytter-modell.md
+++ b/docs/news/articles/agenter-bytter-modell.md
@@ -57,7 +57,7 @@ Pris (USD) per million tokens, slik GitHub publiserte dem 30. august 2026:
 
 Luna koster under en tidel av Sonnet 4.6. Sol koster en tredjedel mindre enn Sonnet 4.6 og 60 % mindre enn Opus 4.6, som er modellen de to tyngste agentene flytter fra.
 
-> **Retting 31. august 2026.** To ting i artikkelen stemmer ikke, og begge ble
+> **Retting 31. august 2026.** Tre ting i artikkelen stemmer ikke, og alle ble
 > oppdaget samme dag.
 >
 > **1. To av de ni pinningene er satt på vent.** `@code-review` og
@@ -85,6 +85,16 @@ Luna koster under en tidel av Sonnet 4.6. Sol koster en tredjedel mindre enn Son
 > regnestykket som endrer seg. Luna er ikke berørt: OpenAIs egen modellside
 > oppgir 0,20 og 1,20 dollar som listepris, og GitHub har ingen fotnote på
 > Luna-raden. Gemini Flash-radene er også kampanjepris, ut 31. desember 2026.
+>
+> **3. Opus 4.6 var ikke med i målingen.** Tabellen over sammenlikner fire
+> modeller, og Opus 4.6, som `@security-champion-agent` og `@nav-pilot-opus`
+> faktisk kjører på, er ikke en av dem. Harnesset kjørte dessuten
+> nav-pilot-konfigurasjonen, ikke disse to agentene. Vi har altså ingen måling
+> som sier at Sol holder nivået til Opus 4.6 for dem, og byttet hviler på prisen
+> alene. Prisgevinsten gjelder i tillegg bare kontekster under 272K tokens: Sol
+> har et eget prisnivå for lang kontekst, Opus 4.6 har ikke det, og over 272K er
+> Sol til antatt standardpris (8 og 30 dollar) dyrere enn Opus 4.6 på begge
+> akser.
 
 Tallene har en dato av en grunn. Sol lå på 5 og 30 dollar da vi sist synkroniserte prisene 10. august, og falt til 2 og 10 i løpet av måneden. Prislista i `apps/my-copilot/src/lib/model-pricing.ts` er den vi regner ut fra.
 


### PR DESCRIPTION
Retter tre påstander som ble med inn i #507. Modellpinningene står urørt: `@security-champion` og `@nav-pilot-opus` blir stående på GPT-5.6 Sol. Det er dokumentasjonen som lovet mer enn tallene bærer.

## 1. «Uten målbart tap mot Opus 4.6»

Den sammenlikningen har aldri vært kjørt. Benchmarken i `docs/nav-pilot-benchmark-og-beslutninger-2026-08.md` målte Claude Sonnet 4.6, GPT-5.6 Sol, GPT-5.6 Luna og GPT-5.6 Terra. Opus 4.6, modellen de to agentene faktisk flytter fra, var ikke med. Harnesset tester dessuten nav-pilot-personaen, ikke disse to agentene, og målingen er én regex-påstand på én prompt med Fisher p = 1,00, altså umulig å skille, ikke likeverdig.

Erstattet med: disse to agentene er ikke målt mot noen modell, og byttet hviler på pris.

## 2. «Billigere på begge akser» holder ikke for lang kontekst

Priser verifisert mot `apps/my-copilot/src/lib/model-pricing.ts`:

| Modell | Input | Output |
|---|---|---|
| Claude Opus 4.6 (flat, ingen langkontekst-rad) | $5.00 | $25.00 |
| GPT-5.6 Sol ≤ 272K, kampanje | $2.00 | $10.00 |
| GPT-5.6 Sol ≤ 272K, antatt standard | $4.00 | $20.00 |
| GPT-5.6 Sol > 272K, kampanje | $4.00 | $15.00 |
| GPT-5.6 Sol > 272K, antatt standard | $8.00 | $30.00 |

Over 272K, etter at kampanjen løper ut, er Sol dyrere enn Opus 4.6 på begge akser. Begge agentene er pitchet mot tung resonnering over store kodebaser, som er arbeidslasten som oftest krysser 272K. Alle «begge akser»-påstandene er kvalifisert med terskelen, som allerede stod i dokumentet.

## 3. Kostnadsregelen velger ikke Sol

Blandet 10:1 til antatt standardpris: Sol 5,45, GPT-5.3-Codex 2,86, Gemini 3.1 Pro 2,91. De to siste er også Powerful. Regelen «når sikkerhet ikke skiller dem, avgjør kostnad» peker på dem, ikke på Sol. Dokumentet sier nå åpent at Sol er valgt som nærmeste erstatter i resonneringssjiktet, at det er en vurdering og ikke en måling, og navngir de billigere alternativene.

## Nyhetsartikkelen

`docs/news/articles/agenter-bytter-modell.md` er publisert og kunngjør byttet. Rettingsboksen er fjernet, og påstandene er rettet der de står: Sol-raden i pristabellen er merket som kampanjepris, gevinsten mot Opus 4.6 er 20 prosent under 272K og negativ over, og det står nå i teksten at Opus 4.6 ikke var med i målingen. Artikkelen er 678 ord mot 923 før. Til slutt står én linje om at den er rettet etter publisering, siden den allerede ligger ute på ki-utvikling.nav.no.

Forbeholdene i langform hører hjemme i `docs/modellvalg.md` og er ikke båret over i artikkelen.

## Godkjenningsregisteret er ute av takt

`copilot-intern/godkjenninger/modell-gpt-5.6.md` fører fortsatt GPT-5.6 Sol som «⏳ Venter godkjenning», uten dato og uten besluttende, samtidig som #507 pinner en sikkerhetsagent til modellen. Alle tre variantene (Sol, Terra, Luna) står slik, selv om vurderingen konkluderer med «Anbefalt å aktivere». Denne PR-en gjør ingenting med det, og fabrikkerer ingen godkjenning. Gapet er meldt i navikt/copilot#512.


