### PR TITLE
feat(nav-pilot): tell a refusal apart from wiring that never arrived

### DIFF
--- a/cli/nav-pilot/internal/local/guard.go
+++ b/cli/nav-pilot/internal/local/guard.go
@@ -119,7 +119,13 @@ type Guard struct {
 	completions atomic.Int64
 }
 
-// Completions is how many prompts this session sent to the local model.
+// isProviderAPIPath reports whether a path is one the provider config would make
+// a client ask for. Anything else reaching this port came from something that is
+// not the client, and must not count as the client having seen the worker.
+func isProviderAPIPath(p string) bool {
+	return strings.HasSuffix(p, "/chat/completions") || strings.HasSuffix(p, "/models")
+}
+
 // SawTraffic reports whether the client sent the guard anything at all.
 //
 // False with zero completions means opencode never used the provider block:
@@ -135,6 +141,7 @@ func (g *Guard) SawTraffic() bool {
 	return g.requests.Load() > 0
 }
 
+// Completions is how many prompts this session sent to the local model.
 func (g *Guard) Completions() int64 {
 	if g == nil {
 		return 0
@@ -271,13 +278,19 @@ func guardHandler(g *Guard, proxy http.Handler, target string) http.Handler {
 	// against itself and leave them racing each other.
 	oneAtATime := make(chan struct{}, 1)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Counted before anything else, and for every request rather than only
-		// completions. A session that dispatched nothing is three different
-		// things, and this is what separates them: if the client asked for the
-		// model list and then never sent a completion, it saw the worker and
-		// declined. If nothing arrived at all, the wiring never reached it, and
-		// that is our bug rather than the orchestrator's judgement.
-		g.requests.Add(1)
+		// Counted for API-shaped requests only, not for everything that reaches
+		// the port. A session that dispatched nothing is three different things,
+		// and this is what separates them: a client that asked for the model list
+		// and then sent no completion saw the worker and declined, while nothing
+		// at all means the wiring never reached it.
+		//
+		// The filter matters. This listens on localhost, and localhost ports get
+		// probed by browsers, security agents and stray curls. One of those would
+		// flip this to true and permanently misclassify broken wiring as an
+		// orchestrator refusal — the exact confusion the counter exists to end.
+		if isProviderAPIPath(r.URL.Path) {
+			g.requests.Add(1)
+		}
 		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/chat/completions") {
 			proxy.ServeHTTP(w, r)
 			return

--- a/cli/nav-pilot/internal/local/guard.go
+++ b/cli/nav-pilot/internal/local/guard.go
@@ -106,6 +106,11 @@ type Guard struct {
 	// runs on its own goroutine and can outlive whatever set the directories up.
 	statsPath string
 
+	// requests counts everything the client sent through the guard, completions
+	// and model lists alike. Completions alone cannot tell a refusal from a
+	// wiring failure; this can.
+	requests atomic.Int64
+
 	// completions counts what actually reached the local server through this
 	// guard. Counted here rather than parsed out of the client's transcript
 	// because this is the only place that sees every one of them, and because a
@@ -115,6 +120,21 @@ type Guard struct {
 }
 
 // Completions is how many prompts this session sent to the local model.
+// SawTraffic reports whether the client sent the guard anything at all.
+//
+// False with zero completions means opencode never used the provider block:
+// the wiring did not reach it, which is a defect here. True with zero
+// completions means it saw the local worker and chose not to dispatch, which is
+// the orchestrator's judgement and the thing worth measuring.
+//
+// Safe on a nil Guard, like Completions, so a hosted session can ask.
+func (g *Guard) SawTraffic() bool {
+	if g == nil {
+		return false
+	}
+	return g.requests.Load() > 0
+}
+
 func (g *Guard) Completions() int64 {
 	if g == nil {
 		return 0
@@ -251,6 +271,13 @@ func guardHandler(g *Guard, proxy http.Handler, target string) http.Handler {
 	// against itself and leave them racing each other.
 	oneAtATime := make(chan struct{}, 1)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Counted before anything else, and for every request rather than only
+		// completions. A session that dispatched nothing is three different
+		// things, and this is what separates them: if the client asked for the
+		// model list and then never sent a completion, it saw the worker and
+		// declined. If nothing arrived at all, the wiring never reached it, and
+		// that is our bug rather than the orchestrator's judgement.
+		g.requests.Add(1)
 		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/chat/completions") {
 			proxy.ServeHTTP(w, r)
 			return

--- a/cli/nav-pilot/internal/local/guard_serial_test.go
+++ b/cli/nav-pilot/internal/local/guard_serial_test.go
@@ -153,3 +153,64 @@ func TestGuardCountsWhatItForwarded(t *testing.T) {
 		t.Error("a nil guard reported completions")
 	}
 }
+
+// TestSawTrafficSeparatesARefusalFromBrokenWiring is the whole point of the
+// counter: a session that dispatched nothing is three different things, and
+// two of them are indistinguishable without this.
+//
+// Zero completions with traffic means the client asked the guard for something —
+// the model list, typically — and then chose not to dispatch. That is the
+// orchestrator's judgement, and the thing worth measuring.
+//
+// Zero completions with no traffic at all means the provider block never reached
+// the client. That is a defect here, and reading it as a refusal would blame the
+// model for our own wiring.
+func TestSawTrafficSeparatesARefusalFromBrokenWiring(t *testing.T) {
+	stubDirs(t)
+	stubOwnership(t, func() error { return nil })
+
+	t.Run("nothing ever arrived", func(t *testing.T) {
+		g := &Guard{}
+		if g.SawTraffic() {
+			t.Error("a guard that was never called reports traffic")
+		}
+		if g.Completions() != 0 {
+			t.Error("a guard that was never called counted a completion")
+		}
+	})
+
+	t.Run("the client looked and did not dispatch", func(t *testing.T) {
+		g := &Guard{}
+		handler := guardHandler(g, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}), "")
+		handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+
+		if !g.SawTraffic() {
+			t.Error("a model-list request did not count as traffic, so a refusal is indistinguishable from broken wiring")
+		}
+		if g.Completions() != 0 {
+			t.Errorf("a model list counted as a dispatch (%d)", g.Completions())
+		}
+	})
+
+	t.Run("the client dispatched", func(t *testing.T) {
+		g := &Guard{}
+		handler := guardHandler(g, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}), "")
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+			strings.NewReader(`{"messages":[{"role":"user","content":"hei"}]}`))
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+
+		if !g.SawTraffic() || g.Completions() != 1 {
+			t.Errorf("traffic=%v completions=%d, want true and 1", g.SawTraffic(), g.Completions())
+		}
+	})
+
+	// A hosted session has no guard at all and must be able to ask.
+	var absent *Guard
+	if absent.SawTraffic() {
+		t.Error("a nil guard reported traffic")
+	}
+}

--- a/cli/nav-pilot/internal/local/guard_serial_test.go
+++ b/cli/nav-pilot/internal/local/guard_serial_test.go
@@ -208,6 +208,21 @@ func TestSawTrafficSeparatesARefusalFromBrokenWiring(t *testing.T) {
 		}
 	})
 
+	t.Run("something that is not the client probed the port", func(t *testing.T) {
+		g := &Guard{}
+		handler := guardHandler(g, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}), "")
+		// A browser, a security agent, a stray curl. One of these must not flip
+		// saw_traffic, or broken wiring is permanently misread as a refusal.
+		for _, path := range []string{"/", "/favicon.ico", "/health", "/v1"} {
+			handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, path, nil))
+		}
+		if g.SawTraffic() {
+			t.Error("a localhost probe counted as the client having seen the worker")
+		}
+	})
+
 	// A hosted session has no guard at all and must be able to ask.
 	var absent *Guard
 	if absent.SawTraffic() {

--- a/cli/nav-pilot/internal/provider/copilot_launch.go
+++ b/cli/nav-pilot/internal/provider/copilot_launch.go
@@ -152,7 +152,7 @@ func LaunchCopilotResolved(resolved domain.ResolvedConfig) error {
 		// rather than delegations. Same instrument, different meaning by client,
 		// which the client attribute keeps separable.
 		defer func() {
-			telemetryRecorder.RecordLocalSession("copilot", worker.Model, guard.Completions())
+			telemetryRecorder.RecordLocalSession("copilot", worker.Model, guard.Completions(), guard.SawTraffic())
 		}()
 	}
 

--- a/cli/nav-pilot/internal/provider/opencode_launch.go
+++ b/cli/nav-pilot/internal/provider/opencode_launch.go
@@ -670,7 +670,7 @@ func LaunchOpenCode(resolved domain.ResolvedConfig) error {
 			if st, ok, err := local.LoadState(); err == nil && ok {
 				model = st.Model
 			}
-			telemetryRecorder.RecordLocalSession("opencode", model, guard.Completions())
+			telemetryRecorder.RecordLocalSession("opencode", model, guard.Completions(), guard.SawTraffic())
 		}()
 		// The provider block names this session's guard port, and the port dies
 		// with the session. Left behind, it points opencode at a number the

--- a/cli/nav-pilot/internal/telemetry/local_instruments_test.go
+++ b/cli/nav-pilot/internal/telemetry/local_instruments_test.go
@@ -44,7 +44,9 @@ func TestRecorderEmitsEveryLocalInstrument(t *testing.T) {
 
 	// Zero dispatches is the value that matters most and the one most likely to
 	// be optimised away by a future "do not record empty sessions" change.
-	tel.RecordLocalSession("opencode", "some/model", 0)
+	// Zero dispatches with traffic: the client saw the worker and declined,
+	// which is the case the attribute exists to distinguish.
+	tel.RecordLocalSession("opencode", "some/model", 0, true)
 	tel.RecordLocalServer("some/model", "ready")
 	tel.RecordLocalReadySeconds("some/model", 4)
 

--- a/cli/nav-pilot/internal/telemetry/telemetry.go
+++ b/cli/nav-pilot/internal/telemetry/telemetry.go
@@ -53,7 +53,7 @@ type Recorder interface {
 	RecordClientAvailable(client string, available bool)
 	RecordLaunchError(client, errorType string)
 	RecordRtkSetup(client, choice, result string)
-	RecordLocalSession(client, model string, dispatches int64)
+	RecordLocalSession(client, model string, dispatches int64, sawTraffic bool)
 	RecordLocalServer(model, event string)
 	RecordLocalReadySeconds(model string, seconds int64)
 	Shutdown(ctx context.Context) error
@@ -62,7 +62,7 @@ type Recorder interface {
 type NoopRecorder struct{}
 
 func (NoopRecorder) RecordCommand(string, string, string, string, string, time.Duration) {}
-func (NoopRecorder) RecordLocalSession(string, string, int64)                            {}
+func (NoopRecorder) RecordLocalSession(string, string, int64, bool)                      {}
 func (NoopRecorder) RecordLocalServer(string, string)                                    {}
 func (NoopRecorder) RecordLocalReadySeconds(string, int64)                               {}
 func (NoopRecorder) RecordInstallItems(string, string, int64)                            {}
@@ -404,9 +404,14 @@ func (t *otelTelemetry) RecordConfig(client, configMode, model, reasoningEffort,
 // The model id is sent whole rather than collapsed to "custom" as the config gauge
 // does. During the alpha we would rather know which local model a developer is on
 // than protect a cardinality budget of at most a handful of manifest entries.
-func (t *otelTelemetry) RecordLocalSession(client, model string, dispatches int64) {
+func (t *otelTelemetry) RecordLocalSession(client, model string, dispatches int64, sawTraffic bool) {
 	t.localDispatches.Record(context.Background(), dispatches, metric.WithAttributes(
 		attribute.String("client", orUnset(client)),
+		// Whether the client sent this guard anything at all. Zero dispatches
+		// with traffic is the orchestrator declining; zero without is wiring
+		// that never reached it. Reported as an attribute rather than a second
+		// metric so a single query can separate them.
+		attribute.Bool("saw_traffic", sawTraffic),
 		attribute.String("model", orUnset(model)),
 		attribute.String("version", t.version),
 		attribute.String("device_id", t.device),


### PR DESCRIPTION
The first field telemetry showed two real users with **zero tasks dispatched**. We reported that as the orchestrator declining. It is one of three things:

1. opencode never accepted the wiring — a defect here
2. there was no dispatchable work in the session
3. the orchestrator saw the worker and chose not to dispatch

Only the third is a finding about the model. The first is our bug, and reading it as a refusal blames the model for our plumbing.

**The guard already saw the difference and threw it away.** It now counts every request the client sends, not only completions, and `RecordLocalSession` carries `saw_traffic` beside the dispatch count.

- zero completions **with** traffic: the client asked for the model list and then chose not to dispatch
- zero completions **without**: the provider block never reached it

One query now separates them, where before both looked identical.

## Why now rather than later

The alpha is collecting data today. Every session recorded before this ships is permanently ambiguous, and the fix only reaches developers through a release plus their update lag — so the clock on interpretable field data starts late no matter what. Two users have already recorded zeros nobody can read.

## Tests

`TestSawTrafficSeparatesARefusalFromBrokenWiring` covers all three states plus the nil guard a hosted session has. Verified with `-race` across eight packages.