### PR TITLE
fix(golden): test 4 kunne ikke passere, og gulvet forkastet gyldige svar

### DIFF
--- a/scripts/nav-pilot-golden.sh
+++ b/scripts/nav-pilot-golden.sh
@@ -822,15 +822,29 @@ record_soft() {
 present() { grep -qiE -- "$2" "$1"; }
 absent()  { ! grep -qiE -- "$2" "$1"; }
 
-# A red-zone declaration as a Fase 2 plan writes it, NOT the Fase 1 checkpoint
-# template's own placeholder line `• 🔴 Rød sone: [liste, eller «ingen»]`. That
-# placeholder is what made a bare `present 'Rød sone'` pass vacuously: any
-# response reproducing the checkpoint block carries it, so the assertion fired
-# on a transcript that had never planned anything. Keying on the literal
-# `[liste` is deliberate and narrow — it is the placeholder syntax the persona's
-# own template uses, and a filled-in declaration («Rød sone: ingen», «Rød sone —
-# skriv selv») never contains it.
-redzone_declared() { grep -iE -- 'Rød sone' "$1" | grep -qv '\[liste'; }
+# A red-zone declaration as `### Fase 2: Plan` item 10 writes it, NOT the Fase 1
+# checkpoint's own red-zone bullet. The persona has two templates that both
+# contain the words, and only one of them is a declaration:
+#
+#   Fase 2 (agent file :204-217)   `🔴 Rød sone — skriv selv (med begrunnelse):`
+#                                  `🔴 Rød sone: ingen for denne oppgaven.`
+#   Fase 1 (agent file :127)       `• 🔴 Rød sone: [liste, eller «ingen»]`
+#
+# The separator is the `•`. All seven checkpoint fields carry it and neither
+# Fase 2 form does, so excluding `•` lines excludes the checkpoint bullet and
+# nothing else.
+#
+# ⚠️  Do NOT key this on the placeholder text `[liste` instead. That separates a
+# verbatim-quoted template from everything else, which is the wrong pair: the
+# checkpoint is a FILL-IN template, so a compliant model emits
+# `• 🔴 Rød sone: ingen`, which has no placeholder and would sail through. That
+# is the persona's specified Fase 1 output, and test 2b exists to push models
+# towards emitting it — keying on the placeholder would turn every Fase 1 stop
+# green the moment 2b starts being met.
+#
+# ⚠️  Exclude `•` only, never markdown `-` or `*`. A plan is free to write its
+# declaration as a list item, and excluding those would false-fail it.
+redzone_declared() { grep -iE -- 'Rød sone' "$1" | grep -qv '^[[:space:]]*•'; }
 count_of() { grep -oiE -- "$2" "$1" 2>/dev/null | wc -l | tr -d ' '; }
 
 # Recommendation verbs, word-bounded on both sides. The boundaries matter:
@@ -906,8 +920,15 @@ RE_CONFIRM='Bekreft for å fortsette'
 RE_FASE1_REACHED='Fase[[:space:]]*1|Intervju'
 
 # Fase 2 or later *work*, the leak the stop invariant forbids. Two markers, both
-# with clean separation: t2 0/18, t4 18/18. Read in both directions: test 2 must
-# not see it, test 4 gates on seeing it (see the Test 4 vocabulary below).
+# with clean separation: t2 0/18, t4 18/18.
+#
+# Test 2's alone. Test 4 briefly shared it, and that was a mistake worth naming:
+# the two tests ask different questions. Test 2 asks "did anything past Fase 1
+# happen", for which a file mutation is perfect evidence. Test 4 asks "was a
+# Fase 2 plan produced", for which a file mutation is no evidence at all — a
+# full-tier Fase 1 turn that leaks one `● Update(...)` line has mutated without
+# planning, and every vacuous pass found in review came through that door. Test
+# 4 keys on RE_FASE2_PLAN below instead.
 #
 #   ^● Edit|Create|…  the client renders one line per file mutation. A full-tier
 #                     Fase 1 turn that writes files has run past its own gate.
@@ -953,6 +974,32 @@ RE_BLINDSPOT_AUDIT='Blindsoner[^.]{0,40}[0-9]+[[:space:]]*/[[:space:]]*11'
 # This is not the false failure #491 removed. That one was accessPolicy used as
 # test 2's *leak* detector, firing on correct Fase 1 answers. Dropping it here
 # removes the same word from the other direction.
+# A Fase 2 plan was produced. Test 4's gate, and deliberately independent of the
+# zone declarations, because zone presence is the thing under test: using
+# `Grønn sone` as the plan detector conflated "a plan exists" with "a green zone
+# was declared", so a plan that dropped BOTH zones — the wholesale-trimming
+# regression this assertion exists to catch — was filed as "no plan" instead of
+# as the failure it is. `Grønn sone` stays as one alternative among several, but
+# it is no longer what decides whether a plan exists.
+#
+# The markers are the persona's own headings, all of which put a colon straight
+# after the number or the word «ferdig» after it:
+#
+#   📐 Fase 2: Plan         `### Delegation format` (agent file :139)
+#   ✅ Fase 2 ferdig        `### Phase transition format` (:120), filled for 2
+#   🟢 Grønn sone           the zone block of `### Fase 2: Plan` item 10 (:211)
+#
+# Deliberately NOT a bare `Fase 2`: two of eighteen Fase 1 answers refer forward
+# to it in prose («jeg bygger plan i Fase 2», «kommer i Fase 2-planen»), and
+# naming the next phase is what stopping before it looks like. Requiring the
+# colon or «ferdig» excludes both of those phrasings.
+#
+# ⚠️  UNMEASURED against a real Fase 2 transcript. The three kept t4 samples all
+# stop in Fase 1, and the 18/18 that RE_FASE2_WORK carries was measured on the
+# old prompt, which this PR replaced. If this is too tight, test 4 reports amber
+# — loud, and never green — and the pinned run recalibrates it. That direction
+# is the safe one; do not widen this to a bare `Fase 2` to make an amber go away.
+RE_FASE2_PLAN='Fase[[:space:]]*2[[:space:]]*:|Fase[[:space:]]*2[[:space:]]+ferdig|Grønn sone'
 RE_OPUS='nav-pilot-opus'
 
 # One pass over the selected prompts. Called once per --repeat, so every
@@ -1101,34 +1148,43 @@ run_pass_nav_pilot() {
   # No Fase 2 output is "could not evaluate", never a pass. Two things enforce
   # that, and both are needed:
   #
-  #   redzone_declared   excludes the template placeholder, so reproducing the
-  #                      checkpoint block is not a declaration. RE_FASE2_WORK
-  #                      alone does not close this: a full-tier Fase 1 turn that
-  #                      leaks one `● Update(...)` line opens the gate, and the
-  #                      checkpoint line underneath it satisfied the assertion.
-  #   Grønn sone         separates "planned without a red zone" (a real failure
-  #                      of the ✅ Always rule — the persona pairs the zones)
-  #                      from "mutated files but produced no plan". The second is
-  #                      what a trivial-tier single-pass looks like: the change
-  #                      is reachable in one file via a defaulted field, and a
-  #                      model that takes that route wrote no Fase 2 plan for the
-  #                      rule to apply to. That is "could not evaluate", not red.
+  #   RE_FASE2_PLAN     the gate is a PLAN, never a file mutation. A mutation is
+  #                     Fase 4 delivery, and a full-tier Fase 1 turn that leaks
+  #                     one `● Update(...)` line has mutated without planning.
+  #                     Gating on mutations let three separate Fase 1 shapes
+  #                     through — placeholder checkpoint, filled-in checkpoint,
+  #                     and a prose forward-reference — each with a `Rød sone`
+  #                     somewhere for the assertion to match. It also mislabelled
+  #                     the legitimate trivial-tier single-pass, which mutates
+  #                     one file and plans nothing: that is genuinely "no plan",
+  #                     and now says so.
+  #   redzone_declared  excludes the Fase 1 checkpoint's `•` bullet, so a
+  #                     response that carries both a checkpoint and a plan cannot
+  #                     satisfy the assertion off the checkpoint half.
+  #
+  # A plan with no red-zone declaration is RED, not amber, whether or not it
+  # declared a green zone. Dropping both zones wholesale is the regression this
+  # assertion exists to catch, and filing it as "could not evaluate" was exactly
+  # backwards.
+  #
+  # Known residual: a Fase 1 stop that happens to write a colon form («Fase 2:
+  # jeg bygger planen når du har svart») opens the plan gate, and its checkpoint
+  # bullet is then the only `Rød sone` there is, so it reports red. Wrong reason,
+  # right colour — it is loud and it is not a pass, which is the direction this
+  # assertion is allowed to be wrong in. Tighten only with measured evidence.
   if selected 4; then
     DESC4="Fase 2 output contains a 🔴 Rød sone declaration"
     T4="$(tx t4)"
     if ! run_prompt t4 "legg til feltet antall i responsen fra det eksisterende /api/oppgaver-endepunktet i Ktor-tjenesten — flere filer, kjent mønster, ingen nye endepunkter, ingen persondata, ingen endringer i auth"; then
       record_error 4 "$DESC4" "$LAST_PROMPT_DETAIL"
-    elif ! present "$T4" "$RE_FASE2_WORK"; then
+    elif ! present "$T4" "$RE_FASE2_PLAN"; then
       record_error 4 "$DESC4" \
-        "no Fase 2 content in the response (no match for: $RE_FASE2_WORK) — the red-zone assertion would pass vacuously off the Fase 1 checkpoint template, so it was not evaluated. Re-run with --keep and check whether compressed-tier traversal regressed."
+        "no Fase 2 plan in the response (no match for: $RE_FASE2_PLAN) — a red-zone declaration is a property of a plan, so with no plan there is nothing to assert and this is not a pass. Either the response stopped in Fase 1, or it took a trivial-tier single pass. Re-run with --keep and read the transcript."
     elif redzone_declared "$T4"; then
       record 4 "$DESC4" 0
-    elif present "$T4" 'Grønn sone'; then
-      record 4 "$DESC4" 1 \
-        "the plan declares a green zone but no red zone — the 🔴 Rød-sone-deklarasjon is mandatory per Boundaries → ✅ Always"
     else
-      record_error 4 "$DESC4" \
-        "the response mutated files but produced no Fase 2 plan (no 'Grønn sone', and no red-zone declaration outside the Fase 1 checkpoint template) — a trivial-tier single pass has no plan for the red-zone rule to apply to, so it was not evaluated. Re-run with --keep and read the transcript."
+      record 4 "$DESC4" 1 \
+        "a Fase 2 plan with no 🔴 Rød-sone-deklarasjon outside the Fase 1 checkpoint — mandatory per \`### Fase 2: Plan\` item 10 and Boundaries → ✅ Always"
     fi
   fi
 

--- a/scripts/nav-pilot-golden.sh
+++ b/scripts/nav-pilot-golden.sh
@@ -67,7 +67,7 @@
 #   --allow-all-tools for non-interactive mode, so the agent can read/write/run
 #   inside that scratch directory. It is removed on exit unless you pass --keep.
 #
-#   The agent EDITS that workspace: t1 fixes a typo, t4 adds an endpoint, t6
+#   The agent EDITS that workspace: t1 fixes a typo, t4 extends a handler, t6
 #   renames a variable across three files. So the workspace is rebuilt from a
 #   pristine template before EVERY prompt, not once per suite and not once per
 #   --repeat pass. Two samples of one prompt have to meet the same repo, or
@@ -480,25 +480,97 @@ spec:
 EOF
 
 cat >"$TEMPLATE/build.gradle.kts" <<'EOF'
-plugins { kotlin("jvm") version "2.1.0" }
-dependencies { implementation("io.ktor:ktor-server-netty:3.0.0") }
+plugins {
+    kotlin("jvm") version "2.1.0"
+    kotlin("plugin.serialization") version "2.1.0"
+}
+dependencies {
+    implementation("io.ktor:ktor-server-netty:3.0.0")
+    implementation("io.ktor:ktor-server-content-negotiation:3.0.0")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:3.0.0")
+}
 EOF
 
-for f in App Routes Config; do
-  cat >"$TEMPLATE/src/main/kotlin/no/nav/demo/$f.kt" <<EOF
+# A minimal but real Ktor skeleton. It used to be three byte-identical files
+# containing only `val maksAntall = 100`, seeded for test 6's rename. That made
+# test 4's premises false: the prompt speaks of "den eksisterende Ktor-tjenesten"
+# and a "kjent mønster", and neither existed in the fixture (see #519). The
+# skeleton below makes both true, and keeps `maksAntall` in exactly three files
+# — declared in Config.kt, used in App.kt and Routes.kt — so test 6's "rename
+# variabelen maksAntall i tre filer" is still literally true, and is now a
+# declaration plus two call sites rather than three copies of one line.
+#
+# ⚠️  Baselines in docs/golden-baselines/ recorded before 2026-08-31 measured
+# the old placeholder fixture. Their t4 and t6 sizes are not comparable with
+# runs made after this change; --compare across that boundary reports a fixture
+# change as a persona change.
+cat >"$TEMPLATE/src/main/kotlin/no/nav/demo/Config.kt" <<'EOF'
 package no.nav.demo
 
-// bruker maksAntall flere steder
-val maksAntall = 100
+// Maks antall oppgaver som returneres i én respons.
+const val maksAntall = 100
 EOF
-done
+
+cat >"$TEMPLATE/src/main/kotlin/no/nav/demo/Oppgave.kt" <<'EOF'
+package no.nav.demo
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Oppgave(val id: String, val tittel: String)
+
+@Serializable
+data class OppgaveRespons(val oppgaver: List<Oppgave>)
+EOF
+
+cat >"$TEMPLATE/src/main/kotlin/no/nav/demo/Routes.kt" <<'EOF'
+package no.nav.demo
+
+import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+
+private val oppgaver = listOf(
+    Oppgave("1", "Registrer soknad"),
+    Oppgave("2", "Send vedtaksbrev"),
+)
+
+fun Application.oppgaveRoutes() {
+    routing {
+        get("/api/oppgaver") {
+            call.respond(OppgaveRespons(oppgaver.take(maksAntall)))
+        }
+    }
+}
+EOF
+
+cat >"$TEMPLATE/src/main/kotlin/no/nav/demo/App.kt" <<'EOF'
+package no.nav.demo
+
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+
+fun main() {
+    println("starter demo-tjeneste, maksAntall=$maksAntall")
+    embeddedServer(Netty, port = 8080) {
+        install(ContentNegotiation) { json() }
+        oppgaveRoutes()
+    }.start(wait = true)
+}
+EOF
 
 # ─── Fixtures for the review agents ──────────────────────────────────────────
-# Seeded ONLY when the agent under test needs them. The nav-pilot template stays
-# byte-for-byte what it was before --agent existed, because every baseline in
-# docs/golden-baselines/ was recorded against that template: two more files for
-# Fase 1 to explore would move the sizes those baselines record, and the
-# comparison would report the fixture change as a persona change.
+# Seeded ONLY when the agent under test needs them, and never for nav-pilot: two
+# more files for Fase 1 to explore would move the sizes the baselines in
+# docs/golden-baselines/ record, and the comparison would report the fixture
+# change as a persona change. (The nav-pilot template itself was byte-for-byte
+# unchanged from before --agent existed until #519 replaced the three
+# placeholder .kt files with the Ktor skeleton above; see the note there.)
 #
 # The review agents cannot be given a clean repo. code-review asserts on what it
 # reports, accessibility on which WCAG rules it names, and both need something
@@ -559,7 +631,7 @@ export function StatusPanel({ status, onSlett }) {
 EOF
 fi
 
-# The agent writes to $WS (t1 fixes the README typo, t4 adds an endpoint, t6
+# The agent writes to $WS (t1 fixes the README typo, t4 extends a handler, t6
 # renames maksAntall), so $WS is thrown away and rebuilt from $TEMPLATE before
 # every prompt. Per prompt, not per --repeat pass: within one pass the prompts
 # also touch each other's files, and re-copying is cheap enough that the
@@ -626,7 +698,15 @@ run_tag() { [[ "$REPEAT" -gt 1 ]] && printf '%s[run %s/%s]%s ' "$DIM" "$RUN" "$R
 # a response. Every assertion below is either an absent() — which succeeds
 # trivially on an empty file — or a present() on a long structured block, so
 # without this floor a crashed or unauthenticated CLI reports green.
-MIN_TRANSCRIPT_BYTES=200
+#
+# It only has to catch an empty or crashed CLI. It must NOT try to judge whether
+# an answer is substantial: the persona answers trivial tier in two sentences by
+# design, and at 200 this floor sat above that length. It discarded a *passing*
+# test 5 canary — a correct 160B TokenX answer, exit 0, 5.84 credits — as an
+# error, and t6 came within seven bytes of the same trap (#519). The per-test
+# gates below do the real work; this one only asks whether there is a response
+# at all.
+MIN_TRANSCRIPT_BYTES=40
 LAST_PROMPT_DETAIL=""
 
 run_prompt() {
@@ -804,7 +884,8 @@ RE_CONFIRM='Bekreft for å fortsette'
 RE_FASE1_REACHED='Fase[[:space:]]*1|Intervju'
 
 # Fase 2 or later *work*, the leak the stop invariant forbids. Two markers, both
-# with clean separation: t2 0/18, t4 18/18.
+# with clean separation: t2 0/18, t4 18/18. Read in both directions: test 2 must
+# not see it, test 4 gates on seeing it (see the Test 4 vocabulary below).
 #
 #   ^● Edit|Create|…  the client renders one line per file mutation. A full-tier
 #                     Fase 1 turn that writes files has run past its own gate.
@@ -835,24 +916,21 @@ MIN_OPEN_QUESTIONS=3
 RE_BLINDSPOT_AUDIT='Blindsoner[^.]{0,40}[0-9]+[[:space:]]*/[[:space:]]*11'
 
 # ── Test 4 vocabulary ───────────────────────────────────────────────────────
-# Fase 2 artifacts that do NOT appear in the Fase 1 checkpoint template.
-# (Note: "🔴 Rød sone" alone is a poor discriminator — the Fase 1 checkpoint
-# block lists it as a summary line — so we key on the green-zone block and on
-# accessPolicy, which the persona mandates in the Fase 2 Nais manifest.)
+# Test 4's presence gate is RE_FASE2_WORK, the same expression test 2 uses as
+# its leak detector. One expression, read in two directions: what test 2 must
+# not see is exactly what test 4 must see, and it is measured in both (t2 0/18,
+# t4 18/18).
 #
-# Deliberately NOT "apiVersion: nais": the seeded workspace ships a nais.yaml
-# whose first line is `apiVersion: nais.io/v1alpha1`, and Fase 1 reads that file
-# to infer the archetype. Echoing it back is correct behaviour, so keying on it
-# would false-fail on its own fixture.
+# It used to have its own regex, `Grønn sone|accessPolicy`, and the accessPolicy
+# half was the bug (#519). Two of eighteen *Fase 1* responses name accessPolicy,
+# reporting that the seeded nais.yaml lacks one. On those runs the gate opened
+# on a Fase 1 answer, and `present "$T4" 'Rød sone'` then matched the
+# `• 🔴 Rød sone: [liste, eller «ingen»]` line of the Fase 1 checkpoint template
+# — the vacuous pass the block comment at test 4 says must never happen.
 #
-# ONE direction only, as test 4's *presence* gate: Fase 2 content must be
-# present before the red-zone assertion means anything. It used to double as
-# test 2's leak detector, and that is why accessPolicy is still in here: two of
-# eighteen correct Fase 1 responses name it, reporting that the seeded nais.yaml
-# lacks one, so as a leak detector it false-failed the runs that behaved. Test 2
-# now keys the leak on RE_FASE2_WORK instead. Widening this regex is safe; do
-# not narrow it without re-checking test 4.
-RE_PHASE2_ARTIFACT='Grønn sone|accessPolicy'
+# This is not the false failure #491 removed. That one was accessPolicy used as
+# test 2's *leak* detector, firing on correct Fase 1 answers. Dropping it here
+# removes the same word from the other direction.
 RE_OPUS='nav-pilot-opus'
 
 # One pass over the selected prompts. Called once per --repeat, so every
@@ -969,6 +1047,22 @@ run_pass_nav_pilot() {
   # in a single non-interactive call. "Rød sone: ingen" is a valid declaration —
   # the invariant is that the declaration exists, not that anything is red.
   #
+  # ⚠️  THE PROMPT MUST NOT ASK FOR A NEW ENDPOINT, NEW DATA OR NEW AUTH. It used
+  # to ask for "et nytt REST-endepunkt", and that prompt cannot reach Fase 2 by
+  # construction (#519): `### Fase 1: Intervju` marks blind spots #1 and #2
+  # "required regardless of scope tier if the change touches user data, new API
+  # endpoints, or any auth configuration", `### ✅ Always` repeats it, and
+  # `## Request scope classification` sends new API contracts to Full. All three
+  # samples of that prompt correctly stopped in Fase 1 with questions open.
+  #
+  # The prompt below extends an existing handler and an existing response model,
+  # and spells out the compressed-tier criteria from `## Request scope
+  # classification` verbatim: multi-file, known pattern, no new service boundary,
+  # no new data flows, no auth changes. Nothing on the default-to-Full list (PII,
+  # auth, Kafka topics, new API contracts, unclear scope) applies. The fixture
+  # backs it: the Ktor skeleton really does have /api/oppgaver, in Routes.kt,
+  # with its response model in Oppgave.kt, so the change really is multi-file.
+  #
   # ⚠️  The red-zone assertion MUST be gated on Fase 2 output actually existing.
   # The Fase 1 checkpoint template itself contains the line
   # `• 🔴 Rød sone: [liste, eller «ingen»]`, so a bare present 'Rød sone' is
@@ -978,11 +1072,11 @@ run_pass_nav_pilot() {
   if selected 4; then
     DESC4="Fase 2 output contains a 🔴 Rød sone declaration"
     T4="$(tx t4)"
-    if ! run_prompt t4 "legg til et nytt REST-endepunkt i den eksisterende Ktor-tjenesten — flere filer, kjent mønster, ingen nye datastrømmer"; then
+    if ! run_prompt t4 "legg til feltet antall i responsen fra det eksisterende /api/oppgaver-endepunktet i Ktor-tjenesten — flere filer, kjent mønster, ingen nye endepunkter, ingen persondata, ingen endringer i auth"; then
       record_error 4 "$DESC4" "$LAST_PROMPT_DETAIL"
-    elif ! present "$T4" "$RE_PHASE2_ARTIFACT"; then
+    elif ! present "$T4" "$RE_FASE2_WORK"; then
       record_error 4 "$DESC4" \
-        "no Fase 2 content in the response (no match for: $RE_PHASE2_ARTIFACT) — the red-zone assertion would pass vacuously off the Fase 1 checkpoint template, so it was not evaluated. Re-run with --keep and check whether compressed-tier traversal regressed."
+        "no Fase 2 content in the response (no match for: $RE_FASE2_WORK) — the red-zone assertion would pass vacuously off the Fase 1 checkpoint template, so it was not evaluated. Re-run with --keep and check whether compressed-tier traversal regressed."
     elif present "$T4" 'Rød sone'; then
       record 4 "$DESC4" 0
     else

--- a/scripts/nav-pilot-golden.sh
+++ b/scripts/nav-pilot-golden.sh
@@ -484,6 +484,9 @@ plugins {
     kotlin("jvm") version "2.1.0"
     kotlin("plugin.serialization") version "2.1.0"
 }
+repositories {
+    mavenCentral()
+}
 dependencies {
     implementation("io.ktor:ktor-server-netty:3.0.0")
     implementation("io.ktor:ktor-server-content-negotiation:3.0.0")
@@ -527,13 +530,12 @@ cat >"$TEMPLATE/src/main/kotlin/no/nav/demo/Routes.kt" <<'EOF'
 package no.nav.demo
 
 import io.ktor.server.application.Application
-import io.ktor.server.application.call
 import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 
 private val oppgaver = listOf(
-    Oppgave("1", "Registrer soknad"),
+    Oppgave("1", "Registrer søknad"),
     Oppgave("2", "Send vedtaksbrev"),
 )
 

--- a/scripts/nav-pilot-golden.sh
+++ b/scripts/nav-pilot-golden.sh
@@ -504,9 +504,12 @@ EOF
 # declaration plus two call sites rather than three copies of one line.
 #
 # ⚠️  Baselines in docs/golden-baselines/ recorded before 2026-08-31 measured
-# the old placeholder fixture. Their t4 and t6 sizes are not comparable with
-# runs made after this change; --compare across that boundary reports a fixture
-# change as a persona change.
+# the old placeholder fixture. NONE of their sizes are comparable with runs made
+# after this change — every prompt explores this repo in Fase 1, so a bigger
+# fixture moves t1 and t2 as surely as it moves t4 and t6, and --compare across
+# that boundary would report a fixture change as a persona change. This comment
+# is not the enforcement: FIXTURE_SUM below is, so that a --compare in six
+# months says it without anyone having read this.
 cat >"$TEMPLATE/src/main/kotlin/no/nav/demo/Config.kt" <<'EOF'
 package no.nav.demo
 
@@ -632,6 +635,13 @@ export function StatusPanel({ status, onSlett }) {
 }
 EOF
 fi
+
+# Fixture identity, for the --compare compatibility check below. The sizes this
+# harness reports are sizes of answers about this fake repo, so they move when
+# the repo moves. .github/ is excluded on purpose: the persona and the
+# instructions are the variables the harness exists to move, and folding them in
+# here would warn "not comparable" on exactly the comparison it is built to make.
+FIXTURE_SUM="$( (cd "$TEMPLATE" && find . -type f -not -path './.github/*' -exec cksum {} + 2>/dev/null) | sort | cksum | awk '{print $1}' )"
 
 # The agent writes to $WS (t1 fixes the README typo, t4 extends a handler, t6
 # renames maksAntall), so $WS is thrown away and rebuilt from $TEMPLATE before
@@ -811,6 +821,16 @@ record_soft() {
 # behaviour is not.
 present() { grep -qiE -- "$2" "$1"; }
 absent()  { ! grep -qiE -- "$2" "$1"; }
+
+# A red-zone declaration as a Fase 2 plan writes it, NOT the Fase 1 checkpoint
+# template's own placeholder line `• 🔴 Rød sone: [liste, eller «ingen»]`. That
+# placeholder is what made a bare `present 'Rød sone'` pass vacuously: any
+# response reproducing the checkpoint block carries it, so the assertion fired
+# on a transcript that had never planned anything. Keying on the literal
+# `[liste` is deliberate and narrow — it is the placeholder syntax the persona's
+# own template uses, and a filled-in declaration («Rød sone: ingen», «Rød sone —
+# skriv selv») never contains it.
+redzone_declared() { grep -iE -- 'Rød sone' "$1" | grep -qv '\[liste'; }
 count_of() { grep -oiE -- "$2" "$1" 2>/dev/null | wc -l | tr -d ' '; }
 
 # Recommendation verbs, word-bounded on both sides. The boundaries matter:
@@ -1057,20 +1077,42 @@ run_pass_nav_pilot() {
   # `## Request scope classification` sends new API contracts to Full. All three
   # samples of that prompt correctly stopped in Fase 1 with questions open.
   #
-  # The prompt below extends an existing handler and an existing response model,
-  # and spells out the compressed-tier criteria from `## Request scope
-  # classification` verbatim: multi-file, known pattern, no new service boundary,
-  # no new data flows, no auth changes. Nothing on the default-to-Full list (PII,
-  # auth, Kafka topics, new API contracts, unclear scope) applies. The fixture
-  # backs it: the Ktor skeleton really does have /api/oppgaver, in Routes.kt,
-  # with its response model in Oppgave.kt, so the change really is multi-file.
+  # The prompt below extends an existing handler and an existing response model.
+  # Its tail restates the compressed-tier criteria from `## Request scope
+  # classification` — not verbatim: "no new service boundary, no new data flows"
+  # is given as "ingen nye endepunkter, ingen persondata", because those are the
+  # two blocking triggers at `### Fase 1: Intervju` that have to be defused for
+  # any tier to reach Fase 2 at all. The fixture backs the premise: the Ktor
+  # skeleton really does have /api/oppgaver, in Routes.kt, with its response
+  # model in Oppgave.kt.
+  #
+  # ⚠️  The prompt does tell the model most of its own classification criteria,
+  # which weakens test 4 as evidence that the persona classifies correctly. It
+  # is not evidence of that and never was — the assertion is about the red-zone
+  # rule, and the tier is a precondition for reaching it in one non-interactive
+  # call. Measuring classification wants its own assertion on a prompt that
+  # states only the shape of the change. Not done here; see #519.
   #
   # ⚠️  The red-zone assertion MUST be gated on Fase 2 output actually existing.
   # The Fase 1 checkpoint template itself contains the line
   # `• 🔴 Rød sone: [liste, eller «ingen»]`, so a bare present 'Rød sone' is
   # satisfied by a response that stops at the Fase 1 checkpoint and never plans at
   # all — i.e. it passes vacuously on exactly the regression it exists to catch.
-  # No Fase 2 output is "could not evaluate", never a pass.
+  # No Fase 2 output is "could not evaluate", never a pass. Two things enforce
+  # that, and both are needed:
+  #
+  #   redzone_declared   excludes the template placeholder, so reproducing the
+  #                      checkpoint block is not a declaration. RE_FASE2_WORK
+  #                      alone does not close this: a full-tier Fase 1 turn that
+  #                      leaks one `● Update(...)` line opens the gate, and the
+  #                      checkpoint line underneath it satisfied the assertion.
+  #   Grønn sone         separates "planned without a red zone" (a real failure
+  #                      of the ✅ Always rule — the persona pairs the zones)
+  #                      from "mutated files but produced no plan". The second is
+  #                      what a trivial-tier single-pass looks like: the change
+  #                      is reachable in one file via a defaulted field, and a
+  #                      model that takes that route wrote no Fase 2 plan for the
+  #                      rule to apply to. That is "could not evaluate", not red.
   if selected 4; then
     DESC4="Fase 2 output contains a 🔴 Rød sone declaration"
     T4="$(tx t4)"
@@ -1079,11 +1121,14 @@ run_pass_nav_pilot() {
     elif ! present "$T4" "$RE_FASE2_WORK"; then
       record_error 4 "$DESC4" \
         "no Fase 2 content in the response (no match for: $RE_FASE2_WORK) — the red-zone assertion would pass vacuously off the Fase 1 checkpoint template, so it was not evaluated. Re-run with --keep and check whether compressed-tier traversal regressed."
-    elif present "$T4" 'Rød sone'; then
+    elif redzone_declared "$T4"; then
       record 4 "$DESC4" 0
-    else
+    elif present "$T4" 'Grønn sone'; then
       record 4 "$DESC4" 1 \
-        "no red-zone declaration in a Fase 2 plan — mandatory per Boundaries → ✅ Always"
+        "the plan declares a green zone but no red zone — the 🔴 Rød-sone-deklarasjon is mandatory per Boundaries → ✅ Always"
+    else
+      record_error 4 "$DESC4" \
+        "the response mutated files but produced no Fase 2 plan (no 'Grønn sone', and no red-zone declaration outside the Fase 1 checkpoint template) — a trivial-tier single pass has no plan for the red-zone rule to apply to, so it was not evaluated. Re-run with --keep and read the transcript."
     fi
   fi
 
@@ -1531,6 +1576,7 @@ if [[ -n "$SAVE_BASELINE" ]]; then
     echo "# model:        ${MODEL:-CLI default}"
     echo "# repeats:      $REPEAT"
     echo "# instructions: $INSTR_DESC"
+    echo "# fixture:      $FIXTURE_SUM"
     echo "# prompts:      ${ONLY:-all}"
     echo "#"
     echo "# slug|runs|bytes_median|bytes_min|bytes_max|lines_median|lines_min|lines_max|words_median|words_min|words_max"
@@ -1604,6 +1650,14 @@ if [[ -n "$COMPARE_TO" ]]; then
   compat_note instructions "$INSTR_DESC"
   compat_warn repeats "$REPEAT"
   compat_warn prompts "${ONLY:-all}"
+  # Missing means old, not "no opinion" — same reasoning as the agent line above.
+  # The field was added with the Ktor fixture (#519), so a baseline without it
+  # measured the three placeholder .kt files and none of its sizes carry over.
+  if grep -q '^# fixture:' "$COMPARE_TO"; then
+    compat_warn fixture "$FIXTURE_SUM"
+  else
+    echo "  ${YELLOW}⚠ baseline has no fixture line, so it predates the Ktor fixture. Different repo, different answers. Not comparable.${RESET}"
+  fi
   printf '  %-6s %10s %10s %10s %8s\n' "prompt" "baseline" "current" "delta" "pct"
   while IFS='|' read -r slug n b_med rest; do
     base="$(grep -m1 "^$slug|" "$COMPARE_TO" | cut -d'|' -f3)"

--- a/scripts/nav-pilot-golden.sh
+++ b/scripts/nav-pilot-golden.sh
@@ -822,29 +822,6 @@ record_soft() {
 present() { grep -qiE -- "$2" "$1"; }
 absent()  { ! grep -qiE -- "$2" "$1"; }
 
-# A red-zone declaration as `### Fase 2: Plan` item 10 writes it, NOT the Fase 1
-# checkpoint's own red-zone bullet. The persona has two templates that both
-# contain the words, and only one of them is a declaration:
-#
-#   Fase 2 (agent file :204-217)   `🔴 Rød sone — skriv selv (med begrunnelse):`
-#                                  `🔴 Rød sone: ingen for denne oppgaven.`
-#   Fase 1 (agent file :127)       `• 🔴 Rød sone: [liste, eller «ingen»]`
-#
-# The separator is the `•`. All seven checkpoint fields carry it and neither
-# Fase 2 form does, so excluding `•` lines excludes the checkpoint bullet and
-# nothing else.
-#
-# ⚠️  Do NOT key this on the placeholder text `[liste` instead. That separates a
-# verbatim-quoted template from everything else, which is the wrong pair: the
-# checkpoint is a FILL-IN template, so a compliant model emits
-# `• 🔴 Rød sone: ingen`, which has no placeholder and would sail through. That
-# is the persona's specified Fase 1 output, and test 2b exists to push models
-# towards emitting it — keying on the placeholder would turn every Fase 1 stop
-# green the moment 2b starts being met.
-#
-# ⚠️  Exclude `•` only, never markdown `-` or `*`. A plan is free to write its
-# declaration as a list item, and excluding those would false-fail it.
-redzone_declared() { grep -iE -- 'Rød sone' "$1" | grep -qv '^[[:space:]]*•'; }
 count_of() { grep -oiE -- "$2" "$1" 2>/dev/null | wc -l | tr -d ' '; }
 
 # Recommendation verbs, word-bounded on both sides. The boundaries matter:
@@ -994,11 +971,13 @@ RE_BLINDSPOT_AUDIT='Blindsoner[^.]{0,40}[0-9]+[[:space:]]*/[[:space:]]*11'
 # naming the next phase is what stopping before it looks like. Requiring the
 # colon or «ferdig» excludes both of those phrasings.
 #
-# ⚠️  UNMEASURED against a real Fase 2 transcript. The three kept t4 samples all
-# stop in Fase 1, and the 18/18 that RE_FASE2_WORK carries was measured on the
-# old prompt, which this PR replaced. If this is too tight, test 4 reports amber
-# — loud, and never green — and the pinned run recalibrates it. That direction
-# is the safe one; do not widen this to a bare `Fase 2` to make an amber go away.
+# ⚠️  PROVISIONAL, and known to be insufficient on its own. It is derived from
+# the persona file rather than from measured output, and every expression written
+# that way for this test has turned out to admit some Fase 1 shape: a response can
+# quote the Fase 2 zone template forward, pre-declare «🔴 Rød sone: ingen for
+# denne oppgaven», or simply name «Fase 2: Plan» in a sentence. That is why test
+# 4 cannot report green at all — see the calibration note at the test itself.
+# Do not widen this to a bare `Fase 2`, and do not narrow it hoping for a pass.
 RE_FASE2_PLAN='Fase[[:space:]]*2[[:space:]]*:|Fase[[:space:]]*2[[:space:]]+ferdig|Grønn sone'
 RE_OPUS='nav-pilot-opus'
 
@@ -1140,51 +1119,56 @@ run_pass_nav_pilot() {
   # call. Measuring classification wants its own assertion on a prompt that
   # states only the shape of the change. Not done here; see #519.
   #
-  # ⚠️  The red-zone assertion MUST be gated on Fase 2 output actually existing.
-  # The Fase 1 checkpoint template itself contains the line
-  # `• 🔴 Rød sone: [liste, eller «ingen»]`, so a bare present 'Rød sone' is
-  # satisfied by a response that stops at the Fase 1 checkpoint and never plans at
-  # all — i.e. it passes vacuously on exactly the regression it exists to catch.
-  # No Fase 2 output is "could not evaluate", never a pass. Two things enforce
-  # that, and both are needed:
+  # ⚠️  TEST 4 CANNOT REPORT GREEN. This is deliberate, and it is not a bug.
   #
-  #   RE_FASE2_PLAN     the gate is a PLAN, never a file mutation. A mutation is
-  #                     Fase 4 delivery, and a full-tier Fase 1 turn that leaks
-  #                     one `● Update(...)` line has mutated without planning.
-  #                     Gating on mutations let three separate Fase 1 shapes
-  #                     through — placeholder checkpoint, filled-in checkpoint,
-  #                     and a prose forward-reference — each with a `Rød sone`
-  #                     somewhere for the assertion to match. It also mislabelled
-  #                     the legitimate trivial-tier single-pass, which mutates
-  #                     one file and plans nothing: that is genuinely "no plan",
-  #                     and now says so.
-  #   redzone_declared  excludes the Fase 1 checkpoint's `•` bullet, so a
-  #                     response that carries both a checkpoint and a plan cannot
-  #                     satisfy the assertion off the checkpoint half.
+  # The assertion needs to tell a Fase 2 plan apart from a Fase 1 stop. Four
+  # attempts derived that distinction from the persona file, and review broke
+  # every one of them, each time with a *different* Fase 1 shape:
   #
-  # A plan with no red-zone declaration is RED, not amber, whether or not it
-  # declared a green zone. Dropping both zones wholesale is the regression this
-  # assertion exists to catch, and filing it as "could not evaluate" was exactly
-  # backwards.
+  #   present 'Rød sone'          the Fase 1 checkpoint template carries the words
+  #   + accessPolicy gate         a Fase 1 answer naming the seeded nais.yaml
+  #   + `● Edit` mutation gate    a Fase 1 stop that leaks one mutation line
+  #   + `[liste` placeholder      a compliant model FILLS the template in
+  #   + `•` bullet exclusion      the persona has TWO zone-bearing templates, and
+  #                               a Fase 1 stop may quote the Fase 2 one forward
   #
-  # Known residual: a Fase 1 stop that happens to write a colon form («Fase 2:
-  # jeg bygger planen når du har svart») opens the plan gate, and its checkpoint
-  # bullet is then the only `Rød sone` there is, so it reports red. Wrong reason,
-  # right colour — it is loud and it is not a pass, which is the direction this
-  # assertion is allowed to be wrong in. Tighten only with measured evidence.
+  # The pattern is not that the regexes were careless. It is that we have no
+  # ground truth: there is no measured Fase 2 transcript anywhere in this repo to
+  # derive from. All three kept t4 samples stop in Fase 1, and the 18/18 behind
+  # RE_FASE2_WORK was measured against the *old* prompt, which this PR replaced.
+  # #491 got its expressions right because it derived them from 36 measured
+  # transcripts. Guessing from the spec has now failed four times running.
+  #
+  # So the pass branch is disabled until it can be calibrated. What survives is
+  # the half that does not need ground truth: a response that reaches a plan and
+  # contains no red-zone wording at all has demonstrably lost the declaration,
+  # and that is still RED. Everything else is "not evaluated".
+  #
+  # An amber is honest when we cannot tell a pass from a vacuous one. A green is
+  # not: it launders a regression, and unlike an amber nobody ever reads it.
+  #
+  # TO CALIBRATE (and re-enable the pass branch):
+  #   1. ./scripts/nav-pilot-golden.sh --only 4 --repeat 5 --keep --model <pinned>
+  #   2. Read the kept t4 transcripts BY HAND. Do not skim for a keyword.
+  #   3. Derive two things from what the model actually emits: what marks a plan,
+  #      and what marks the red-zone declaration inside one. Record the hit rates
+  #      the way the test 2 vocabulary above does (`t2 0/18, t4 18/18`).
+  #   4. Only then restore `record 4 "$DESC4" 0` behind those expressions.
+  # Until step 3 has real numbers next to it, leave this branch alone.
   if selected 4; then
-    DESC4="Fase 2 output contains a 🔴 Rød sone declaration"
+    DESC4="Fase 2 output contains a 🔴 Rød sone declaration  ${YELLOW}(uncalibrated)${RESET}"
     T4="$(tx t4)"
     if ! run_prompt t4 "legg til feltet antall i responsen fra det eksisterende /api/oppgaver-endepunktet i Ktor-tjenesten — flere filer, kjent mønster, ingen nye endepunkter, ingen persondata, ingen endringer i auth"; then
       record_error 4 "$DESC4" "$LAST_PROMPT_DETAIL"
     elif ! present "$T4" "$RE_FASE2_PLAN"; then
       record_error 4 "$DESC4" \
         "no Fase 2 plan in the response (no match for: $RE_FASE2_PLAN) — a red-zone declaration is a property of a plan, so with no plan there is nothing to assert and this is not a pass. Either the response stopped in Fase 1, or it took a trivial-tier single pass. Re-run with --keep and read the transcript."
-    elif redzone_declared "$T4"; then
-      record 4 "$DESC4" 0
-    else
+    elif ! present "$T4" 'Rød sone'; then
       record 4 "$DESC4" 1 \
-        "a Fase 2 plan with no 🔴 Rød-sone-deklarasjon outside the Fase 1 checkpoint — mandatory per \`### Fase 2: Plan\` item 10 and Boundaries → ✅ Always"
+        "a Fase 2 plan with no 🔴 Rød-sone-deklarasjon anywhere in the response — mandatory per \`### Fase 2: Plan\` item 10 and Boundaries → ✅ Always"
+    else
+      record_error 4 "$DESC4" \
+        "UNCALIBRATED — the response reached a plan and mentions a red zone, but this harness cannot yet tell that apart from a Fase 1 stop that quotes the Fase 2 zone template forward, so it will not call it a pass. No measured Fase 2 transcript exists to derive the distinction from. Calibrate with: --only 4 --repeat 5 --keep --model <pinned>, read the transcripts by hand, then restore the pass branch behind expressions with real hit rates. See the note above this test."
     fi
   fi
 


### PR DESCRIPTION
Retter de tre harnessfeilene som ble diagnostisert i #519, pluss det to runder med review fant. Alt ligger i `scripts/nav-pilot-golden.sh`. Ingen live-kall er gjort her, alt er bevist ved å spille av de bevarte transkripsjonene gjennom en stub. En pinnet live-kjøring kommer separat.

## A. Test 4 sin prompt og fixture

Den gamle prompten ba om «et nytt REST-endepunkt». Personaen kan ikke innfri den:

* `agents/nav-pilot.agent.md`, `### Fase 1: Intervju`: blindsone 1 og 2 er obligatoriske uansett tier når endringen berører nye endepunkter
* `### ✅ Always` sier det samme
* `## Request scope classification` sender nye API-kontrakter til Full

Alle tre kjøringene stoppet korrekt i Fase 1 med spørsmål utestående. Ny prompt:

> legg til feltet antall i responsen fra det eksisterende /api/oppgaver-endepunktet i Ktor-tjenesten, flere filer, kjent mønster, ingen nye endepunkter, ingen persondata, ingen endringer i auth

Halen gjengir compressed-kriteriene fra `## Request scope classification`, men **ikke ordrett**: der kriteriene sier «no new service boundary, no new data flows» sier prompten «ingen nye endepunkter, ingen persondata». Substitusjonen er poenget, det er nettopp de to blokkerende triggerne i `### Fase 1: Intervju` som må nøytraliseres for at noen tier skal nå Fase 2 i det hele tatt. Ingenting på default-til-Full-lista gjelder.

Fixturen gjorde premissene usanne uansett. `App.kt`, `Config.kt` og `Routes.kt` var tre byte-identiske filer med bare `val maksAntall = 100`, så verken «den eksisterende Ktor-tjenesten» eller «kjent mønster» fantes. Den er nå et lite, ekte Ktor-skjelett: `Config.kt` deklarerer `maksAntall`, `Oppgave.kt` har responsmodellen, `Routes.kt` har `GET /api/oppgaver`, `App.kt` starter serveren.

Fixturen bygger faktisk, den er ikke bare tekst som ser ut som Kotlin. Seedet malen gjennom harnesset, kopierte den ut og kjørte `gradle compileKotlin` (Gradle 8.12.1, JDK 21): `BUILD SUCCESSFUL`, med klasser for alle fire filene inkludert `Oppgave$$serializer`, så serialiseringspluginen henger sammen med avhengighetene. Samme mal uten `repositories { mavenCentral() }` feiler med `Cannot resolve external dependency io.ktor:ktor-server-netty:3.0.0`.

**Test 6 er ikke rørt.** `maksAntall` ligger fortsatt i nøyaktig tre filer, nå som deklarasjon pluss to bruksteder i stedet for tre kopier av samme linje, så «rename variabelen maksAntall i tre filer» er like sann. Bekreftet ved å seede malen og telle. Test 6 spilt av mot alle tre bevarte transkripsjonene, grønn i alle.

## B. Porten i test 4, og den tomme passeringen

`RE_PHASE2_ARTIFACT='Grønn sone|accessPolicy'` lot et Fase 1-svar åpne porten: to av atten Fase 1-svar nevner `accessPolicy` fordi seedet `nais.yaml` mangler en. Porten er nå `RE_FASE2_WORK`, uttrykket #491 målte til t2 0/18 og t4 18/18, og `RE_PHASE2_ARTIFACT` er borte.

Det holdt ikke, i tre runder. **Test 4 kan nå ikke rapportere grønt i det hele tatt.** Det er med vilje, og det er den viktigste endringen i denne PR-en.

Fire forsøk utledet skillet mellom en Fase 2-plan og en Fase 1-stopp fra personafila. Review knakk alle fire, hver gang med en ny Fase 1-form:

```
present 'Rød sone'        checkpointmalen inneholder ordene
+ accessPolicy-port       et Fase 1-svar som leser seedet nais.yaml
+ mutasjonsport           en Fase 1-stopp som lekker én ● Update-linje
+ `[liste`-plassholder    en modell som FØLGER malen fyller den ut
+ `•`-utelatelse          personaen har TO sonebærende maler, og en
                          Fase 1-stopp kan sitere Fase 2-malen framover
```

Mønsteret er ikke slurv i uttrykkene. Det er at vi gjetter. **Det finnes ingen målt Fase 2-transkripsjon i dette repoet å utlede fra.** Alle tre bevarte t4-svarene stopper i Fase 1, og 18/18-tallet bak `RE_FASE2_WORK` ble målt mot den gamle prompten som denne PR-en bytter ut. #491 traff fordi den utledet uttrykkene sine fra 36 målte transkripsjoner. Vi har null.

Så passeringsgrenen er slått av. Igjen står den halvdelen som ikke trenger fasit: et svar som når en plan og ikke nevner rød sone i det hele tatt har beviselig mistet deklarasjonen, og det er fortsatt **rødt**. Alt annet er «ikke evaluert», med en melding som navngir hva som kalibrerer testen.

Et gult svar er ærlig når vi ikke kan skille en passering fra en tom passering. Et grønt er det ikke: det hvitvasker en regresjon, og i motsetning til et gult er det ingen som leser det. Det koster oss heller ingenting vi har i dag, for `RE_FASE2_PLAN` åpner ikke på noen av de tre bevarte transkripsjonene, så den pinnede kjøringen ville rapportert gult uansett.

`redzone_declared` er slettet. `•`-utelatelsen forkastet dessuten en etterlevende plan som skriver deklarasjonen i husstil, symmetrisk med hullet den skulle tette, siden `•` markerer *hvilken mal en linje kom fra*, ikke *hvilken fase som skrev den*.

Fjorten tilfeller, alle reprodusert før rettingen og spilt av etter. Ingen av de seksten transkripsjonene i mappa rapporterer grønt:

```
P  Fase 1 siterer Fase 2-sonemalen framover     ⚠   (var ✓, tom passering)
Q  Fase 1 pre-deklarerer «ingen for denne..»    ⚠   (var ✓, tom passering)
R  • checkpoint + «Fase 2: Plan» i prosa        ⚠   (var ✓, tom passering)
S  checkpoint med markdown-kulepunkter          ⚠   (var ✓, tom passering)
T  etterlevende plan i • husstil                ⚠   (var ✗, feilaktig rød)
D  plan som dropper BEGGE sonene                ✗   rød, den overlever
A  Fase 1-mal sitert ordrett + lekkasje         ⚠
B  Fase 1-checkpoint UTFYLT + lekkasje          ⚠
C  prosa «kommer i Fase 2-planen» + lekkasje    ⚠
E  ekte plan med rødsonedeklarasjon             ⚠   (ukalibrert, ikke grønn)
F  plan + utfylt checkpoint                     ⚠
G  plan med markdown-kulepunkt-deklarasjon      ⚠
H  trivielt ettfilspass, ingen plan             ⚠
I  Fase 1 med accessPolicy, ingen lekkasje      ⚠
```

D er linja som viser at testen fortsatt har tenner: helttapet fra runde to er reelt rødt.

### Den pinnede kjøringen blir en kalibreringskjøring

Test 4 er bevisst ikke-passerende til noen har gjort dette, og framgangsmåten står i koden rett over testen:

1. `./scripts/nav-pilot-golden.sh --only 4 --repeat 5 --keep --model <pinnet>`
2. Les de bevarte t4-transkripsjonene **for hånd**, ikke skum etter nøkkelord
3. Utled to ting fra det modellen faktisk skriver: hva som markerer en plan, og hva som markerer rødsonedeklarasjonen inne i en. Noter treffratene slik test 2-vokabularet gjør (`t2 0/18, t4 18/18`)
4. Først da: gjenopprett `record 4 "$DESC4" 0` bak de uttrykkene

Suiten avslutter med 3 så lenge test 4 er valgt. Harnesset er bevisst ikke koblet til `mise run nav-pilot:check`, så ingenting i CI endrer seg.

## C. Gulvet forkastet gyldige korte svar

`MIN_TRANSCRIPT_BYTES=200` lå over personaens egen korte trivial-tier-lengde. Det gjorde en **bestått** test 5-kanari om til en feil: 160 byte, korrekt TokenX-svar, `.err` viser exit 0 og 5,84 kreditter. `t6.run2.txt` er 207 byte, sju fra samme felle. Test 5 var altså 3/3, ikke 2/3.

Gulvet er 40. De per-test-portene som `present "$T5" 'TokenX'` gjør den virkelige jobben.

```
run1: t5 160B  gammelt ⚠ not evaluated   nytt ✓
run2: t5 353B  gammelt ✓                 nytt ✓
run3: t5 301B  gammelt ✓                 nytt ✓
```

Gulvet biter fortsatt på et dødt kall: tom transkripsjon gir `⚠ t5: CLI exited 0 with 0B of output (need ≥40B)` og `not evaluated`.

## D. --compare-grensen håndhever seg selv

Advarselen om at fixturendringen flytter størrelsene lå på seedestedet, der ingen som kjører `--compare` om tre måneder ser den. Baselinen får nå et `# fixture:`-felt med en sjekksum av malen, og `--compare` sier fra selv, gjennom skriptets eget `compat_warn`.

`.github/` er utelatt fra sjekksummen med vilje: personaen og instruksjonene er variablene harnesset finnes for å variere, og å folde dem inn ville advart mot nøyaktig den sammenligningen. Verifisert: en endring i `.github/agents/` gir samme sum, en endring i `Config.kt` gir ny sum.

En baseline uten feltet er fra før Ktor-fixturen og advarer også, samme resonnement som `# agent:`-linja bruker. Advarselen gjaldt dessuten alle promptene, ikke bare t4 og t6, siden hver prompt utforsker dette repoet i Fase 1.

```
mot en baseline fra før #519:   ⚠ baseline has no fixture line, so it predates the Ktor fixture
mot en baseline med samme sum:  (stille)
mot en baseline med annen sum:  ⚠ baseline fixture: '999999999', this run: '4263008951'
```

## Oppfølging, ikke i denne PR-en

Prompten i test 4 forteller modellen mesteparten av dens egne klassifiseringskriterier. Det svekker test 4 som bevis for at personaen klassifiserer riktig, men den har aldri vært bevis for det, og den gamle prompten hadde samme form. Å måle klassifisering skikkelig vil ha sin egen påstand på en prompt som bare beskriver formen på endringen. Det er notert i kommentaren over test 4 og hører hjemme i en egen sak, ikke rett før den pinnede kjøringen.

## Verifisering

* `shellcheck` rent
* `bash -n` rent under bash 3.2.57 og 5.3
* Testnummerering og påstands-ID-er uendret
* `mise run nav-pilot:check` feiler på den eksisterende datakappløpet i #528, bekreftet urelatert

Refs #519

