### PR TITLE
docs: startup takes seconds, not minutes — and fix the download path that claim assumed

### DIFF
--- a/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
+++ b/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
@@ -1655,7 +1655,7 @@ const CONFIG_KEYS = [
     key: "local_autostart",
     flag: "—",
     values: "true · false",
-    desc: "La en vanlig 'nav-pilot' starte serveren selv når den trengs og ingen kjører. Av som standard: å starte en 21 GB prosess uten å bli bedt om det er ikke greit, og første oppstart på kald cache tar minutter som ser ut som en heng.",
+    desc: "La en vanlig 'nav-pilot' starte serveren selv når den trengs og ingen kjører. Av som standard: å starte en 21 GB prosess uten å bli bedt om det er ikke greit.",
   },
   {
     key: "local_loop_guard",
@@ -2009,7 +2009,8 @@ function LocalModelSection() {
             Kom i gang
           </LinkableHeading>
           <BodyShort size="small" className="mt-2 mb-4" style={{ color: "#475569" }}>
-            Første <code className="font-mono text-xs">start</code> tar noen minutter mens modellen lastes inn i minnet.
+            Første <code className="font-mono text-xs">start</code> laster modellen inn i minnet. Ti målte oppstarter på seks
+            maskiner lå alle under 50 sekunder, seks av dem under ti.
           </BodyShort>
           <CodeBlock compact>
             {`nav-pilot alpha local init      # laster ned modellen og setter opp miljøet
@@ -2027,9 +2028,8 @@ nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først`
           </BodyLong>
           <CodeBlock compact>{`nav-pilot config set local_autostart true`}</CodeBlock>
           <BodyLong className="mt-2" size="small" style={{ color: "#475569" }}>
-            Den er av som standard, og det er med vilje: å starte en 21 GB prosess uten å bli bedt om det er ikke greit,
-            og første oppstart på kald cache tar minutter som ser ut som om noe har hengt seg. Med den på venter
-            launchen på at serveren er klar. To samtidige launcher starter ikke to servere.
+            Den er av som standard, og det er med vilje: å starte en 21 GB prosess uten å bli bedt om det er ikke greit.
+            Med den på venter launchen på at serveren er klar. To samtidige launcher starter ikke to servere.
           </BodyLong>
           <Box padding="space-16" borderRadius="8" className="mt-4" style={{ background: "#f8fafc" }}>
             <Label size="small">Vi måler dette tettere enn resten av nav-pilot mens det er alfa</Label>

--- a/cli/nav-pilot/internal/cli/alpha_local.go
+++ b/cli/nav-pilot/internal/cli/alpha_local.go
@@ -9,7 +9,8 @@ package cli
 //
 // The five commands split along what each one costs. init spends an afternoon
 // of bandwidth and says so first. start loads the weights and blocks until the
-// server has answered a real completion, because a port bind proves nothing. status spends one probe. stop and off spend nothing.
+// server has answered a real completion, because a port bind proves nothing.
+// status spends one probe. stop and off spend nothing.
 //
 // Nothing here runs sudo. Raising the wired-memory limit is the one privileged
 // action in the neighbourhood and it stays a command the developer types:
@@ -277,7 +278,7 @@ func cmdLocalInit() error {
 		fmt.Printf("  %s\n", dim("For a cloud agent with a local worker, switch with: nav-pilot config set client opencode"))
 	}
 
-	fmt.Printf("%s Starting the server (loading the weights takes seconds)…\n", dim("→"))
+	fmt.Printf("%s Starting the server (measured starts have been under a minute)…\n", dim("→"))
 	if err := cmdLocalStart(); err != nil {
 		return err
 	}
@@ -338,8 +339,8 @@ func wrapIndent(s, indent string, width int) string {
 // ─── start ───────────────────────────────────────────────────────────────────
 
 func cmdLocalStart() error {
-	// Interrupt has to reach the child. A cold start takes minutes, so an
-	// impatient Ctrl-C is the normal case rather than the unlucky one, and
+	// Interrupt has to reach the child. A start that wedges sits until the ten
+	// minute readyTimeout, so an impatient Ctrl-C is the normal case, and
 	// without this it killed nav-pilot while the server carried on loading: 21 GB
 	// of resident memory holding a port, with no state file written yet, so
 	// `stop` and `status` both reported nothing recorded. Cancelling here makes
@@ -373,6 +374,18 @@ func cmdLocalStart() error {
 		if err := local.ClearState(); err != nil {
 			return err
 		}
+	}
+
+	// mlx-lm fetches a model it does not find, so without this `start` on a
+	// machine that never ran init begins a 23 GB download with nothing on
+	// screen saying so, and either finishes inside readyTimeout as a start that
+	// looks pathologically slow or dies at ten minutes naming neither cause.
+	// The autostart path has always refused this; `start` only claimed to.
+	if present, err := local.WeightsPresent(model.Model); err != nil {
+		return err
+	} else if !present {
+		return fmt.Errorf("the weights for %s are not on this machine.\n\n  Download them first:\n\n    %s",
+			model.Model, bold("nav-pilot alpha local init"))
 	}
 
 	wired, err := local.CheckWiredLimit(model)

--- a/cli/nav-pilot/internal/cli/alpha_local.go
+++ b/cli/nav-pilot/internal/cli/alpha_local.go
@@ -8,9 +8,8 @@ package cli
 // everywhere and no other command behaves differently.
 //
 // The five commands split along what each one costs. init spends an afternoon
-// of bandwidth and says so first. start spends minutes loading weights and
-// blocks until the server has answered a real completion, because a port bind
-// proves nothing. status spends one probe. stop and off spend nothing.
+// of bandwidth and says so first. start loads the weights and blocks until the
+// server has answered a real completion, because a port bind proves nothing. status spends one probe. stop and off spend nothing.
 //
 // Nothing here runs sudo. Raising the wired-memory limit is the one privileged
 // action in the neighbourhood and it stays a command the developer types:
@@ -278,7 +277,7 @@ func cmdLocalInit() error {
 		fmt.Printf("  %s\n", dim("For a cloud agent with a local worker, switch with: nav-pilot config set client opencode"))
 	}
 
-	fmt.Printf("%s Starting the server (the first start takes a few minutes)…\n", dim("→"))
+	fmt.Printf("%s Starting the server (loading the weights takes seconds)…\n", dim("→"))
 	if err := cmdLocalStart(); err != nil {
 		return err
 	}
@@ -391,7 +390,7 @@ func cmdLocalStart() error {
 	}
 
 	fmt.Printf("%s Starting %s…\n", dim("→"), bold(model.Name))
-	fmt.Printf("  %s\n", dim("Ready means it answered a real completion, not that the port is open — minutes on a cold cache."))
+	fmt.Printf("  %s\n", dim("Ready means it answered a real completion, not that the port is open."))
 	started := timeNow()
 	srv := &local.Server{} // Port 0: Start asks the kernel for a free one.
 	if err := srv.Start(ctx, model); err != nil {

--- a/cli/nav-pilot/internal/cli/alpha_local_test.go
+++ b/cli/nav-pilot/internal/cli/alpha_local_test.go
@@ -557,3 +557,39 @@ func TestWrapIndent(t *testing.T) {
 		t.Errorf("wrapIndent()\n got: %q\nwant: %q", got, want)
 	}
 }
+
+// markProvisioned writes the environment stamp `local.Installed` looks for, so
+// a test can reach the checks that come after it without provisioning anything.
+// The pins are duplicated from internal/local deliberately: they are unexported,
+// and a test that silently stopped exercising the code below the Installed check
+// would be worse than one that fails loudly when the pin moves.
+func markProvisioned(t *testing.T) {
+	t.Helper()
+	dir := filepath.Join(os.Getenv("HOME"), ".nav-pilot", "local")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stamp := `{"mlx_lm":"0.31.3","mlx":"0.32.0"}`
+	if err := os.WriteFile(filepath.Join(dir, "env.json"), []byte(stamp), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !local.Installed() {
+		t.Fatalf("markProvisioned did not satisfy local.Installed(); the version pins in "+
+			"internal/local/runtime.go have moved and this helper still writes %s", stamp)
+	}
+}
+
+// TestLocalStartRefusesMissingWeights: start must not reach mlx-lm without the
+// weights on disk. mlx-lm downloads whatever it cannot find, so this guard is
+// the only thing between `start` and a silent 23 GB fetch inside readyTimeout,
+// which surfaces either as a start that looks pathologically slow or as a
+// timeout naming neither cause. Autostart has always refused it; start's own
+// comment claimed it did too, and did not.
+func TestLocalStartRefusesMissingWeights(t *testing.T) {
+	localTestHome(t)
+	markProvisioned(t)
+	err := cmdLocalStart()
+	if err == nil || !strings.Contains(err.Error(), "not on this machine") {
+		t.Errorf("cmdLocalStart() without weights = %v, want an error naming the missing weights", err)
+	}
+}

--- a/cli/nav-pilot/internal/cli/config_cmd.go
+++ b/cli/nav-pilot/internal/cli/config_cmd.go
@@ -148,7 +148,7 @@ var configKeyDefs = []configKeyDef{
 	{
 		name:        "local_autostart",
 		kind:        keyKindBool,
-		description: "Start the local server automatically when a launch needs it and nothing is running. Off by default: the first start on a cold cache takes minutes.",
+		description: "Start the local server automatically when a launch needs it and nothing is running. Off by default: a launch that starts a 21 GB process unasked is a surprise rather than a convenience.",
 		allowed:     nil,
 		defaultVal:  "false",
 		flag:        "",
@@ -284,8 +284,8 @@ version = 1
 # local_enabled = false
 
 # Start the local server when a launch needs it and nothing is running. Off by
-# default: the first start on a cold cache takes minutes, and a launch that
-# starts a 21 GB process unasked is a surprise rather than a convenience.
+# default: a launch that starts a 21 GB process unasked is a surprise rather
+# than a convenience.
 # Default: false
 # local_autostart = false
 

--- a/cli/nav-pilot/internal/domain/domain.go
+++ b/cli/nav-pilot/internal/domain/domain.go
@@ -37,8 +37,7 @@ type Config struct {
 	LocalEnabled *bool `toml:"local_enabled"`
 	// LocalAutostart starts the local server on demand at launch, when local
 	// dispatch is on and nothing is running. Off by default, because starting a
-	// 21 GB process is not something to do without being asked, and because the
-	// first start on a cold cache takes minutes that would look like a hang.
+	// 21 GB process is not something to do without being asked.
 	LocalAutostart *bool `toml:"local_autostart"`
 	// LocalLoopGuard is how many identical consecutive tool calls end a local
 	// turn. Unset means the built-in default. It is a knob because the right

--- a/cli/nav-pilot/internal/local/guard.go
+++ b/cli/nav-pilot/internal/local/guard.go
@@ -119,7 +119,13 @@ type Guard struct {
 	completions atomic.Int64
 }
 
-// Completions is how many prompts this session sent to the local model.
+// isProviderAPIPath reports whether a path is one the provider config would make
+// a client ask for. Anything else reaching this port came from something that is
+// not the client, and must not count as the client having seen the worker.
+func isProviderAPIPath(p string) bool {
+	return strings.HasSuffix(p, "/chat/completions") || strings.HasSuffix(p, "/models")
+}
+
 // SawTraffic reports whether the client sent the guard anything at all.
 //
 // False with zero completions means opencode never used the provider block:
@@ -135,6 +141,7 @@ func (g *Guard) SawTraffic() bool {
 	return g.requests.Load() > 0
 }
 
+// Completions is how many prompts this session sent to the local model.
 func (g *Guard) Completions() int64 {
 	if g == nil {
 		return 0
@@ -271,13 +278,19 @@ func guardHandler(g *Guard, proxy http.Handler, target string) http.Handler {
 	// against itself and leave them racing each other.
 	oneAtATime := make(chan struct{}, 1)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Counted before anything else, and for every request rather than only
-		// completions. A session that dispatched nothing is three different
-		// things, and this is what separates them: if the client asked for the
-		// model list and then never sent a completion, it saw the worker and
-		// declined. If nothing arrived at all, the wiring never reached it, and
-		// that is our bug rather than the orchestrator's judgement.
-		g.requests.Add(1)
+		// Counted for API-shaped requests only, not for everything that reaches
+		// the port. A session that dispatched nothing is three different things,
+		// and this is what separates them: a client that asked for the model list
+		// and then sent no completion saw the worker and declined, while nothing
+		// at all means the wiring never reached it.
+		//
+		// The filter matters. This listens on localhost, and localhost ports get
+		// probed by browsers, security agents and stray curls. One of those would
+		// flip this to true and permanently misclassify broken wiring as an
+		// orchestrator refusal — the exact confusion the counter exists to end.
+		if isProviderAPIPath(r.URL.Path) {
+			g.requests.Add(1)
+		}
 		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/chat/completions") {
 			proxy.ServeHTTP(w, r)
 			return

--- a/cli/nav-pilot/internal/local/guard.go
+++ b/cli/nav-pilot/internal/local/guard.go
@@ -106,6 +106,11 @@ type Guard struct {
 	// runs on its own goroutine and can outlive whatever set the directories up.
 	statsPath string
 
+	// requests counts everything the client sent through the guard, completions
+	// and model lists alike. Completions alone cannot tell a refusal from a
+	// wiring failure; this can.
+	requests atomic.Int64
+
 	// completions counts what actually reached the local server through this
 	// guard. Counted here rather than parsed out of the client's transcript
 	// because this is the only place that sees every one of them, and because a
@@ -115,6 +120,21 @@ type Guard struct {
 }
 
 // Completions is how many prompts this session sent to the local model.
+// SawTraffic reports whether the client sent the guard anything at all.
+//
+// False with zero completions means opencode never used the provider block:
+// the wiring did not reach it, which is a defect here. True with zero
+// completions means it saw the local worker and chose not to dispatch, which is
+// the orchestrator's judgement and the thing worth measuring.
+//
+// Safe on a nil Guard, like Completions, so a hosted session can ask.
+func (g *Guard) SawTraffic() bool {
+	if g == nil {
+		return false
+	}
+	return g.requests.Load() > 0
+}
+
 func (g *Guard) Completions() int64 {
 	if g == nil {
 		return 0
@@ -251,6 +271,13 @@ func guardHandler(g *Guard, proxy http.Handler, target string) http.Handler {
 	// against itself and leave them racing each other.
 	oneAtATime := make(chan struct{}, 1)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Counted before anything else, and for every request rather than only
+		// completions. A session that dispatched nothing is three different
+		// things, and this is what separates them: if the client asked for the
+		// model list and then never sent a completion, it saw the worker and
+		// declined. If nothing arrived at all, the wiring never reached it, and
+		// that is our bug rather than the orchestrator's judgement.
+		g.requests.Add(1)
 		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/chat/completions") {
 			proxy.ServeHTTP(w, r)
 			return

--- a/cli/nav-pilot/internal/local/guard_serial_test.go
+++ b/cli/nav-pilot/internal/local/guard_serial_test.go
@@ -153,3 +153,64 @@ func TestGuardCountsWhatItForwarded(t *testing.T) {
 		t.Error("a nil guard reported completions")
 	}
 }
+
+// TestSawTrafficSeparatesARefusalFromBrokenWiring is the whole point of the
+// counter: a session that dispatched nothing is three different things, and
+// two of them are indistinguishable without this.
+//
+// Zero completions with traffic means the client asked the guard for something —
+// the model list, typically — and then chose not to dispatch. That is the
+// orchestrator's judgement, and the thing worth measuring.
+//
+// Zero completions with no traffic at all means the provider block never reached
+// the client. That is a defect here, and reading it as a refusal would blame the
+// model for our own wiring.
+func TestSawTrafficSeparatesARefusalFromBrokenWiring(t *testing.T) {
+	stubDirs(t)
+	stubOwnership(t, func() error { return nil })
+
+	t.Run("nothing ever arrived", func(t *testing.T) {
+		g := &Guard{}
+		if g.SawTraffic() {
+			t.Error("a guard that was never called reports traffic")
+		}
+		if g.Completions() != 0 {
+			t.Error("a guard that was never called counted a completion")
+		}
+	})
+
+	t.Run("the client looked and did not dispatch", func(t *testing.T) {
+		g := &Guard{}
+		handler := guardHandler(g, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}), "")
+		handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+
+		if !g.SawTraffic() {
+			t.Error("a model-list request did not count as traffic, so a refusal is indistinguishable from broken wiring")
+		}
+		if g.Completions() != 0 {
+			t.Errorf("a model list counted as a dispatch (%d)", g.Completions())
+		}
+	})
+
+	t.Run("the client dispatched", func(t *testing.T) {
+		g := &Guard{}
+		handler := guardHandler(g, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}), "")
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+			strings.NewReader(`{"messages":[{"role":"user","content":"hei"}]}`))
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+
+		if !g.SawTraffic() || g.Completions() != 1 {
+			t.Errorf("traffic=%v completions=%d, want true and 1", g.SawTraffic(), g.Completions())
+		}
+	})
+
+	// A hosted session has no guard at all and must be able to ask.
+	var absent *Guard
+	if absent.SawTraffic() {
+		t.Error("a nil guard reported traffic")
+	}
+}

--- a/cli/nav-pilot/internal/local/guard_serial_test.go
+++ b/cli/nav-pilot/internal/local/guard_serial_test.go
@@ -208,6 +208,21 @@ func TestSawTrafficSeparatesARefusalFromBrokenWiring(t *testing.T) {
 		}
 	})
 
+	t.Run("something that is not the client probed the port", func(t *testing.T) {
+		g := &Guard{}
+		handler := guardHandler(g, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}), "")
+		// A browser, a security agent, a stray curl. One of these must not flip
+		// saw_traffic, or broken wiring is permanently misread as a refusal.
+		for _, path := range []string{"/", "/favicon.ico", "/health", "/v1"} {
+			handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, path, nil))
+		}
+		if g.SawTraffic() {
+			t.Error("a localhost probe counted as the client having seen the worker")
+		}
+	})
+
 	// A hosted session has no guard at all and must be able to ask.
 	var absent *Guard
 	if absent.SawTraffic() {

--- a/cli/nav-pilot/internal/local/local.go
+++ b/cli/nav-pilot/internal/local/local.go
@@ -493,8 +493,7 @@ var autostart bool
 func SetAutostart(on bool) { autostart = on }
 
 // Autostart reports whether a launch may start the server when none is running.
-// Off by default: starting a 21 GB process is not something to do unasked, and
-// the first start on a cold cache takes minutes that would read as a hang.
+// Off by default: starting a 21 GB process is not something to do unasked.
 func Autostart() bool { return autostart }
 
 // IsLocal reports whether a model id is served locally *and* local dispatch is

--- a/cli/nav-pilot/internal/local/runtime.go
+++ b/cli/nav-pilot/internal/local/runtime.go
@@ -707,7 +707,7 @@ const (
 
 	// HealthStarting: the process is alive but has not yet answered a
 	// completion. mlx-lm binds the port before it maps the weights, so this
-	// state can last minutes on a large model and is not a fault.
+	// state outlasts the bind on a large model and is not a fault.
 	HealthStarting Health = "starting"
 
 	// HealthReady: a real completion came back with tokens in it.
@@ -1414,6 +1414,9 @@ func EnsureServerRunning(ctx context.Context, announce func(string)) error {
 	// Autostart must not start a 23 GB download inside a launch. `alpha local
 	// start` checks this too; here it matters more, because the download would
 	// run invisibly while this holds the machine-wide lock.
+	//
+	// That claim about `start` was false until it was made true: the guard was
+	// only ever here, and start reached mlx-lm without it.
 	if present, err := WeightsPresent(m.Model); err != nil {
 		return err
 	} else if !present {

--- a/cli/nav-pilot/internal/provider/copilot_launch.go
+++ b/cli/nav-pilot/internal/provider/copilot_launch.go
@@ -152,7 +152,7 @@ func LaunchCopilotResolved(resolved domain.ResolvedConfig) error {
 		// rather than delegations. Same instrument, different meaning by client,
 		// which the client attribute keeps separable.
 		defer func() {
-			telemetryRecorder.RecordLocalSession("copilot", worker.Model, guard.Completions())
+			telemetryRecorder.RecordLocalSession("copilot", worker.Model, guard.Completions(), guard.SawTraffic())
 		}()
 	}
 

--- a/cli/nav-pilot/internal/provider/opencode_launch.go
+++ b/cli/nav-pilot/internal/provider/opencode_launch.go
@@ -670,7 +670,7 @@ func LaunchOpenCode(resolved domain.ResolvedConfig) error {
 			if st, ok, err := local.LoadState(); err == nil && ok {
 				model = st.Model
 			}
-			telemetryRecorder.RecordLocalSession("opencode", model, guard.Completions())
+			telemetryRecorder.RecordLocalSession("opencode", model, guard.Completions(), guard.SawTraffic())
 		}()
 		// The provider block names this session's guard port, and the port dies
 		// with the session. Left behind, it points opencode at a number the

--- a/cli/nav-pilot/internal/provider/opencode_launch.go
+++ b/cli/nav-pilot/internal/provider/opencode_launch.go
@@ -737,7 +737,7 @@ func localWorker() (local.Model, error) {
 	// which is also what keeps that check the single seam the tests stub.
 	if local.Autostart() {
 		if err := local.EnsureServerRunning(context.Background(), func(model string) {
-			fmt.Fprintf(os.Stderr, "%s Starting the local %s server. The first start after a reboot takes minutes.\n",
+			fmt.Fprintf(os.Stderr, "%s Starting the local %s server. Loading the weights takes seconds.\n",
 				domain.Dim("ℹ"), domain.Bold(model))
 		}); err != nil {
 			return local.Model{}, err

--- a/cli/nav-pilot/internal/provider/opencode_launch.go
+++ b/cli/nav-pilot/internal/provider/opencode_launch.go
@@ -737,7 +737,7 @@ func localWorker() (local.Model, error) {
 	// which is also what keeps that check the single seam the tests stub.
 	if local.Autostart() {
 		if err := local.EnsureServerRunning(context.Background(), func(model string) {
-			fmt.Fprintf(os.Stderr, "%s Starting the local %s server. Loading the weights takes seconds.\n",
+			fmt.Fprintf(os.Stderr, "%s Starting the local %s server. Measured starts have been under a minute.\n",
 				domain.Dim("ℹ"), domain.Bold(model))
 		}); err != nil {
 			return local.Model{}, err

--- a/cli/nav-pilot/internal/telemetry/local_instruments_test.go
+++ b/cli/nav-pilot/internal/telemetry/local_instruments_test.go
@@ -44,7 +44,9 @@ func TestRecorderEmitsEveryLocalInstrument(t *testing.T) {
 
 	// Zero dispatches is the value that matters most and the one most likely to
 	// be optimised away by a future "do not record empty sessions" change.
-	tel.RecordLocalSession("opencode", "some/model", 0)
+	// Zero dispatches with traffic: the client saw the worker and declined,
+	// which is the case the attribute exists to distinguish.
+	tel.RecordLocalSession("opencode", "some/model", 0, true)
 	tel.RecordLocalServer("some/model", "ready")
 	tel.RecordLocalReadySeconds("some/model", 4)
 

--- a/cli/nav-pilot/internal/telemetry/telemetry.go
+++ b/cli/nav-pilot/internal/telemetry/telemetry.go
@@ -53,7 +53,7 @@ type Recorder interface {
 	RecordClientAvailable(client string, available bool)
 	RecordLaunchError(client, errorType string)
 	RecordRtkSetup(client, choice, result string)
-	RecordLocalSession(client, model string, dispatches int64)
+	RecordLocalSession(client, model string, dispatches int64, sawTraffic bool)
 	RecordLocalServer(model, event string)
 	RecordLocalReadySeconds(model string, seconds int64)
 	Shutdown(ctx context.Context) error
@@ -62,7 +62,7 @@ type Recorder interface {
 type NoopRecorder struct{}
 
 func (NoopRecorder) RecordCommand(string, string, string, string, string, time.Duration) {}
-func (NoopRecorder) RecordLocalSession(string, string, int64)                            {}
+func (NoopRecorder) RecordLocalSession(string, string, int64, bool)                      {}
 func (NoopRecorder) RecordLocalServer(string, string)                                    {}
 func (NoopRecorder) RecordLocalReadySeconds(string, int64)                               {}
 func (NoopRecorder) RecordInstallItems(string, string, int64)                            {}
@@ -404,9 +404,14 @@ func (t *otelTelemetry) RecordConfig(client, configMode, model, reasoningEffort,
 // The model id is sent whole rather than collapsed to "custom" as the config gauge
 // does. During the alpha we would rather know which local model a developer is on
 // than protect a cardinality budget of at most a handful of manifest entries.
-func (t *otelTelemetry) RecordLocalSession(client, model string, dispatches int64) {
+func (t *otelTelemetry) RecordLocalSession(client, model string, dispatches int64, sawTraffic bool) {
 	t.localDispatches.Record(context.Background(), dispatches, metric.WithAttributes(
 		attribute.String("client", orUnset(client)),
+		// Whether the client sent this guard anything at all. Zero dispatches
+		// with traffic is the orchestrator declining; zero without is wiring
+		// that never reached it. Reported as an attribute rather than a second
+		// metric so a single query can separate them.
+		attribute.Bool("saw_traffic", sawTraffic),
 		attribute.String("model", orUnset(model)),
 		attribute.String("version", t.version),
 		attribute.String("device_id", t.device),

--- a/cli/nav-pilot/internal/telemetry/telemetry.go
+++ b/cli/nav-pilot/internal/telemetry/telemetry.go
@@ -252,7 +252,7 @@ func InitTelemetry(ctx context.Context, cliVersion string, rtkInstalled string) 
 		return NoopRecorder{}, fmt.Errorf("create local server counter: %w", err)
 	}
 	localReadySeconds, err := meter.Int64Histogram("nav_pilot_local_ready_seconds",
-		metric.WithDescription("Seconds from start to a real completion. We quote two to five minutes from one machine; this is the distribution."))
+		metric.WithDescription("Seconds from start to a real completion. Recorded only for starts that came up, so the slow tail is missing."))
 	if err != nil {
 		return NoopRecorder{}, fmt.Errorf("create local ready histogram: %w", err)
 	}

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -145,8 +145,7 @@ Vil du slippe å starte serveren selv, kan en vanlig `nav-pilot` gjøre det når
 nav-pilot config set local_autostart true
 ```
 
-Av som standard, med vilje: å starte en 21 GB prosess uten å bli bedt om det er ikke greit, og
-første oppstart på kald cache tar minutter som ser ut som om noe har hengt seg.
+Av som standard, med vilje: å starte en 21 GB prosess uten å bli bedt om det er ikke greit.
 
 Ingenting av dette skjer med mindre du kjører `init` selv. Gjør du ikke det, er nav-pilot
 uendret.


### PR DESCRIPTION
Six places in the docs and CLI told developers the first local start "takes minutes on a cold cache". The fleet says otherwise, and checking *why* the claim was safe to remove turned up a real bug.

## The measurement

`nav_pilot_local_ready_seconds` over seven days, now that counters reach Mimir:

| bucket | starts |
|---|---|
| ≤ 5s | 4 |
| 5–10s | 2 |
| 10–25s | 3 |
| 25–50s | 1 |
| > 50s | **0** |

Ten starts across six machines, none over 50 seconds.

## The bug the claim assumed away

The first commit justified the change with "weights are downloaded by `init`, never by `start`". True of these ten samples; **false about the code.**

`cmdLocalStart` checked `local.Installed()` and the wired limit, then handed an unqualified model id to `mlx_lm.server`, which downloads whatever it cannot find. `HF_HUB_OFFLINE` is set nowhere in the repo. So `alpha local start` on a machine that never ran `init` began a 23 GB download with nothing on screen saying so — finishing inside the ten-minute `readyTimeout` as a start that looked pathologically slow, or dying at the timeout naming neither cause. Either outcome lands in the same histogram this PR reads startup times from.

The guard existed, on the autostart path only (`runtime.go`), where its comment read *"`alpha local start` checks this too"*. It did not. That comment is how the false claim got written in the first place, so it now records what was actually true.

`TestLocalStartRefusesMissingWeights` covers it, and fails without the guard — verified by removing it.

## Why the docs number mattered

It was the stated reason `local_autostart` is off by default, in both the config help and the docs. It was also how a developer told a slow start from a hang, which is backwards: told to expect minutes, you wait through a hang.

Autostart stays off. The reason that survives stands on its own: starting a 21 GB process unasked is a surprise rather than a convenience.

## Survivorship, stated rather than hidden

`RecordLocalReadySeconds` fires only after `srv.Start` returns nil, so a start that hits `readyTimeout` or is interrupted records nothing. **The slowest starts are exactly the ones missing.** The honest reading is "no successful start took a minute", not "no start ever will".

Two strings in the first commit overclaimed in that direction ("loading the weights takes seconds") and now say what was measured. The Norwegian copy always did. The histogram's own description now names the gap, and #531 carries the fix — an `outcome` attribute, so the panel also answers how often a start fails.

## Sites corrected

`config_cmd.go` (help and generated config), `alpha_local.go`, `opencode_launch.go`, `local.go`, `domain.go`, `telemetry.go` (the only place "two to five minutes" was ever written), `docs/README.nav-pilot.md`, and three passages in `nav-pilot/docs/page.tsx`.

## Checks

`go build`, `go vet`, `go test ./...` all green across the CLI. `tsc --noEmit` clean. Reviewed adversarially before this second commit; every finding above came out of that review.