### PR TITLE
fix(nav-pilot): guarden hadde ingen synkronisert avslutning

### DIFF
--- a/cli/nav-pilot/internal/local/guard.go
+++ b/cli/nav-pilot/internal/local/guard.go
@@ -102,6 +102,17 @@ type Guard struct {
 	ln  net.Listener
 	srv *http.Server
 
+	// conns counts the connection goroutines the server has open, so [Guard.Close]
+	// can wait for them instead of merely cutting them loose. A handler that
+	// outlives its caller keeps reading package state the caller is already
+	// tearing down.
+	conns sync.WaitGroup
+
+	// cancelHandlers ends every request in flight. It is what makes the wait in
+	// [Guard.Close] bounded, and closing the connections is not a substitute for
+	// it: see the note there.
+	cancelHandlers context.CancelFunc
+
 	// statsPath is resolved when the guard starts, not per request. A handler
 	// runs on its own goroutine and can outlive whatever set the directories up.
 	statsPath string
@@ -133,7 +144,8 @@ func (g *Guard) URL() string {
 }
 
 // StartGuard puts the guard in front of a local server and returns once it is
-// listening. Close it when the session ends.
+// listening. Close it when the session ends: the guard's goroutines outlive the
+// call that started them, and only [Guard.Close] waits for them.
 func StartGuard(target string) (*Guard, error) {
 	u, err := url.Parse(target)
 	if err != nil {
@@ -154,26 +166,98 @@ func StartGuard(target string) (*Guard, error) {
 	// dropped connection mid-generation.
 	proxy.FlushInterval = -1
 
-	// Resolved once, here, because the handler runs on its own goroutine and
-	// must not read the directory globals while something else is changing them.
-	g := &Guard{ln: ln, statsPath: statsPath()}
+	// The parent of every request context this guard serves. net/http derives a
+	// connection context from BaseContext and the request context from that, so
+	// cancelling this one ends every handler in flight at whatever it is waiting
+	// on, without a second cancellation channel to thread through each of them.
+	handlerCtx, cancelHandlers := context.WithCancel(context.Background())
+
+	// statsPath is resolved here and not per request, because the handler runs
+	// on its own goroutine and must not read the directory globals while
+	// something else is changing them.
+	g := &Guard{ln: ln, statsPath: statsPath(), cancelHandlers: cancelHandlers}
 	g.srv = &http.Server{
 		Handler:           guardHandler(g, proxy, target),
 		ReadHeaderTimeout: 30 * time.Second,
 		// No write timeout: a completion on a local model legitimately takes
 		// longer than any number that would be safe on a network service.
+
+		BaseContext: func(net.Listener) context.Context { return handlerCtx },
+
+		// The counter [Guard.Close] waits on. ConnState and not a wrapper around
+		// the handler, because the wrapper's Add would race the Wait: a
+		// connection accepted just before Close could reach it after the counter
+		// had already fallen to zero, and joining a WaitGroup at zero while a
+		// Wait is running is the misuse its own documentation forbids.
+		//
+		// ConnState has no such window, which rests on two things inside
+		// net/http rather than on its documented API. Both are worth re-checking
+		// on a Go upgrade, and both are one grep away in server.go. Verified on
+		// go1.26.7:
+		//
+		//   - server.go:3463 sets StateNew on the accept loop's own goroutine,
+		//     immediately before `go c.serve(connCtx)`, and carries the literal
+		//     comment "before Serve can return". So every Add happens before
+		//     Serve returns.
+		//   - Server.Close calls listenerGroup.Wait() internally (server.go:3111),
+		//     so it returns only once Serve has.
+		//
+		// Close therefore cannot reach the Wait below until every Add is done.
+		ConnState: func(_ net.Conn, state http.ConnState) {
+			switch state {
+			case http.StateNew:
+				g.conns.Add(1)
+			case http.StateHijacked, http.StateClosed:
+				g.conns.Done()
+			}
+		},
 	}
-	go g.srv.Serve(ln)
+	go func() { _ = g.srv.Serve(ln) }()
 	return g, nil
 }
 
-// Close stops the guard. Safe on a nil Guard so a caller can defer it beside a
-// failed start.
+// Close stops the guard and returns once its goroutines have finished. Safe on
+// a nil Guard so a caller can defer it beside a failed start.
+//
+// The wait is the point. http.Server.Close returns as soon as the listener and
+// the connections are shut, while the goroutines that were serving them are
+// still unwinding, and one of those still reads the package-level directory
+// overrides through [statePath]. In a test that is a data race against the
+// cleanup that restores them; in a session it is a handler outliving the launch
+// that owns it. Waiting means the read is over before anything writes, rather
+// than merely unreported.
+//
+// The cancellation first is what keeps that wait short, and closing the
+// connections is emphatically not a substitute for it. net/http cancels a
+// request context on a lost connection only from the background read of the
+// request body, and for a request whose body the handler has not read yet that
+// read is deferred until the body hits EOF (server.go registers it through
+// registerOnHitEOF). This handler queues on [lockServer] long before it reads a
+// body, so a handler parked on the machine-wide lock while another session
+// completes would keep polling with a live context, and cutting its socket
+// would not tell it otherwise. Close would then block for as long as the other
+// session took. Cancelling the base context reaches it where closing the socket
+// does not.
+//
+// Not http.Server.Shutdown: that waits for the request in flight to answer, and
+// a completion on a local model runs for minutes. What is waited for here is
+// only the unwinding of requests already told to stop.
+//
+// No timeout on the wait, deliberately. A timeout that fired would let a live
+// handler run on past the caller's teardown, which is the race this exists to
+// remove, so it would trade a bounded wait for the original bug. The bound
+// comes from the cancellation instead. The one step it cannot reach is the
+// ownership probe, which takes no context: three subprocess and HTTP probes at
+// probeTimeout each, so a little under half a minute in the worst case, and in
+// practice zero because Close runs after the client process is gone.
 func (g *Guard) Close() error {
 	if g == nil {
 		return nil
 	}
-	if err := g.srv.Close(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+	g.cancelHandlers()
+	err := g.srv.Close()
+	g.conns.Wait()
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return err
 	}
 	return nil

--- a/cli/nav-pilot/internal/local/guard_test.go
+++ b/cli/nav-pilot/internal/local/guard_test.go
@@ -9,7 +9,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
+	"syscall"
 	"testing"
+	"time"
 )
 
 // stubOwnership replaces the guard's ownership proof. The real one needs a
@@ -254,7 +257,16 @@ func TestStartGuardProxiesToTheServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StartGuard: %v", err)
 	}
-	defer g.Close()
+	// A defer and not a t.Cleanup, and it matters which: cleanups run after
+	// every defer in the test body, so this closes the guard, and waits for its
+	// handler goroutines, before stubDirs writes the directory overrides back.
+	// The handler reads those through statePath while it is serving, so without
+	// the wait the two overlap and -race says so.
+	defer func() {
+		if err := g.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	}()
 
 	body := conversation(`{"role":"user","content":"hei"}`)
 	resp, err := http.Post(g.URL()+"/v1/chat/completions", "application/json", strings.NewReader(string(body)))
@@ -264,6 +276,145 @@ func TestStartGuardProxiesToTheServer(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("guard returned %s for a request that is not a loop", resp.Status)
+	}
+}
+
+// TestGuardCloseWaitsForItsHandlers pins what the loop-guard data race was
+// really about. http.Server.Close returns as soon as the connections are cut,
+// with the goroutines that were serving them still unwinding and still reading
+// the package-level directory overrides; a test's cleanup then writes those
+// back underneath a live reader, and a session's launch tears down around one.
+// Close has to outlast its handlers, so the read is finished rather than merely
+// unreported.
+//
+// The handler is held inside the ownership check rather than at the upstream,
+// because cutting the connection cancels the request context and a proxied call
+// unwinds on its own: what has to be proven is that Close waits even for work
+// no cancellation reaches.
+func TestGuardCloseWaitsForItsHandlers(t *testing.T) {
+	stubDirs(t)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"choices":[]}`))
+	}))
+	defer upstream.Close()
+
+	inHandler, release := make(chan struct{}), make(chan struct{})
+	var handlerDone atomic.Bool
+	stubOwnership(t, func() error {
+		close(inHandler)
+		<-release
+		handlerDone.Store(true)
+		return nil
+	})
+
+	g, err := StartGuard(upstream.URL)
+	if err != nil {
+		t.Fatalf("StartGuard: %v", err)
+	}
+	body := conversation(`{"role":"user","content":"hei"}`)
+	go func() {
+		resp, err := http.Post(g.URL()+"/v1/chat/completions", "application/json", strings.NewReader(string(body)))
+		if err == nil {
+			resp.Body.Close()
+		}
+	}()
+	<-inHandler
+
+	// The handshake is not decoration. Without it the goroutine below might not
+	// have been scheduled at all inside the window, and "Close has not returned
+	// yet" would pass for a Close that had never been called. Waiting for
+	// entering means the window times a Close that has actually begun.
+	entering, closed := make(chan struct{}), make(chan error, 1)
+	go func() {
+		close(entering)
+		closed <- g.Close()
+	}()
+	<-entering
+	select {
+	case err := <-closed:
+		t.Fatalf("Close returned while a handler was still running: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Close never returned after the handler finished")
+	}
+	if !handlerDone.Load() {
+		t.Error("Close returned before the handler had finished")
+	}
+}
+
+// TestGuardCloseDoesNotWaitForAnotherSessionsLock is the bound on that wait.
+//
+// Waiting for the handlers is only safe if something reliably tells them to
+// stop, and cutting the connection does not: net/http cancels a request context
+// on connection loss from the background read of the request body, and for a
+// body the handler has not read yet that read is deferred until EOF. The guard
+// queues on the machine-wide server lock well before it reads a body, so a
+// handler parked there when the session ends has a live context and a lock held
+// by somebody else.
+//
+// Two terminals is ordinary work: session A is mid-completion holding the lock,
+// session B has a prompt queued behind it and is interrupted. B's exit must not
+// wait for A, which may be minutes away, or forever if A is in the wedged state
+// the lock exists to guard against.
+func TestGuardCloseDoesNotWaitForAnotherSessionsLock(t *testing.T) {
+	data, _ := stubDirs(t)
+	stubOwnership(t, func() error { return nil })
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"choices":[]}`))
+	}))
+	defer upstream.Close()
+
+	// The other session, holding the lock for the whole test and never giving it
+	// up. lockServer polls for it once a second and would never be handed it.
+	held, err := os.OpenFile(filepath.Join(data, "server.lock"), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("opening the lock: %v", err)
+	}
+	defer held.Close()
+	if err := syscall.Flock(int(held.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("taking the lock: %v", err)
+	}
+
+	g, err := StartGuard(upstream.URL)
+	if err != nil {
+		t.Fatalf("StartGuard: %v", err)
+	}
+	body := conversation(`{"role":"user","content":"hei"}`)
+	go func() {
+		resp, err := http.Post(g.URL()+"/v1/chat/completions", "application/json", strings.NewReader(string(body)))
+		if err == nil {
+			resp.Body.Close()
+		}
+	}()
+	// Completions is incremented on the line before lockServer, so this says the
+	// handler is at the lock and nowhere earlier. The pause covers the few
+	// instructions between the two.
+	deadline := time.Now().Add(10 * time.Second)
+	for g.Completions() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("the request never reached the guard")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	closed := make(chan error, 1)
+	go func() { closed <- g.Close() }()
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("Close blocked behind a lock held by another session")
 	}
 }
 


### PR DESCRIPTION
Lukker #528. Kappløpet der er reelt, men rapporten navngir ett av tre
lesesteder, og akkurat det ene ble borte av seg selv da #529 landet.
Årsaken står igjen.

## Hva som faktisk feiler

`StartGuard` starter en HTTP-server i en egen goroutine. `Close` kalte
`http.Server.Close`, som stenger lytteren, klipper forbindelsene og
returnerer med det samme. Goroutinene som betjente dem holder på en
stund til, og de leser pakkenivå-variablene for katalogoverstyring
gjennom `statePath()`.

I en test er det et datakappløp mot opprydningen i `stubDirs`. I en
sesjon er det en handler som lever videre etter launchen som eier den.

## Status på main

`mise run nav-pilot:check` er grønn på `origin/main` i dag. #529 flyttet
`statsPath()` ut av forespørselsgoroutinen og inn i `StartGuard`, og
fjernet dermed nøyaktig den lesingen stakksporet i #528 navngir. Riktig
endring av andre grunner, men den lukket ikke saken: handleren leser de
samme variablene to andre steder, gjennom `lockServer()` og gjennom
`LoadState()`.

Reprodusert på ren `origin/main` med en midlertidig test som holder
handleren fast inne i eierskapssjekken og slipper den løs mens
opprydningen i `stubDirs` kjører:

```
Write at 0x... by goroutine 8:
  local.stubDirs.func3()                 runtime_test.go:41
Previous read at 0x... by goroutine 15:
  local.statePath()                      attach.go:77
  local.LoadState()                      attach.go:105
  local.StartGuard.guardHandler.func4()  guard.go:321
```

Samme form som i saken, med `LoadState` der `RecordCompletion` sto.

## Endringen

To halvdeler, og begge trengs.

**Ventingen.** `Guard` teller forbindelsesgoroutinene sine i en
`sync.WaitGroup`, og `Close` venter på dem.

Tellingen ligger i `ConnState` og ikke i en innpakning rundt handleren.
`StateNew` kjøres på accept-løkkens egen goroutine før forbindelsens
egen startes, slik stdlib selv kommenterer linja, så hvert `Add` skjer
før `Serve` returnerer. `http.Server.Close` venter på at `Serve`
returnerer før den returnerer selv, så ingen kan melde seg inn etter at
ventingen er i gang. En innpakning rundt handleren ville hatt akkurat
det hullet.

**Kanselleringen.** `Close` kansellerer forespørselskontekstene først,
gjennom en `BaseContext` på serveren. Uten den kan ventingen henge.

Det er ikke nok å klippe forbindelsen. net/http kansellerer en
forespørselskontekst ved tapt forbindelse bare fra bakgrunnslesingen av
kroppen, og for en forespørsel der handleren ikke har lest kroppen ennå
er den lesingen utsatt til kroppen treffer EOF, registrert gjennom
`registerOnHitEOF` i `server.go:2053`. Kansellering skjer i
`handleReadErrorLocked` på `server.go:773`, som bare nås derfra.

Guarden køer i `oneAtATime` og `lockServer` lenge før den leser noen
kropp. En handler som står parkert på den maskinbrede fillåsen når
sesjonen avsluttes har altså en levende kontekst, og å klippe socketen
forteller den ingenting. Den fortsetter å polle låsen én gang i
sekundet.

Scenarioet ligger midt i normal bruk av funksjonen, ikke i en avkrok: to
terminaler, sesjon A er midt i en completion og holder låsen, sesjon B
har en prompt i kø og blir avbrutt. Før denne PR-en returnerte B sin
`Close` med det samme og goroutinen døde med prosessen. Med bare
ventingen ville B sin avslutning blokkert til A var ferdig, altså
minutter, og uten øvre grense dersom A står i den fastlåste tilstanden
låsen finnes for å beskytte mot.

`BaseContext` og ikke en egen kanal med `select` på hvert ventested:
net/http utleder forbindelseskonteksten fra `BaseContext` og
forespørselskonteksten fra den igjen (`server.go:3422` til `3464`,
`1966`, `1034`), så én kansellering treffer hvert eneste sted handleren
venter på `r.Context()`. Ingen ventesteder å gå glipp av, verken de som
finnes nå eller de som kommer.

Ingen timeout på ventingen, med vilje. En timeout som slo inn ville
sluppet en levende handler forbi opprydningen til den som kalte, altså
nøyaktig kappløpet dette retter. Grensen kommer fra kanselleringen i
stedet.

## Produksjonsveien

Ingen atferdsendring. Begge launchveiene, `LaunchCopilotResolved` og
`startLocalDispatch`, har `defer guard.Close()` fra før, og begge leser
`guard.Completions()` i en defer som kjører før den. Rekkefølgen er
uendret.

Det `Close` gjør nytt er å vente. Hvert ventested i handleren som kan
blokkere hører på forespørselskonteksten, og kanselleringen over når
dem. Det ene steget som ikke tar noen kontekst i det hele tatt er
eierskapssjekken, og den er avgrenset av sine egne timeouter: `ps` i
`processStart`, `lsof` i `portListeners` og `/v1/models` i
`servedModelCount`, hver på `probeTimeout` lik 8 sekunder. Verste
tilfelle er altså i underkant av et halvt minutt, ikke 8 sekunder.

I praksis er ventetiden null. `Close` er deferred til slutten av
launchen, altså etter at klientprosessen har avsluttet, og da er ingen
completion i flukt.

Guarden er ikke serveren. Modellserveren løsriver seg med vilje og lever
videre etter launchen, slik #21 slo fast. Guarden tar en efemer port per
sesjon og dør med sesjonen, og det er den som skulle vært ryddet ned
hele tiden.

## Verifisering

To tester, én per halvdel, og hver av dem feiler når sin halvdel fjernes.

`TestGuardCloseWaitsForItsHandlers` holder handleren fast inne i
eierskapssjekken, sjekker at `Close` ikke returnerer, slipper den løs og
sjekker at `Close` returnerer etterpå.

`TestGuardCloseDoesNotWaitForAnotherSessionsLock` tar den maskinbrede
låsen i testen og gir den aldri fra seg, parkerer handleren på den og
krever at `Close` returnerer likevel. Uten kanselleringen blokkerer den
til testen gir opp:

```
--- FAIL: TestGuardCloseDoesNotWaitForAnotherSessionsLock (15.21s)
    guard_test.go:409: Close blocked behind a lock held by another session
```

At kappløpet forsvinner fordi lesingen er ferdig og ikke fordi den er
skjult, er vist med fire varianter av reproduksjonen over:

| Close | go test -race |
|---|---|
| ikke kalt | DATA RACE |
| kalt, uten ventingen | DATA RACE |
| kalt, med kansellering men uten ventingen | DATA RACE |
| kalt, komplett | rent, 5 kjøringer |

Kanselleringen alene retter altså ikke kappløpet, og ventingen alene
henger. Begge trengs.

`go test -race ./...` grønn i tre urørte kjøringer av hele modulen.
`mise run nav-pilot:check` grønn.

Refs #528
