### PR TITLE
docs(nav-pilot): document alpha local ask, and link the findings report

### DIFF
--- a/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
+++ b/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
@@ -1645,6 +1645,24 @@ const CONFIG_KEYS = [
     values: "none · error · warning · info · debug",
     desc: "Loggnivå for OpenTelemetry-eksport.",
   },
+  {
+    key: "local_enabled",
+    flag: "—",
+    values: "true · false",
+    desc: "Send avgrensede oppgaver til bakkemodellen (alfa). Settes av 'alpha local init', nullstilles av 'alpha local off'. Så lenge den er false finnes ingen lokale modeller i nav-pilot i det hele tatt.",
+  },
+  {
+    key: "local_autostart",
+    flag: "—",
+    values: "true · false",
+    desc: "La en vanlig 'nav-pilot' starte serveren selv når den trengs og ingen kjører. Av som standard: å starte en 21 GB prosess uten å bli bedt om det er ikke greit, og første oppstart på kald cache tar minutter som ser ut som en heng.",
+  },
+  {
+    key: "local_loop_guard",
+    flag: "—",
+    values: "et tall, standard 8",
+    desc: "Hvor mange identiske tool calls på rad som avslutter en lokal tur. Lokale modeller setter seg fast og gjentar det samme kallet; vi har målt serier på 203.",
+  },
 ];
 
 function KlienterOgKonfigurasjonSection() {
@@ -2003,6 +2021,16 @@ nav-pilot alpha local on        # skru på igjen etter off
 nav-pilot alpha local off       # slutt å sende oppgaver dit; vektene blir liggende
 nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først`}
           </CodeBlock>
+          <BodyLong className="mt-4" size="small" style={{ color: "#475569" }}>
+            Vil du slippe å starte serveren selv, kan en vanlig <code className="font-mono text-xs">nav-pilot</code>{" "}
+            gjøre det for deg:
+          </BodyLong>
+          <CodeBlock compact>{`nav-pilot config set local_autostart true`}</CodeBlock>
+          <BodyLong className="mt-2" size="small" style={{ color: "#475569" }}>
+            Den er av som standard, og det er med vilje: å starte en 21 GB prosess uten å bli bedt om det er ikke greit,
+            og første oppstart på kald cache tar minutter som ser ut som om noe har hengt seg. Med den på venter
+            launchen på at serveren er klar. To samtidige launcher starter ikke to servere.
+          </BodyLong>
           <Box padding="space-16" borderRadius="8" className="mt-4" style={{ background: "#f8fafc" }}>
             <Label size="small">Vi måler dette tettere enn resten av nav-pilot mens det er alfa</Label>
             <BodyLong size="small" className="mt-2" style={{ color: "#475569" }}>

--- a/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
+++ b/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
@@ -1996,7 +1996,8 @@ function LocalModelSection() {
           <CodeBlock compact>
             {`nav-pilot alpha local init      # laster ned modellen og setter opp miljøet
 nav-pilot alpha local start     # starter serveren
-nav-pilot alpha local status    # kjører den? svarer den? hvilken modell?
+nav-pilot alpha local status    # kjører den? svarer den? hvilken modell? hva har den gjort?
+nav-pilot alpha local ask -p "..."  # still ett spørsmål rett til modellen
 nav-pilot alpha local stop
 nav-pilot alpha local on        # skru på igjen etter off
 nav-pilot alpha local off       # slutt å sende oppgaver dit; vektene blir liggende

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -131,12 +131,22 @@ Krever en Mac med Apple Silicon og 48 GB minne, og rundt 26 GB ledig disk. `init
 
 ```bash
 nav-pilot alpha local init      # gjør alt: miljø, vekter, minnegrense, og starter serveren
-nav-pilot alpha local status    # kjører den? svarer den? hvilken modell?
+nav-pilot alpha local status    # kjører den? svarer den? hvilken modell? hva har den gjort?
+nav-pilot alpha local ask -p "..."  # still ett spørsmål rett til modellen
 nav-pilot alpha local stop      # og start igjen med start
 nav-pilot alpha local on        # skru på igjen etter off
 nav-pilot alpha local off       # slutt å sende oppgaver dit; vektene blir liggende
 nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først
 ```
+
+Vil du slippe å starte serveren selv, kan en vanlig `nav-pilot` gjøre det når den trenger den:
+
+```bash
+nav-pilot config set local_autostart true
+```
+
+Av som standard, med vilje: å starte en 21 GB prosess uten å bli bedt om det er ikke greit, og
+første oppstart på kald cache tar minutter som ser ut som om noe har hengt seg.
 
 Ingenting av dette skjer med mindre du kjører `init` selv. Gjør du ikke det, er nav-pilot
 uendret.

--- a/docs/news/articles/lokale-modeller-i-nav-pilot.md
+++ b/docs/news/articles/lokale-modeller-i-nav-pilot.md
@@ -86,4 +86,4 @@ Så lenge dette er alfa, måler vi tettere enn i resten av nav-pilot: hvor mange
 
 Meld deg i #nav-pilot. Vi tar inn én og én i starten.
 
-Målinger og metode ligger i [navikt/mlx-workspace](https://github.com/navikt/mlx-workspace), også kjøringene som gikk galt.
+Hele rapporten, med metode og alle tallene: [local-inference-findings.md](https://github.com/navikt/mlx-workspace/blob/main/reports/local-inference-findings.md). Hvorfor akkurat denne modellen, og hva vi forkastet: [alpha-model-decision.md](https://github.com/navikt/mlx-workspace/blob/main/reports/alpha-model-decision.md). Rådataene ligger i [navikt/mlx-workspace](https://github.com/navikt/mlx-workspace), også kjøringene som gikk galt.


### PR DESCRIPTION
Two gaps found after #483 merged.

**`alpha local ask` was undocumented.** The docs listed every other `alpha local` command. `ask` is the fastest way for someone to find out whether the model works at all, and the only thing that separates "the model is broken" from "the orchestrator never dispatched" — which is the distinction the runbook asks triage to make first.

**The news article pointed at a repository, not an answer.** It linked the root of `navikt/mlx-workspace`. It now links the findings report and the model-decision report directly, because "why this model and not the one that writes better code" is the question a reader actually has, and the answer is a specific document.

No behaviour change.