### PR TITLE
docs(news): the 8-av-11-tallet er ikke etterprøvbart, og malen forklarer det ikke

### DIFF
--- a/docs/news/articles/lokale-modeller-i-nav-pilot.md
+++ b/docs/news/articles/lokale-modeller-i-nav-pilot.md
@@ -49,7 +49,7 @@ Først prøvde vi åtte modeller og bygg på det samme oppgavesettet: elleve opp
 - **Qwen3.6-35B-A3B, vanlig 4-bit.** Samme modell, annet bygg. Gikk i tool-loop og brukte 220 kall på én oppgave.
 - **KAT-Coder V2.5.** Løste like mange, men trengte flere kall på å komme dit.
 - **Qwen3.6-27B.** For treg. Median 113 sekunder mot 18.
-- **Qwen3.8-27B i 4-, 6- og 8-bit.** Verre jo høyere presisjon. 6-bit brukte median 284 sekunder, og 8-bit gikk i timeout på 8 av 11 oppgaver. **Rettelse 31. august:** de målingene gikk gjennom en chat-mal vi skrev selv, og den kodet verktøyargumenter om slik at modellen leste sin egen historikk feil. Det er den eneste malen i sammenligningen som skilte seg fra det alle de andre modellene fikk. Vi har rettet malen og skal måle på nytt. Til det er gjort: Qwen3.8 er ikke valgt, men grunnen er under ny vurdering.
+- **Qwen3.8-27B i 4-, 6- og 8-bit.** Ikke valgt. 6-bit brukte median 284 sekunder. Tallet vi publiserte for 8-bit kom fra en kjøring som stille erstattet en tidligere kjøring med et annet resultat, og vi vet ennå ikke hvilken av dem som gjelder.
 - **Granite 4.1 8B.** For liten. Løste 1 av 8.
 
 Deretter 200 kjøringer på én maskin med modellen vi valgte, fordelt på to klienter, seks oppgavetyper, tre refactor-strategier og tre kodebaser: en Ktor-app, en Spring-app og en frontend.
@@ -90,3 +90,5 @@ Så lenge dette er alfa, måler vi tettere enn i resten av nav-pilot: hvor mange
 Meld deg i #nav-pilot. Vi tar inn én og én i starten.
 
 Hele rapporten, med metode og alle tallene: [local-inference-findings.md](https://github.com/navikt/mlx-workspace/blob/main/reports/local-inference-findings.md). Hvorfor akkurat denne modellen, og hva vi forkastet: [alpha-model-decision.md](https://github.com/navikt/mlx-workspace/blob/main/reports/alpha-model-decision.md). Rådataene ligger i [navikt/mlx-workspace](https://github.com/navikt/mlx-workspace), også kjøringene som gikk galt.
+
+> **Rettelse 31. august:** Saken oppga først at 8-bit gikk i timeout på 8 av 11 oppgaver, et tall vi ikke kan stå inne for.

--- a/docs/news/articles/lokale-modeller-i-nav-pilot.md
+++ b/docs/news/articles/lokale-modeller-i-nav-pilot.md
@@ -91,4 +91,4 @@ Meld deg i #nav-pilot. Vi tar inn én og én i starten.
 
 Hele rapporten, med metode og alle tallene: [local-inference-findings.md](https://github.com/navikt/mlx-workspace/blob/main/reports/local-inference-findings.md). Hvorfor akkurat denne modellen, og hva vi forkastet: [alpha-model-decision.md](https://github.com/navikt/mlx-workspace/blob/main/reports/alpha-model-decision.md). Rådataene ligger i [navikt/mlx-workspace](https://github.com/navikt/mlx-workspace), også kjøringene som gikk galt.
 
-> **Rettelse 31. august:** Saken oppga først at 8-bit gikk i timeout på 8 av 11 oppgaver, et tall vi ikke kan stå inne for.
+> **Rettelse 31. august:** Saken oppga først at 8-bit gikk i timeout på 8 av 11 oppgaver, og forklarte deretter tallet med en chat-mal vi skrev selv, men verken tallet eller den forklaringen kan vi stå inne for.


### PR DESCRIPTION
Følger opp #532, som allerede er merget. Rettelsen der forklarte tallet med en chat-mal vi skrev selv. Den forklaringen holder ikke mot det som er committet, så brødteksten er nå rettet i seg selv i stedet.

## Hvorfor mal-forklaringen ikke holder

`chat_templates/qwen3.8-27b.jinja` i `navikt/mlx-workspace` er bare bundet av to profiler:

| Profil | `MLX_SERVER_TYPE` | Setter `MLX_CHAT_TEMPLATE` |
|---|---|---|
| `qwen3.8-27b-8bit.toml` | `omlx` | ja |
| `qwen3.8-27b-8bit-48gb.toml` | `omlx` | ja |
| `qwen3.8-27b-4bit.toml` | `mlx-lm` | nei |
| `qwen3.8-27b-4bit-reppen.toml` | `mlx-lm` | nei |
| `qwen3.8-27b-6bit.toml` | `mlx-lm` | nei |
| `qwen3.8-27b-8bit-mlx.toml` | `mlx-lm` | nei |

`.mise/tasks/server` legger på `--chat-template` bare i mlx-lm-grenen (linje 141-142). oMLX-grenen bygger `omlx serve --port` uten flagg. `MODELS.md` linje 564 sier det rett ut: «oMLX ignores most profile params ... `MLX_CHAT_TEMPLATE` ... have no effect for oMLX profiles».

De fire profilene som ga de publiserte tallene setter ikke `MLX_CHAT_TEMPLATE` i noen commit i historikken sin. Sjekket over alle commits som rører hver av de fire filene.

Malen er altså bare bundet der den ikke virker, og ikke bundet der tallene ble til.

## Hva som faktisk er understøttet

`bench/results-qwen3.8-27b-8bit-mlx.json`, samme fil, samme dag:

| Commit | Tid | Tidsavbrudd | Median |
|---|---|---|---|
| `e2f241e2` | 29. aug 08:20 (+0200) | 4 av 11 | 194,5 s |
| `6920c934` | 29. aug 12:11 (+0200) | 8 av 11 | 900,1 s |

`6920c934` heter «feat: a Spring Boot benchmark target, and why most navikt repos cannot be one» og nevner ikke Qwen3.8 med ett ord. Filen har ingen metadata om rigg, minnegrense eller tidspunkt, så den sier ikke selv hvilken kjøring den er. Versjonen på main i dag er byte-identisk med `6920c934`.

Artikkelen publiserte 900,1-kjøringen. `MODELS.md` linje 200 og `alpha-model-decision.md` linje 51 publiserer fortsatt 194,5-kjøringen.

## Hva saken sier nå

Punktet er skrevet om så brødteksten er riktig i seg selv:

> **Qwen3.8-27B i 4-, 6- og 8-bit.** Ikke valgt. 6-bit brukte median 284 sekunder. Tallet vi publiserte for 8-bit kom fra en kjøring som stille erstattet en tidligere kjøring med et annet resultat, og vi vet ennå ikke hvilken av dem som gjelder.

284-tallet står fordi det er stabilt: `bench/results-qwen3.8-27b-6bit.json` gir 284,2 s og 2 tidsavbrudd, og har ikke byttet seg selv ut.

«Verre jo høyere presisjon» er fjernet. Begge datasettene motsier den: i 194,5-kjøringen var 8-bit raskere enn 6-bit på 284,2 s, og 6-bit-profilen står som `status = "broken"`.

Ingen påstand om at malen forårsaket noe. Ingen påstand om at modellen gjorde det bra heller. Det vi vet er at tallet ikke er til å stole på, ikke at det var feil i en bestemt retning.

Rettelsesblokken midt i punktet er borte, og merknaden er én setning til slutt. Den dekker begge de publiserte påstandene: både 8-av-11-tallet fra den første versjonen og mal-forklaringen fra #532, som denne PR-en fjerner. En leser som så #532-versjonen skal ikke oppdage at forklaringen er borte ved at den bare er borte. Saken er 5410 tegn mot 5467 før, altså kortere.

## Om innspillene i gjennomgangen av #532

Tre av dem stemmer ikke mot main i `navikt/mlx-workspace`, og alle tre ble committet før gjennomgangen ble skrevet:

- **«`mise run bench-template-check` finnes ikke.»** Den finnes: `.mise/tasks/bench-template-check`, commit `a76d971`, 31. august 13:18.
- **«Malen er ikke rettet.»** Den er rettet: commit `843fafb`, 31. august 12:22, la inn `{%- if tool_call.arguments is string %}` foran `tojson`.
- **«De påberopte forbeholdene finnes ikke.»** De finnes: `MODELS.md` linje 56-73 og `alpha-model-decision.md` linje 5-11, begge datert 31. august.

Innspillet som avgjør saken, punkt 1 og punkt 5, stemmer, og det er de to denne PR-en handler om.

## De to dokumentene i `navikt/mlx-workspace`

Ikke rørt. De motsier ikke lenger saken om at avvisningen er uavklart, men de begrunner den annerledes:

- `alpha-model-decision.md` linje 5-11 har et forbehold datert 31. august som ber leseren «treat ... the rejection of Qwen3.8 as unproven», og begrunner det med chat-malen.
- `MODELS.md` linje 56-73 sier «"Held back because it loops" should be read as "held back under a template we have reason to doubt"», og begrunner det med chat-malen.

Brødteksten i begge står urørt under forbeholdene, som er riktig for et append-only-dokument. Begge slår altså fortsatt fast at avvisningen er uavklart, men peker på malen, mens saken nå peker på den stille resultatendringen. Det er den samme konklusjonen med to ulike årsaker, og malårsaken er den konfigurasjonen over motsier.

`MODELS.md` sitt eget avsnitt undergraver den dessuten: det slår fast at «mlx-lm parses `arguments` into a mapping before it renders the template, so through our serving path the string case never arises», og alle fire profilene er mlx-lm.

Det bør rettes i `navikt/mlx-workspace`, men det er ikke gjort her, og ingenting i det repoet er endret av denne PR-en.

## Innspillet om komma

Setningen med «slik at» uten komma er borte sammen med rettelsesblokken. Ingen «slik at» igjen i filen.

## Den stille resultatendringen

Meldt som eget issue: #539

