### PR TITLE
docs(news): correct the Qwen3.8 claim while the reason is re-verified

### DIFF
--- a/docs/news/articles/lokale-modeller-i-nav-pilot.md
+++ b/docs/news/articles/lokale-modeller-i-nav-pilot.md
@@ -49,7 +49,7 @@ Først prøvde vi åtte modeller og bygg på det samme oppgavesettet: elleve opp
 - **Qwen3.6-35B-A3B, vanlig 4-bit.** Samme modell, annet bygg. Gikk i tool-loop og brukte 220 kall på én oppgave.
 - **KAT-Coder V2.5.** Løste like mange, men trengte flere kall på å komme dit.
 - **Qwen3.6-27B.** For treg. Median 113 sekunder mot 18.
-- **Qwen3.8-27B i 4-, 6- og 8-bit.** Verre jo høyere presisjon. 6-bit brukte median 284 sekunder, og 8-bit gikk i timeout på 8 av 11 oppgaver.
+- **Qwen3.8-27B i 4-, 6- og 8-bit.** Verre jo høyere presisjon. 6-bit brukte median 284 sekunder, og 8-bit gikk i timeout på 8 av 11 oppgaver. **Rettelse 31. august:** de målingene gikk gjennom en chat-mal vi skrev selv, og den kodet verktøyargumenter om slik at modellen leste sin egen historikk feil. Det er den eneste malen i sammenligningen som skilte seg fra det alle de andre modellene fikk. Vi har rettet malen og skal måle på nytt. Til det er gjort: Qwen3.8 er ikke valgt, men grunnen er under ny vurdering.
 - **Granite 4.1 8B.** For liten. Løste 1 av 8.
 
 Deretter 200 kjøringer på én maskin med modellen vi valgte, fordelt på to klienter, seks oppgavetyper, tre refactor-strategier og tre kodebaser: en Ktor-app, en Spring-app og en frontend.


### PR DESCRIPTION
The article tells readers Qwen3.8-27B timed out on 8 of 11 tasks. Those runs went through a chat template **we wrote ourselves**, which re-encoded tool arguments with `tojson` so the model read its own history as a quoted string instead of an object.

It is the only template in that comparison that differed from what every other model got, and it differed silently. `mise run bench-template-check` now confirms the official templates all behave the same way as each other; ours did not.

The template is fixed. The retest is not done — three attempts have failed for harness reasons, most recently because the server was quietly serving the 6-bit build while the profile said 8-bit. So the honest public position is that Qwen3.8 was not chosen and the reason is under review.

Correcting the published sentence beats finishing the retest: the retest can wait a week without cost, because Qwen3.8 is not shipping to anyone. The sentence in front of readers cannot.

`MODELS.md` and `reports/alpha-model-decision.md` in navikt/mlx-workspace already carry the same caveat.