### PR TITLE
docs(nav-pilot): lagre baselinene bak pinningsbeslutningen for to agenter

### DIFF
--- a/docs/golden-baselines/2026-08-31-accessibility-claude-sonnet-4.6.txt
+++ b/docs/golden-baselines/2026-08-31-accessibility-claude-sonnet-4.6.txt
@@ -1,0 +1,17 @@
+# golden-prompt SIZE MEASUREMENT: RECORDED, NOT A TARGET
+# Nothing asserts against these numbers, and no run fails because it
+# missed them. They describe one agent, one revision, one model, one day.
+# Only comparable with another run made the same way (--compare).
+# agent:        accessibility
+# date:         2026-08-31
+# revision:     ecd2ef86
+# client:       copilot
+# model:        claude-sonnet-4.6
+# repeats:      5
+# instructions: 17 installed, 3 always-on
+# prompts:      all
+#
+# slug|runs|bytes_median|bytes_min|bytes_max|lines_median|lines_min|lines_max|words_median|words_min|words_max
+uu-review|5|1326|1181|2173|33|32|57|180|155|272
+uu-ask|5|2107|1268|2491|54|32|64|221|143|299
+uu-trivial|5|784|631|1277|28|21|35|111|93|179

--- a/docs/golden-baselines/2026-08-31-accessibility-gpt-5.6-luna.txt
+++ b/docs/golden-baselines/2026-08-31-accessibility-gpt-5.6-luna.txt
@@ -1,0 +1,17 @@
+# golden-prompt SIZE MEASUREMENT: RECORDED, NOT A TARGET
+# Nothing asserts against these numbers, and no run fails because it
+# missed them. They describe one agent, one revision, one model, one day.
+# Only comparable with another run made the same way (--compare).
+# agent:        accessibility
+# date:         2026-08-31
+# revision:     ecd2ef86
+# client:       copilot
+# model:        gpt-5.6-luna
+# repeats:      5
+# instructions: 17 installed, 3 always-on
+# prompts:      all
+#
+# slug|runs|bytes_median|bytes_min|bytes_max|lines_median|lines_min|lines_max|words_median|words_min|words_max
+uu-review|5|1528|1269|2226|40|30|65|211|171|272
+uu-ask|5|1657|1128|2306|50|34|55|181|135|256
+uu-trivial|5|892|832|1050|29|24|29|131|113|150

--- a/docs/golden-baselines/2026-08-31-code-review-gpt-5.3-codex.txt
+++ b/docs/golden-baselines/2026-08-31-code-review-gpt-5.3-codex.txt
@@ -1,0 +1,16 @@
+# golden-prompt SIZE MEASUREMENT: RECORDED, NOT A TARGET
+# Nothing asserts against these numbers, and no run fails because it
+# missed them. They describe one agent, one revision, one model, one day.
+# Only comparable with another run made the same way (--compare).
+# agent:        code-review
+# date:         2026-08-31
+# revision:     e15c8b9b
+# client:       copilot
+# model:        gpt-5.3-codex
+# repeats:      5
+# instructions: 17 installed, 3 always-on
+# prompts:      all
+#
+# slug|runs|bytes_median|bytes_min|bytes_max|lines_median|lines_min|lines_max|words_median|words_min|words_max
+cr-kotlin|5|1758|1260|2192|40|26|51|211|179|286
+cr-tsx|5|2042|1948|2729|36|29|54|277|250|327

--- a/docs/golden-baselines/2026-08-31-code-review-gpt-5.6-luna.txt
+++ b/docs/golden-baselines/2026-08-31-code-review-gpt-5.6-luna.txt
@@ -1,0 +1,16 @@
+# golden-prompt SIZE MEASUREMENT: RECORDED, NOT A TARGET
+# Nothing asserts against these numbers, and no run fails because it
+# missed them. They describe one agent, one revision, one model, one day.
+# Only comparable with another run made the same way (--compare).
+# agent:        code-review
+# date:         2026-08-31
+# revision:     e15c8b9b
+# client:       copilot
+# model:        gpt-5.6-luna
+# repeats:      5
+# instructions: 17 installed, 3 always-on
+# prompts:      all
+#
+# slug|runs|bytes_median|bytes_min|bytes_max|lines_median|lines_min|lines_max|words_median|words_min|words_max
+cr-kotlin|5|1488|1108|1888|31|22|43|204|146|256
+cr-tsx|5|2504|1860|3323|51|30|70|305|241|428


### PR DESCRIPTION
Fire målinger tatt 31. august 2026 med `--agent`-flagget fra #509, fem gjentakelser hver.

| Agent | Modell | Resultat |
| --- | --- | --- |
| code-review | GPT-5.3-Codex (dagens pinning) | cr1 5/5, cr2 4/5, cr3 5/5, cr4 0/5 |
| code-review | GPT-5.6 Luna | cr1 5/5, cr2 5/5, cr3 3/5, cr4 0/5 |
| accessibility | Claude Sonnet 4.6 (dagens pinning) | uu1 5/5, uu2 5/5, uu3 0/5, uu4 5/5 |
| accessibility | GPT-5.6 Luna | uu1 5/5, uu2 5/5, uu3 0/5, uu4 5/5 |

Begge pinningene blir stående. Ikke fordi de billigere modellene målte dårligere, for de målte likt, men fordi den ene sikkerhetsnære påstanden i hver agent feiler på samtlige modeller: `cr4` (delegering videre til tilgjengelighetsspesialisten) og `uu3` (Ask First før en egendefinert ARIA-rolle). Et bytte ville skjedd i blinde på nettopp den egenskapen det er verdt å være forsiktig med.

Forskjellene som finnes ellers er støy. Med n=5 er 4/5 mot 5/5 og 3/5 mot 5/5 ikke til å skille fra hverandre.

Sporene ligger i #514 og #517. Filene inneholder størrelsesmålinger, ikke transkripsjoner, og ingenting asserterer mot tallene, slik headeren i hver fil sier.