### PR TITLE
test(pris): feil når vår egen fil lover en kampanje som har gått ut

### DIFF
--- a/apps/my-copilot/src/lib/model-pricing.test.ts
+++ b/apps/my-copilot/src/lib/model-pricing.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { MODEL_PRICING } from "./model-pricing";
+import { getCurrentOsloDate } from "./news";
 
 describe("promotionEndsOn", () => {
   it("merker nøyaktig radene med kampanjefotnote hos GitHub", () => {
@@ -19,5 +20,49 @@ describe("promotionEndsOn", () => {
   it("lar modeller uten fotnote være", () => {
     expect(MODEL_PRICING.find((m) => m.model === "GPT-5.6 Luna (Default, ≤ 200K)")?.promotionEndsOn).toBeUndefined();
     expect(MODEL_PRICING.find((m) => m.model === "Gemini 3.5 Flash (Default)")?.promotionEndsOn).toBeUndefined();
+  });
+});
+
+describe("utløpte kampanjer", () => {
+  // Denne vakta er med vilje offline. Prisene er tredjeparts data, og
+  // `.github/workflows/pricing-sync.yaml` argumenterer i fila for hvorfor et
+  // nettverkskall ikke skal gate en PR: da blir GitHubs prisendring en rød
+  // build på main for den som tilfeldigvis pusher etterpå. Det holder. Men
+  // spørsmålet «lover vår egen committede fil en kampanje som har gått ut?»
+  // trenger ikke nett, og det er nøyaktig feilen 4. september.
+  it("lover ingen kampanje som allerede har gått ut", () => {
+    // Datoene er rene datoer, ikke tidspunkt, så de sammenlignes som ISO-
+    // strenger. YYYY-MM-DD sorterer kronologisk, og da slipper vi Date-
+    // aritmetikk som kan bomme med et døgn over et døgnskille.
+    //
+    // Klokka er Oslo-tid, ikke UTC og ikke kjørerens sone. CI kjører i UTC,
+    // og en dato-only sammenligning mot feil sone flytter grensa med noen
+    // timer. `getCurrentOsloDate` finnes allerede i news.ts til nettopp dette.
+    const today = getCurrentOsloDate();
+    expect(today, "Oslo-datoen lot seg ikke lese. Vakta under er da avskrudd, ikke grønn.").toMatch(
+      /^\d{4}-\d{2}-\d{2}$/
+    );
+
+    // GitHub skriver «through September 3, 2026», altså til og med. Kampanjen
+    // gjelder fortsatt den 3., og er utløpt fra den 4. Derfor streng `<`.
+    const expired = MODEL_PRICING.filter((m) => m.promotionEndsOn && m.promotionEndsOn < today).map(
+      (m) => `${m.model} (t.o.m. ${m.promotionEndsOn})`
+    );
+
+    expect(
+      expired,
+      [
+        `model-pricing.ts oppgir en kampanjepris som gikk ut før ${today}:`,
+        ...expired.map((row) => `  ${row}`),
+        "",
+        "Dette er ikke en ødelagt test, og den skal ikke slettes. Prisen i fila",
+        "er utdatert, og prissiden er offentlig, så den viser nå en pris Nav ikke",
+        "får. Kjør `mise run pricing:sync` og commit den regenererte fila, eller",
+        "merge PR-en fra .github/workflows/pricing-sync.yaml hvis den står åpen.",
+        "",
+        "Rødt her er meningen: det er det eneste som kobler en utløpt kampanje til",
+        "noen som ser den. Skru den av, og fila blir stille feil i stedet.",
+      ].join("\n")
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
Siste av tre for #503. Bygger på #537, så basen er `issue-503-promotions`. Assertionen hører hjemme i fila den PR-en peker om, og merges #537 først blir denne automatisk mot main.

## Problemet

Ingenting fanger opp at en kampanjepris er utløpt. 4. september reverterer GPT-5.6 Sol, og fram til noen merger sync-PR-en viser den offentlige prissiden $2.00 inn og $10.00 ut for en modell som fra da av koster det dobbelte.

## Hvorfor offline, og ikke en nettverksgate

`.github/workflows/pricing-sync.yaml` argumenterer i fila for hvorfor synkroniseringen ikke gater PR-er: prisene er tredjeparts data, GitHub endrer dem på sin egen tidsplan, og en gate gjør deres prisendring til en rød build på main for den som tilfeldigvis pusher etterpå. Det argumentet står, og det er ikke rørt her.

Men det er ikke det spørsmålet som mangler svar. Dette spør: **lover vår egen committede fil en kampanje som allerede har gått ut?** Det trenger ikke nett, det leses av data som ligger i repoet, og vitest kjører allerede på PR-er som rører `apps/my-copilot/**`. Ingen ny arbeidsflyt, ingen ny avhengighet.

Forskjellen i praksis: en nettverksgate blir rød når GitHub endrer en pris. Denne blir rød når *vi* ligger etter, og det er noe vi selv kan gjøre noe med.

## Døgnskillet

Tre valg, alle med vilje:

**ISO-strenger, ikke Date-aritmetikk.** `promotionEndsOn` er en ren dato uten klokkeslett. YYYY-MM-DD sorterer kronologisk som streng, så sammenligningen slipper unna både `Date.parse`-sonetolkning og millisekundregning som kan bomme med et døgn. Samme grunn som #516 bygde datoen av en månedstabell.

**Oslo-tid, ikke UTC.** `getCurrentOsloDate` finnes allerede i `src/lib/news.ts` til nettopp dette, så den er gjenbrukt. CI kjører i UTC, og en dato-only sammenligning mot feil sone flytter grensa med noen timer.

**Streng `<`, ikke `<=`.** GitHub skriver «through September 3, 2026», altså til og med. Kampanjen gjelder fortsatt den 3. og er utløpt fra den 4.

Verifisert mot falsk klokke:

| UTC | Oslo-dato | utløpt |
|---|---|---|
| 2026-09-03T12:00Z | 2026-09-03 | ingen |
| 2026-09-03T21:00Z | 2026-09-03 | ingen |
| 2026-09-03T22:30Z | **2026-09-04** | begge Sol-radene |
| 2026-09-04T12:00Z | 2026-09-04 | begge Sol-radene |
| 2026-12-31T12:00Z | 2026-12-31 | Sol |
| 2027-01-01T12:00Z | 2027-01-01 | Sol og begge Gemini |

Rad tre er poenget: grensa går ved midnatt i Oslo, ikke ved midnatt i UTC.

Det er også en `toMatch` på at Oslo-datoen faktisk lot seg lese. `getCurrentOsloDate` returnerer tom streng om formateringa svikter, og da ville alle sammenligningene blitt false og vakta stått grønn uten å sjekke noe. En vakt som skrur seg selv av i stillhet er feilen dette skal hindre.

## Den blir rød 4. september

Det er meningen, og feilmeldinga sier det:

```
model-pricing.ts oppgir en kampanjepris som gikk ut før 2026-09-04:
  GPT-5.6 Sol (Default, ≤ 272K) (t.o.m. 2026-09-03)
  GPT-5.6 Sol (Long context, 272K) (t.o.m. 2026-09-03)

Dette er ikke en ødelagt test, og den skal ikke slettes. Prisen i fila
er utdatert, og prissiden er offentlig, så den viser nå en pris Nav ikke
får. Kjør `mise run pricing:sync` og commit den regenererte fila, eller
merge PR-en fra .github/workflows/pricing-sync.yaml hvis den står åpen.

Rødt her er meningen: det er det eneste som kobler en utløpt kampanje til
noen som ser den. Skru den av, og fila blir stille feil i stedet.
```

Uten den siste setningen leser den neste dette som en flaky test og sletter den. Da er vi tilbake til at koblingen mellom en prisendring og noen som ser den er et menneske som husker, som er det saken sier ikke holder.

Rødt løses ved å merge sync-PR-en, som er arbeidet som uansett måtte gjøres. Vakta gjør bare at det skjer før noen leser en feil pris, ikke etter.

## Verifisering

`pnpm check` fra `apps/my-copilot`: eslint, tsc, prettier, knip og 507 vitest-tester grønne.

Refs #503