### PR TITLE
fix: stop counting Ctrl-C as a launch failure, and three labels that fell through

### DIFF
--- a/cli/nav-pilot/internal/provider/copilot_launch.go
+++ b/cli/nav-pilot/internal/provider/copilot_launch.go
@@ -190,7 +190,9 @@ func LaunchCopilotResolved(resolved domain.ResolvedConfig) error {
 		if !errors.As(err, &exitErr) {
 			fmt.Fprintf(os.Stderr, "%s Could not launch %s: %v\n", domain.Yellow("⚠"), displayName, err)
 		}
-		telemetryRecorder.RecordLaunchError("copilot", classifyLaunchError(err))
+		if kind := classifyLaunchError(err); kind != "" {
+			telemetryRecorder.RecordLaunchError("copilot", kind)
+		}
 		return err
 	}
 	return nil

--- a/cli/nav-pilot/internal/provider/cplt.go
+++ b/cli/nav-pilot/internal/provider/cplt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"syscall"
 
 	"github.com/navikt/copilot/cli/nav-pilot/internal/domain"
 )
@@ -109,21 +110,44 @@ func launchViaCplt(spec cpltLaunch) error {
 		if !errors.As(err, &exitErr) {
 			fmt.Fprintf(os.Stderr, "%s Could not launch %s via cplt: %v\n", domain.Yellow("⚠"), spec.displayName, err)
 		}
-		telemetryRecorder.RecordLaunchError(spec.agent, classifyLaunchError(err))
+		if kind := classifyLaunchError(err); kind != "" {
+			telemetryRecorder.RecordLaunchError(spec.agent, kind)
+		}
 		return err
 	}
 	return nil
 }
 
-// classifyLaunchError maps a launch error to a normalized error_type label
-// used in nav_pilot_launch_error_total telemetry. Keeps cardinality bounded.
+// classifyLaunchError maps a launch error to a normalized error_type label for
+// nav_pilot_launch_error_total. "" means do not record this at all.
+//
+// The distinction that matters: did the client start? cmd.Run returns an
+// *exec.ExitError whenever the launched client exits non-zero, and that
+// includes a developer pressing Ctrl-C. Classifying every ExitError as
+// launch_failed made a counter described as "client launch failures" mostly a
+// count of normal session endings, so the panel measured how much people used
+// the tool and called it a failure rate.
+//
+// A signalled exit is the developer quitting, which is not an event worth a
+// data point at all. Any other non-zero exit is the client failing after it
+// started, which is worth knowing and is not a launch failure either — the real
+// launch failure is the one where nothing ever ran.
 func classifyLaunchError(err error) string {
 	if err == nil {
 		return ""
 	}
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
-		return "launch_failed"
+		if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Signaled() {
+			return ""
+		}
+		// 128+n is how a shell reports a signalled child, and some clients pass
+		// their own child's status through that way rather than being signalled
+		// themselves. 130 is SIGINT, 143 is SIGTERM.
+		if code := exitErr.ExitCode(); code == 130 || code == 143 {
+			return ""
+		}
+		return "client_exit"
 	}
 	if errors.Is(err, exec.ErrNotFound) {
 		return "client_not_found"

--- a/cli/nav-pilot/internal/provider/cplt_test.go
+++ b/cli/nav-pilot/internal/provider/cplt_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -47,5 +48,44 @@ func TestLaunchOpenCode_RequiresCplt(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "cplt") {
 		t.Errorf("expected cplt-not-found error, got: %v", err)
+	}
+}
+
+// TestClassifyLaunchErrorSeparatesQuittingFromFailing pins the distinction the
+// instrument exists for.
+//
+// cmd.Run returns an *exec.ExitError whenever the launched client exits
+// non-zero, Ctrl-C included, and every one of those used to be recorded as
+// "launch_failed". A counter described as "client launch failures" was
+// therefore mostly a count of normal session endings: the more people used the
+// tool, the worse the panel looked.
+func TestClassifyLaunchErrorSeparatesQuittingFromFailing(t *testing.T) {
+	run := func(t *testing.T, script string) error {
+		t.Helper()
+		return exec.Command("/bin/sh", "-c", script).Run()
+	}
+
+	tests := []struct {
+		name   string
+		err    error
+		want   string
+		reason string
+	}{
+		{"nothing went wrong", nil, "", "no error is not an event"},
+		{"binary is not on PATH", exec.ErrNotFound, "client_not_found",
+			"the real launch failure: nothing ever ran"},
+		{"the client exited non-zero", run(t, "exit 3"), "client_exit",
+			"it started and then failed, which is not a launch failure"},
+		{"the developer pressed Ctrl-C", run(t, "kill -INT $$"), "",
+			"quitting is not worth a data point"},
+		{"a shell reported a signalled child", run(t, "exit 130"), "",
+			"128+SIGINT, how a shell passes its child's status through"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyLaunchError(tt.err); got != tt.want {
+				t.Errorf("classifyLaunchError(%v) = %q, want %q — %s", tt.err, got, tt.want, tt.reason)
+			}
+		})
 	}
 }

--- a/cli/nav-pilot/internal/telemetry/telemetry.go
+++ b/cli/nav-pilot/internal/telemetry/telemetry.go
@@ -603,9 +603,18 @@ func normalizeTelemetryDimension(v, fallback string) string {
 		return fallback
 	}
 	switch v {
+	// alpha, update and auto_sync were missing and have no dot or hyphen to hit
+	// the escape hatch below, so all three reported as command="unknown" and
+	// were indistinguishable from each other on every panel. Alpha adoption was
+	// invisible while we were running an alpha.
 	case "install", "sync", "upgrade", "list", "startup", "launch", "doctor",
+		"alpha", "update", "auto_sync",
 		"init", "export", "uninstall", "config", "validate", "env", "feedback", "models", "ignore", "add",
-		"interactive", "non_interactive",
+		// A dry-run sync builds mode as "<mode>_dry_run"; unlisted, both spellings
+		// fell back to "non_interactive", so the dry-run distinction the code
+		// deliberately makes was discarded and an interactive dry run was
+		// recorded as non-interactive.
+		"interactive", "non_interactive", "interactive_dry_run", "non_interactive_dry_run",
 		"repo", "user", "auto", "none", "unknown",
 		"go", "node", "jvm", "python", "na",
 		"success", "error", "updates_available", "dev",
@@ -619,7 +628,7 @@ func normalizeTelemetryDimension(v, fallback string) string {
 		"darwin", "linux", "windows",
 		"amd64", "arm64", "arm", "386",
 		"copilot", "opencode", "pi",
-		"client_not_found", "launch_failed", "network_error", "auth_error", "sync_failed", "panic",
+		"client_not_found", "client_exit", "launch_failed", "network_error", "auth_error", "sync_failed", "panic",
 		"yes", "no", "aborted", "brew_failed", "brew_missing", "init_failed", "already_installed":
 		return v
 	default:


### PR DESCRIPTION
Four wrong numbers, all currently on a dashboard. Found in the telemetry audit behind #548.

## `launch_error_total` mostly counted people using the tool

`cmd.Run` returns an `*exec.ExitError` whenever the launched client exits non-zero — **Ctrl-C included** — and every one of those was classified `launch_failed`. A counter whose own description reads "client launch failures" was therefore mostly a count of normal session endings. The more people used nav-pilot, the worse the panel looked.

Three outcomes now, along the line that actually matters — *did the client start?*

| situation | recorded |
|---|---|
| binary not on PATH | `client_not_found` — the real launch failure, nothing ever ran |
| client exited non-zero | `client_exit` — it ran and then failed |
| developer pressed Ctrl-C | **nothing** |
| shell passed a signalled child through (130/143) | **nothing** |

Quitting is not an event worth a data point. Call sites skip an empty classification rather than passing `""` and letting it normalise to `"unknown"`, which would have moved the noise instead of removing it.

## Three labels fell through to their fallback

None were in the allow-list, and none contain a dot or hyphen to hit the escape hatch:

**`alpha`, `update`, `auto_sync`** all arrived as `command="unknown"`, stacked on top of each other and on every genuinely unknown command. Alpha adoption was invisible while we are running an alpha.

**Sync's dry-run mode.** The code builds `"<mode>_dry_run"` deliberately; unlisted, *both* spellings fell back to `"non_interactive"`. So the dry-run distinction was silently discarded **and** an interactive dry run was recorded as non-interactive, contaminating the default reading of `sync_updates_total`.

## Test

Drives real processes rather than hand-built errors, because the thing being classified is whatever `exec` actually returns: `/bin/sh -c 'exit 3'` for a failure, `kill -INT $$` for a genuine signal, `exit 130` for a shell passing its child's status through. Each case names why it belongs on its side of the line.

## Checks

`go build`, `go test ./...` green, and green under `DO_NOT_TRACK=1`.