### PR TITLE
fix: one measurement per question, and device_id on all of them

### DIFF
--- a/cli/nav-pilot/RUNBOOKS.md
+++ b/cli/nav-pilot/RUNBOOKS.md
@@ -10,7 +10,6 @@ nav-pilot CLI emitterer disse metrikkene i dag (se `cli/nav-pilot/telemetry.go`)
 
 | Metrikk | Type | Datapunkt-dimensjoner |
 |---------|------|-----------------------|
-| `nav_pilot_command_total` | Counter | `command`, `mode`, `scope`, `result`, `version`, `execution_context` |
 | `nav_pilot_command_duration_ms` | Histogram | `command`, `mode`, `scope`, `result`, `version`, `execution_context` |
 | `nav_pilot_command_error_total` | Counter | `command`, `mode`, `scope`, `version`, `execution_context` |
 | `nav_pilot_rtk_setup_total` | Counter | `client`, `choice`, `result`, `version`, `execution_context` |
@@ -44,9 +43,9 @@ Pluss resource-attributtene `service.name`, `service.version`, `os`, `arch`, `de
 > **Avledet metrikk** — `install_success_rate` emitteres ikke direkte. Bygg den fra dagens metrikker, f.eks.:
 > ```promql
 > 1 - (
->   sum(increase(nav_pilot_command_error_total{command="install"}[1h]))
+>   sum(sum_over_time(nav_pilot_command_error_total{command="install"}[1h]))
 >   /
->   sum(increase(nav_pilot_command_total{command="install"}[1h]))
+>   sum(sum_over_time(nav_pilot_command_duration_ms_count{command="install"}[1h]))
 > )
 > ```
 

--- a/cli/nav-pilot/TELEMETRY.md
+++ b/cli/nav-pilot/TELEMETRY.md
@@ -8,8 +8,7 @@ nav-pilot sender **pseudonymiserte bruks- og ytelsesmetrikker** via OpenTelemetr
 
 | Metrikk | Type | Beskrivelse | Eksempler på dimensjoner |
 |---------|------|-------------|--------------------------|
-| `nav_pilot_command_total` | Counter | Antall kommandoer kjørt | `command=install`, `mode=interactive`, `scope=repo`, `result=success` |
-| `nav_pilot_command_duration_ms` | Histogram | Kjøringstid per kommando (ms) | Samme som over |
+| `nav_pilot_command_duration_ms` | Histogram | Kjøringstid per kommando (ms). `_count` er også antallet kommandoer kjørt | `command=install`, `mode=interactive`, `scope=repo`, `result=success` |
 | `nav_pilot_command_error_total` | Counter | Antall kommandoer som feilet | `command=sync`, `scope=user` |
 | `nav_pilot_launch_error_total` | Counter | Klient-oppstart som feilet | `client=copilot`, `error_type=launch_failed` |
 | `nav_pilot_rtk_setup_total` | Counter | Resultat av interaktiv RTK-prompt | `client=copilot`, `choice=yes`, `result=success` |
@@ -31,7 +30,7 @@ nav-pilot sender **pseudonymiserte bruks- og ytelsesmetrikker** via OpenTelemetr
 
 **Merk om `nav_pilot_config_info`:**
 - `config_mode` er konfig-modus (`default`/`plan`/`autopilot`) — ikke å forveksle
-  med `mode` på `nav_pilot_command_total` som er kjøremodus (`interactive`/`non_interactive`).
+  med `mode` på `nav_pilot_command_duration_ms` som er kjøremodus (`interactive`/`non_interactive`).
 - `model` baseres på konfigurert/CLI modell-id (ikke launch-normalisert med
   `ToOpenCodeModel`) og kollapses til kjent klient-modell-id, `custom`
   (ukjent/egendefinert) eller `unset` for å holde kardinaliteten lav. For
@@ -240,8 +239,8 @@ histogram_quantile(0.95, sum by (command, le) (increase(nav_pilot_command_durati
 
 **Feiltakt (% feil av alle kommandoer):**
 ```promql
-100 * sum(increase(nav_pilot_command_error_total[$__range]))
-    / clamp_min(sum(increase(nav_pilot_command_total[$__range])), 1)
+100 * sum(sum_over_time(nav_pilot_command_error_total[$__range]))
+    / clamp_min(sum(sum_over_time(nav_pilot_command_duration_ms_count[$__range])), 1)
 ```
 
 **Sync-konflikter (totalt) per scope:**
@@ -251,8 +250,25 @@ sum by (scope) (increase(nav_pilot_sync_conflicts_total[$__range]))
 
 **Antall kommandokjøringer per versjon:**
 ```promql
-sum by (version) (increase(nav_pilot_command_total[$__range]))
+sum by (version) (sum_over_time(nav_pilot_command_duration_ms_count[$__range]))
 ```
+
+## Metrikker som er fjernet
+
+`nav_pilot_command_total` og `nav_pilot_local_server_total` finnes ikke lenger.
+
+`command_total` var label for label identisk med `nav_pilot_command_duration_ms_count`:
+samme funksjon, samme `attrs`-slice, ett `Add` og ett `Record`. Histogrammets `_count`
+*er* antallet kommandoer. Bruk den. De så forskjellige ut en periode fordi tellere ble
+sendt som delta og forkastet, mens histogrammer kom fram hele tiden.
+
+`local_server_total` skrev samme hendelse fra samme kallsted som
+`nav_pilot_local_ready_seconds`, som nå har `outcome`. Den ene verdien den hadde for seg
+selv, `hung`, kunne aldri komme fram: kallstedet sender `Status()`, og bare `Health(ctx)`
+produserer `hung`. Den har rapportert `ready` og ingenting annet.
+
+**En måling per spørsmål.** To metrikker som svarer på det samme er ikke redundans,
+det er to tall som kan bli uenige.
 
 > En ferdig Grafana-dashboard ligger i [`dashboards/nav-pilot-cli.json`](../../dashboards/nav-pilot-cli.json)
 > (uid tildeles ved import). Spørringene er robuste mot manglende data under utrulling

--- a/cli/nav-pilot/internal/cli/alpha_local.go
+++ b/cli/nav-pilot/internal/cli/alpha_local.go
@@ -429,16 +429,16 @@ func cmdLocalStart() error {
 	// not ready is a pid `status` reports as crashed hours later, which reads
 	// as "it died" rather than "it never started".
 	status := srv.Status()
-	// One closed vocabulary for the outcome: ready, failed, interrupted. The
-	// health value goes to RecordLocalServer, which is the instrument for it;
-	// letting it leak in here too would give the same panel two spellings of
-	// the same state.
+	// One closed vocabulary for the outcome: ready, failed, interrupted. This
+	// is now the only record of how a start ended — nav_pilot_local_server_total
+	// carried the same event from the same call site and was removed, since its
+	// one distinctive value, `hung`, could never arrive here: Status() cannot
+	// return it, only Health(ctx) produces it, and that is never fed in.
 	readyOutcome := "ready"
 	if status.Health != local.HealthReady || status.PID <= 0 {
 		readyOutcome = "failed"
 	}
 	telemetry.RecordLocalReadySeconds(model.Model, readyOutcome, int64(timeNow().Sub(started).Seconds()))
-	telemetry.RecordLocalServer(model.Model, string(status.Health))
 	if status.Health != local.HealthReady || status.PID <= 0 {
 		_ = srv.Stop()
 		return fmt.Errorf("the local %s server did not come up (%s); nothing was recorded.\n\n  What it printed is in %s", model.Model, status.Health, local.LogPath())

--- a/cli/nav-pilot/internal/telemetry/local_instruments_test.go
+++ b/cli/nav-pilot/internal/telemetry/local_instruments_test.go
@@ -26,10 +26,6 @@ func TestRecorderEmitsEveryLocalInstrument(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	serverTotal, err := meter.Int64Counter("nav_pilot_local_server_total")
-	if err != nil {
-		t.Fatal(err)
-	}
 	ready, err := meter.Int64Histogram("nav_pilot_local_ready_seconds")
 	if err != nil {
 		t.Fatal(err)
@@ -37,7 +33,6 @@ func TestRecorderEmitsEveryLocalInstrument(t *testing.T) {
 	tel := &otelTelemetry{
 		provider:          provider,
 		localDispatches:   dispatches,
-		localServerTotal:  serverTotal,
 		localReadySeconds: ready,
 		version:           "test",
 		device:            "device-under-test",
@@ -48,7 +43,6 @@ func TestRecorderEmitsEveryLocalInstrument(t *testing.T) {
 	// Zero dispatches with traffic: the client saw the worker and declined,
 	// which is the case the attribute exists to distinguish.
 	tel.RecordLocalSession("opencode", "some/model", 0, true)
-	tel.RecordLocalServer("some/model", "ready")
 	// Both outcomes, because the failing one is the reason the attribute
 	// exists: recorded only on success, this histogram cannot see the starts
 	// that hung, and its slow tail is missing by construction.
@@ -67,7 +61,6 @@ func TestRecorderEmitsEveryLocalInstrument(t *testing.T) {
 	}
 	for _, want := range []string{
 		"nav_pilot_local_dispatches",
-		"nav_pilot_local_server_total",
 		"nav_pilot_local_ready_seconds",
 	} {
 		if !seen[want] {

--- a/cli/nav-pilot/internal/telemetry/telemetry.go
+++ b/cli/nav-pilot/internal/telemetry/telemetry.go
@@ -54,7 +54,6 @@ type Recorder interface {
 	RecordLaunchError(client, errorType string)
 	RecordRtkSetup(client, choice, result string)
 	RecordLocalSession(client, model string, dispatches int64, sawTraffic bool)
-	RecordLocalServer(model, event string)
 	RecordLocalReadySeconds(model, outcome string, seconds int64)
 	Shutdown(ctx context.Context) error
 }
@@ -63,7 +62,6 @@ type NoopRecorder struct{}
 
 func (NoopRecorder) RecordCommand(string, string, string, string, string, time.Duration) {}
 func (NoopRecorder) RecordLocalSession(string, string, int64, bool)                      {}
-func (NoopRecorder) RecordLocalServer(string, string)                                    {}
 func (NoopRecorder) RecordLocalReadySeconds(string, string, int64)                       {}
 func (NoopRecorder) RecordInstallItems(string, string, int64)                            {}
 func (NoopRecorder) RecordSyncUpdates(string, string, int64)                             {}
@@ -83,7 +81,6 @@ func (NoopRecorder) Shutdown(context.Context) error        { return nil }
 type otelTelemetry struct {
 	provider *sdkmetric.MeterProvider
 
-	commandTotal       metric.Int64Counter
 	commandDurationMS  metric.Int64Histogram
 	commandErrorTotal  metric.Int64Counter
 	launchErrorTotal   metric.Int64Counter
@@ -100,7 +97,6 @@ type otelTelemetry struct {
 	versionSkewDays    metric.Int64Histogram
 	rtkSetupTotal      metric.Int64Counter
 	localDispatches    metric.Int64Histogram
-	localServerTotal   metric.Int64Counter
 	localReadySeconds  metric.Int64Histogram
 
 	version          string
@@ -174,10 +170,6 @@ func InitTelemetry(ctx context.Context, cliVersion string, rtkInstalled string) 
 	)
 
 	meter := provider.Meter("github.com/navikt/copilot/cli/nav-pilot")
-	commandTotal, err := meter.Int64Counter("nav_pilot_command_total")
-	if err != nil {
-		return NoopRecorder{}, fmt.Errorf("create command total counter: %w", err)
-	}
 	commandDurationMS, err := meter.Int64Histogram("nav_pilot_command_duration_ms")
 	if err != nil {
 		return NoopRecorder{}, fmt.Errorf("create command duration histogram: %w", err)
@@ -246,11 +238,6 @@ func InitTelemetry(ctx context.Context, cliVersion string, rtkInstalled string) 
 	if err != nil {
 		return NoopRecorder{}, fmt.Errorf("create local dispatches histogram: %w", err)
 	}
-	localServerTotal, err := meter.Int64Counter("nav_pilot_local_server_total",
-		metric.WithDescription("Local server lifecycle events, including the hung state a developer would otherwise just restart past."))
-	if err != nil {
-		return NoopRecorder{}, fmt.Errorf("create local server counter: %w", err)
-	}
 	localReadySeconds, err := meter.Int64Histogram("nav_pilot_local_ready_seconds",
 		metric.WithDescription("Seconds a start took, split by outcome: ready, failed or interrupted."))
 	if err != nil {
@@ -259,7 +246,6 @@ func InitTelemetry(ctx context.Context, cliVersion string, rtkInstalled string) 
 
 	tel := &otelTelemetry{
 		provider:           provider,
-		commandTotal:       commandTotal,
 		commandDurationMS:  commandDurationMS,
 		commandErrorTotal:  commandErrorTotal,
 		launchErrorTotal:   launchErrorTotal,
@@ -276,7 +262,6 @@ func InitTelemetry(ctx context.Context, cliVersion string, rtkInstalled string) 
 		versionSkewDays:    versionSkewDays,
 		rtkSetupTotal:      rtkSetupTotal,
 		localDispatches:    localDispatches,
-		localServerTotal:   localServerTotal,
 		localReadySeconds:  localReadySeconds,
 		version:            version,
 		device:             device,
@@ -418,22 +403,6 @@ func (t *otelTelemetry) RecordLocalSession(client, model string, dispatches int6
 	))
 }
 
-// RecordLocalServer counts server lifecycle events: started, ready, hung, crashed,
-// stopped.
-//
-// `hung` is the one worth the instrument. It is unrecoverable, the developer's fix
-// is a restart, and a restart is exactly what makes it invisible to us: nobody
-// files a report for something they fixed in ten seconds. If serialising the guard
-// did not hold in real use, this is where it shows.
-func (t *otelTelemetry) RecordLocalServer(model, event string) {
-	t.localServerTotal.Add(context.Background(), 1, metric.WithAttributes(
-		attribute.String("model", orUnset(model)),
-		attribute.String("event", orUnset(event)),
-		attribute.String("version", t.version),
-		attribute.String("device_id", t.device),
-	))
-}
-
 // RecordLocalReadySeconds emits how long a start took, and how it ended.
 //
 // outcome is what makes the histogram readable. Recorded only on success, this
@@ -476,7 +445,6 @@ func (t *otelTelemetry) RecordCommand(command, mode, scope, result, errorType st
 		attribute.String("execution_context", t.executionContext),
 	}
 
-	t.commandTotal.Add(context.Background(), 1, metric.WithAttributes(attrs...))
 	t.commandDurationMS.Record(context.Background(), maxInt64(0, duration.Milliseconds()), metric.WithAttributes(attrs...))
 
 	if result == "error" {
@@ -722,10 +690,16 @@ func temporalityFor(sdkmetric.InstrumentKind) metricdata.Temporality {
 	//
 	// Delta was the reasonable default for a CLI: each invocation reports what
 	// it did and there is no series to reset. In practice every delta counter
-	// nav-pilot has ever emitted was lost. nav_pilot_command_total has one
-	// series in Mimir and it carries no device_id, while this machine ran
-	// commands all day and has none; the histograms from the same processes
-	// arrive every time, with device ids.
+	// nav-pilot has ever emitted was lost, while cumulative histograms from the
+	// same processes arrived every time. That is the evidence, and it is the
+	// whole of it.
+	//
+	// An earlier version of this comment also blamed delta for those counters
+	// carrying no device_id. Wrong, and worth recording because it sent the
+	// next reader down the wrong path: device_id is attached per instrument, by
+	// hand, and seventeen metrics simply never had it typed in — including
+	// nav_pilot_command_duration_ms, a histogram recorded from the same call
+	// that arrived perfectly well without it.
 	//
 	// A process that lives seconds has no reset problem for delta to solve, and
 	// a Prometheus-lineage backend ingests cumulative natively without a

--- a/cli/nav-pilot/internal/telemetry/telemetry_extra_test.go
+++ b/cli/nav-pilot/internal/telemetry/telemetry_extra_test.go
@@ -5,12 +5,17 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 // newFullTestTelemetry builds an otelTelemetry with ALL instruments so every
 // Record* method can be exercised without a nil-pointer panic.
+//
+// It said "ALL" while missing four, which nothing noticed because no test called
+// the four. TestEveryInstrumentCarriesDeviceID does, and found them by panicking.
 func newFullTestTelemetry(t *testing.T) (*otelTelemetry, *sdkmetric.ManualReader) {
 	t.Helper()
 	reader := sdkmetric.NewManualReader()
@@ -41,7 +46,6 @@ func newFullTestTelemetry(t *testing.T) (*otelTelemetry, *sdkmetric.ManualReader
 
 	tel := &otelTelemetry{
 		provider:           provider,
-		commandTotal:       counter("nav_pilot_command_total"),
 		commandDurationMS:  hist("nav_pilot_command_duration_ms"),
 		commandErrorTotal:  counter("nav_pilot_command_error_total"),
 		installItemsTotal:  counter("nav_pilot_install_items_total"),
@@ -55,6 +59,10 @@ func newFullTestTelemetry(t *testing.T) (*otelTelemetry, *sdkmetric.ManualReader
 		stalenessCheck:     counter("nav_pilot_staleness_check_total"),
 		upToDate:           gauge("nav_pilot_up_to_date"),
 		versionSkewDays:    hist("nav_pilot_version_skew_days"),
+		launchErrorTotal:   counter("nav_pilot_launch_error_total"),
+		rtkSetupTotal:      counter("nav_pilot_rtk_setup_total"),
+		localDispatches:    hist("nav_pilot_local_dispatches"),
+		localReadySeconds:  hist("nav_pilot_local_ready_seconds"),
 		version:            "test",
 		device:             "dev-1",
 		executionContext:   "organic",
@@ -230,5 +238,73 @@ func TestApplyOpenCodeOTelEnv(t *testing.T) {
 	}
 	if got := LookupEnvValue(env, "OTEL_LOGS_EXPORTER"); got != "none" {
 		t.Errorf("OTEL_LOGS_EXPORTER = %q, want none", got)
+	}
+}
+
+// TestEveryInstrumentCarriesDeviceID is the regression test for the whole class.
+//
+// device_id is attached by hand, per instrument. Seventeen of twenty-six metrics
+// never had it typed in, so each collapsed to a single series for the entire
+// fleet while nav_pilot_info saw 266 distinct devices. Aggregate totals survived
+// that; every "how many people", "which versions", "who is affected" question did
+// not, and four gauges were worse than unattributed — last-write-wins across the
+// fleet, reading as fleet state while reporting whichever machine exported last.
+//
+// Nothing in the type system prevents the next instrument from repeating it. This
+// does: it exercises every Record* method on a real recorder and fails if any
+// point reaches the reader without a device_id.
+func TestEveryInstrumentCarriesDeviceID(t *testing.T) {
+	tel, reader := newFullTestTelemetry(t)
+
+	tel.RecordCommand("install", "interactive", "repo", "error", "network_error", time.Second)
+	tel.RecordClientAvailable("opencode", true)
+	tel.RecordInstallItems("repo", "interactive", 3)
+	tel.RecordSyncUpdates("repo", "interactive", 2)
+	tel.RecordSyncConflicts("repo", "interactive", 1)
+	tel.RecordInstallPresent("repo", "collection", true)
+	tel.RecordInstalledItems("repo", "agent", "active", 4)
+	tel.RecordStalenessCheck("cli", "repo", "up_to_date")
+	tel.RecordUpToDate("cli", "repo", true)
+	tel.RecordVersionSkewDays("cli", "repo", 9)
+	tel.RecordLaunchError("opencode", "client_not_found")
+	tel.RecordRtkSetup("opencode", "yes", "success")
+	tel.RecordLocalSession("opencode", "some/model", 0, true)
+	tel.RecordLocalReadySeconds("some/model", "ready", 4)
+	tel.RecordConfig("opencode", "repo", "custom", "high", "large", "info", false, true)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatal(err)
+	}
+
+	seen := 0
+	check := func(name string, attrs attribute.Set) {
+		seen++
+		if v, ok := attrs.Value(attribute.Key("device_id")); !ok || v.AsString() == "" {
+			t.Errorf("%s emits a point with no device_id: %v", name, attrs.ToSlice())
+		}
+	}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			switch d := m.Data.(type) {
+			case metricdata.Sum[int64]:
+				for _, dp := range d.DataPoints {
+					check(m.Name, dp.Attributes)
+				}
+			case metricdata.Gauge[int64]:
+				for _, dp := range d.DataPoints {
+					check(m.Name, dp.Attributes)
+				}
+			case metricdata.Histogram[int64]:
+				for _, dp := range d.DataPoints {
+					check(m.Name, dp.Attributes)
+				}
+			default:
+				t.Errorf("%s has unhandled data type %T; this test no longer covers every instrument", m.Name, m.Data)
+			}
+		}
+	}
+	if seen == 0 {
+		t.Fatal("collected no data points at all; the test proves nothing")
 	}
 }

--- a/dashboards/nav-pilot-cli.json
+++ b/dashboards/nav-pilot-cli.json
@@ -42,7 +42,7 @@
                     "group": "prometheus",
                     "kind": "DataQuery",
                     "spec": {
-                      "expr": "sum by (command) (sum_over_time(nav_pilot_command_total{version=~\"$version\", execution_context=~\"$execution_context\", command=~\"$command\", scope=~\"$scope\"}[$__interval]))",
+                      "expr": "sum by (command) (sum_over_time(nav_pilot_command_duration_ms_count{version=~\"$version\", execution_context=~\"$execution_context\", command=~\"$command\", scope=~\"$scope\"}[$__interval]))",
                       "legendFormat": "{{command}}"
                     },
                     "version": "v0"
@@ -1607,7 +1607,7 @@
                     "group": "prometheus",
                     "kind": "DataQuery",
                     "spec": {
-                      "expr": "sum(sum_over_time(nav_pilot_command_total{version=~\"$version\", execution_context=~\"$execution_context\", command=~\"$command\", scope=~\"$scope\"}[$__range])) or vector(0)",
+                      "expr": "sum(sum_over_time(nav_pilot_command_duration_ms_count{version=~\"$version\", execution_context=~\"$execution_context\", command=~\"$command\", scope=~\"$scope\"}[$__range])) or vector(0)",
                       "legendFormat": ""
                     },
                     "version": "v0"
@@ -1688,7 +1688,7 @@
                     "group": "prometheus",
                     "kind": "DataQuery",
                     "spec": {
-                      "expr": "100 * sum(sum_over_time(nav_pilot_command_error_total{version=~\"$version\", execution_context=~\"$execution_context\", command=~\"$command\", scope=~\"$scope\"}[$__range])) / clamp_min(sum(sum_over_time(nav_pilot_command_total{version=~\"$version\", execution_context=~\"$execution_context\", command=~\"$command\", scope=~\"$scope\"}[$__range])), 1)",
+                      "expr": "100 * sum(sum_over_time(nav_pilot_command_error_total{version=~\"$version\", execution_context=~\"$execution_context\", command=~\"$command\", scope=~\"$scope\"}[$__range])) / clamp_min(sum(sum_over_time(nav_pilot_command_duration_ms_count{version=~\"$version\", execution_context=~\"$execution_context\", command=~\"$command\", scope=~\"$scope\"}[$__range])), 1)",
                       "legendFormat": ""
                     },
                     "version": "v0"
@@ -1979,7 +1979,7 @@
                     "group": "prometheus",
                     "kind": "DataQuery",
                     "spec": {
-                      "expr": "label_replace(sum by (execution_context) (sum_over_time(nav_pilot_command_total{version=~\"$version\", execution_context=~\"$execution_context\", command=~\"$command\", scope=~\"$scope\"}[$__range])), \"execution_context\", \"ukjent\", \"execution_context\", \"^$\")",
+                      "expr": "label_replace(sum by (execution_context) (sum_over_time(nav_pilot_command_duration_ms_count{version=~\"$version\", execution_context=~\"$execution_context\", command=~\"$command\", scope=~\"$scope\"}[$__range])), \"execution_context\", \"ukjent\", \"execution_context\", \"^$\")",
                       "legendFormat": "{{execution_context}}"
                     },
                     "version": "v0"
@@ -2067,7 +2067,7 @@
                     "group": "prometheus",
                     "kind": "DataQuery",
                     "spec": {
-                      "expr": "sum by (command) (sum_over_time(nav_pilot_command_total{version=~\"$version\", execution_context=~\"$execution_context\", command=~\"$command\", scope=~\"$scope\"}[$__range]))",
+                      "expr": "sum by (command) (sum_over_time(nav_pilot_command_duration_ms_count{version=~\"$version\", execution_context=~\"$execution_context\", command=~\"$command\", scope=~\"$scope\"}[$__range]))",
                       "legendFormat": "{{command}}"
                     },
                     "version": "v0"
@@ -2593,7 +2593,7 @@
           "text": "All",
           "value": "$__all"
         },
-        "definition": "label_values(nav_pilot_command_total, execution_context)",
+        "definition": "label_values(nav_pilot_command_duration_ms_count, execution_context)",
         "hide": "dontHide",
         "includeAll": true,
         "label": "Kjøringskontekst",
@@ -2608,7 +2608,7 @@
           "kind": "DataQuery",
           "spec": {
             "qryType": 1,
-            "query": "label_values(nav_pilot_command_total, execution_context)",
+            "query": "label_values(nav_pilot_command_duration_ms_count, execution_context)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "version": "v0"
@@ -2629,7 +2629,7 @@
           "text": "All",
           "value": "$__all"
         },
-        "definition": "label_values(nav_pilot_command_total, scope)",
+        "definition": "label_values(nav_pilot_command_duration_ms_count, scope)",
         "hide": "dontHide",
         "includeAll": true,
         "label": "Scope",
@@ -2644,7 +2644,7 @@
           "kind": "DataQuery",
           "spec": {
             "qryType": 1,
-            "query": "label_values(nav_pilot_command_total, scope)",
+            "query": "label_values(nav_pilot_command_duration_ms_count, scope)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "version": "v0"
@@ -2665,7 +2665,7 @@
           "text": "All",
           "value": "$__all"
         },
-        "definition": "label_values(nav_pilot_command_total, command)",
+        "definition": "label_values(nav_pilot_command_duration_ms_count, command)",
         "hide": "dontHide",
         "includeAll": true,
         "label": "Kommando",
@@ -2680,7 +2680,7 @@
           "kind": "DataQuery",
           "spec": {
             "qryType": 1,
-            "query": "label_values(nav_pilot_command_total, command)",
+            "query": "label_values(nav_pilot_command_duration_ms_count, command)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "version": "v0"

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -225,8 +225,7 @@ ikke allerede er satt, og injiserer resource-attributtene `nav.pilot.launcher`,
 
 Støttede MVP-metrikker:
 
-- `nav_pilot_command_total`
-- `nav_pilot_command_duration_ms`
+- `nav_pilot_command_duration_ms` (`_count` er også antall kommandoer)
 - `nav_pilot_command_error_total`
 - `nav_pilot_install_items_total`
 - `nav_pilot_sync_updates_total`


### PR DESCRIPTION
Two instruments removed, and the seventeen metrics that carried no `device_id` now do. Follows #547, #548 and #549.

## Removed

**`nav_pilot_command_total`** was label for label identical to `nav_pilot_command_duration_ms_count`. Same function, same `attrs` slice, one `Add` and one `Record`:

```go
attrs := []attribute.KeyValue{ /* command, mode, scope, result, version, execution_context */ }
t.commandTotal.Add(ctx, 1, metric.WithAttributes(attrs...))
t.commandDurationMS.Record(ctx, ms, metric.WithAttributes(attrs...))
```

The histogram's `_count` *is* the command count. They looked different only because counters were delta and silently dropped while histograms always arrived. Eleven dashboard queries and four documented examples now use `_count`.

**`nav_pilot_local_server_total`** wrote the same event from the same call site as `nav_pilot_local_ready_seconds`, which carries `outcome` as of #547. Its one distinctive value, `hung`, could never arrive: the call site passes `Status()`, whose switch cannot return it, and only `Health(ctx)` produces it. It has recorded `event="ready"` and nothing else — behind a description and an eight-line comment justifying a measurement that cannot occur.

## device_id, on everything

`device_id` is attached by hand, per instrument, and had been typed into five. The other seventeen collapsed to **one series for the entire fleet** while `nav_pilot_info` saw **266 distinct devices**.

Aggregate totals survived that. "How many people hit this error", "which versions are affected", "how many use this command" did not. And four gauges were worse than unattributed: `client_available`, `install_present`, `installed_items` and `up_to_date` are last-write-wins across the fleet, so they read as fleet state while reporting whichever machine exported most recently.

Cardinality: roughly 23 label combinations times device count. Small for Mimir.

## The guard

`TestEveryInstrumentCarriesDeviceID` exercises every `Record*` method on a real recorder and fails on any point that reaches the reader without a `device_id`. Nothing in the type system prevents the next instrument from repeating this; this does.

It earned its place twice before the commit landed:

- `newFullTestTelemetry` claimed in its own comment to build **ALL** instruments while missing four. No test had noticed, because no test called them. It found them by panicking.
- It caught **twelve duplicated `device_id` attributes in this very change** — a script that ran twice over an uncommitted tree that followed a branch checkout.

## Also corrected

`temporalityFor`'s comment blamed delta temporality for the missing device ids. Both halves are wrong: `device_id` is a per-instrument attribute, and `nav_pilot_command_duration_ms` is a histogram from the same call that arrived fine and also had none. The cumulative switch stands on its own evidence; the comment now says only that.

`TELEMETRY.md` gains a section on what was removed and why, ending on the rule: **two metrics that answer the same question are not redundancy, they are two numbers that can disagree.**

## Checks

`go build`, `go vet`, `go test ./...` green — and green with `DO_NOT_TRACK=1` set, which main was not before #549.