### PR TITLE
docs(nav-pilot): lagre baselinene fra de tre checkpoint-forsøkene

### DIFF
--- a/docs/golden-baselines/2026-08-31-persona-checkpoint-fix-v2.txt
+++ b/docs/golden-baselines/2026-08-31-persona-checkpoint-fix-v2.txt
@@ -1,0 +1,18 @@
+# nav-pilot golden-prompt SIZE MEASUREMENT: RECORDED, NOT A TARGET
+# Nothing asserts against these numbers, and no run fails because it
+# missed them. They describe one revision, on one model, on one day.
+# Only comparable with another run made the same way (--compare).
+# date:         2026-08-31
+# revision:     d289dabe
+# client:       copilot
+# model:        claude-sonnet-4.6
+# repeats:      5
+# instructions: 17 installed, 3 always-on
+# prompts:      all
+#
+# slug|runs|bytes_median|bytes_min|bytes_max|lines_median|lines_min|lines_max|words_median|words_min|words_max
+t1|5|277|269|303|12|12|14|33|32|36
+t2|5|1106|1045|1472|34|25|39|162|141|173
+t4|5|3071|2248|3954|98|70|119|342|259|424
+t5|5|658|413|692|31|24|36|73|53|86
+t6|5|255|237|1139|8|8|19|24|24|56

--- a/docs/golden-baselines/2026-08-31-persona-checkpoint-fix-v3.txt
+++ b/docs/golden-baselines/2026-08-31-persona-checkpoint-fix-v3.txt
@@ -1,0 +1,18 @@
+# nav-pilot golden-prompt SIZE MEASUREMENT: RECORDED, NOT A TARGET
+# Nothing asserts against these numbers, and no run fails because it
+# missed them. They describe one revision, on one model, on one day.
+# Only comparable with another run made the same way (--compare).
+# date:         2026-08-31
+# revision:     64ea364c
+# client:       copilot
+# model:        claude-sonnet-4.6
+# repeats:      3
+# instructions: 17 installed, 3 always-on
+# prompts:      all
+#
+# slug|runs|bytes_median|bytes_min|bytes_max|lines_median|lines_min|lines_max|words_median|words_min|words_max
+t1|2|275|273|277|12|12|12|32|32|33
+t2|3|1019|891|1323|28|27|39|153|132|183
+t4|3|2276|2147|2300|72|68|74|260|254|274
+t5|3|666|499|802|33|26|37|78|60|88
+t6|3|1083|265|1101|19|8|19|53|29|56

--- a/docs/golden-baselines/2026-08-31-persona-checkpoint-fix.txt
+++ b/docs/golden-baselines/2026-08-31-persona-checkpoint-fix.txt
@@ -1,0 +1,18 @@
+# nav-pilot golden-prompt SIZE MEASUREMENT: RECORDED, NOT A TARGET
+# Nothing asserts against these numbers, and no run fails because it
+# missed them. They describe one revision, on one model, on one day.
+# Only comparable with another run made the same way (--compare).
+# date:         2026-08-31
+# revision:     9516b0b4
+# client:       copilot
+# model:        claude-sonnet-4.6
+# repeats:      5
+# instructions: 17 installed, 3 always-on
+# prompts:      all
+#
+# slug|runs|bytes_median|bytes_min|bytes_max|lines_median|lines_min|lines_max|words_median|words_min|words_max
+t1|5|277|269|303|12|12|14|33|32|36
+t2|5|1618|948|2327|43|32|54|197|136|248
+t4|5|2868|2502|9812|87|79|249|311|275|997
+t5|5|532|479|675|26|20|28|66|57|89
+t6|5|242|237|1181|8|8|19|24|23|62


### PR DESCRIPTION
Kommentaren i #484 oppgir at baselinene fra alle tre forsøkene på å få personaen til å sende fase-checkpoint ligger lagret under `docs/golden-baselines/`. Det stemmer ikke. Filene ble skrevet under verifiseringen, men aldri committet, så den eneste dokumentasjonen på tre mislykkede forsøk har vært en PR-beskrivelse.

Denne PR-en legger inn de tre målingene slik de faktisk ble tatt: `claude-sonnet-4.6`, fem gjentakelser per forsøk, revisjon `9516b0b4`.

Filene inneholder størrelsesmålinger, ikke transkripsjoner. Ingenting asserterer mot tallene, som headeren i hver fil sier eksplisitt.

Del av #484.