### PR TITLE
fix: the ready histogram could not see the starts that failed

### DIFF
--- a/cli/nav-pilot/internal/cli/alpha_local.go
+++ b/cli/nav-pilot/internal/cli/alpha_local.go
@@ -410,6 +410,16 @@ func cmdLocalStart() error {
 		// The process may be up but not answering; do not leave it behind. This
 		// is also the interrupt path: a cancelled context lands here.
 		_ = srv.Stop()
+		// Recorded here as well as on the way out. Measuring only the starts
+		// that came up hides exactly the ones worth seeing: a start that runs
+		// into readyTimeout is the slow tail, and leaving it out turned the
+		// histogram into a distribution of the starts that worked, which is
+		// how the docs came to quote a startup time the fleet contradicts.
+		outcome := "failed"
+		if ctx.Err() != nil {
+			outcome = "interrupted"
+		}
+		telemetry.RecordLocalReadySeconds(model.Model, outcome, int64(timeNow().Sub(started).Seconds()))
 		if ctx.Err() != nil {
 			return fmt.Errorf("interrupted before the server was ready; it has been stopped")
 		}
@@ -419,7 +429,15 @@ func cmdLocalStart() error {
 	// not ready is a pid `status` reports as crashed hours later, which reads
 	// as "it died" rather than "it never started".
 	status := srv.Status()
-	telemetry.RecordLocalReadySeconds(model.Model, int64(timeNow().Sub(started).Seconds()))
+	// One closed vocabulary for the outcome: ready, failed, interrupted. The
+	// health value goes to RecordLocalServer, which is the instrument for it;
+	// letting it leak in here too would give the same panel two spellings of
+	// the same state.
+	readyOutcome := "ready"
+	if status.Health != local.HealthReady || status.PID <= 0 {
+		readyOutcome = "failed"
+	}
+	telemetry.RecordLocalReadySeconds(model.Model, readyOutcome, int64(timeNow().Sub(started).Seconds()))
 	telemetry.RecordLocalServer(model.Model, string(status.Health))
 	if status.Health != local.HealthReady || status.PID <= 0 {
 		_ = srv.Stop()

--- a/cli/nav-pilot/internal/telemetry/local_instruments_test.go
+++ b/cli/nav-pilot/internal/telemetry/local_instruments_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
@@ -48,7 +49,11 @@ func TestRecorderEmitsEveryLocalInstrument(t *testing.T) {
 	// which is the case the attribute exists to distinguish.
 	tel.RecordLocalSession("opencode", "some/model", 0, true)
 	tel.RecordLocalServer("some/model", "ready")
-	tel.RecordLocalReadySeconds("some/model", 4)
+	// Both outcomes, because the failing one is the reason the attribute
+	// exists: recorded only on success, this histogram cannot see the starts
+	// that hung, and its slow tail is missing by construction.
+	tel.RecordLocalReadySeconds("some/model", "ready", 4)
+	tel.RecordLocalReadySeconds("some/model", "failed", 600)
 
 	var rm metricdata.ResourceMetrics
 	if err := reader.Collect(context.Background(), &rm); err != nil {
@@ -67,6 +72,35 @@ func TestRecorderEmitsEveryLocalInstrument(t *testing.T) {
 	} {
 		if !seen[want] {
 			t.Errorf("the recorder never emitted %s; collected %v", want, seen)
+		}
+	}
+
+	// The outcome attribute has to reach the data point, not just the call.
+	// Without it the histogram is a distribution of the starts that worked,
+	// which is how the docs came to quote a startup time the fleet contradicts.
+	outcomes := map[string]bool{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "nav_pilot_local_ready_seconds" {
+				continue
+			}
+			hist, ok := m.Data.(metricdata.Histogram[int64])
+			if !ok {
+				t.Fatalf("nav_pilot_local_ready_seconds is %T, want a histogram", m.Data)
+			}
+			for _, dp := range hist.DataPoints {
+				v, found := dp.Attributes.Value(attribute.Key("outcome"))
+				if !found {
+					t.Errorf("a ready_seconds point carries no outcome attribute: %v", dp.Attributes.ToSlice())
+					continue
+				}
+				outcomes[v.AsString()] = true
+			}
+		}
+	}
+	for _, want := range []string{"ready", "failed"} {
+		if !outcomes[want] {
+			t.Errorf("no ready_seconds point with outcome=%q; got %v", want, outcomes)
 		}
 	}
 }

--- a/cli/nav-pilot/internal/telemetry/telemetry.go
+++ b/cli/nav-pilot/internal/telemetry/telemetry.go
@@ -55,7 +55,7 @@ type Recorder interface {
 	RecordRtkSetup(client, choice, result string)
 	RecordLocalSession(client, model string, dispatches int64, sawTraffic bool)
 	RecordLocalServer(model, event string)
-	RecordLocalReadySeconds(model string, seconds int64)
+	RecordLocalReadySeconds(model, outcome string, seconds int64)
 	Shutdown(ctx context.Context) error
 }
 
@@ -64,7 +64,7 @@ type NoopRecorder struct{}
 func (NoopRecorder) RecordCommand(string, string, string, string, string, time.Duration) {}
 func (NoopRecorder) RecordLocalSession(string, string, int64, bool)                      {}
 func (NoopRecorder) RecordLocalServer(string, string)                                    {}
-func (NoopRecorder) RecordLocalReadySeconds(string, int64)                               {}
+func (NoopRecorder) RecordLocalReadySeconds(string, string, int64)                       {}
 func (NoopRecorder) RecordInstallItems(string, string, int64)                            {}
 func (NoopRecorder) RecordSyncUpdates(string, string, int64)                             {}
 func (NoopRecorder) RecordSyncConflicts(string, string, int64)                           {}
@@ -252,7 +252,7 @@ func InitTelemetry(ctx context.Context, cliVersion string, rtkInstalled string) 
 		return NoopRecorder{}, fmt.Errorf("create local server counter: %w", err)
 	}
 	localReadySeconds, err := meter.Int64Histogram("nav_pilot_local_ready_seconds",
-		metric.WithDescription("Seconds from start to a real completion. Recorded only for starts that came up, so the slow tail is missing."))
+		metric.WithDescription("Seconds a start took, split by outcome: ready, failed or interrupted."))
 	if err != nil {
 		return NoopRecorder{}, fmt.Errorf("create local ready histogram: %w", err)
 	}
@@ -434,14 +434,18 @@ func (t *otelTelemetry) RecordLocalServer(model, event string) {
 	))
 }
 
-// RecordLocalReadySeconds emits how long a start took to answer a real completion.
+// RecordLocalReadySeconds emits how long a start took, and how it ended.
 //
-// The documentation tells developers to expect two to five minutes, from one
-// machine with a warm page cache. This replaces that guess with a distribution
-// across the machines people actually have.
-func (t *otelTelemetry) RecordLocalReadySeconds(model string, seconds int64) {
+// outcome is what makes the histogram readable. Recorded only on success, this
+// instrument cannot see the starts that hung: the slow tail is exactly what
+// goes missing, and a p95 read off it is a p95 of the starts that worked. The
+// documentation quoted minutes from one machine on that basis; the fleet says
+// under a minute, and that correction is only worth as much as the sample it
+// came from.
+func (t *otelTelemetry) RecordLocalReadySeconds(model, outcome string, seconds int64) {
 	t.localReadySeconds.Record(context.Background(), seconds, metric.WithAttributes(
 		attribute.String("model", orUnset(model)),
+		attribute.String("outcome", orUnset(outcome)),
 		attribute.String("version", t.version),
 		attribute.String("device_id", t.device),
 	))


### PR DESCRIPTION
Follow-up to #546, which corrected a startup-time claim in the docs using this histogram — and in doing so showed the histogram cannot see its own worst case.

## The gap

`RecordLocalReadySeconds` was called only after `srv.Start` returned nil. A start that ran into the ten-minute `readyTimeout`, or that the developer interrupted, recorded **nothing**.

So the slow tail is missing by construction. A p95 read off this instrument is a p95 of the starts that worked, and "no start took a minute" and "no *successful* start took a minute" are different claims that this data cannot distinguish.

## The fix

Recorded on all three paths, with an `outcome` attribute:

| outcome | when |
|---|---|
| `ready` | the server answered a real completion |
| `failed` | `Start` returned an error, or health was not ready |
| `interrupted` | the context was cancelled — Ctrl-C during a start |

The same panel now also answers **how often a local start fails**, which nothing measures today.

Health values (`ready`, `starting`, `crashed`, `not started`) stay on `RecordLocalServer`, which is the instrument for them. Letting them leak into `outcome` too would give one panel two spellings of the same state.

## Test

`TestRecorderEmitsEveryLocalInstrument` now records both a `ready` and a `failed` observation and asserts the attribute reaches the **data point**, not just the call — it walks the collected `metricdata.Histogram` and checks `dp.Attributes`. Verified it fails without the attribute:

```
local_instruments_test.go:94: a ready_seconds point carries no outcome attribute:
    [{device_id device-under-test} {model some/model} {version test}]
```

## Known and deliberately not in here

`local.EnsureServerRunning` records nothing at all, so **autostart starts are invisible to this histogram whatever their outcome** — only `alpha local start` is instrumented. `internal/local` does not import the telemetry package, so giving it a recorder is a wiring change rather than a one-liner. Filed against #531, where the dashboard panel that would misread this lives.

## Checks

`go build ./...`, `go vet ./...`, `go test ./...` all green.