### PR TITLE
feat: a dashboard for local inference, with every query checked against Mimir

### DIFF
--- a/dashboards/nav-pilot-local.json
+++ b/dashboards/nav-pilot-local.json
@@ -1,0 +1,1274 @@
+{
+  "annotations": [
+    {
+      "kind": "AnnotationQuery",
+      "spec": {
+        "builtIn": true,
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "query": {
+          "datasource": {
+            "name": "-- Grafana --"
+          },
+          "group": "grafana",
+          "kind": "DataQuery",
+          "spec": {},
+          "version": "v0"
+        }
+      }
+    }
+  ],
+  "cursorSync": "Crosshair",
+  "description": "Lokal inferens i nav-pilot alpha: hvem bruker den, hva sender de dit, og kommer serveren opp. Alle spørringer bruker sum_over_time, ikke increase() — en nav-pilot-prosess eksporterer én gang og avslutter, så increase() har ingen andre sample å regne differanse fra og gir 0.",
+  "editable": true,
+  "elements": {
+    "panel-1": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "refId": "A",
+                  "query": {
+                    "datasource": {
+                      "name": "${DS_METRICS}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "count(count by (device_id) (sum_over_time(nav_pilot_local_dispatches_count{version=~\"$version\"}[$__range])))",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  }
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Hvor mange som har kjørt minst én lokal sesjon i perioden. Nevneren for alt annet her.",
+        "id": 1,
+        "links": [],
+        "title": "Maskiner med lokal kjøring",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "decimals": 0,
+                "noValue": "0",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.0.1+security-01"
+        }
+      }
+    },
+    "panel-2": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "refId": "A",
+                  "query": {
+                    "datasource": {
+                      "name": "${DS_METRICS}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "sum(sum_over_time(nav_pilot_local_dispatches_count{version=~\"$version\"}[$__range]))",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  }
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Én sesjon er én klientkjøring med lokal worker tilgjengelig, talt når klienten avslutter.",
+        "id": 2,
+        "links": [],
+        "title": "Sesjoner",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "decimals": 0,
+                "noValue": "0",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.0.1+security-01"
+        }
+      }
+    },
+    "panel-3": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "refId": "A",
+                  "query": {
+                    "datasource": {
+                      "name": "${DS_METRICS}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "sum(sum_over_time(nav_pilot_local_dispatches_sum{version=~\"$version\"}[$__range]))",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  }
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Sum av oppgaver hovedagenten faktisk sendte til den lokale modellen.",
+        "id": 3,
+        "links": [],
+        "title": "Oppgaver sendt lokalt",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "decimals": 0,
+                "noValue": "0",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.0.1+security-01"
+        }
+      }
+    },
+    "panel-4": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "refId": "A",
+                  "query": {
+                    "datasource": {
+                      "name": "${DS_METRICS}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "100 * sum(sum_over_time(nav_pilot_local_dispatches_bucket{version=~\"$version\", le=\"0\"}[$__range])) / clamp_min(sum(sum_over_time(nav_pilot_local_dispatches_count{version=~\"$version\"}[$__range])), 1)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  }
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Panelet som avgjør om alfaen utvides. Se fordelingen under for hvorfor tallet er som det er — en null betyr ikke det samme i de to tilfellene.",
+        "id": 4,
+        "links": [],
+        "title": "Andel sesjoner uten dispatch",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "decimals": 0,
+                "noValue": "0",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.0.1+security-01"
+        }
+      }
+    },
+    "panel-10": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "refId": "A",
+                  "query": {
+                    "datasource": {
+                      "name": "${DS_METRICS}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "sum by (saw_traffic) (sum_over_time(nav_pilot_local_dispatches_bucket{version=~\"$version\", le=\"0\"}[$__interval]))",
+                      "legendFormat": "så workeren: {{saw_traffic}}"
+                    },
+                    "version": "v0"
+                  }
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Den ene grafen som er verdt å bygge dashbordet for. saw_traffic=true betyr at klienten nådde workeren og lot være å bruke den — det er en dom over modellen. saw_traffic=false betyr at oppkoblingen aldri kom fram, som er vår feil, ikke modellens. Uten dette skillet er en null tre forskjellige ting rapportert som én.\n\nVENTER PÅ DATA: saw_traffic ble lagt til etter at alfaen gikk ut, så panelet er tomt til folk har oppdatert. Tomt er riktig her — en null vi ikke kan tolke er verre enn ingen strek.",
+        "id": 10,
+        "links": [],
+        "title": "Sesjoner uten dispatch, delt på om klienten så workeren",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 20,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [
+                  "mean",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            }
+          },
+          "version": "13.0.1+security-01"
+        }
+      }
+    },
+    "panel-11": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "refId": "A",
+                  "query": {
+                    "datasource": {
+                      "name": "${DS_METRICS}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "sum(sum_over_time(nav_pilot_local_dispatches_bucket{version=~\"$version\", le=\"0\"}[$__range]))",
+                      "legendFormat": "0 oppgaver"
+                    },
+                    "version": "v0"
+                  }
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "refId": "B",
+                  "query": {
+                    "datasource": {
+                      "name": "${DS_METRICS}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "sum(sum_over_time(nav_pilot_local_dispatches_bucket{version=~\"$version\", le=\"5\"}[$__range])) - sum(sum_over_time(nav_pilot_local_dispatches_bucket{version=~\"$version\", le=\"0\"}[$__range]))",
+                      "legendFormat": "1–5"
+                    },
+                    "version": "v0"
+                  }
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "refId": "C",
+                  "query": {
+                    "datasource": {
+                      "name": "${DS_METRICS}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "sum(sum_over_time(nav_pilot_local_dispatches_count{version=~\"$version\"}[$__range])) - sum(sum_over_time(nav_pilot_local_dispatches_bucket{version=~\"$version\", le=\"5\"}[$__range]))",
+                      "legendFormat": "6+"
+                    },
+                    "version": "v0"
+                  }
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Fordeling, aldri gjennomsnitt: de fleste sesjonene sender ingenting og noen få sender mye, og et snitt av de to beskriver ingen faktisk sesjon. Bøttene er trukket fra hverandre, så hver søyle er sesjoner i akkurat det intervallet.",
+        "id": 11,
+        "links": [],
+        "title": "Oppgaver per sesjon",
+        "vizConfig": {
+          "group": "barchart",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {},
+              "overrides": []
+            },
+            "options": {}
+          },
+          "version": "13.0.1+security-01"
+        }
+      }
+    },
+    "panel-12": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "refId": "A",
+                  "query": {
+                    "datasource": {
+                      "name": "${DS_METRICS}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "sum by (client) (sum_over_time(nav_pilot_local_dispatches_count{version=~\"$version\"}[$__interval]))",
+                      "legendFormat": "{{client}}"
+                    },
+                    "version": "v0"
+                  }
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "opencode kjører modellen som subagent under en skyagent; Copilot CLI kjører hele økten lokalt.",
+        "id": 12,
+        "links": [],
+        "title": "Sesjoner per intervall, per klient",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 20,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [
+                  "mean",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            }
+          },
+          "version": "13.0.1+security-01"
+        }
+      }
+    },
+    "panel-20": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "refId": "A",
+                  "query": {
+                    "datasource": {
+                      "name": "${DS_METRICS}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "histogram_quantile(0.5, sum by (le) (sum_over_time(nav_pilot_local_ready_seconds_bucket{version=~\"$version\", outcome=\"ready\"}[$__range])))",
+                      "legendFormat": "p50"
+                    },
+                    "version": "v0"
+                  }
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "refId": "B",
+                  "query": {
+                    "datasource": {
+                      "name": "${DS_METRICS}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "histogram_quantile(0.95, sum by (le) (sum_over_time(nav_pilot_local_ready_seconds_bucket{version=~\"$version\", outcome=\"ready\"}[$__range])))",
+                      "legendFormat": "p95"
+                    },
+                    "version": "v0"
+                  }
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "p50 og p95 for oppstarter som faktisk kom opp. Filteret outcome=\"ready\" er ikke pynt: en oppstart som går i timeout bidrar med ti minutter, og en p95 uten filteret måler feilene, ikke ventetiden.\n\nVENTER PÅ DATA: outcome kom inn etter forrige release, så panelet fylles først når folk har oppdatert.",
+        "id": 20,
+        "links": [],
+        "title": "Tid til klar",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 20,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [
+                  "mean",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            }
+          },
+          "version": "13.0.1+security-01"
+        }
+      }
+    },
+    "panel-21": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "refId": "A",
+                  "query": {
+                    "datasource": {
+                      "name": "${DS_METRICS}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "sum by (outcome) (sum_over_time(nav_pilot_local_ready_seconds_count{version=~\"$version\"}[$__interval]))",
+                      "legendFormat": "{{outcome}}"
+                    },
+                    "version": "v0"
+                  }
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "ready, failed eller interrupted. Fram til denne fantes ble bare vellykkede oppstarter registrert, så den trege halen manglet per konstruksjon.\n\nVENTER PÅ DATA: outcome kom inn etter forrige release og fylles etter hvert som folk oppdaterer.",
+        "id": 21,
+        "links": [],
+        "title": "Hvordan oppstarter endte",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 20,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [
+                  "mean",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            }
+          },
+          "version": "13.0.1+security-01"
+        }
+      }
+    },
+    "panel-22": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "refId": "A",
+                  "query": {
+                    "datasource": {
+                      "name": "${DS_METRICS}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "sum by (model) (sum_over_time(nav_pilot_local_dispatches_count{version=~\"$version\"}[$__range]))",
+                      "legendFormat": "{{model}}"
+                    },
+                    "version": "v0"
+                  }
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Skal være én. Flere betyr at noen kjører noe vi ikke har målt.",
+        "id": 22,
+        "links": [],
+        "title": "Modeller i bruk",
+        "vizConfig": {
+          "group": "piechart",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  }
+                },
+                "noValue": "0",
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "displayLabels": [
+                "percent"
+              ],
+              "legend": {
+                "displayMode": "table",
+                "placement": "right",
+                "showLegend": true,
+                "values": [
+                  "value"
+                ]
+              },
+              "pieType": "donut",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "sort": "desc",
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "single",
+                "sort": "desc"
+              }
+            }
+          },
+          "version": "13.0.1+security-01"
+        }
+      }
+    }
+  },
+  "layout": {
+    "kind": "RowsLayout",
+    "spec": {
+      "rows": [
+        {
+          "kind": "RowsLayoutRow",
+          "spec": {
+            "collapse": false,
+            "title": "Adopsjon",
+            "layout": {
+              "kind": "GridLayout",
+              "spec": {
+                "items": [
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-1"
+                      },
+                      "height": 4,
+                      "width": 6,
+                      "x": 0,
+                      "y": 0
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-2"
+                      },
+                      "height": 4,
+                      "width": 6,
+                      "x": 6,
+                      "y": 0
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-3"
+                      },
+                      "height": 4,
+                      "width": 6,
+                      "x": 12,
+                      "y": 0
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-4"
+                      },
+                      "height": 4,
+                      "width": 6,
+                      "x": 18,
+                      "y": 0
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "kind": "RowsLayoutRow",
+          "spec": {
+            "collapse": false,
+            "title": "Dispatch — brukes workeren?",
+            "layout": {
+              "kind": "GridLayout",
+              "spec": {
+                "items": [
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-10"
+                      },
+                      "height": 8,
+                      "width": 8,
+                      "x": 0,
+                      "y": 0
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-11"
+                      },
+                      "height": 8,
+                      "width": 8,
+                      "x": 8,
+                      "y": 0
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-12"
+                      },
+                      "height": 8,
+                      "width": 8,
+                      "x": 16,
+                      "y": 0
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "kind": "RowsLayoutRow",
+          "spec": {
+            "collapse": false,
+            "title": "Lokal server",
+            "layout": {
+              "kind": "GridLayout",
+              "spec": {
+                "items": [
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-20"
+                      },
+                      "height": 8,
+                      "width": 8,
+                      "x": 0,
+                      "y": 0
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-21"
+                      },
+                      "height": 8,
+                      "width": 8,
+                      "x": 8,
+                      "y": 0
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-22"
+                      },
+                      "height": 8,
+                      "width": 8,
+                      "x": 16,
+                      "y": 0
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "links": [],
+  "liveNow": false,
+  "preload": false,
+  "tags": [
+    "nav-pilot",
+    "lokal-inferens",
+    "alpha"
+  ],
+  "timeSettings": {
+    "autoRefresh": "",
+    "autoRefreshIntervals": [
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "fiscalYearStartMonth": 0,
+    "from": "now-7d",
+    "hideTimepicker": false,
+    "timezone": "browser",
+    "to": "now"
+  },
+  "title": "nav-pilot — lokal inferens",
+  "variables": [
+    {
+      "kind": "DatasourceVariable",
+      "spec": {
+        "allowCustomValue": true,
+        "current": {
+          "text": "nav-metrics",
+          "value": "P91A6F0B3584B90E7"
+        },
+        "hide": "dontHide",
+        "includeAll": false,
+        "label": "Metrics",
+        "multi": false,
+        "name": "DS_METRICS",
+        "options": [],
+        "pluginId": "prometheus",
+        "refresh": "onDashboardLoad",
+        "regex": "",
+        "skipUrlSync": false
+      }
+    },
+    {
+      "kind": "QueryVariable",
+      "spec": {
+        "allValue": ".*",
+        "allowCustomValue": true,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "definition": "label_values(nav_pilot_info, version)",
+        "hide": "dontHide",
+        "includeAll": true,
+        "label": "Versjon",
+        "multi": true,
+        "name": "version",
+        "options": [],
+        "query": {
+          "datasource": {
+            "name": "${DS_METRICS}"
+          },
+          "group": "prometheus",
+          "kind": "DataQuery",
+          "spec": {
+            "qryType": 1,
+            "query": "label_values(nav_pilot_info, version)",
+            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+          },
+          "version": "v0"
+        },
+        "refresh": "onTimeRangeChanged",
+        "regex": "",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": "alphabeticalAsc"
+      }
+    }
+  ]
+}

--- a/scripts/build-local-dashboard.py
+++ b/scripts/build-local-dashboard.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Generate dashboards/nav-pilot-local.json.
+
+Written as a generator rather than hand-edited JSON because the interesting
+part of this dashboard is nine PromQL expressions, and everything around them
+is nine hundred lines of Grafana boilerplate that hides them. Here the queries
+sit together where they can be read against each other, and the house style is
+lifted from `nav-pilot-cli.json` at build time so the two cannot drift.
+
+Two rules are baked in, both bought with a wrong PR:
+
+  sum_over_time, never increase(). A nav-pilot process exports its counters
+  once and exits, so increase() has no second sample to difference and returns
+  0.0 on every one of these series. Verified against live data: increase()
+  totalled 0.0 across five series where sum_over_time totalled 58.
+
+  histogram_quantile over sum_over_time of _bucket is correct *here*, and only
+  because these instruments are recorded once per process at exit. Each export
+  is one run's own cumulative buckets, so summing them across the window gives
+  a valid aggregate histogram. It would be wrong for an instrument recorded at
+  startup, which the 10-second PeriodicReader re-exports for the life of the
+  process — nav_pilot_version_skew_days is the example not to copy.
+
+  scripts/build-local-dashboard.py            # write the dashboard
+  scripts/build-local-dashboard.py --check    # fail if it is out of date
+"""
+import argparse
+import copy
+import json
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+HOUSE = ROOT / "dashboards" / "nav-pilot-cli.json"
+OUT = ROOT / "dashboards" / "nav-pilot-local.json"
+
+SEL = '{version=~"$version"}'
+SEL_LE0 = '{version=~"$version", le="0"}'
+
+
+def panels():
+    """Every panel, as (id, title, viz, description, [(expr, legend)])."""
+    return [
+        (1, "Maskiner med lokal kjøring", "stat",
+         "Hvor mange som har kjørt minst én lokal sesjon i perioden. Nevneren for alt annet her.",
+         [(f"count(count by (device_id) (sum_over_time(nav_pilot_local_dispatches_count{SEL}[$__range])))", "")]),
+        (2, "Sesjoner", "stat",
+         "Én sesjon er én klientkjøring med lokal worker tilgjengelig, talt når klienten avslutter.",
+         [(f"sum(sum_over_time(nav_pilot_local_dispatches_count{SEL}[$__range]))", "")]),
+        (3, "Oppgaver sendt lokalt", "stat",
+         "Sum av oppgaver hovedagenten faktisk sendte til den lokale modellen.",
+         [(f"sum(sum_over_time(nav_pilot_local_dispatches_sum{SEL}[$__range]))", "")]),
+        (4, "Andel sesjoner uten dispatch", "stat",
+         "Panelet som avgjør om alfaen utvides. Se fordelingen under for hvorfor tallet er "
+         "som det er — en null betyr ikke det samme i de to tilfellene.",
+         [(f"100 * sum(sum_over_time(nav_pilot_local_dispatches_bucket{SEL_LE0}[$__range]))"
+           f" / clamp_min(sum(sum_over_time(nav_pilot_local_dispatches_count{SEL}[$__range])), 1)", "")]),
+
+        (10, "Sesjoner uten dispatch, delt på om klienten så workeren", "timeseries",
+         "Den ene grafen som er verdt å bygge dashbordet for. saw_traffic=true betyr at klienten "
+         "nådde workeren og lot være å bruke den — det er en dom over modellen. saw_traffic=false "
+         "betyr at oppkoblingen aldri kom fram, som er vår feil, ikke modellens. Uten dette skillet "
+         "er en null tre forskjellige ting rapportert som én.\n\n"
+         "VENTER PÅ DATA: saw_traffic ble lagt til etter at alfaen gikk ut, så panelet er tomt til "
+         "folk har oppdatert. Tomt er riktig her — en null vi ikke kan tolke er verre enn ingen strek.",
+         [(f'sum by (saw_traffic) (sum_over_time(nav_pilot_local_dispatches_bucket{SEL_LE0}[$__interval]))',
+           "så workeren: {{saw_traffic}}")]),
+        # Explicit differences, not the raw le series. A bar per cumulative
+        # bucket reads as "31 sessions sent 0, 55 sent 5" when it actually means
+        # "≤0" and "≤5", and every viewer makes that mistake once.
+        (11, "Oppgaver per sesjon", "barchart",
+         "Fordeling, aldri gjennomsnitt: de fleste sesjonene sender ingenting og noen få sender "
+         "mye, og et snitt av de to beskriver ingen faktisk sesjon. Bøttene er trukket fra "
+         "hverandre, så hver søyle er sesjoner i akkurat det intervallet.",
+         [(f'sum(sum_over_time(nav_pilot_local_dispatches_bucket{SEL_LE0}[$__range]))', "0 oppgaver"),
+          (f'sum(sum_over_time(nav_pilot_local_dispatches_bucket{{version=~"$version", le="5"}}[$__range]))'
+           f' - sum(sum_over_time(nav_pilot_local_dispatches_bucket{SEL_LE0}[$__range]))', "1–5"),
+          (f'sum(sum_over_time(nav_pilot_local_dispatches_count{SEL}[$__range]))'
+           f' - sum(sum_over_time(nav_pilot_local_dispatches_bucket{{version=~"$version", le="5"}}[$__range]))', "6+")]),
+        (12, "Sesjoner per intervall, per klient", "timeseries",
+         "opencode kjører modellen som subagent under en skyagent; Copilot CLI kjører hele økten lokalt.",
+         [(f"sum by (client) (sum_over_time(nav_pilot_local_dispatches_count{SEL}[$__interval]))", "{{client}}")]),
+
+        (20, "Tid til klar", "timeseries",
+         "p50 og p95 for oppstarter som faktisk kom opp. Filteret outcome=\"ready\" er ikke pynt: "
+         "en oppstart som går i timeout bidrar med ti minutter, og en p95 uten filteret måler "
+         "feilene, ikke ventetiden.\n\n"
+         "VENTER PÅ DATA: outcome kom inn etter forrige release, så panelet fylles først når folk "
+         "har oppdatert.",
+         [(f'histogram_quantile(0.5, sum by (le) (sum_over_time(nav_pilot_local_ready_seconds_bucket{{version=~"$version", outcome="ready"}}[$__range])))', "p50"),
+          (f'histogram_quantile(0.95, sum by (le) (sum_over_time(nav_pilot_local_ready_seconds_bucket{{version=~"$version", outcome="ready"}}[$__range])))', "p95")]),
+        (21, "Hvordan oppstarter endte", "timeseries",
+         "ready, failed eller interrupted. Fram til denne fantes ble bare vellykkede oppstarter "
+         "registrert, så den trege halen manglet per konstruksjon.\n\n"
+         "VENTER PÅ DATA: outcome kom inn etter forrige release og fylles etter hvert som folk oppdaterer.",
+         [(f'sum by (outcome) (sum_over_time(nav_pilot_local_ready_seconds_count{SEL}[$__interval]))', "{{outcome}}")]),
+        (22, "Modeller i bruk", "piechart",
+         "Skal være én. Flere betyr at noen kjører noe vi ikke har målt.",
+         [(f"sum by (model) (sum_over_time(nav_pilot_local_dispatches_count{SEL}[$__range]))", "{{model}}")]),
+    ]
+
+
+ROWS = [
+    ("Adopsjon", [1, 2, 3, 4]),
+    ("Dispatch — brukes workeren?", [10, 11, 12]),
+    ("Lokal server", [20, 21, 22]),
+]
+
+
+def house_viz(house, group):
+    """Borrow a vizConfig of this type from the CLI dashboard, so the two
+    dashboards cannot drift apart on styling."""
+    for p in house["elements"].values():
+        if p["spec"]["vizConfig"]["group"] == group:
+            return copy.deepcopy(p["spec"]["vizConfig"])
+    # No panel of that type to copy: a minimal one, still valid.
+    return {"group": group, "kind": "VizConfig",
+            "spec": {"fieldConfig": {"defaults": {}, "overrides": []}, "options": {}},
+            "version": "13.0.1+security-01"}
+
+
+def build():
+    house = json.loads(HOUSE.read_text())
+    ds = {"name": "${DS_METRICS}"}
+
+    elements = {}
+    for pid, title, group, desc, queries in panels():
+        viz = house_viz(house, group)
+        if group == "stat" and pid == 4:
+            viz["spec"]["fieldConfig"]["defaults"]["unit"] = "percent"
+        elements[f"panel-{pid}"] = {
+            "kind": "Panel",
+            "spec": {
+                "data": {"kind": "QueryGroup", "spec": {
+                    "queries": [
+                        {"kind": "PanelQuery", "spec": {
+                            "hidden": False, "refId": chr(ord("A") + i),
+                            "query": {"datasource": ds, "group": "prometheus", "kind": "DataQuery",
+                                      "spec": {"expr": expr, "legendFormat": legend}, "version": "v0"},
+                        }} for i, (expr, legend) in enumerate(queries)
+                    ],
+                    "queryOptions": {}, "transformations": []}},
+                "description": desc,
+                "id": pid,
+                "links": [],
+                "title": title,
+                "vizConfig": viz,
+            },
+        }
+
+    rows = []
+    for title, ids in ROWS:
+        items, x = [], 0
+        width = 24 // len(ids)
+        for pid in ids:
+            items.append({"kind": "GridLayoutItem", "spec": {
+                "element": {"kind": "ElementReference", "name": f"panel-{pid}"},
+                "height": 8 if pid >= 10 else 4, "width": width, "x": x, "y": 0}})
+            x += width
+        rows.append({"kind": "RowsLayoutRow", "spec": {
+            "collapse": False, "title": title,
+            "layout": {"kind": "GridLayout", "spec": {"items": items}}}})
+
+    # Only the two variables that mean anything here. The CLI dashboard's
+    # command/scope filters have no counterpart in the local instruments, and a
+    # filter that cannot narrow anything is a control that lies.
+    variables = [v for v in house["variables"]
+                 if v["spec"]["name"] in ("DS_METRICS", "version")]
+
+    return {
+        "annotations": house.get("annotations", {"kind": "AnnotationQueries", "spec": []}),
+        "cursorSync": house.get("cursorSync", "Off"),
+        "description": (
+            "Lokal inferens i nav-pilot alpha: hvem bruker den, hva sender de dit, og kommer "
+            "serveren opp. Alle spørringer bruker sum_over_time, ikke increase() — en nav-pilot-"
+            "prosess eksporterer én gang og avslutter, så increase() har ingen andre sample å "
+            "regne differanse fra og gir 0."),
+        "editable": True,
+        "elements": elements,
+        "layout": {"kind": "RowsLayout", "spec": {"rows": rows}},
+        "links": [],
+        "liveNow": False,
+        "preload": False,
+        "tags": ["nav-pilot", "lokal-inferens", "alpha"],
+        "timeSettings": house.get("timeSettings", {"from": "now-7d", "to": "now"}),
+        "title": "nav-pilot — lokal inferens",
+        "variables": variables,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser(prog="build-local-dashboard")
+    ap.add_argument("--check", action="store_true", help="fail if the committed file is stale")
+    args = ap.parse_args()
+
+    want = json.dumps(build(), indent=2, ensure_ascii=False) + "\n"
+    if args.check:
+        have = OUT.read_text() if OUT.exists() else ""
+        if have != want:
+            print("✗ dashboards/nav-pilot-local.json is out of date — run scripts/build-local-dashboard.py")
+            return 1
+        print("✓ dashboard is up to date")
+        return 0
+    OUT.write_text(want)
+    print(f"wrote {OUT.relative_to(ROOT)}: {len(build()['elements'])} panels, {len(ROWS)} rows")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes the half of #531 that was actually asked for. The other half — which aggregation these panels must use — was settled earlier by measuring, and that reasoning now sits in a comment at the top of the generator so nobody re-derives it.

## What it shows

Ten panels, three rows: **Adopsjon**, **Dispatch — brukes workeren?**, **Lokal server**.

The panel worth building the dashboard for is **zero-dispatch sessions split by `saw_traffic`**. Zero *with* traffic means the orchestrator reached the worker and declined — a verdict on the model. Zero *without* means our wiring never arrived, which is not. Undivided, that number is three different things reported as one, and it is what decides whether the alpha widens.

## Generated, not hand-written

`scripts/build-local-dashboard.py`. The interesting part is nine PromQL expressions; the rest is nine hundred lines of Grafana boilerplate that hides them. In the generator the queries sit together where they can be read against each other, and the `vizConfig` is lifted from `nav-pilot-cli.json` at build time so the two dashboards cannot drift apart on styling. `--check` fails if the committed JSON is stale.

## Every query was run against live Mimir before committing

That caught two things review would not have.

**A misleading panel of mine.** A bar chart over raw `le` buckets plots *cumulative* counts, so it would have read as "31 sessions sent 0, 55 sent 5" when it means "≤0" and "≤5" — a mistake every viewer makes once. The buckets are now subtracted explicitly:

| bucket | sessions |
|---|---|
| 0 oppgaver | 31 |
| 1–5 | 24 |
| 6+ | 3 |

Which matches the distribution measured by hand.

**Three panels are empty on arrival.** `saw_traffic` (#535) and `outcome` (#547) shipped after the last release, so no build in the field emits them yet. Their descriptions say exactly that, in the panel. Empty is the right answer here — a zero we cannot interpret is worse than no line at all, which is the rule that got a wrong PR of mine closed earlier this week.

Live values behind the rest, over 24h: 4 devices, 58 sessions, 142 tasks, 53.45% of sessions with no dispatch, one model in use.

## Deliberately excluded

`nav_pilot_local_server_total`, which #551 removes as a duplicate of `local_ready_seconds{outcome}`. Building a panel on it would have shipped a dead query a day later.

## Aggregation

`sum_over_time` throughout, never `increase()`. A nav-pilot process exports once and exits, so `increase()` has no second sample to difference and returns 0.0 on every one of these series — measured, after a PR of mine arguing the opposite was closed on the evidence.

`histogram_quantile` over `sum_over_time` of `_bucket` is correct **here**, and the generator says why: these instruments are recorded once per process at exit, so each export is one run's own cumulative buckets and summing them across the window gives a valid aggregate histogram. It would be wrong for an instrument recorded at startup, which the 10-second `PeriodicReader` re-exports for the life of the process — `nav_pilot_version_skew_days` is the example not to copy.