### PR TITLE
fix: opting out of telemetry still shipped the repo name to Nav's collector

### DIFF
--- a/cli/nav-pilot/DESIGN.md
+++ b/cli/nav-pilot/DESIGN.md
@@ -184,7 +184,7 @@ flagget (opencode bruker sin egen standard). opencode aksepterer bare store boks
 
 Når et OTel-endepunkt er konfigurert (via `OTEL_EXPORTER_OTLP_ENDPOINT` eller `NAV_PILOT_COPILOT_OTEL_ENDPOINT`), gjør nav-pilot:
 1. Kaller `ensureOpenCodeOTelConfig()` for å sette `experimental.openTelemetry = true` i `~/.config/opencode/opencode.json`
-2. Injiserer `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_RESOURCE_ATTRIBUTES` og `OPENCODE_CLIENT=nav-pilot` i opencodes miljø
+2. Injiserer `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_RESOURCE_ATTRIBUTES` og `OPENCODE_CLIENT=nav-pilot` i opencodes miljø — men ingenting av det hvis telemetri er slått av (`DO_NOT_TRACK=1` eller `NAV_PILOT_TELEMETRY_ENABLED=false`)
 
 OTel-konfigurasjonssammenslåingen er dyp (beholder eksisterende `experimental.*`-nøkler) og idempotent.
 

--- a/cli/nav-pilot/TELEMETRY.md
+++ b/cli/nav-pilot/TELEMETRY.md
@@ -125,6 +125,7 @@ for Copilot CLI til collector-base uten `/v1/metrics`, slik at Copilot kan sende
 både metrics og traces. Egen override for Copilot er `NAV_PILOT_COPILOT_OTEL_ENDPOINT`
 (den har høyere prioritet enn en generell `OTEL_EXPORTER_OTLP_ENDPOINT`).
 nav-pilot setter også `COPILOT_OTEL_ENABLED=true` hvis den ikke allerede er satt.
+Alt dette er betinget av at telemetri er på; se avsnittet om opt-out under.
 
 I tillegg injiserer nav-pilot egne resource-attributter i Copilots
 `OTEL_RESOURCE_ATTRIBUTES`, slik at Copilot-traces kan attribueres tilbake til
@@ -137,8 +138,17 @@ nav-pilot. Eksisterende nøkler beholdes (append-merge, ingen overskriving):
 | `nav.pilot.device_id` | pseudonymt `nav-pilot-<hash>` | Join (på verdi) mot nav-pilots egen `device_id`-attributt |
 | `nav.repo` | `navikt/<repo>`-slug fra `origin`-remote | Join (server-side, ved spørring) mot repo→team-mapping, slik at sessionsdata kan aggregeres per team (issue #344) |
 
-`nav.pilot.device_id` injiseres kun når nav-pilot-telemetri er aktiv; med
-`NAV_PILOT_TELEMETRY_ENABLED=false` utelates den (launcher/version beholdes).
+Er nav-pilot-telemetri av, injiseres **ingenting av dette**. Med
+`NAV_PILOT_TELEMETRY_ENABLED=false` eller `DO_NOT_TRACK=1` setter nav-pilot verken
+endepunkt, `COPILOT_OTEL_ENABLED` eller resource-attributter, og klienten startes
+med miljøet den ellers ville hatt. Det gjelder også når `NAV_PILOT_COPILOT_OTEL_ENDPOINT`
+er satt eksplisitt: har du sagt begge deler, er det opt-out som gjelder.
+
+Tidligere gjaldt dette bare `nav.pilot.device_id`. Resten ble injisert uansett, med
+den begrunnelsen at launcher og versjon ikke identifiserer noen. Det stemmer, og det
+dekker ikke `nav.repo`, som gikk ut ved siden av. En bruker som hadde reservert seg
+havnet dermed i dataene som rader med repo og uten device_id — ikke til å skille fra
+et oppslag som feilet, og dermed heller ikke til å filtrere bort i ettertid.
 
 `nav.repo` settes kun når nav-pilot startes inne i et git-repo hvis
 `origin`-remote peker på GitHub-organisasjonen `navikt` (både ssh-formen

--- a/cli/nav-pilot/internal/cli/main_test.go
+++ b/cli/nav-pilot/internal/cli/main_test.go
@@ -1903,7 +1903,12 @@ func TestDetectNewItems_Instructions(t *testing.T) {
 // ─── copilotEnv tests ───────────────────────────────────────────────────────
 
 func TestCopilotEnv_NoInstructions(t *testing.T) {
-	// Even without instructions, copilotEnv injects OTel defaults for launched copilot/cplt.
+	// Even without instructions, copilotEnv injects OTel defaults for launched
+	// copilot/cplt — as long as telemetry is on. The opt-out now suppresses the
+	// whole injection, so the environment has to be pinned or this asserts the
+	// developer's own DO_NOT_TRACK setting rather than the code.
+	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("NAV_PILOT_TELEMETRY_ENABLED", "")
 	env := copilotEnv("none")
 	if env == nil {
 		t.Fatal("expected non-nil env from copilotEnv")

--- a/cli/nav-pilot/internal/provider/golden_local_test.go
+++ b/cli/nav-pilot/internal/provider/golden_local_test.go
@@ -109,6 +109,8 @@ func TestGoldenLocalDisabledLeavesLaunchArgsAlone(t *testing.T) {
 // pin. What a launch *adds* is, and with local off it is a written-down list
 // that a new variable — local or otherwise — would break.
 func TestGoldenLaunchEnvIsUnchangedWithoutLocal(t *testing.T) {
+	telemetryOn(t)
+
 	// A home with no ~/.copilot customizations and no OTel endpoint, so the
 	// golden below is the launch's own doing and not the machine's.
 	t.Setenv("HOME", t.TempDir())

--- a/cli/nav-pilot/internal/provider/opencode_launch_test.go
+++ b/cli/nav-pilot/internal/provider/opencode_launch_test.go
@@ -302,6 +302,8 @@ func TestEnsureOpenCodeOTelConfig(t *testing.T) {
 }
 
 func TestApplyOpenCodeOTelEnvInjectsClientWhenEndpointSet(t *testing.T) {
+	telemetryOn(t)
+
 	env := []string{"OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318"}
 	result, changed := telemetrypkg.ApplyOpenCodeOTelEnv(env, cliVersion)
 	if !changed {
@@ -663,4 +665,14 @@ func TestNoServerWarningTellsThemWhatItCost(t *testing.T) {
 			t.Errorf("the warning never mentions %q; a developer cannot act on it.\ngot: %s", want, out)
 		}
 	}
+}
+
+// telemetryOn neutralises both opt-out variables for a test that asserts the
+// launcher injected something. The opt-out now covers the whole injection, so
+// without this the suite fails on any machine with DO_NOT_TRACK set — which is
+// exactly the machine whose owner cares most that it behaves correctly.
+func telemetryOn(t *testing.T) {
+	t.Helper()
+	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("NAV_PILOT_TELEMETRY_ENABLED", "")
 }

--- a/cli/nav-pilot/internal/telemetry/copilot_otel.go
+++ b/cli/nav-pilot/internal/telemetry/copilot_otel.go
@@ -4,7 +4,25 @@ import "strings"
 
 const copilotOTelEndpointOverride = "NAV_PILOT_COPILOT_OTEL_ENDPOINT"
 
+// clientTelemetryOptedOut reports whether nav-pilot must not configure a
+// launched client's telemetry at all.
+//
+// The opt-out used to gate only the device id, on the reasoning that launcher
+// and version are non-identifying. Two things were wrong with that. The repo
+// slug went in beside them and is not non-identifying, and an opted-out
+// developer's Copilot session was still pointed at Nav's collector and still
+// exported — arriving as rows with a repo and no device id, indistinguishable
+// from a device-id lookup failure. Opting out produced worse data than either
+// keeping it on or leaving it off.
+//
+// An explicit endpoint override does not survive the opt-out. Someone who sets
+// both has said "do not track" second, and that is the one to honour.
+func clientTelemetryOptedOut() bool { return !TelemetryEnabled() }
+
 func ApplyCopilotOTelEnv(env []string, cliVersion string) ([]string, bool) {
+	if clientTelemetryOptedOut() {
+		return env, false
+	}
 	changed := false
 	endpoint := copilotOTelEndpoint(env)
 	if endpoint == "" {
@@ -23,10 +41,9 @@ func ApplyCopilotOTelEnv(env []string, cliVersion string) ([]string, bool) {
 	env, updated = SetEnvIfAbsent(env, "COPILOT_OTEL_ENABLED", "true")
 	changed = changed || updated
 
-	// device_id is the only pseudonymous identifier we inject; honour the
-	// nav-pilot telemetry opt-out so an opted-out user is not re-identified
-	// through Copilot's telemetry. launcher/version are non-identifying and
-	// are always included.
+	// Kept as a second line of defence rather than simplified away: this
+	// function is exported, and a future caller reaching it past the guard
+	// above should still not inject an identifier.
 	deviceID := ""
 	if TelemetryEnabled() {
 		deviceID = CopilotDeviceID()
@@ -40,6 +57,9 @@ func ApplyCopilotOTelEnv(env []string, cliVersion string) ([]string, bool) {
 // ApplyOpenCodeOTelEnv injects OTel env vars for opencode, reusing the same
 // approach as ApplyCopilotOTelEnv. Also sets OPENCODE_CLIENT=nav-pilot.
 func ApplyOpenCodeOTelEnv(env []string, cliVersion string) ([]string, bool) {
+	if clientTelemetryOptedOut() {
+		return env, false
+	}
 	changed := false
 	endpoint := copilotOTelEndpoint(env)
 	if endpoint == "" {

--- a/cli/nav-pilot/internal/telemetry/copilot_otel_test.go
+++ b/cli/nav-pilot/internal/telemetry/copilot_otel_test.go
@@ -59,6 +59,8 @@ func TestCopilotOTelEndpointPrecedence(t *testing.T) {
 }
 
 func TestApplyCopilotOTelEnv(t *testing.T) {
+	telemetryOn(t)
+
 	t.Run("sets endpoint and enabled when absent", func(t *testing.T) {
 		env, changed := ApplyCopilotOTelEnv([]string{}, "dev")
 		if !changed {
@@ -319,4 +321,18 @@ func TestEncodeResourceAttrValue(t *testing.T) {
 			t.Fatalf("encodeResourceAttrValue(%q) = %q, want %q", tt.in, got, tt.want)
 		}
 	}
+}
+
+// telemetryOn neutralises both opt-out variables for a test that asserts
+// injection happens.
+//
+// Without it the suite depends on the developer's own environment: since the
+// opt-out began covering the whole injection rather than just the device id,
+// a machine with DO_NOT_TRACK set correctly injects nothing, and every test
+// asserting an injected value fails for a reason that is not a bug. The people
+// most likely to hit that are the ones who set DO_NOT_TRACK on purpose.
+func telemetryOn(t *testing.T) {
+	t.Helper()
+	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("NAV_PILOT_TELEMETRY_ENABLED", "")
 }

--- a/cli/nav-pilot/internal/telemetry/copilot_otel_test.go
+++ b/cli/nav-pilot/internal/telemetry/copilot_otel_test.go
@@ -124,17 +124,42 @@ func TestApplyCopilotOTelEnv(t *testing.T) {
 		}
 	})
 
-	t.Run("omits device_id when telemetry is opted out", func(t *testing.T) {
-		t.Setenv("NAV_PILOT_TELEMETRY_ENABLED", "false")
-		envOut, _ := ApplyCopilotOTelEnv([]string{}, "dev")
-		got := LookupEnvValue(envOut, "OTEL_RESOURCE_ATTRIBUTES")
-		if strings.Contains(got, "nav.pilot.device_id=") {
-			t.Fatalf("device_id should be omitted when opted out: %q", got)
-		}
-		if !strings.Contains(got, "nav.pilot.launcher=nav-pilot") {
-			t.Fatalf("launcher should still be present: %q", got)
-		}
-	})
+	// Opting out used to drop the device id and inject everything else, which
+	// still pointed the client at Nav's collector and still tagged the export
+	// with the repository. The result was a population of repo-labelled rows
+	// with no device id, indistinguishable from a lookup failure — worse data
+	// than either honouring the opt-out or ignoring it.
+	for _, optOut := range []struct{ name, key, value string }{
+		{"NAV_PILOT_TELEMETRY_ENABLED=false", "NAV_PILOT_TELEMETRY_ENABLED", "false"},
+		{"DO_NOT_TRACK=1", "DO_NOT_TRACK", "1"},
+	} {
+		t.Run("injects nothing when opted out via "+optOut.name, func(t *testing.T) {
+			stubDetectNavRepo(t, "navikt/foo")
+			t.Setenv(optOut.key, optOut.value)
+			for _, fn := range []struct {
+				name string
+				run  func([]string, string) ([]string, bool)
+			}{
+				{"ApplyCopilotOTelEnv", ApplyCopilotOTelEnv},
+				{"ApplyOpenCodeOTelEnv", ApplyOpenCodeOTelEnv},
+			} {
+				envOut, changed := fn.run([]string{}, "dev")
+				if changed || len(envOut) != 0 {
+					t.Errorf("%s while opted out returned changed=%v env=%v, want no changes at all",
+						fn.name, changed, envOut)
+				}
+				for _, key := range []string{
+					"OTEL_EXPORTER_OTLP_ENDPOINT",
+					"OTEL_RESOURCE_ATTRIBUTES",
+					"COPILOT_OTEL_ENABLED",
+				} {
+					if v := LookupEnvValue(envOut, key); v != "" {
+						t.Errorf("%s while opted out set %s=%q", fn.name, key, v)
+					}
+				}
+			}
+		})
+	}
 
 	t.Run("injects nav.repo when launched inside a navikt repo", func(t *testing.T) {
 		stubDetectNavRepo(t, "navikt/foo")

--- a/cli/nav-pilot/internal/telemetry/telemetry.go
+++ b/cli/nav-pilot/internal/telemetry/telemetry.go
@@ -460,6 +460,7 @@ func (t *otelTelemetry) RecordClientAvailable(client string, available bool) {
 	t.clientAvailable.Record(context.Background(), v, metric.WithAttributes(
 		attribute.String("client", client),
 		attribute.String("version", t.version),
+		attribute.String("device_id", t.device),
 		attribute.String("execution_context", t.executionContext),
 	))
 }
@@ -471,6 +472,7 @@ func (t *otelTelemetry) RecordCommand(command, mode, scope, result, errorType st
 		attribute.String("scope", normalizeTelemetryDimension(scope, "unknown")),
 		attribute.String("result", normalizeTelemetryDimension(result, "error")),
 		attribute.String("version", t.version),
+		attribute.String("device_id", t.device),
 		attribute.String("execution_context", t.executionContext),
 	}
 
@@ -484,6 +486,7 @@ func (t *otelTelemetry) RecordCommand(command, mode, scope, result, errorType st
 			attribute.String("scope", normalizeTelemetryDimension(scope, "unknown")),
 			attribute.String("error_type", normalizeTelemetryDimension(errorType, "unknown")),
 			attribute.String("version", t.version),
+			attribute.String("device_id", t.device),
 			attribute.String("execution_context", t.executionContext),
 		))
 	}
@@ -498,6 +501,7 @@ func (t *otelTelemetry) RecordInstallItems(scope, mode string, count int64) {
 		attribute.String("mode", normalizeTelemetryDimension(mode, "non_interactive")),
 		attribute.String("scope", normalizeTelemetryDimension(scope, "unknown")),
 		attribute.String("version", t.version),
+		attribute.String("device_id", t.device),
 		attribute.String("execution_context", t.executionContext),
 	))
 }
@@ -511,6 +515,7 @@ func (t *otelTelemetry) RecordSyncUpdates(scope, mode string, count int64) {
 		attribute.String("mode", normalizeTelemetryDimension(mode, "non_interactive")),
 		attribute.String("scope", normalizeTelemetryDimension(scope, "unknown")),
 		attribute.String("version", t.version),
+		attribute.String("device_id", t.device),
 		attribute.String("execution_context", t.executionContext),
 	))
 }
@@ -524,6 +529,7 @@ func (t *otelTelemetry) RecordSyncConflicts(scope, mode string, count int64) {
 		attribute.String("mode", normalizeTelemetryDimension(mode, "non_interactive")),
 		attribute.String("scope", normalizeTelemetryDimension(scope, "unknown")),
 		attribute.String("version", t.version),
+		attribute.String("device_id", t.device),
 		attribute.String("execution_context", t.executionContext),
 	))
 }
@@ -537,6 +543,7 @@ func (t *otelTelemetry) RecordInstallPresent(scope, collection string, present b
 		attribute.String("scope", normalizeTelemetryDimension(scope, "unknown")),
 		attribute.String("collection", normalizeTelemetryDimension(collection, "other")),
 		attribute.String("version", t.version),
+		attribute.String("device_id", t.device),
 		attribute.String("execution_context", t.executionContext),
 	))
 }
@@ -550,6 +557,7 @@ func (t *otelTelemetry) RecordInstalledItems(scope, itemType, status string, cou
 		attribute.String("type", normalizeTelemetryDimension(itemType, "unknown")),
 		attribute.String("status", normalizeTelemetryDimension(status, "active")),
 		attribute.String("version", t.version),
+		attribute.String("device_id", t.device),
 		attribute.String("execution_context", t.executionContext),
 	))
 }
@@ -560,6 +568,7 @@ func (t *otelTelemetry) RecordStalenessCheck(component, scope, result string) {
 		attribute.String("scope", normalizeTelemetryDimension(scope, "unknown")),
 		attribute.String("result", normalizeTelemetryDimension(result, "error")),
 		attribute.String("version", t.version),
+		attribute.String("device_id", t.device),
 		attribute.String("execution_context", t.executionContext),
 	))
 }
@@ -573,6 +582,7 @@ func (t *otelTelemetry) RecordUpToDate(component, scope string, upToDate bool) {
 		attribute.String("component", normalizeTelemetryDimension(component, "unknown")),
 		attribute.String("scope", normalizeTelemetryDimension(scope, "unknown")),
 		attribute.String("version", t.version),
+		attribute.String("device_id", t.device),
 		attribute.String("execution_context", t.executionContext),
 	))
 }
@@ -585,6 +595,7 @@ func (t *otelTelemetry) RecordVersionSkewDays(component, scope string, days int6
 		attribute.String("component", normalizeTelemetryDimension(component, "unknown")),
 		attribute.String("scope", normalizeTelemetryDimension(scope, "unknown")),
 		attribute.String("version", t.version),
+		attribute.String("device_id", t.device),
 		attribute.String("execution_context", t.executionContext),
 	))
 }
@@ -601,6 +612,7 @@ func (t *otelTelemetry) RecordLaunchError(client, errorType string) {
 		attribute.String("client", normalizeTelemetryDimension(client, "unknown")),
 		attribute.String("error_type", normalizeTelemetryDimension(errorType, "unknown")),
 		attribute.String("version", t.version),
+		attribute.String("device_id", t.device),
 		attribute.String("execution_context", t.executionContext),
 	))
 }
@@ -612,6 +624,7 @@ func (t *otelTelemetry) RecordRtkSetup(client, choice, result string) {
 		attribute.String("choice", normalizeTelemetryDimension(choice, "unknown")),
 		attribute.String("result", normalizeTelemetryDimension(result, "unknown")),
 		attribute.String("version", t.version),
+		attribute.String("device_id", t.device),
 		attribute.String("execution_context", t.executionContext),
 	))
 }

--- a/cli/nav-pilot/internal/telemetry/telemetry_extra_test.go
+++ b/cli/nav-pilot/internal/telemetry/telemetry_extra_test.go
@@ -219,6 +219,8 @@ func TestCopilotOTelEndpointConfigured(t *testing.T) {
 }
 
 func TestApplyOpenCodeOTelEnv(t *testing.T) {
+	telemetryOn(t)
+
 	env, changed := ApplyOpenCodeOTelEnv([]string{}, "dev")
 	if !changed {
 		t.Fatal("expected env to be changed")

--- a/cli/nav-pilot/internal/telemetry/telemetry_test.go
+++ b/cli/nav-pilot/internal/telemetry/telemetry_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestTelemetryEnabled(t *testing.T) {
+	t.Setenv("DO_NOT_TRACK", "")
+
 	t.Setenv("NAV_PILOT_TELEMETRY_ENABLED", "")
 	if !TelemetryEnabled() {
 		t.Fatal("expected TelemetryEnabled to return true by default")


### PR DESCRIPTION
Found during a telemetry audit prompted by the local-inference alpha. This one is about trust rather than data quality, so it goes first.

## What happened

`ApplyCopilotOTelEnv` and `ApplyOpenCodeOTelEnv` gated exactly one thing on the opt-out: the device id.

```go
deviceID := ""
if TelemetryEnabled() {
    deviceID = CopilotDeviceID()
}
```

Everything around it ran regardless. With `DO_NOT_TRACK=1` set, nav-pilot still:

- pointed the launched client at `collector-internet.nav.cloud.nais.io`
- set `COPILOT_OTEL_ENABLED=true`
- exported `nav.repo` — **the repository the developer was working in**

The old test asserted this deliberately (*"launcher should still be present"*), and the comment gave the reasoning: launcher and version are non-identifying. That is true, and it does not cover the repo slug passed in beside them by `detectNavRepo()`, which sits outside the guard.

## It also made the data worse, not smaller

An opted-out developer arrived as rows carrying a repository and no device id — indistinguishable from a device-id lookup failure. So the opt-out population could not be identified or excluded after the fact either. Opting out produced worse data than either honouring it or ignoring it.

## The fix

Both functions return the env untouched when telemetry is off. The device-id branch stays as a second line of defence: both functions are exported, and a future caller reaching them past the guard should still not inject an identifier.

An explicit endpoint override (`NAV_PILOT_COPILOT_OTEL_ENDPOINT`) does not survive the opt-out — someone who sets both has said "do not track" second, and that is the one to honour. Flagging it since it is a real behaviour change for anyone pointing the override at their own collector.

## Test

Covers both functions and both opt-out spellings (`NAV_PILOT_TELEMETRY_ENABLED=false` and `DO_NOT_TRACK=1`), and asserts nothing at all is injected. Without the guard it fails with the leak printed in full:

```
ApplyCopilotOTelEnv while opted out returned changed=true env=[
  OTEL_EXPORTER_OTLP_ENDPOINT=https://collector-internet.nav.cloud.nais.io
  OTEL_LOGS_EXPORTER=none
  COPILOT_OTEL_ENABLED=true
  OTEL_RESOURCE_ATTRIBUTES=nav.pilot.launcher=nav-pilot,nav.pilot.version=dev,nav.repo=navikt%2Ffoo]
want no changes at all
```

nav-pilot's own metrics were never affected: `InitTelemetry` returns `NoopRecorder{}` before any exporter is built, so the opt-out there is clean. This was confined to the env injected into launched clients.

## Checks

`go build ./...`, `go test ./...` green.