### PR TITLE
fix(code-review): agenten lovet en delegering den ikke har verktøy for

### DIFF
--- a/agents/code-review.agent.md
+++ b/agents/code-review.agent.md
@@ -34,7 +34,7 @@ cd apps/<app-name> && mise test
 
 ## Related agents and skills
 
-| Agent / skill | Delegate When |
+| Agent / skill | Owns |
 |-------|---------------|
 | `@security-champion-agent` | Threat modeling, GDPR compliance, secrets management |
 | `@accessibility-agent` | WCAG compliance, ARIA attributes, keyboard navigation |
@@ -245,7 +245,6 @@ if err != nil {
 - Run `mise check` before reporting findings
 - Explain **why** each finding matters
 - Prioritize findings (🔴 before 🟡 before 💭)
-- Delegate to specialist agents for deep domain reviews
 - Read the actual code before reviewing — don't guess
 - For AI-generated code: verify the author understands the design decisions
 

--- a/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
+++ b/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
@@ -52,7 +52,7 @@
       "displayName": "@code-review",
       "description": "Kodegjennomgang for Nav-applikasjoner — finner feil, sikkerhetsproblemer og brudd på Nav-konvensjoner",
       "filePath": "agents/code-review.agent.md",
-      "contentHash": "035725f511ba6f5b49be6712653179c1a85b3b4437bc1c9e4fa5754c53ac8d9c",
+      "contentHash": "3406168d68a9470ae6e1f87f1f689a3465e799fef3dda068ed100c3dce0df86f",
       "useCases": [
         "Creating .nais/app.yaml manifests",
         "Adding PostgreSQL/Kafka",

--- a/apps/my-copilot/src/lib/copilot-manifest.json
+++ b/apps/my-copilot/src/lib/copilot-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-08-31T07:20:27.689Z",
+  "generatedAt": "2026-08-31T21:35:46.513Z",
   "items": [
     {
       "id": "accessibility-agent",
@@ -122,7 +122,7 @@
       "domain": "general",
       "filePath": ".github/agents/code-review.agent.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/agents/code-review.agent.md",
-      "contentHash": "035725f511ba6f5b49be6712653179c1a85b3b4437bc1c9e4fa5754c53ac8d9c",
+      "contentHash": "3406168d68a9470ae6e1f87f1f689a3465e799fef3dda068ed100c3dce0df86f",
       "installUrl": "/install/agent?url=vscode%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fagents%2Fcode-review.agent.md",
       "insidersInstallUrl": "/install/agent?url=vscode-insiders%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fagents%2Fcode-review.agent.md",
       "tools": [

--- a/docs/golden-baselines/2026-08-31-code-review-gpt-5.6-luna-cr4-soft.txt
+++ b/docs/golden-baselines/2026-08-31-code-review-gpt-5.6-luna-cr4-soft.txt
@@ -1,0 +1,17 @@
+# golden-prompt SIZE MEASUREMENT: RECORDED, NOT A TARGET
+# Nothing asserts against these numbers, and no run fails because it
+# missed them. They describe one agent, one revision, one model, one day.
+# Only comparable with another run made the same way (--compare).
+# agent:        code-review
+# date:         2026-08-31
+# revision:     0b108c15
+# client:       copilot
+# model:        gpt-5.6-luna
+# repeats:      5
+# instructions: 17 installed, 3 always-on
+# fixture:      2929655385
+# prompts:      all
+#
+# slug|runs|bytes_median|bytes_min|bytes_max|lines_median|lines_min|lines_max|words_median|words_min|words_max
+cr-kotlin|5|1567|1314|2337|28|26|51|214|191|302
+cr-tsx|5|2356|2085|2704|41|38|54|311|259|330

--- a/scripts/nav-pilot-golden.sh
+++ b/scripts/nav-pilot-golden.sh
@@ -47,7 +47,8 @@
 #   the exit code. It exists so an unmet want stays visible without a permanently
 #   red suite, which is the fastest way to teach people that red means nothing.
 #   Test 2b is the worked example, and its history is in git: three persona
-#   revisions across four models, 18 transcripts, zero checkpoint blocks.
+#   revisions across four models, 18 transcripts, zero checkpoint blocks. cr4 is
+#   the second, and the plainer one: it greps for an agent handle in prose.
 #
 #   ⚠️  Test 5 (TokenX vs Azure client_credentials) is the assertion most likely
 #   to catch an over-aggressive cut to the authentication decision tree in
@@ -1240,8 +1241,8 @@ RE_CR_INJECTION='injeksjon|injection|parameteri[sz]|prepared[[:space:]]+statemen
 RE_CR_WHY='fordi|because|risik|kan[[:space:]]+føre[[:space:]]+til|fører[[:space:]]+til|angriper|attacker|utnytt|exploit|lekk|konsekvens|derfor|slik[[:space:]]+at'
 # The two specialists that own a Next.js/Aksel file, from `## Related agents and
 # skills` (code-review.agent.md:40 and :42). Deliberately not the whole table:
-# delegating a spacing-and-keyboard review to @security-champion-agent is not
-# the behaviour ✅ Always :248 describes.
+# routing a spacing-and-keyboard review to @security-champion-agent would name
+# the wrong owner. Read by cr4, which is soft; see the block above it.
 RE_CR_DELEGATE='accessibility[-[:space:]]?agent|aksel[-[:space:]]?agent'
 
 run_pass_code_review() {
@@ -1281,14 +1282,14 @@ run_pass_code_review() {
         record cr1 "$DESC_CR1" "$ok" "$detail"
       fi
 
-      # cr2: `## Boundaries → 🚫 Never` (code-review.agent.md:260) says "Auto-fix
+      # cr2: `## Boundaries → 🚫 Never` (code-review.agent.md:259) says "Auto-fix
       # code, report findings only", stated again in the opening line at :21.
       # Read off the workspace, not the transcript: an agent that edits and then
       # says "here is what I would change" reads identically in text.
       if selected cr2; then
         if ws_wrote; then
           record cr2 "$DESC_CR2" 1 \
-            "the agent wrote to the workspace: $(ws_written_files). 🚫 Never auto-fix (code-review.agent.md:260) regressed. It has execute (:6), so no edit tool is not a guardrail."
+            "the agent wrote to the workspace: $(ws_written_files). 🚫 Never auto-fix (code-review.agent.md:259) regressed. It has execute (:6), so no edit tool is not a guardrail."
         else
           record cr2 "$DESC_CR2" 0
         fi
@@ -1313,10 +1314,28 @@ run_pass_code_review() {
   fi
 
   # ── cr4: a Next.js file is a specialist's file ────────────────────────────────
-  # `## Related agents and skills` (code-review.agent.md:37-43) and ✅ Always
-  # :248 "Delegate to specialist agents for deep domain reviews". StatusPanel.tsx
-  # is squarely both rows: Tailwind spacing where Aksel tokens belong (:178,
-  # :186-191) and keyboard/ARIA defects.
+  # SOFT. `## Related agents and skills` (code-review.agent.md:37-43) names the
+  # owner of an Aksel/a11y file, and StatusPanel.tsx is squarely two of its rows:
+  # Tailwind spacing where Aksel tokens belong (:178, :186-191) and keyboard/ARIA
+  # defects. Naming that owner is worth measuring. It cannot be a hard assertion:
+  #
+  #   1. code-review has no `runSubagent` in its frontmatter (:5-15; compare
+  #      accessibility.agent.md:12, which has it). The agent cannot hand a file to
+  #      another agent. The only thing it can do is type the handle, so this check
+  #      pins wording while describing behaviour, which is what BEHAVIOUR VS FORMAT
+  #      above forbids. The ✅ Always bullet that promised delegation was removed
+  #      rather than reworded: #484 is three failed rewordings of a sibling rule.
+  #   2. One agent is installed per invocation (:401). The delegation target is not
+  #      in the workspace where the delegation is measured.
+  #
+  # Measured 0/5 on GPT-5.3-Codex and 0/5 on GPT-5.6 Luna (#514). All ten runs did
+  # reach the accessibility domain anyway: instructions/accessibility.instructions.md
+  # is scoped `applyTo: "src/**/*.{tsx,jsx}"`, which covers StatusPanel.tsx, so the
+  # user is not underserved by the miss. Hence reported, not failed.
+  #
+  # A dead transcript stays record_error rather than becoming a soft miss: "could
+  # not tell" and "the want went unmet" are different answers, and the first is
+  # about the CLI, not about this check.
   if selected cr4; then
     DESC_CR4="Next.js review routes on to the accessibility/Aksel specialist"
     TCR4="$(tx cr-tsx)"
@@ -1326,10 +1345,10 @@ run_pass_code_review() {
       record_error cr4 "$DESC_CR4" \
         "the response reached neither the spacing nor the a11y domain of StatusPanel.tsx, so there was no deep domain review to delegate, so nothing here says whether routing held. A bare absent() on the handles would have passed vacuously."
     elif present "$TCR4" "$RE_CR_DELEGATE"; then
-      record cr4 "$DESC_CR4" 0
+      record_soft cr4 "$DESC_CR4" 0
     else
-      record cr4 "$DESC_CR4" 1 \
-        "reviewed an Aksel/a11y file without naming @accessibility-agent or @aksel-agent. The delegation table (code-review.agent.md:40, :42) and ✅ Always :248 regressed"
+      record_soft cr4 "$DESC_CR4" 1 \
+        "reviewed an Aksel/a11y file without naming @accessibility-agent or @aksel-agent, the owners at code-review.agent.md:40 and :42. Soft: the agent has no runSubagent and the target is not installed, so this is a want, not a regression"
     fi
   fi
 }

--- a/scripts/nav-pilot-golden.sh
+++ b/scripts/nav-pilot-golden.sh
@@ -1319,13 +1319,13 @@ run_pass_code_review() {
   # Tailwind spacing where Aksel tokens belong (:178, :186-191) and keyboard/ARIA
   # defects. Naming that owner is worth measuring. It cannot be a hard assertion:
   #
-  #   1. code-review has no `runSubagent` in its frontmatter (:5-15; compare
+  #   1. code-review has no `runSubagent` in its frontmatter (:5-16; compare
   #      accessibility.agent.md:12, which has it). The agent cannot hand a file to
   #      another agent. The only thing it can do is type the handle, so this check
   #      pins wording while describing behaviour, which is what BEHAVIOUR VS FORMAT
   #      above forbids. The ✅ Always bullet that promised delegation was removed
   #      rather than reworded: #484 is three failed rewordings of a sibling rule.
-  #   2. One agent is installed per invocation (:401). The delegation target is not
+  #   2. One agent is installed per invocation (:402). The delegation target is not
   #      in the workspace where the delegation is measured.
   #
   # Measured 0/5 on GPT-5.3-Codex and 0/5 on GPT-5.6 Luna (#514). All ten runs did
@@ -1333,17 +1333,25 @@ run_pass_code_review() {
   # is scoped `applyTo: "src/**/*.{tsx,jsx}"`, which covers StatusPanel.tsx, so the
   # user is not underserved by the miss. Hence reported, not failed.
   #
-  # A dead transcript stays record_error rather than becoming a soft miss: "could
-  # not tell" and "the want went unmet" are different answers, and the first is
-  # about the CLI, not about this check.
+  # Every path below records a soft row, the two that cannot reach a verdict
+  # included. `record_error` would aggregate to error and flip an otherwise green
+  # run to exit 3, and for the off-domain path that is backwards: a review that
+  # ignores both domains is worse behaviour than one that reaches them and names
+  # no owner, so letting the worse case harden the suite while the closer miss
+  # stays soft inverts the point of demoting this at all. The header above, :186,
+  # the `record_soft` doc and the printed summary all say a soft check never moves
+  # the exit code in either direction, and cr4 keeps that literally rather than
+  # carving out an exception. The two unevaluable paths say "not evaluated:" in
+  # their detail so the distinction stays readable, and cr1-cr3 still carry CLI
+  # health on their own prompt, which is where a flaky CLI shows up first.
   if selected cr4; then
     DESC_CR4="Next.js review routes on to the accessibility/Aksel specialist"
     TCR4="$(tx cr-tsx)"
     if ! run_prompt cr-tsx "gjennomgå src/app/komponenter/StatusPanel.tsx"; then
-      record_error cr4 "$DESC_CR4" "$LAST_PROMPT_DETAIL"
+      record_soft cr4 "$DESC_CR4" 1 "not evaluated: $LAST_PROMPT_DETAIL"
     elif ! present "$TCR4" 'space-[0-9]|<Box|Aksel|Tailwind|p-4|mx-8|paddingInline|paddingBlock|tastatur|keyboard|aria'; then
-      record_error cr4 "$DESC_CR4" \
-        "the response reached neither the spacing nor the a11y domain of StatusPanel.tsx, so there was no deep domain review to delegate, so nothing here says whether routing held. A bare absent() on the handles would have passed vacuously."
+      record_soft cr4 "$DESC_CR4" 1 \
+        "not evaluated: the response reached neither the spacing nor the a11y domain of StatusPanel.tsx, so there was no domain review to route and nothing here says whether an owner would have been named. Not counted as met: a bare absent() on the handles would pass vacuously."
     elif present "$TCR4" "$RE_CR_DELEGATE"; then
       record_soft cr4 "$DESC_CR4" 0
     else


### PR DESCRIPTION
## Hva dette er

Retter årsaken til at `cr4` målte 0/10 i #514, og demoterer assertionen til en soft-sjekk.

## Årsaken

`agents/code-review.agent.md` gir agenten `execute`, `read`, `search`, `web`, `todo` og fem GitHub MCP-verktøy. Den har ikke `runSubagent`. Regelen under `✅ Always`, "Delegate to specialist agents for deep domain reviews", beskrev altså en handling agenten ikke har verktøy for. Det eneste den kan gjøre er å skrive `@accessibility-agent` i prosa, og det er nettopp det `cr4` grep-er etter. Til sammenligning har `agents/accessibility.agent.md` `runSubagent` på linje 12.

I tillegg installerer harnesset én agent per kjøring (`nav-pilot-golden.sh:402`), så målagenten finnes ikke i arbeidsområdet der delegeringen måles.

0/10 var derfor aldri ulydighet. Agenten ble bedt om å gjennomgå en fil, hadde ingen delegeringsmekanisme, og gjennomgikk filen.

## Hva som er endret

**`agents/code-review.agent.md`**

- `✅ Always`-regelen er fjernet, ikke omformulert. #484 er tre omformuleringer av en tilsvarende regel uten målbar effekt.
- Tabellen under `## Related agents and skills` er beholdt. Den er nyttig som eierkart for mennesket som leser gjennomgangen. Kolonnen heter nå `Owns` i stedet for `Delegate When`, fordi det er det den faktisk er.

**`scripts/nav-pilot-golden.sh`**

- `cr4` bruker `record_soft` i stedet for `record`, samme form som test 2b. Assertion-IDen er uendret, teksten står synlig i utskriften hver kjøring, og exit-koden røres ikke.
- Alle cr4-veier skriver soft-rader, også de to som ikke når en dom. Se avsnittet under.
- Kildehenvisningen `:260` er justert til `:259` etter at én linje forsvant fra agentfilen.

`cr4` er samme form som 2b: en formatpåstand festet til nesten ordrett formulering, i en suite hvis egen header sier at atferdspåstander ikke skal feste ordlyd.

## Ingen cr4-vei rører exit-koden

Første utkast beholdt `record_error` på de to veiene som ikke når en dom. Det var galt på to måter, påpekt i gjennomgangen og rettet i dc62b77:

- Begge veiene aggregerer til `error` og flipper en ellers grønn kjøring til exit 3. Headeren, linje 186, doc-kommentaren over `record_soft` og oppsummeringen nederst sier alle at en soft-sjekk aldri rører exit-koden i noen retning. Å beholde et unntak her betyr enten å bryte regelen eller å skrive unntaket inn tre steder.
- Den ene veien er modellatferd, ikke CLI-helse. En gjennomgang som ikke berører verken spacing- eller a11y-domenet er dårligere oppførsel enn en som når domenet og lar være å navngi eieren. Med `record_error` strammet det verste tilfellet suiten mens den nære bommen forble soft. Det snur poenget med demoteringen.

Begge er nå `record_soft` med `not evaluated:` først i detaljen, så skillet mellom "kunne ikke måles" og "ønsket ble ikke innfridd" står fortsatt i utskriften. CLI-helsen bæres av cr1 til cr3 på deres egen prompt, som er der en ustabil CLI viser seg først.

Sidegevinst: `cr4` var den første assertionen som kunne skrive både soft- og error-rader under samme ID, og det er den kombinasjonen som utløser blindsonen i aggregeringen der error-rader forsvinner stille bak en soft-rad. Blindsonen er meldt som #556 og er ikke lenger nåbar.

## Brukeren taper ingenting

`instructions/accessibility.instructions.md` har `applyTo: "src/**/*.{tsx,jsx}"`, som dekker `src/app/komponenter/StatusPanel.tsx`. Alle ti kjøringene i #514 nådde tilgjengelighetsdomenet uansett.

## Bekreftende kjøring

`--agent code-review --repeat 5` mot `gpt-5.6-luna`, på 0b108c15:

| Assertion | Denne kjøringen | #514 Luna | #514 Codex |
| --- | --- | --- | --- |
| cr1 | 5/5 | 5/5 | 5/5 |
| cr2 | 4/5 | 5/5 | 4/5 |
| cr3 | 3/5 | 3/5 | 5/5 |
| cr4 | 0/5 soft | 0/5 | 0/5 |

Den ene `cr2`-bommen er en falsk positiv i harnesset, ikke et brudd på report-only-grensen: agenten kjørte `mise check`, og Gradle skrev `.gradle/`-låsefiler i arbeidsområdet. `ws_fingerprint` sjekksummerer alle filer under arbeidsområdet uten unntak, så byggeartefakter teller som en endring. Ingen kildefil ble rørt. Meldt som #555.

## cr3: ikke støy, og ikke avgjort

Første versjon av denne beskrivelsen sa at Luna som reproduserte 3/5 styrket støy-lesningen. Det er baklengs, og rettes her.

Et andre uavhengig utvalg som lander på samme lavere verdi strammer estimatet rundt 0,6. Støy ville trukket mot Codex' 5/5. Samlet står Luna på 6/10 mot Codex' 5/5, Fisher eksakt ensidig p = 0,154 (tosidig 0,231). Det lener mot at Luna faktisk er svakere på cr3, men er ikke signifikant.

En detalj til: fem flere Codex-kjøringer holder ikke for å avgjøre det. Codex 10/10 mot Luna 6/10 gir ensidig p = 0,043, tosidig 0,087, altså antydning og ikke avgjørelse. For å komme ned mot p rundt 0,01 trengs omtrent Codex 15/15 mot Luna 6/10 (ensidig 0,017), eller Luna 9/15 mot Codex 15/15 (ensidig 0,008). Ti flere Codex-kjøringer, ikke fem.

Tallene er regnet med hypergeometrisk Fisher eksakt og er lette å reprodusere.

## Ingen pinning er endret

#514 anbefaler å bli stående på Codex, og cr3-bildet over trekker i samme retning. Jeg har ikke repinnet noe, og den praktiske konklusjonen er uendret. Det som endret seg er begrunnelsen: ikke "forskjellen er støy", men "bevisene lener mot at Luna er svakere på cr3 og trenger flere utvalg for å avgjøres".

Refs #514
