### PR TITLE
feat(pricing): les kampanjefotnotene fra prissiden

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -90,6 +90,10 @@ run = "bash scripts/lint-collections.sh"
 description = "Check if model pricing data is in sync with GitHub docs"
 run = "node scripts/sync-model-pricing.mjs --check"
 
+[tasks."pricing:test"]
+description = "Test the pricing parser, including the promotion footnotes"
+run = "node --test scripts/sync-model-pricing.test.mjs"
+
 [tasks."pricing:sync"]
 description = "Fetch latest model pricing from GitHub docs and update data file"
 run = "node scripts/sync-model-pricing.mjs"

--- a/apps/my-copilot/src/lib/model-pricing.ts
+++ b/apps/my-copilot/src/lib/model-pricing.ts
@@ -1,7 +1,7 @@
 /**
  * GitHub Copilot model pricing data.
  * Source: https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
- * Last updated: 2026-08-30
+ * Last updated: 2026-08-31
  *
  * All prices are per 1 million tokens in USD.
  * 1 AI credit = $0.01 USD.
@@ -18,6 +18,8 @@ export interface ModelPrice {
   cachedInput: number;
   cacheWrite?: number;
   output: number;
+  /** ISO date the promotional price in the note runs through, if any. */
+  promotionEndsOn?: string;
   note?: string;
 }
 
@@ -124,6 +126,8 @@ export const MODEL_PRICING: ModelPrice[] = [
     cachedInput: 0.2,
     cacheWrite: 2.5,
     output: 10,
+    promotionEndsOn: "2026-09-03",
+    note: "GPT-5.6 Sol is available at promotional pricing, 50% off standard rates, through September 3, 2026. The default tier is $2.00 per 1M input tokens, $0.20 per 1M cached input tokens, $2.50 per 1M cache write tokens, and $10.00 per 1M output tokens. The long context tier is $4.00 per 1M input tokens, $0.40 per 1M cached input tokens, $5.00 per 1M cache write tokens, and $15.00 per 1M output tokens.",
   },
   {
     model: "GPT-5.6 Sol (Long context, 272K)",
@@ -134,6 +138,8 @@ export const MODEL_PRICING: ModelPrice[] = [
     cachedInput: 0.4,
     cacheWrite: 5,
     output: 15,
+    promotionEndsOn: "2026-09-03",
+    note: "GPT-5.6 Sol is available at promotional pricing, 50% off standard rates, through September 3, 2026. The default tier is $2.00 per 1M input tokens, $0.20 per 1M cached input tokens, $2.50 per 1M cache write tokens, and $10.00 per 1M output tokens. The long context tier is $4.00 per 1M input tokens, $0.40 per 1M cached input tokens, $5.00 per 1M cache write tokens, and $15.00 per 1M output tokens.",
   },
   {
     model: "GPT-5.6 Terra (Default, ≤ 272K)",
@@ -312,6 +318,8 @@ export const MODEL_PRICING: ModelPrice[] = [
     input: 0.75,
     cachedInput: 0.075,
     output: 3.75,
+    promotionEndsOn: "2026-12-31",
+    note: "Gemini 3.6 Flash and Gemini 3.7 Flash are available at the promotional pricing of $0.75 per 1M input tokens, $0.075 per 1M cached input tokens, and $3.75 per 1M output tokens through December 31, 2026.",
   },
   {
     model: "Gemini 3.7 Flash (Default)",
@@ -321,6 +329,8 @@ export const MODEL_PRICING: ModelPrice[] = [
     input: 0.75,
     cachedInput: 0.075,
     output: 3.75,
+    promotionEndsOn: "2026-12-31",
+    note: "Gemini 3.6 Flash and Gemini 3.7 Flash are available at the promotional pricing of $0.75 per 1M input tokens, $0.075 per 1M cached input tokens, and $3.75 per 1M output tokens through December 31, 2026.",
   },
   // GitHub
   {
@@ -373,4 +383,4 @@ export const MODEL_PRICING: ModelPrice[] = [
 ];
 
 export const PRICING_SOURCE_URL = "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing";
-export const PRICING_LAST_UPDATED = "2026-08-30";
+export const PRICING_LAST_UPDATED = "2026-08-31";

--- a/hack/check.sh
+++ b/hack/check.sh
@@ -40,7 +40,7 @@ else
 fi
 
 echo "💰 pricing:"
-if mise run pricing:check; then
+if mise run pricing:test && mise run pricing:check; then
   echo ""
 else
   failed+=("pricing")

--- a/scripts/sync-model-pricing.mjs
+++ b/scripts/sync-model-pricing.mjs
@@ -21,7 +21,7 @@ const TARGET_FILE = new URL(
 );
 
 import { readFileSync, writeFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 // --- Fetch and parse ---
 
@@ -37,6 +37,7 @@ async function fetchPricingPage() {
  */
 function parsePricingTables(html) {
   const models = [];
+  const footnotes = parseFootnotes(html);
 
   // Extract provider sections by matching h3 headers followed by tables
   const sections = [
@@ -82,9 +83,8 @@ function parsePricingTables(html) {
     }
 
     for (let i = 1; i < rows.length; i++) {
-      const cells = [...rows[i][1].matchAll(/<t[dh][^>]*>([\s\S]*?)<\/t[dh]>/g)].map(
-       (m) => stripHtml(m[1]).trim()
-      );
+      const rawCells = [...rows[i][1].matchAll(/<t[dh][^>]*>([\s\S]*?)<\/t[dh]>/g)].map((m) => m[1]);
+      const cells = rawCells.map((c) => stripHtml(c).trim());
       const model = getCell(cells, requiredColumns.model);
       if (!model) continue;
 
@@ -113,6 +113,17 @@ function parsePricingTables(html) {
 
       if (cacheWrite !== undefined) {
         entry.cacheWrite = cacheWrite;
+      }
+
+      // Promotional prices live in footnotes the model cell links to. The
+      // price itself parses fine without them, but it is the promotional one,
+      // so a row without its footnote reads as permanent when it is not.
+      const footnoteId = findFootnoteId(getCell(rawCells, requiredColumns.model));
+      const note = footnoteId ? footnotes.get(footnoteId) : undefined;
+      if (note) {
+        entry.note = note;
+        const endsOn = parsePromotionEndDate(note);
+        if (endsOn) entry.promotionEndsOn = endsOn;
       }
 
       models.push(entry);
@@ -148,6 +159,50 @@ function findHeaderIndex(headerMap, names) {
 function getCell(cells, index) {
   if (index < 0 || index >= cells.length) return undefined;
   return cells[index];
+}
+
+/** Footnote id a model cell references, e.g. "gpt-56-sol-promo". */
+function findFootnoteId(rawCell) {
+  return rawCell?.match(/#user-content-fn-([\w-]+)/)?.[1];
+}
+
+/** Map of footnote id to plain text from the page's <section data-footnotes>. */
+function parseFootnotes(html) {
+  const notes = new Map();
+  const section = html.match(/<section[^>]*data-footnotes[\s\S]*?<\/section>/)?.[0];
+  if (!section) return notes;
+  for (const [, id, body] of section.matchAll(/<li id="user-content-fn-([\w-]+)">([\s\S]*?)<\/li>/g)) {
+    // stripHtml drops the backref anchors along with the rest of the markup.
+    const text = stripHtml(body).replace(/\s+/g, " ").trim();
+    if (text) notes.set(id, text);
+  }
+  return notes;
+}
+
+const MONTHS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+/**
+ * ISO date from a footnote's "through September 3, 2026". Date.parse is
+ * avoided on purpose: it reads the date as local midnight, which toISOString
+ * then shifts a day backwards east of UTC.
+ */
+function parsePromotionEndDate(note) {
+  const match = note.match(new RegExp(`through (${MONTHS.join("|")}) (\\d{1,2}), (\\d{4})`, "i"));
+  if (!match) return undefined;
+  const month = MONTHS.findIndex((m) => m.toLowerCase() === match[1].toLowerCase()) + 1;
+  return `${match[3]}-${String(month).padStart(2, "0")}-${match[2].padStart(2, "0")}`;
+}
+
+/**
+ * Rows carrying a footnote we could not date. The price is promotional, and
+ * shipping it without an end date is the silent wrong answer, so the caller
+ * must fail rather than publish it.
+ */
+function findUndatedPromotions(models) {
+  return models.filter((m) => m.note && !m.promotionEndsOn);
 }
 
 function stripHtml(html) {
@@ -243,6 +298,9 @@ function generateTypeScript(models) {
         entries += `    cacheWrite: ${m.cacheWrite},\n`;
       }
       entries += `    output: ${m.output},\n`;
+      if (m.promotionEndsOn) {
+        entries += `    promotionEndsOn: ${JSON.stringify(m.promotionEndsOn)},\n`;
+      }
       if (m.note) {
         entries += `    note: ${JSON.stringify(m.note)},\n`;
       }
@@ -270,6 +328,8 @@ export interface ModelPrice {
   cachedInput: number;
   cacheWrite?: number;
   output: number;
+  /** ISO date the promotional price in the note runs through, if any. */
+  promotionEndsOn?: string;
   note?: string;
 }
 
@@ -302,6 +362,15 @@ async function main() {
       `ERROR: parsed ${models.length} models, down from ${currentCount} in the generated file.`,
     );
     console.error("The page structure may have changed. Manual update required.");
+    process.exit(1);
+  }
+
+  const undatedPromotions = findUndatedPromotions(models);
+  if (undatedPromotions.length > 0) {
+    console.error("ERROR: models with a footnote whose end date could not be parsed:");
+    for (const m of undatedPromotions) {
+      console.error(`  ${m.provider}/${m.model}: ${m.note}`);
+    }
     process.exit(1);
   }
 
@@ -344,7 +413,11 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error("Failed:", err.message);
-  process.exit(1);
-});
+export { parsePricingTables, parseFootnotes, parsePromotionEndDate, findFootnoteId, findUndatedPromotions };
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error("Failed:", err.message);
+    process.exit(1);
+  });
+}

--- a/scripts/sync-model-pricing.mjs
+++ b/scripts/sync-model-pricing.mjs
@@ -9,8 +9,9 @@
  *
  * --check exit codes: 0 up to date (only the timestamp would move), 2 prices
  * moved, 1 the check could not be made (fetch failed, parse floor tripped, a
- * model came back unpriced). 2 is separate from 1 so a caller can act on real
- * drift without also acting on a check that never got an answer.
+ * model came back unpriced, or a promotion footnote did not resolve to an end
+ * date). 2 is separate from 1 so a caller can act on real drift without also
+ * acting on a check that never got an answer.
  */
 
 const PRICING_URL =
@@ -119,11 +120,16 @@ function parsePricingTables(html) {
       // price itself parses fine without them, but it is the promotional one,
       // so a row without its footnote reads as permanent when it is not.
       const footnoteId = findFootnoteId(getCell(rawCells, requiredColumns.model));
-      const note = footnoteId ? footnotes.get(footnoteId) : undefined;
-      if (note) {
-        entry.note = note;
-        const endsOn = parsePromotionEndDate(note);
-        if (endsOn) entry.promotionEndsOn = endsOn;
+      if (footnoteId) {
+        // Kept on the record even when the footnote does not resolve, so the
+        // guard below can see the reference and refuse to publish the row.
+        entry.footnoteId = footnoteId;
+        const note = footnotes.get(footnoteId);
+        if (note) {
+          entry.note = note;
+          const endsOn = parsePromotionEndDate(note);
+          if (endsOn) entry.promotionEndsOn = endsOn;
+        }
       }
 
       models.push(entry);
@@ -197,12 +203,14 @@ function parsePromotionEndDate(note) {
 }
 
 /**
- * Rows carrying a footnote we could not date. The price is promotional, and
- * shipping it without an end date is the silent wrong answer, so the caller
- * must fail rather than publish it.
+ * Rows whose footnote reference did not turn into an end date, either because
+ * the footnote body is missing from the page or because its date would not
+ * parse. Both mean the price is promotional and we cannot say until when, and
+ * shipping that is the silent wrong answer, so the caller must fail rather
+ * than publish the row.
  */
-function findUndatedPromotions(models) {
-  return models.filter((m) => m.note && !m.promotionEndsOn);
+function findUnresolvedPromotions(models) {
+  return models.filter((m) => m.footnoteId && !m.promotionEndsOn);
 }
 
 function stripHtml(html) {
@@ -365,11 +373,13 @@ async function main() {
     process.exit(1);
   }
 
-  const undatedPromotions = findUndatedPromotions(models);
-  if (undatedPromotions.length > 0) {
-    console.error("ERROR: models with a footnote whose end date could not be parsed:");
-    for (const m of undatedPromotions) {
-      console.error(`  ${m.provider}/${m.model}: ${m.note}`);
+  const unresolvedPromotions = findUnresolvedPromotions(models);
+  if (unresolvedPromotions.length > 0) {
+    console.error("ERROR: models with a footnote that did not yield a promotion end date:");
+    for (const m of unresolvedPromotions) {
+      console.error(
+        `  ${m.provider}/${m.model}: ${m.note ?? `footnote #${m.footnoteId} not found on the page`}`,
+      );
     }
     process.exit(1);
   }
@@ -413,7 +423,7 @@ async function main() {
   }
 }
 
-export { parsePricingTables, parseFootnotes, parsePromotionEndDate, findFootnoteId, findUndatedPromotions };
+export { parsePricingTables, parseFootnotes, parsePromotionEndDate, findFootnoteId, findUnresolvedPromotions };
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch((err) => {

--- a/scripts/sync-model-pricing.test.mjs
+++ b/scripts/sync-model-pricing.test.mjs
@@ -15,8 +15,13 @@ import {
   parsePricingTables,
   parseFootnotes,
   parsePromotionEndDate,
-  findUndatedPromotions,
+  findUnresolvedPromotions,
 } from "./sync-model-pricing.mjs";
+
+// The fixtures carry two provider tables, not all six, and the parser warns
+// once per missing section. Silenced so a green `mise run check` stays green
+// looking.
+console.warn = () => {};
 
 // Verbatim from docs.github.com, 2026-08-31.
 const FOOTNOTES = `<section data-footnotes="" class="footnotes"><h2 class="sr-only" id="footnote-label" tabindex="-1">Footnotes</h2>
@@ -86,16 +91,36 @@ test("models without a footnote get neither field", () => {
   }
 });
 
+const SOL_ROWS = ["GPT-5.6 Sol (Default, ≤ 272K)", "GPT-5.6 Sol (Long context, 272K)"];
+
 test("an undatable footnote is flagged, not silently dropped", () => {
   const broken = PAGE.replace("through September 3, 2026", "through the end of the promotion");
-  const models = parsePricingTables(broken);
-  const undated = findUndatedPromotions(models);
-  assert.deepEqual(
-    undated.map((m) => m.model),
-    ["GPT-5.6 Sol (Default, ≤ 272K)", "GPT-5.6 Sol (Long context, 272K)"],
-  );
+  const unresolved = findUnresolvedPromotions(parsePricingTables(broken));
+  assert.deepEqual(unresolved.map((m) => m.model), SOL_ROWS);
   // The note survives so the error message can name what went unparsed.
-  assert.match(undated[0].note, /through the end of the promotion/);
+  assert.match(unresolved[0].note, /through the end of the promotion/);
+});
+
+test("a reference to a footnote that is not on the page is flagged too", () => {
+  // The whole footnotes section fails to match, which is what an upstream
+  // markup change looks like. Every reference is then dangling.
+  const unresolved = findUnresolvedPromotions(parsePricingTables(OPENAI_TABLE + GOOGLE_TABLE));
+  assert.deepEqual(unresolved.map((m) => m.model), [
+    ...SOL_ROWS,
+    "Gemini 3.6 Flash (Default)",
+    "Gemini 3.7 Flash (Default)",
+  ]);
+  assert.equal(unresolved[0].note, undefined);
+  assert.equal(unresolved[0].footnoteId, "gpt-56-sol-promo");
+});
+
+test("a reference to a footnote id missing from the list is flagged", () => {
+  const renamed = PAGE.replace('<li id="user-content-fn-gpt-56-sol-promo">', '<li id="user-content-fn-sol-promo-2027">');
+  const unresolved = findUnresolvedPromotions(parsePricingTables(renamed));
+  assert.deepEqual(unresolved.map((m) => m.model), SOL_ROWS);
+  // Gemini still resolves, so the guard is not just firing on everything.
+  const gemini = parsePricingTables(renamed).find((m) => m.model === "Gemini 3.6 Flash (Default)");
+  assert.equal(gemini.promotionEndsOn, "2026-12-31");
 });
 
 test("date parsing handles the shapes the page uses", () => {

--- a/scripts/sync-model-pricing.test.mjs
+++ b/scripts/sync-model-pricing.test.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * Tests for the footnote parsing in sync-model-pricing.mjs.
+ *
+ * Usage: node --test scripts/sync-model-pricing.test.mjs
+ *
+ * The fixtures are copied verbatim from the live pricing page, so a change in
+ * how GitHub marks up promotions shows up here as a failing test.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  parsePricingTables,
+  parseFootnotes,
+  parsePromotionEndDate,
+  findUndatedPromotions,
+} from "./sync-model-pricing.mjs";
+
+// Verbatim from docs.github.com, 2026-08-31.
+const FOOTNOTES = `<section data-footnotes="" class="footnotes"><h2 class="sr-only" id="footnote-label" tabindex="-1">Footnotes</h2>
+<ol>
+<li id="user-content-fn-gpt-56-sol-promo">
+<p>GPT-5.6 Sol is available at promotional pricing, 50% off standard rates, through September 3, 2026. The default tier is $2.00 per 1M input tokens, $0.20 per 1M cached input tokens, $2.50 per 1M cache write tokens, and $10.00 per 1M output tokens. The long context tier is $4.00 per 1M input tokens, $0.40 per 1M cached input tokens, $5.00 per 1M cache write tokens, and $15.00 per 1M output tokens. <a href="#user-content-fnref-gpt-56-sol-promo" data-footnote-backref="" aria-label="Back to reference 1" class="data-footnote-backref">↩</a> <a href="#user-content-fnref-gpt-56-sol-promo-2" data-footnote-backref="" aria-label="Back to reference 1-2" class="data-footnote-backref">↩<sup>2</sup></a></p>
+</li>
+<li id="user-content-fn-gemini-flash-promo">
+<p>Gemini 3.6 Flash and Gemini 3.7 Flash are available at the promotional pricing of $0.75 per 1M input tokens, $0.075 per 1M cached input tokens, and $3.75 per 1M output tokens through December 31, 2026. <a href="#user-content-fnref-gemini-flash-promo" data-footnote-backref="" aria-label="Back to reference 2" class="data-footnote-backref">↩</a> <a href="#user-content-fnref-gemini-flash-promo-2" data-footnote-backref="" aria-label="Back to reference 2-2" class="data-footnote-backref">↩<sup>2</sup></a></p>
+</li>
+</ol>
+</section>`;
+
+const solRef = (suffix) =>
+  `<sup><a href="#user-content-fn-gpt-56-sol-promo" id="user-content-fnref-gpt-56-sol-promo${suffix}" data-footnote-ref="" aria-describedby="footnote-label">1</a></sup>`;
+const flashRef = (suffix) =>
+  `<sup><a href="#user-content-fn-gemini-flash-promo" id="user-content-fnref-gemini-flash-promo${suffix}" data-footnote-ref="" aria-describedby="footnote-label">2</a></sup>`;
+
+const OPENAI_TABLE = `<h3 id="openai">OpenAI</h3><table aria-labelledby="openai"><thead><tr><th scope="col">Model</th><th scope="col">Release status</th><th scope="col">Category</th><th scope="col">Tier</th><th scope="col">Threshold (input tokens)</th><th scope="col">Input</th><th scope="col">Cached input</th><th scope="col">Cache write</th><th scope="col">Output</th></tr></thead><tbody>
+<tr><td>GPT-5.6 Sol${solRef("")}</td><td>GA</td><td>Powerful</td><td>Default</td><td>≤ 272K</td><td>$2.00</td><td>$0.20</td><td>$2.50</td><td>$10.00</td></tr>
+<tr><td>GPT-5.6 Sol${solRef("-2")}</td><td>GA</td><td>Powerful</td><td>Long context</td><td>&gt; 272K</td><td>$4.00</td><td>$0.40</td><td>$5.00</td><td>$15.00</td></tr>
+<tr><td>GPT-5.6 Luna</td><td>GA</td><td>Versatile</td><td>Default</td><td>Not applicable</td><td>$1.25</td><td>$0.125</td><td>Not applicable</td><td>$10.00</td></tr>
+</tbody></table>`;
+
+const GOOGLE_TABLE = `<h3 id="google">Google</h3><table aria-labelledby="google"><thead><tr><th scope="col">Model</th><th scope="col">Release status</th><th scope="col">Category</th><th scope="col">Tier</th><th scope="col">Threshold (input tokens)</th><th scope="col">Input</th><th scope="col">Cached input</th><th scope="col">Output</th></tr></thead><tbody>
+<tr><td>Gemini 3.5 Flash</td><td>GA</td><td>Lightweight</td><td>Default</td><td>Not applicable</td><td>$1.50</td><td>$0.15</td><td>$9.00</td></tr>
+<tr><td>Gemini 3.6 Flash${flashRef("")}</td><td>GA</td><td>Versatile</td><td>Default</td><td>Not applicable</td><td>$0.75</td><td>$0.075</td><td>$3.75</td></tr>
+<tr><td>Gemini 3.7 Flash${flashRef("-2")}</td><td>GA</td><td>Versatile</td><td>Default</td><td>Not applicable</td><td>$0.75</td><td>$0.075</td><td>$3.75</td></tr>
+</tbody></table>`;
+
+const PAGE = OPENAI_TABLE + GOOGLE_TABLE + FOOTNOTES;
+const byModel = (models, name) => models.find((m) => m.model === name);
+
+test("footnote list parses into id-keyed text without backref arrows", () => {
+  const notes = parseFootnotes(PAGE);
+  assert.deepEqual([...notes.keys()], ["gpt-56-sol-promo", "gemini-flash-promo"]);
+  assert.match(notes.get("gpt-56-sol-promo"), /^GPT-5\.6 Sol is available at promotional pricing/);
+  assert.ok(!notes.get("gpt-56-sol-promo").includes("↩"));
+});
+
+test("both GPT-5.6 Sol rows carry the promotion end date and the note", () => {
+  const models = parsePricingTables(PAGE);
+  for (const name of ["GPT-5.6 Sol (Default, ≤ 272K)", "GPT-5.6 Sol (Long context, 272K)"]) {
+    const row = byModel(models, name);
+    assert.ok(row, `missing row: ${name}`);
+    assert.equal(row.promotionEndsOn, "2026-09-03");
+    assert.match(row.note, /50% off standard rates/);
+  }
+});
+
+test("both promoted Gemini Flash rows carry the promotion end date", () => {
+  const models = parsePricingTables(PAGE);
+  for (const name of ["Gemini 3.6 Flash (Default)", "Gemini 3.7 Flash (Default)"]) {
+    const row = byModel(models, name);
+    assert.ok(row, `missing row: ${name}`);
+    assert.equal(row.promotionEndsOn, "2026-12-31");
+  }
+});
+
+test("models without a footnote get neither field", () => {
+  const models = parsePricingTables(PAGE);
+  for (const name of ["GPT-5.6 Luna (Default)", "Gemini 3.5 Flash (Default)"]) {
+    const row = byModel(models, name);
+    assert.ok(row, `missing row: ${name}`);
+    assert.equal(row.promotionEndsOn, undefined);
+    assert.equal(row.note, undefined);
+  }
+});
+
+test("an undatable footnote is flagged, not silently dropped", () => {
+  const broken = PAGE.replace("through September 3, 2026", "through the end of the promotion");
+  const models = parsePricingTables(broken);
+  const undated = findUndatedPromotions(models);
+  assert.deepEqual(
+    undated.map((m) => m.model),
+    ["GPT-5.6 Sol (Default, ≤ 272K)", "GPT-5.6 Sol (Long context, 272K)"],
+  );
+  // The note survives so the error message can name what went unparsed.
+  assert.match(undated[0].note, /through the end of the promotion/);
+});
+
+test("date parsing handles the shapes the page uses", () => {
+  assert.equal(parsePromotionEndDate("... through September 3, 2026."), "2026-09-03");
+  assert.equal(parsePromotionEndDate("... through December 31, 2026."), "2026-12-31");
+  assert.equal(parsePromotionEndDate("... through Smarch 3, 2026."), undefined);
+  assert.equal(parsePromotionEndDate("no end date at all"), undefined);
+});


### PR DESCRIPTION
Første av tre for #503. Denne PR-en er parseren alene.

## Problemet

GitHub merker kampanjepriser i fotnoter på prissiden. `scripts/sync-model-pricing.mjs` leste prisen, men ikke fotnoten, så en midlertidig pris havnet i `apps/my-copilot/src/lib/model-pricing.ts` som om den var ordinær. GPT-5.6 Sol reverterer 3. september, altså om tre dager, og da blir fila stille feil.

Informasjonen døde tre steder i `stripHtml`: `<sup>` ble fjernet med innhold, `<a>` ble fjernet med href-en som navngir fotnoten, og `parsePricingTables` så aldri på `<section data-footnotes>`.

## Hva som er gjort

Modellcella fanges rå før `stripHtml` kjører, `#user-content-fn-...` plukkes ut av den, fotnotelista parses én gang, og sluttdatoen leses ut av setningsformen «through September 3, 2026». To felt settes på raden:

- `promotionEndsOn`, ISO-dato, ny i `ModelPrice`
- `note`, fotnoteteksten. Feltet fantes allerede i både `ModelPrice` og `generateTypeScript`, men ingenting satte det.

Datoen bygges av en månedstabell, ikke `Date.parse`. `Date.parse` leser datoen som lokal midnatt, og `toISOString` flytter den da en dag bakover øst for UTC, altså hos oss. Det er nettopp den typen stille avvik saken handler om.

En fotnote vi ikke klarer å datere gir exit 1, i samme stil som vakta for umerkede priser. Notatet beholdes så feilmeldinga kan navngi teksten som ikke lot seg lese. Et merke som stille forsvinner er feilen dette skal hindre.

`main()` kjører bare når skriptet startes direkte, så parserfunksjonene kan importeres av testen.

## Tallene i den regenererte fila

| rad | `promotionEndsOn` |
|---|---|
| GPT-5.6 Sol (Default, ≤ 272K) | 2026-09-03 |
| GPT-5.6 Sol (Long context, 272K) | 2026-09-03 |
| Gemini 3.6 Flash (Default) | 2026-12-31 |
| Gemini 3.7 Flash (Default) | 2026-12-31 |

Luna og Gemini 3.5 Flash har ingen fotnote og får ingen felt, slik saken sa.

## Verifisering

`scripts/sync-model-pricing.test.mjs` kjører på `node --test` fra standardbiblioteket. Vitest dekker bare `apps/my-copilot/src/**`, og `scripts/` har ingen kjører i dag, så stdlib sparer oss både en ny avhengighet og en ny prosjektkonfigurasjon. De to fotnoteblokkene er kopiert ordrett fra prissiden, så en omlegging av markupen hos GitHub dukker opp som en rød test.

- `node --test scripts/sync-model-pricing.test.mjs`: 6 av 6 grønne
- `node scripts/sync-model-pricing.mjs --check`: exit 0 mot den regenererte fila
- `pnpm --filter my-copilot check`: eslint, tsc, prettier, knip og 503 vitest-tester grønne

## Utenfor omfang

`apps/my-copilot/src/lib/model-promotions.ts` og `apps/my-copilot/src/app/priser/page.tsx` er urørt, og det er ikke lagt inn noen CI-vakt her. De to gjenstående PR-ene er slettinga av den håndholdte lista og vakta for utløpte kampanjer.

Refs #503
