### PR TITLE
fix(harness): tre funn fra gjennomgangen av #509

### DIFF
--- a/scripts/nav-pilot-golden.sh
+++ b/scripts/nav-pilot-golden.sh
@@ -196,6 +196,7 @@ TIMEOUT_SECS="${NAV_PILOT_GOLDEN_TIMEOUT:-300}"
 AGENT="nav-pilot"
 PERSONA=""
 AGENT_NAME=""
+VALID_IDS=""
 
 # Per-prompt wall-clock guard, so one hung call cannot stall the suite. macOS
 # has no coreutils `timeout` by default; fall back to running unguarded.
@@ -263,12 +264,32 @@ PERSONA="$REPO_ROOT/agents/$AGENT.agent.md"
 # An --agent with no assertion group must not run. It would select zero tests
 # and print "All 0 assertions passed ✓" with exit 0, which is the loudest
 # possible vacuous pass: someone repins a model, sees green, ships.
+#
+# VALID_IDS is that list made explicit, so --only can be checked against it.
+# Keep each row in sync with the record_* IDs in the matching run_pass_<agent>:
+# an ID added there and not here is rejected by --only.
 case "$AGENT" in
-  nav-pilot|code-review|accessibility) ;;
+  nav-pilot)     VALID_IDS="1 2 3 4 5 6" ;;
+  code-review)   VALID_IDS="cr1 cr2 cr3 cr4" ;;
+  accessibility) VALID_IDS="uu1 uu2 uu3 uu4" ;;
   *) fail_preflight \
       "no assertion group for agent '$AGENT'" \
       "This harness has prompts and assertions for: nav-pilot, code-review, accessibility. Add a run_pass_<agent> derived from that agent's own file before benchmarking it." ;;
 esac
+
+# --only is the same trap one level down. IDs are prefixed per agent, so
+# `--agent code-review --only 2` matches no cr* ID: every `selected` call
+# returns false, nothing runs, and the summary reads "All 0 assertions
+# passed ✓" with exit 0. An ID the selected agent does not have is a typo
+# or a stale command line, never a request to assert nothing.
+if [[ -n "$ONLY" ]]; then
+  IFS=',' read -r -a only_ids <<<"$ONLY"
+  for only_id in "${only_ids[@]}"; do
+    [[ " $VALID_IDS " == *" $only_id "* ]] || fail_preflight \
+      "--only '$only_id' is not an assertion ID for agent '$AGENT'" \
+      "Assertion IDs for $AGENT: $VALID_IDS"
+  done
+fi
 
 # What the CLI is told to load. Read from the agent file's frontmatter, not
 # guessed from the filename: accessibility.agent.md declares
@@ -278,6 +299,16 @@ AGENT_NAME="$(awk '/^---$/ {n++; next} n==1 && /^name:[[:space:]]*/ {sub(/^name:
 [[ -n "$AGENT_NAME" ]] || fail_preflight \
   "$PERSONA has no 'name:' in its frontmatter" \
   "The CLI is launched with --agent <that name>; without it the harness cannot know which agent it would actually be measuring."
+
+# The name is frontmatter, and frontmatter is untrusted input on a branch
+# nobody has read yet. It is interpolated straight into a destination path
+# ($TEMPLATE/.github/agents/$AGENT_NAME.agent.md), so a `name: ../../../etc/x`
+# would have cp write outside the scratch workspace. Check it looks like a
+# filename before using it as one. Every name in agents/ matches: they are all
+# lowercase words joined by hyphens.
+[[ "$AGENT_NAME" =~ ^[A-Za-z0-9_-]+$ ]] || fail_preflight \
+  "$PERSONA declares an unusable agent name: '$AGENT_NAME'" \
+  "It becomes a filename and a --agent argument, so it must be letters, digits, '-' or '_' only."
 
 [[ "$REPEAT" =~ ^[1-9][0-9]*$ ]] || fail_preflight \
   "--repeat takes a positive integer, got '$REPEAT'" \
@@ -1455,7 +1486,14 @@ if [[ -n "$COMPARE_TO" ]]; then
   # is what a missing field means. Silence would let a nav-pilot baseline be
   # compared against a code-review run and reported as a size regression.
   BASE_AGENT="$(sed -n 's/^# agent:[[:space:]]*//p' "$COMPARE_TO" | head -1)"
-  [[ -n "$BASE_AGENT" ]] || BASE_AGENT="nav-pilot (assumed: baseline predates --agent)"
+  if [[ -z "$BASE_AGENT" ]]; then
+    # The assumption is a note, not part of the compared value. Folding it into
+    # BASE_AGENT made the string never equal "nav-pilot", so every valid
+    # nav-pilot-to-nav-pilot comparison against an older baseline warned about
+    # a mismatch that was not there.
+    BASE_AGENT="nav-pilot"
+    echo "  ${DIM}baseline has no agent line, so it predates --agent and can only have measured nav-pilot. Compared as nav-pilot.${RESET}"
+  fi
   [[ "$BASE_AGENT" == "$AGENT" ]] || \
     echo "  ${YELLOW}⚠ baseline agent: '$BASE_AGENT', this run: '$AGENT'. Different agents, different prompts. Not comparable.${RESET}"
   compat_warn model "${MODEL:-CLI default}"

--- a/scripts/nav-pilot-golden.sh
+++ b/scripts/nav-pilot-golden.sh
@@ -297,7 +297,10 @@ fi
 # guessed from the filename: accessibility.agent.md declares
 # `name: accessibility-agent`, and --agent accessibility would silently load
 # nothing. First `---` opens the block, the first `name:` inside it wins.
-AGENT_NAME="$(awk '/^---$/ {n++; next} n==1 && /^name:[[:space:]]*/ {sub(/^name:[[:space:]]*/, ""); print; exit}' "$PERSONA" | tr -d "\"'" | tr -d '[:space:]')"
+# The value is only trimmed and unquoted one layer, never squeezed: deleting
+# every space would turn `name: a b` into the plausible-looking `ab` and walk
+# it straight past the check below, launching an agent the file never declared.
+AGENT_NAME="$(awk '/^---$/ {n++; next} n==1 && /^name:[[:space:]]*/ {sub(/^name:[[:space:]]*/, ""); print; exit}' "$PERSONA" | sed -e 's/[[:space:]]*$//' -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'\$/\1/")"
 [[ -n "$AGENT_NAME" ]] || fail_preflight \
   "$PERSONA has no 'name:' in its frontmatter" \
   "The CLI is launched with --agent <that name>; without it the harness cannot know which agent it would actually be measuring."
@@ -306,8 +309,9 @@ AGENT_NAME="$(awk '/^---$/ {n++; next} n==1 && /^name:[[:space:]]*/ {sub(/^name:
 # nobody has read yet. It is interpolated straight into a destination path
 # ($TEMPLATE/.github/agents/$AGENT_NAME.agent.md), so a `name: ../../../etc/x`
 # would have cp write outside the scratch workspace. Check it looks like a
-# filename before using it as one. Every name in agents/ matches: they are all
-# lowercase words joined by hyphens.
+# filename before using it as one: letters, digits, '-' and '_', nothing else.
+# Every name in agents/ matches; they happen to be lowercase and hyphenated,
+# but the check does not require that.
 [[ "$AGENT_NAME" =~ ^[A-Za-z0-9_-]+$ ]] || fail_preflight \
   "$PERSONA declares an unusable agent name: '$AGENT_NAME'" \
   "It becomes a filename and a --agent argument, so it must be letters, digits, '-' or '_' only."
@@ -1562,7 +1566,7 @@ if [[ $((pass_count + fail_count + error_count)) -eq 0 ]]; then
   if [[ $soft_count -gt 0 ]]; then
     echo "${DIM}Only soft checks were selected, and a soft check cannot fail. This run proved nothing.${RESET}"
   fi
-  echo "${DIM}Select at least one assertion that can fail: --only 2 runs the stop invariant and reports 2b with it.${RESET}"
+  echo "${DIM}Select at least one assertion that can fail. Assertion IDs for $AGENT: $VALID_IDS${RESET}"
   exit 3
 fi
 if [[ $fail_count -eq 0 && $error_count -eq 0 ]]; then

--- a/scripts/nav-pilot-golden.sh
+++ b/scripts/nav-pilot-golden.sh
@@ -176,8 +176,10 @@
 #   1  at least one assertion failed
 #   2  preflight failed (no client, not authenticated, agent file missing,
 #      an --agent with no assertion group, bad flag)
-#   3  no assertion failed, but at least one test could not be evaluated
-#      (empty transcript, or the response never reached the phase under test).
+#   3  nothing failed, but nothing was proven either: at least one test could
+#      not be evaluated (empty transcript, or the response never reached the
+#      phase under test), or the selection contained no assertion that can fail
+#      at all (--only naming only soft IDs, like `--only 2b`).
 #      This is deliberately NOT 0: a test that never ran has proven nothing.
 #
 #   Soft checks (ids like 2b) never change the exit code, in either direction.
@@ -269,7 +271,7 @@ PERSONA="$REPO_ROOT/agents/$AGENT.agent.md"
 # Keep each row in sync with the record_* IDs in the matching run_pass_<agent>:
 # an ID added there and not here is rejected by --only.
 case "$AGENT" in
-  nav-pilot)     VALID_IDS="1 2 3 4 5 6" ;;
+  nav-pilot)     VALID_IDS="1 2 2b 3 4 5 6" ;;
   code-review)   VALID_IDS="cr1 cr2 cr3 cr4" ;;
   accessibility) VALID_IDS="uu1 uu2 uu3 uu4" ;;
   *) fail_preflight \
@@ -889,7 +891,7 @@ run_pass_nav_pilot() {
   # N/11` with justification for the skipped ones is required by `### Fase 1:
   # Intervju`, it is the one field the prose ending does not replace in any run,
   # and it is a real audit loss for as long as it is missing.
-  if selected 2 || selected 3; then
+  if selected 2 || selected 2b || selected 3; then
     DESC2="full tier: response stops after Fase 1 with questions outstanding"
     DESC2B="full tier: Fase 1 checkpoint block emitted, with the blind-spot count"
     DESC3="full tier: blind spots #1 (personvern) and #2 (tilgangskontroll) both raised"
@@ -923,8 +925,10 @@ run_pass_nav_pilot() {
         fi
       fi
 
-      if selected 2; then
-        # SOFT. See the block comment above tests 2 + 2b. Each part is reported
+      if selected 2 || selected 2b; then
+        # SOFT. See the block comment above tests 2 + 2b. `--only 2` keeps
+        # reporting both parts of the split, and `--only 2b` asks for this part
+        # alone; an ID that preflight accepts has to reach the code that runs it. Each part is reported
         # separately: if the audit count starts showing up as prose while the block
         # still does not, that is progress and the next attempt should see it.
         missing=""
@@ -1548,6 +1552,18 @@ fi
 echo "─────────────────────────────────────────────"
 if [[ $soft_count -gt 0 ]]; then
   echo "${DIM}$soft_count soft check(s) reported above. Soft checks never move the exit code.${RESET}"
+fi
+if [[ $((pass_count + fail_count + error_count)) -eq 0 ]]; then
+  # Preflight rejects an --only that names nothing, but an --only naming only
+  # soft IDs passes it and still asserts nothing: a soft check reports and never
+  # fails, so `--only 2b` alone would reach the green line below with a count of
+  # zero. Same vacuous pass as an unknown ID, one step further down.
+  echo "${YELLOW}${BOLD}No hard assertion ran ⚠${RESET}"
+  if [[ $soft_count -gt 0 ]]; then
+    echo "${DIM}Only soft checks were selected, and a soft check cannot fail. This run proved nothing.${RESET}"
+  fi
+  echo "${DIM}Select at least one assertion that can fail: --only 2 runs the stop invariant and reports 2b with it.${RESET}"
+  exit 3
 fi
 if [[ $fail_count -eq 0 && $error_count -eq 0 ]]; then
   echo "${GREEN}${BOLD}All $pass_count assertions passed ✓${RESET}"


### PR DESCRIPTION
Retter de tre funnene fra gjennomgangen av #509. PR-en ble merget før funnene var adressert, så alle tre står på main nå.

Referanser til de opprinnelige kommentarene:
- https://github.com/navikt/copilot/pull/509#discussion_r3892282363 (`--only` velger null assertions)
- https://github.com/navikt/copilot/pull/509#discussion_r3892282389 (falsk "Different agents"-advarsel)
- https://github.com/navikt/copilot/pull/509#discussion_r3892282406 (uvalidert frontmatter i en sti)

## 1. `--only` kunne velge null assertions

IDene er prefikset per agent, så `--agent code-review --only 2` traff ingen `cr*`-ID. Hver `selected`-sjekk returnerte usant, ingenting kjørte, og oppsummeringen skrev en grønn null. `--agent` var allerede vernet mot akkurat dette; `--only` var det ikke.

Før, på main:

```
$ ./scripts/nav-pilot-golden.sh --agent code-review --only 2
─────────────────────────────────────────────
All 0 assertions passed ✓
exit=0
```

Etter:

```
$ ./scripts/nav-pilot-golden.sh --agent code-review --only 2
✗ preflight: --only '2' is not an assertion ID for agent 'code-review'
  → Assertion IDs for code-review: cr1 cr2 cr3 cr4
exit=2
```

Gyldige IDer går fortsatt gjennom, verifisert med `--dry-run` for alle tre gruppene: `1,2,3,4,5,6`, `cr1,cr2,cr3,cr4` og `uu1,uu2,uu3,uu4`.

## 2. Falsk "Different agents"-advarsel

En baseline uten `# agent:`-linje satte `BASE_AGENT` til `"nav-pilot (assumed: baseline predates --agent)"`, som aldri er lik `nav-pilot`. Dermed advarte hver eneste gyldige nav-pilot-mot-nav-pilot-sammenligning mot en gammel baseline.

Antagelsen hører ikke hjemme i verdien som sammenlignes. Manglende linje leses nå som `nav-pilot`, og antagelsen skrives som en egen merknad i `compat_note`-stil (dempet, ikke `⚠`), siden den er opplysning og ikke et avvik.

Før, mot en baseline uten `# agent:`:

```
  ⚠ baseline agent: 'nav-pilot (assumed: baseline predates --agent)', this run: 'nav-pilot'. Different agents, different prompts. Not comparable.
```

Etter, samme baseline:

```
  baseline has no agent line, so it predates --agent and can only have measured nav-pilot. Compared as nav-pilot.
```

Et reelt avvik advarer fortsatt. Mot en baseline med `# agent: code-review`:

```
  ⚠ baseline agent: 'code-review', this run: 'nav-pilot'. Different agents, different prompts. Not comparable.
```

## 3. Uvalidert frontmatter i en sti

`AGENT_NAME` leses fra frontmatter og interpoleres rett inn i `$TEMPLATE/.github/agents/$AGENT_NAME.agent.md`. Dette er ikke teoretisk. Med en agentfil som deklarerer `name: ../../../../pwned` skrev `cp` utenfor arbeidsmappa på main:

```
$ ls -l $TMPDIR/pwned.agent.md
-rw-r--r--  1 hans  staff  59 Aug 31 09:07 /var/folders/.../T/pwned.agent.md
```

Navnet valideres nå mot `^[A-Za-z0-9_-]+$` før første bruk:

```
✗ preflight: .../code-review.agent.md declares an unusable agent name: '../../../../pwned'
  → It becomes a filename and a --agent argument, so it must be letters, digits, '-' or '_' only.
```

Ingenting skrives utenfor arbeidsmappa etterpå. Mønsteret er konservativt, men avviser ingen ekte agent: alle ti navnene i `agents/` passerer.

```
  accept   accessibility-agent          accessibility.agent.md
  accept   aksel-agent                  aksel.agent.md
  accept   code-review                  code-review.agent.md
  accept   forfatter                    forfatter.agent.md
  accept   kafka-agent                  kafka.agent.md
  accept   nav-pilot-opus               nav-pilot-opus.agent.md
  accept   nav-pilot                    nav-pilot.agent.md
  accept   research-agent               research.agent.md
  accept   rust-agent                   rust.agent.md
  accept   security-champion-agent      security-champion.agent.md
```

Avvist: `../../../../pwned`, `/etc/passwd`, `..`, `a/b`, `a b`, `$(id)`.

## Verifisering

- `shellcheck` og `bash -n` rene, under både bash 3.2 (systemets `/bin/bash`) og bash 5.3. Alle preflight-bevisene over er kjørt under begge.
- `mise run nav-pilot:check` passerer.
- Ingen assertion-ID og ingen testnummerering er endret, så lagrede baselines under `docs/golden-baselines/` er fortsatt sammenlignbare.
- Ingen kall mot en ekte klient. Funn 1 og 3 stopper i preflight, funn 2 er verifisert med en stubbet `copilot` på PATH i en midlertidig mappe.

## 4. `--only 2b` etter #491

#491 ble merget mens denne grenen lå ute, så konflikten som var varslet er nå reell. Rebaset på main uten konflikt: #491 rørte andre deler av filen enn de tre rettelsene.

`2b` er ført opp i `VALID_IDS` for nav-pilot. Det alene var ikke nok. Den myke sjekken var portet på `selected 2`, så `--only 2b` ville passert preflight og deretter kjørt ingenting, altså akkurat den tomme grønne kjøringen punkt 1 fjerner, bare gjennom en ID som faktisk finnes. Porten leser nå `selected 2 || selected 2b`.

Og en myk sjekk kan per definisjon ikke feile, så et utvalg som bare inneholder myke IDer traff fortsatt den grønne linjen med null talte assertions:

```
$ ./scripts/nav-pilot-golden.sh --only 2b     # på main
─────────────────────────────────────────────
All 0 assertions passed ✓
exit=0
```

Etter:

```
$ ./scripts/nav-pilot-golden.sh --only 2b
  ✓ 2b full tier: Fase 1 checkpoint block emitted, with the blind-spot count (soft)
─────────────────────────────────────────────
1 soft check(s) reported above. Soft checks never move the exit code.
No hard assertion ran ⚠
Only soft checks were selected, and a soft check cannot fail. This run proved nothing.
Select at least one assertion that can fail: --only 2 runs the stop invariant and reports 2b with it.
exit=3
```

Den myke sjekken kjører altså nå på ekte når man ber om den, og kjøringen lyver ikke om hva den beviste. Exit 3 er dokumentert på nytt til å dekke begge måtene en kjøring kan bevise ingenting på.

`--only 2` er uendret og rapporterer fortsatt begge delene av splitten. Utskrift og exit-kode er byte for byte lik main for både `--only 2` og en full kjøring; bare et rent mykt utvalg oppfører seg annerledes.

Avvist fortsatt: `2c`, `7`, `2B`, og `cr1` under `--agent nav-pilot`.

## Myke rader forstyrrer ikke sammenligningen

Kontrollert siden #491 la til `record_soft`: myke rader går til `AGG_TESTS`, mens `--compare` og `--save-baseline` leser `AGG_SIZES`, som er nøklet på prompt-slug (`t1`, `t2`). En baseline skrevet etter #491 inneholder ingen `2b`- eller `soft`-rad, og sammenligningstabellen er identisk med main sin.
