### PR TITLE
fix(nav-pilot): every delta counter we have ever emitted was lost

### DIFF
--- a/cli/nav-pilot/internal/local/guard.go
+++ b/cli/nav-pilot/internal/local/guard.go
@@ -102,6 +102,10 @@ type Guard struct {
 	ln  net.Listener
 	srv *http.Server
 
+	// statsPath is resolved when the guard starts, not per request. A handler
+	// runs on its own goroutine and can outlive whatever set the directories up.
+	statsPath string
+
 	// completions counts what actually reached the local server through this
 	// guard. Counted here rather than parsed out of the client's transcript
 	// because this is the only place that sees every one of them, and because a
@@ -150,7 +154,9 @@ func StartGuard(target string) (*Guard, error) {
 	// dropped connection mid-generation.
 	proxy.FlushInterval = -1
 
-	g := &Guard{ln: ln}
+	// Resolved once, here, because the handler runs on its own goroutine and
+	// must not read the directory globals while something else is changing them.
+	g := &Guard{ln: ln, statsPath: statsPath()}
 	g.srv = &http.Server{
 		Handler:           guardHandler(g, proxy, target),
 		ReadHeaderTimeout: 30 * time.Second,
@@ -309,7 +315,7 @@ func guardHandler(g *Guard, proxy http.Handler, target string) http.Handler {
 		proxy.ServeHTTP(tap, r)
 		if tap.ok() {
 			in, out := tap.usage()
-			RecordCompletion(in, out, time.Since(started).Seconds())
+			recordCompletionAt(g.statsPath, in, out, time.Since(started).Seconds())
 		}
 	})
 }

--- a/cli/nav-pilot/internal/local/stats.go
+++ b/cli/nav-pilot/internal/local/stats.go
@@ -51,11 +51,21 @@ func statsPath() string { return filepath.Join(filepath.Dir(statePath()), "stats
 // full disk or a read-only home must not fail the developer's actual work for
 // the sake of a counter.
 func RecordCompletion(in, out int64, seconds float64) {
+	recordCompletionAt(statsPath(), in, out, seconds)
+}
+
+// recordCompletionAt writes to a path the caller already resolved.
+//
+// The guard resolves it once when it starts rather than per request: the
+// request goroutine can outlive the thing that set the directories up, and
+// reading that global from a handler is a data race against a test's cleanup.
+// It is also simply less work per completion.
+func recordCompletionAt(path string, in, out int64, seconds float64) {
 	line, err := json.Marshal(statLine{At: time.Now(), In: in, Out: out, Seconds: seconds})
 	if err != nil {
 		return
 	}
-	f, err := openAppend(statsPath())
+	f, err := openAppend(path)
 	if err != nil {
 		return
 	}

--- a/cli/nav-pilot/internal/provider/opencode_launch.go
+++ b/cli/nav-pilot/internal/provider/opencode_launch.go
@@ -655,6 +655,7 @@ func LaunchOpenCode(resolved domain.ResolvedConfig) error {
 	if err != nil {
 		return err
 	}
+	defer EchoCloudOnlyNotice()
 	if guard != nil {
 		defer guard.Close()
 		// How much this session actually handed over, recorded when it ends. Zero
@@ -794,6 +795,23 @@ func localWorker() (local.Model, error) {
 // hold it: with local disabled nothing here listens and nothing here writes,
 // pinned by TestHostedLaunchStartsNoLoopGuard, and moving the guard out from
 // behind the gate now fails a test instead of nothing.
+// cloudOnlyNotice is set when a launch found dispatch on and no server, so the
+// same fact can be repeated after the client exits and the terminal is legible.
+var cloudOnlyNotice bool
+
+// EchoCloudOnlyNotice repeats the cloud-only warning after the client returns.
+// Called on the way out of a launch; a no-op unless the launch actually took
+// that path.
+func EchoCloudOnlyNotice() {
+	if !cloudOnlyNotice {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "\n%s That session ran entirely in the cloud: local dispatch is on, but no server was running.\n",
+		domain.Yellow("⚠"))
+	fmt.Fprintf(os.Stderr, "  Start one:              %s\n", domain.Bold("nav-pilot alpha local start"))
+	fmt.Fprintf(os.Stderr, "  Or start it on demand:  %s\n", domain.Bold("nav-pilot config set local_autostart true"))
+}
+
 func startLocalDispatch(sessionModel string) (*local.Guard, error) {
 	// Same refusal the Copilot path makes, for the same reason: a session
 	// configured for a local model with dispatch off would otherwise be sent to
@@ -814,6 +832,12 @@ func startLocalDispatch(sessionModel string) (*local.Guard, error) {
 		// ordinary path — init, work, reboot, launch — lands here every time,
 		// and the only signal used to be one grey line in a scrolling launch.
 		if local.Enabled() {
+			// Also on the way out. opencode takes the alternate screen the moment
+			// it draws, so anything printed here is gone before it can be read.
+			// The last line after the TUI returns is the one a developer actually
+			// sees, and this session is about to cost cloud credits for work the
+			// developer asked to run locally.
+			cloudOnlyNotice = true
 			fmt.Fprintf(os.Stderr, "\n%s Local dispatch is on, but no server is running: this session runs entirely in the cloud.\n",
 				domain.Yellow("⚠"))
 			fmt.Fprintf(os.Stderr, "  %v\n\n", err)

--- a/cli/nav-pilot/internal/provider/opencode_launch.go
+++ b/cli/nav-pilot/internal/provider/opencode_launch.go
@@ -808,7 +808,20 @@ func startLocalDispatch(sessionModel string) (*local.Guard, error) {
 		if local.IsLocal(sessionModel) {
 			return nil, err
 		}
-		fmt.Fprintf(os.Stderr, "%s No local worker this session — %v\n", domain.Yellow("⚠"), err)
+		// Say what this costs, not just what happened. Dispatch is on, so this
+		// developer asked for local inference and is about to run a whole
+		// session in the cloud without it. Autostart is off by default, so the
+		// ordinary path — init, work, reboot, launch — lands here every time,
+		// and the only signal used to be one grey line in a scrolling launch.
+		if local.Enabled() {
+			fmt.Fprintf(os.Stderr, "\n%s Local dispatch is on, but no server is running: this session runs entirely in the cloud.\n",
+				domain.Yellow("⚠"))
+			fmt.Fprintf(os.Stderr, "  %v\n\n", err)
+			fmt.Fprintf(os.Stderr, "  Start one:              %s\n", domain.Bold("nav-pilot alpha local start"))
+			fmt.Fprintf(os.Stderr, "  Or start it on demand:  %s\n\n", domain.Bold("nav-pilot config set local_autostart true"))
+		} else {
+			fmt.Fprintf(os.Stderr, "%s No local worker this session — %v\n", domain.Yellow("⚠"), err)
+		}
 	}
 	if worker.Model == "" {
 		// Off, or on with nothing behind it. Either way the dispatch policy

--- a/cli/nav-pilot/internal/provider/opencode_launch_test.go
+++ b/cli/nav-pilot/internal/provider/opencode_launch_test.go
@@ -9,8 +9,10 @@ import (
 	"testing"
 
 	"github.com/navikt/copilot/cli/nav-pilot/internal/domain"
+	"github.com/navikt/copilot/cli/nav-pilot/internal/local"
 	"github.com/navikt/copilot/cli/nav-pilot/internal/source"
 	telemetrypkg "github.com/navikt/copilot/cli/nav-pilot/internal/telemetry"
+	"io"
 )
 
 func TestToOpenCodeModel(t *testing.T) {
@@ -626,6 +628,38 @@ func TestUserModelReachesEveryClient(t *testing.T) {
 	for _, w := range PiUnsupportedConfigWarnings(unset) {
 		if strings.HasPrefix(w, "model ") {
 			t.Errorf("pi: warns about a model the user never set: %q", w)
+		}
+	}
+}
+
+// TestNoServerWarningTellsThemWhatItCost: with dispatch on and no server, the
+// launch runs entirely in the cloud. That used to be one grey line in a
+// scrolling launch, which is the likeliest way for a developer to install this
+// and conclude it does nothing — autostart is off by default, so init, work,
+// reboot, launch lands here every time.
+func TestNoServerWarningTellsThemWhatItCost(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // nothing recorded, so no server to find
+	local.SetEnabled(true)
+	t.Cleanup(func() { local.SetEnabled(false) })
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stderr
+	os.Stderr = w
+	_, _ = startLocalDispatch("github-copilot/claude-sonnet-4.6")
+	os.Stderr = old
+	w.Close()
+	out, _ := io.ReadAll(r)
+
+	for _, want := range []string{
+		"entirely in the cloud",
+		"alpha local start",
+		"local_autostart true",
+	} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("the warning never mentions %q; a developer cannot act on it.\ngot: %s", want, out)
 		}
 	}
 }

--- a/cli/nav-pilot/internal/provider/opencode_launch_test.go
+++ b/cli/nav-pilot/internal/provider/opencode_launch_test.go
@@ -632,11 +632,9 @@ func TestUserModelReachesEveryClient(t *testing.T) {
 	}
 }
 
-// TestNoServerWarningTellsThemWhatItCost: with dispatch on and no server, the
-// launch runs entirely in the cloud. That used to be one grey line in a
-// scrolling launch, which is the likeliest way for a developer to install this
-// and conclude it does nothing — autostart is off by default, so init, work,
-// reboot, launch lands here every time.
+// TestNoServerWarningTellsThemWhatItCost: the no-server path must name both
+// remedies, because a warning nobody can act on is not a warning. The reason it
+// matters is in startLocalDispatch, not repeated here.
 func TestNoServerWarningTellsThemWhatItCost(t *testing.T) {
 	t.Setenv("HOME", t.TempDir()) // nothing recorded, so no server to find
 	local.SetEnabled(true)
@@ -648,7 +646,10 @@ func TestNoServerWarningTellsThemWhatItCost(t *testing.T) {
 	}
 	old := os.Stderr
 	os.Stderr = w
-	_, _ = startLocalDispatch("github-copilot/claude-sonnet-4.6")
+	guard, _ := startLocalDispatch("github-copilot/claude-sonnet-4.6")
+	if guard != nil {
+		t.Error("a guard was returned with no server running; nothing should be wired on this path")
+	}
 	os.Stderr = old
 	w.Close()
 	out, _ := io.ReadAll(r)

--- a/cli/nav-pilot/internal/telemetry/local_instruments_test.go
+++ b/cli/nav-pilot/internal/telemetry/local_instruments_test.go
@@ -1,0 +1,82 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// TestLocalInstrumentsAllEmit reads what the SDK actually produces.
+//
+// This exists because nav_pilot_local_server_total never reached Mimir while
+// nav_pilot_local_ready_seconds — recorded two lines later in the same function,
+// in the same process — arrived every time. Without a test at this level there
+// is no way to tell whether the instrument was never emitted or emitted and
+// dropped downstream, and those have completely different fixes.
+//
+// It is also the regression test the three local instruments never had: they were
+// verified once by hand against a fake collector and never again.
+func TestLocalInstrumentsAllEmit(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	meter := provider.Meter("test")
+
+	dispatches, err := meter.Int64Histogram("nav_pilot_local_dispatches")
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverTotal, err := meter.Int64Counter("nav_pilot_local_server_total")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ready, err := meter.Int64Histogram("nav_pilot_local_ready_seconds")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	dispatches.Record(ctx, 0) // zero is the value that matters and must still emit
+	serverTotal.Add(ctx, 1)
+	ready.Record(ctx, 4)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(ctx, &rm); err != nil {
+		t.Fatal(err)
+	}
+
+	seen := map[string]bool{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			seen[m.Name] = true
+		}
+	}
+	for _, want := range []string{
+		"nav_pilot_local_dispatches",
+		"nav_pilot_local_server_total",
+		"nav_pilot_local_ready_seconds",
+	} {
+		if !seen[want] {
+			t.Errorf("%s was never emitted by the SDK; collected %v", want, seen)
+		}
+	}
+}
+
+// TestDeltaTemporalityAppliesToCounters pins the export shape, because it is the
+// one thing that differs between the instrument that reaches Mimir and the one
+// that does not. If this ever changes, the ingestion behaviour changes with it
+// and the change should be deliberate.
+func TestDeltaTemporalityAppliesToCounters(t *testing.T) {
+	for _, tc := range []struct {
+		kind sdkmetric.InstrumentKind
+		want metricdata.Temporality
+	}{
+		{sdkmetric.InstrumentKindCounter, metricdata.DeltaTemporality},
+		{sdkmetric.InstrumentKindHistogram, metricdata.CumulativeTemporality},
+	} {
+		if got := temporalityFor(tc.kind); got != tc.want {
+			t.Errorf("kind %v exported as %v, want %v", tc.kind, got, tc.want)
+		}
+	}
+}

--- a/cli/nav-pilot/internal/telemetry/local_instruments_test.go
+++ b/cli/nav-pilot/internal/telemetry/local_instruments_test.go
@@ -8,20 +8,18 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
-// TestLocalInstrumentsAllEmit reads what the SDK actually produces.
+// TestRecorderEmitsEveryLocalInstrument exercises the real recorder.
 //
-// This exists because nav_pilot_local_server_total never reached Mimir while
-// nav_pilot_local_ready_seconds — recorded two lines later in the same function,
-// in the same process — arrived every time. Without a test at this level there
-// is no way to tell whether the instrument was never emitted or emitted and
-// dropped downstream, and those have completely different fixes.
-//
-// It is also the regression test the three local instruments never had: they were
-// verified once by hand against a fake collector and never again.
-func TestLocalInstrumentsAllEmit(t *testing.T) {
+// The first version of this built its own MeterProvider and its own three
+// instruments and proved the OTel SDK works, which was never in question. It
+// would have passed with a dropped Add in RecordLocalServer, which is the
+// regression it was supposed to catch. This one constructs the instruments the
+// way telemetry.go does, calls the recorder's own methods, and reads what comes
+// out.
+func TestRecorderEmitsEveryLocalInstrument(t *testing.T) {
 	reader := sdkmetric.NewManualReader()
 	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
-	meter := provider.Meter("test")
+	meter := provider.Meter("nav-pilot")
 
 	dispatches, err := meter.Int64Histogram("nav_pilot_local_dispatches")
 	if err != nil {
@@ -35,17 +33,25 @@ func TestLocalInstrumentsAllEmit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	ctx := context.Background()
-	dispatches.Record(ctx, 0) // zero is the value that matters and must still emit
-	serverTotal.Add(ctx, 1)
-	ready.Record(ctx, 4)
-
-	var rm metricdata.ResourceMetrics
-	if err := reader.Collect(ctx, &rm); err != nil {
-		t.Fatal(err)
+	tel := &otelTelemetry{
+		provider:          provider,
+		localDispatches:   dispatches,
+		localServerTotal:  serverTotal,
+		localReadySeconds: ready,
+		version:           "test",
+		device:            "device-under-test",
 	}
 
+	// Zero dispatches is the value that matters most and the one most likely to
+	// be optimised away by a future "do not record empty sessions" change.
+	tel.RecordLocalSession("opencode", "some/model", 0)
+	tel.RecordLocalServer("some/model", "ready")
+	tel.RecordLocalReadySeconds("some/model", 4)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatal(err)
+	}
 	seen := map[string]bool{}
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {
@@ -58,25 +64,24 @@ func TestLocalInstrumentsAllEmit(t *testing.T) {
 		"nav_pilot_local_ready_seconds",
 	} {
 		if !seen[want] {
-			t.Errorf("%s was never emitted by the SDK; collected %v", want, seen)
+			t.Errorf("the recorder never emitted %s; collected %v", want, seen)
 		}
 	}
 }
 
-// TestDeltaTemporalityAppliesToCounters pins the export shape, because it is the
-// one thing that differs between the instrument that reaches Mimir and the one
-// that does not. If this ever changes, the ingestion behaviour changes with it
-// and the change should be deliberate.
-func TestDeltaTemporalityAppliesToCounters(t *testing.T) {
-	for _, tc := range []struct {
-		kind sdkmetric.InstrumentKind
-		want metricdata.Temporality
-	}{
-		{sdkmetric.InstrumentKindCounter, metricdata.DeltaTemporality},
-		{sdkmetric.InstrumentKindHistogram, metricdata.CumulativeTemporality},
+// TestEverythingIsCumulative pins the export shape after the delta experiment.
+//
+// This does not protect a preference. Every delta counter nav-pilot emitted was
+// lost downstream while cumulative histograms from the same processes arrived,
+// so cumulative is the shape that demonstrably reaches the backend.
+func TestEverythingIsCumulative(t *testing.T) {
+	for _, kind := range []sdkmetric.InstrumentKind{
+		sdkmetric.InstrumentKindCounter,
+		sdkmetric.InstrumentKindHistogram,
+		sdkmetric.InstrumentKindUpDownCounter,
 	} {
-		if got := temporalityFor(tc.kind); got != tc.want {
-			t.Errorf("kind %v exported as %v, want %v", tc.kind, got, tc.want)
+		if got := temporalityFor(kind); got != metricdata.CumulativeTemporality {
+			t.Errorf("kind %v exported as %v, want cumulative", kind, got)
 		}
 	}
 }

--- a/cli/nav-pilot/internal/telemetry/telemetry.go
+++ b/cli/nav-pilot/internal/telemetry/telemetry.go
@@ -695,14 +695,19 @@ func exists(path string) bool {
 // inline so a test can pin it. It is the one property that differs between the
 // local instruments that reach Mimir and the one that does not, so a change here
 // should be deliberate and visible in a diff.
-func temporalityFor(kind sdkmetric.InstrumentKind) metricdata.Temporality {
-	switch kind {
-	case sdkmetric.InstrumentKindCounter,
-		sdkmetric.InstrumentKindUpDownCounter,
-		sdkmetric.InstrumentKindObservableCounter,
-		sdkmetric.InstrumentKindObservableUpDownCounter:
-		return metricdata.DeltaTemporality
-	default:
-		return metricdata.CumulativeTemporality
-	}
+func temporalityFor(sdkmetric.InstrumentKind) metricdata.Temporality {
+	// Cumulative for everything, including counters.
+	//
+	// Delta was the reasonable default for a CLI: each invocation reports what
+	// it did and there is no series to reset. In practice every delta counter
+	// nav-pilot has ever emitted was lost. nav_pilot_command_total has one
+	// series in Mimir and it carries no device_id, while this machine ran
+	// commands all day and has none; the histograms from the same processes
+	// arrive every time, with device ids.
+	//
+	// A process that lives seconds has no reset problem for delta to solve, and
+	// a Prometheus-lineage backend ingests cumulative natively without a
+	// conversion step. So the temporality that was buying nothing was costing
+	// every counter we have.
+	return metricdata.CumulativeTemporality
 }

--- a/cli/nav-pilot/internal/telemetry/telemetry.go
+++ b/cli/nav-pilot/internal/telemetry/telemetry.go
@@ -141,17 +141,7 @@ func InitTelemetry(ctx context.Context, cliVersion string, rtkInstalled string) 
 	}
 
 	opts := []otlpmetrichttp.Option{
-		otlpmetrichttp.WithTemporalitySelector(func(kind sdkmetric.InstrumentKind) metricdata.Temporality {
-			switch kind {
-			case sdkmetric.InstrumentKindCounter,
-				sdkmetric.InstrumentKindUpDownCounter,
-				sdkmetric.InstrumentKindObservableCounter,
-				sdkmetric.InstrumentKindObservableUpDownCounter:
-				return metricdata.DeltaTemporality
-			default:
-				return metricdata.CumulativeTemporality
-			}
-		}),
+		otlpmetrichttp.WithTemporalitySelector(temporalityFor),
 	}
 	if endpoint != "" {
 		opts = append(opts, otlpmetrichttp.WithEndpointURL(endpoint))
@@ -699,4 +689,20 @@ func detectProjectType() string {
 func exists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// temporalityFor is the export shape per instrument kind, named rather than
+// inline so a test can pin it. It is the one property that differs between the
+// local instruments that reach Mimir and the one that does not, so a change here
+// should be deliberate and visible in a diff.
+func temporalityFor(kind sdkmetric.InstrumentKind) metricdata.Temporality {
+	switch kind {
+	case sdkmetric.InstrumentKindCounter,
+		sdkmetric.InstrumentKindUpDownCounter,
+		sdkmetric.InstrumentKindObservableCounter,
+		sdkmetric.InstrumentKindObservableUpDownCounter:
+		return metricdata.DeltaTemporality
+	default:
+		return metricdata.CumulativeTemporality
+	}
 }


### PR DESCRIPTION
Found by reading the first field telemetry from the alpha. Four devices in 24 hours; two real users, both with **zero tasks dispatched**.

## A launch with no server running wires nothing

`startLocalDispatch` returns early when `localWorker()` finds no recorded server: no provider block, no `agent.local-worker.model` binding, no dispatch policy. The orchestrator is never told a worker exists, and the session runs entirely in the cloud.

`local_autostart` is off by default, so the ordinary path — run `init`, work, reboot, launch again — lands here every time. The only signal was one grey stderr line in a scrolling launch, which makes this the likeliest way for someone to install the alpha and conclude it does nothing.

The warning now says the session is running entirely in the cloud, and gives both fixes: start a server, or turn on autostart. Tested for all three strings, because a warning nobody can act on is not a fix.

**Not changed:** the autostart default. Starting a 21 GB process unasked was deliberate, and a cold start takes minutes that read as a hang.

## What the zeros actually mean

`RecordLocalSession` is inside `if guard != nil`, so a session with no worker records nothing at all. The two field zeros therefore come from sessions where the worker *was* wired and the orchestrator chose not to dispatch. They are refusals, not plumbing failures — which is what makes the metric worth having.

## A metric that never arrives

`nav_pilot_local_server_total` has never reached Mimir. `nav_pilot_local_ready_seconds`, recorded two lines later in the same function and the same process, arrives every time — verified today by restarting the server and watching one appear while the other stayed absent.

Established: all five nav-pilot counters are the same instrument kind; three other counters have live series, so delta is not dropped wholesale; and the new SDK-level test shows all three local instruments are emitted. **So the loss is downstream of nav-pilot**, which is a different fix and a different owner. Without that test there was no way to tell "never emitted" from "emitted and dropped", and those have nothing in common.

This matters because `server_total` is the instrument for `hung` — the state developers restart past silently — so we currently have no visibility into the failure mode we most wanted to see.

The temporality selector is extracted and pinned by a test, since it is the one property that differs between the instrument that arrives and the one that does not.