### PR TITLE
feat(nyheter): la en sak festes øverst uten å endre datoen

### DIFF
--- a/apps/my-copilot/src/lib/news-types.ts
+++ b/apps/my-copilot/src/lib/news-types.ts
@@ -5,6 +5,7 @@ export interface NewsItem {
   title: string;
   date: string;
   draft: boolean;
+  featured?: boolean;
   category: NewsCategory;
   excerpt: string;
   tags: string[];

--- a/apps/my-copilot/src/lib/news.test.ts
+++ b/apps/my-copilot/src/lib/news.test.ts
@@ -102,6 +102,58 @@ describe("CATEGORY_CONFIG", () => {
       },
     ];
 
+    it("puts a festet sak above newer items", () => {
+      const featured: NewsItem = {
+        slug: "festet",
+        title: "Festet",
+        date: "2026-05-01",
+        draft: false,
+        featured: true,
+        category: "nav-pilot",
+        excerpt: "",
+        tags: [],
+        type: "article",
+      };
+      const newer: NewsItem = { ...featured, slug: "nyere", title: "Nyere", date: "2026-06-01", featured: false };
+
+      expect(selectNewsItems([newer, featured]).map((i) => i.slug)).toEqual(["festet", "nyere"]);
+    });
+
+    it("orders festede saker among themselves by date", () => {
+      const base: NewsItem = {
+        slug: "",
+        title: "",
+        date: "",
+        draft: false,
+        featured: true,
+        category: "nav-pilot",
+        excerpt: "",
+        tags: [],
+        type: "article",
+      };
+      const older = { ...base, slug: "eldre", date: "2026-05-01" };
+      const newer = { ...base, slug: "nyere", date: "2026-06-01" };
+
+      expect(selectNewsItems([older, newer]).map((i) => i.slug)).toEqual(["nyere", "eldre"]);
+    });
+
+    it("leaves date order alone when nothing is festet", () => {
+      const base: NewsItem = {
+        slug: "",
+        title: "",
+        date: "",
+        draft: false,
+        category: "nav-pilot",
+        excerpt: "",
+        tags: [],
+        type: "article",
+      };
+      const older = { ...base, slug: "eldre", date: "2026-05-01" };
+      const newer = { ...base, slug: "nyere", date: "2026-06-01" };
+
+      expect(selectNewsItems([older, newer]).map((i) => i.slug)).toEqual(["nyere", "eldre"]);
+    });
+
     it("keeps old external excerpts when not rendering front page", () => {
       const result = selectNewsItems(items, { now });
       expect(result.map((item) => item.slug)).toEqual(["fresh-link", "old-link", "old-article"]);

--- a/apps/my-copilot/src/lib/news.ts
+++ b/apps/my-copilot/src/lib/news.ts
@@ -87,7 +87,12 @@ export function isExternalExcerptFresh(item: NewsItem, now: Date = new Date()): 
 
 export function selectNewsItems(items: NewsItem[], options: GetNewsItemsOptions = {}): NewsItem[] {
   const visibleItems = options.frontPage ? items.filter((item) => isExternalExcerptFresh(item, options.now)) : items;
-  return visibleItems.sort((a, b) => b.date.localeCompare(a.date));
+  // A festet sak outranks the date so an item can be lifted back to the top
+  // without back-dating it. Only the flag is consulted; among festede saker,
+  // and among the rest, the ordinary date order still applies.
+  return visibleItems.sort(
+    (a, b) => Number(b.featured ?? false) - Number(a.featured ?? false) || b.date.localeCompare(a.date)
+  );
 }
 
 function resolveArticlesDir(): string {
@@ -112,6 +117,7 @@ function parseNewsFile(fileName: string): NewsItem {
     title: data.title,
     date: toDateOnly(data.date),
     draft: data.draft === true,
+    featured: data.featured === true,
     category: parseCategory(data.category, slug),
     excerpt: data.excerpt ?? "",
     tags: data.tags ?? [],
@@ -145,6 +151,7 @@ export function getArticle(slug: string): (NewsItem & { content: string }) | nul
     title: data.title,
     date: toDateOnly(data.date),
     draft: data.draft === true,
+    featured: data.featured === true,
     category: parseCategory(data.category, slug),
     excerpt: data.excerpt ?? "",
     tags: data.tags ?? [],

--- a/docs/news/articles/lokale-modeller-i-nav-pilot.md
+++ b/docs/news/articles/lokale-modeller-i-nav-pilot.md
@@ -1,6 +1,7 @@
 ---
 title: "Nav-pilot lander på bakken"
 date: 2026-08-30
+featured: true
 author: starefossen
 category: praksis
 excerpt: "En AI-modell på din egen maskin tar de mekaniske oppgavene. Den bruker ingen kreditter, men den er tregere, og den tar ingen avgjørelser."


### PR DESCRIPTION
Nyhetslista sorterer bare på dato (`selectNewsItems` i `apps/my-copilot/src/lib/news.ts`), så den eneste måten å løfte en sak tilbake til toppen har vært å gi den en dato den ikke hadde.

Saken om lokale modeller er tilfellet som utløste dette. Den er datert 30. august, mens funksjonen den beskriver først ble merget 31. august i #483, så den lå under saken om modellbyttet.

## Endringen

Frontmatter kan nå sette `featured: true`. Festede saker sorteres foran resten, og innbyrdes fortsatt på dato, så rekkefølgen ellers er uendret. Feltet er valgfritt, så ingen eksisterende sak eller fixture trenger endring.

`docs/news/articles/lokale-modeller-i-nav-pilot.md` får flagget. Datoen står urørt på 30. august.

## Hvorfor ikke bare endre datoen

Å sette den til 31. august ville gitt lik dato som `agenter-bytter-modell`. Uavgjort avgjøres av rekkefølgen `fs.readdirSync` gir, og den er ikke spesifisert. Prøvd på denne maskinen havner `agenter-bytter-modell` øverst, men utfallet avhenger av filsystemet og kan bli et annet på byggeserveren. Datoendring ville altså vært upålitelig, i tillegg til å gi saken en publiseringsdato den ikke hadde.

## Verifisering

Tre nye tester: at en festet sak går foran en nyere usatt sak, at festede saker seg imellom fortsatt sorteres på dato, og at rekkefølgen er uendret når ingenting er festet.

Den første er den som pinner selve funksjonen. Fjerner jeg flagget fra sorteringen, feiler den med `expected [ nyere, festet ] to deeply equal [ festet, nyere ]`. De to andre passerer også med gammel sortering, men de pinner invarianter og er ment som regresjonsvern, ikke som gjentakelse av implementasjonen.

Kjørt mot det faktiske saksarkivet er `lokale-modeller-i-nav-pilot` nå øverst på forsida. `pnpm check` er grønn, 506 tester. `mise run generate` gir ingen diff.

## To kjente svakheter

`featured: yes` eller `featured: "true"` i frontmatter blir strenger og treffer ikke `=== true`, så saken blir stille ikke festet uten noe varsel. Det følger mønsteret fra `draft`, som oppfører seg likt, men det er verdt å vite for den som skriver flagget for hånd.

Flagget utløper ikke og må fjernes manuelt. Siden denne saken bare ligger én dag bak, blir flagget raskt liggende igjen som dødvekt. Hvis mønsteret skal brukes igjen, bør det bli et `featured_until` som sammenlignes med Oslo-datohjelperen som allerede finnes.