### PR TITLE
fix: autostart started servers and told nobody

### DIFF
--- a/cli/nav-pilot/internal/local/autostart_test.go
+++ b/cli/nav-pilot/internal/local/autostart_test.go
@@ -15,7 +15,7 @@ func TestAutostartOffRefusesAndSaysHowToTurnItOn(t *testing.T) {
 	SetAutostart(false)
 	t.Cleanup(func() { SetAutostart(false) })
 
-	err := EnsureServerRunning(context.Background(), nil)
+	err := EnsureServerRunning(context.Background(), nil, nil)
 	if err == nil {
 		t.Fatal("EnsureServerRunning with autostart off returned nil and started nothing")
 	}
@@ -64,7 +64,7 @@ func TestConcurrentLaunchesStartOneServer(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			errs[i] = EnsureServerRunning(context.Background(), nil)
+			errs[i] = EnsureServerRunning(context.Background(), nil, nil)
 		}(i)
 	}
 	wg.Wait()
@@ -90,4 +90,44 @@ func indexOf(s, sub string) int {
 		}
 	}
 	return -1
+}
+
+// TestAutostartRecordsNothingWhenNoStartWasAttempted guards the boundary the
+// callback sits on.
+//
+// Autostart refuses before it spawns anything for several reasons — the feature
+// is off, the wired-memory limit is too low, the weights are not downloaded.
+// None of those is a start that failed, and recording them as one would put
+// configuration problems into a histogram of how long servers take to come up,
+// which is the mirror image of the bug that made this callback necessary: the
+// instrument measuring the wrong population.
+func TestAutostartRecordsNothingWhenNoStartWasAttempted(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		setup func(t *testing.T)
+	}{
+		{"autostart is off", func(t *testing.T) { SetAutostart(false) }},
+		{"weights are not on the machine", func(t *testing.T) {
+			SetAutostart(true)
+			SetActive(&Manifest{Models: []Model{testModel()}})
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			stubDirs(t)
+			t.Cleanup(func() { SetAutostart(false) })
+			tt.setup(t)
+
+			var recorded []string
+			err := EnsureServerRunning(context.Background(), nil,
+				func(model, outcome string, seconds int64) {
+					recorded = append(recorded, outcome)
+				})
+			if err == nil {
+				t.Fatal("expected a refusal, got nil")
+			}
+			if len(recorded) != 0 {
+				t.Errorf("recorded %v for a refusal that never reached Start; want nothing", recorded)
+			}
+		})
+	}
 }

--- a/cli/nav-pilot/internal/local/runtime.go
+++ b/cli/nav-pilot/internal/local/runtime.go
@@ -1357,7 +1357,18 @@ func sysctlInt(ctx context.Context, name string) (int64, error) {
 // Nothing here stops the server afterwards. A launch that started it leaves it
 // running on purpose: the prompt cache is worth more than the memory, and the
 // developer stops it when they choose.
-func EnsureServerRunning(ctx context.Context, announce func(string)) error {
+// RecordStart is how a caller learns what an autostart cost and how it ended.
+// internal/local deliberately imports no telemetry package — that would pull
+// the OTel SDK into the runtime — so the recording happens on the far side of
+// this callback, in the package that already holds a recorder.
+//
+// It exists because autostart is the common path: a launch starts the server,
+// not a developer typing `alpha local start`. Only the typed command was
+// instrumented, so the ready-time histogram was drawn entirely from the rarer
+// population, and no failed autostart appeared anywhere at all.
+type RecordStart func(model, outcome string, seconds int64)
+
+func EnsureServerRunning(ctx context.Context, announce func(string), record RecordStart) error {
 	if err := EnsureOwnServer(); err == nil {
 		return nil
 	} else if !errors.Is(err, ErrNoServerRecorded) {
@@ -1424,20 +1435,34 @@ func EnsureServerRunning(ctx context.Context, announce func(string)) error {
 			m.Model, domain.Bold("nav-pilot alpha local init"))
 	}
 
+	started := time.Now()
+	report := func(outcome string) {
+		if record != nil {
+			record(m.Model, outcome, int64(time.Since(started).Seconds()))
+		}
+	}
+
 	srv := &Server{}
 	if err := srv.Start(ctx, m); err != nil {
 		// Unlike `alpha local start`, nothing here will report a half-started
 		// server to the developer, so leaving one behind means the next launch
 		// finds nothing recorded and starts another. Each retry is another 21 GB.
 		_ = srv.Stop()
+		if ctx.Err() != nil {
+			report("interrupted")
+		} else {
+			report("failed")
+		}
 		return err
 	}
 	status := srv.Status()
 	if status.Health != HealthReady || status.PID <= 0 {
 		_ = srv.Stop()
+		report("failed")
 		return fmt.Errorf("the local %s server did not come up (%s); what it printed is in %s",
 			m.Model, status.Health, LogPath())
 	}
+	report("ready")
 	return SaveState(State{PID: status.PID, Model: m.Model, Started: time.Now(), Port: srv.Port})
 }
 

--- a/cli/nav-pilot/internal/provider/opencode_launch.go
+++ b/cli/nav-pilot/internal/provider/opencode_launch.go
@@ -739,6 +739,11 @@ func localWorker() (local.Model, error) {
 		if err := local.EnsureServerRunning(context.Background(), func(model string) {
 			fmt.Fprintf(os.Stderr, "%s Starting the local %s server. Measured starts have been under a minute.\n",
 				domain.Dim("ℹ"), domain.Bold(model))
+		}, func(model, outcome string, seconds int64) {
+			// The common path. Until this existed the ready-time histogram was
+			// drawn only from hand-typed `alpha local start`, and a failed
+			// autostart appeared nowhere at all.
+			telemetryRecorder.RecordLocalReadySeconds(model, outcome, seconds)
 		}); err != nil {
 			return local.Model{}, err
 		}

--- a/dashboards/nav-pilot-local.json
+++ b/dashboards/nav-pilot-local.json
@@ -833,7 +833,7 @@
             "transformations": []
           }
         },
-        "description": "ready, failed eller interrupted. Fram til denne fantes ble bare vellykkede oppstarter registrert, så den trege halen manglet per konstruksjon.\n\nVENTER PÅ DATA: outcome kom inn etter forrige release og fylles etter hvert som folk oppdaterer.",
+        "description": "ready, failed eller interrupted. Fram til denne fantes ble bare vellykkede oppstarter registrert, så den trege halen manglet per konstruksjon.\n\nVENTER PÅ DATA: outcome kom inn etter forrige release og fylles etter hvert som folk oppdaterer. Fra samme release teller også autostart, som er den vanlige veien inn — tidligere målte histogrammet bare oppstarter noen skrev inn for hånd.",
         "id": 21,
         "links": [],
         "title": "Hvordan oppstarter endte",

--- a/scripts/build-local-dashboard.py
+++ b/scripts/build-local-dashboard.py
@@ -92,7 +92,9 @@ def panels():
         (21, "Hvordan oppstarter endte", "timeseries",
          "ready, failed eller interrupted. Fram til denne fantes ble bare vellykkede oppstarter "
          "registrert, så den trege halen manglet per konstruksjon.\n\n"
-         "VENTER PÅ DATA: outcome kom inn etter forrige release og fylles etter hvert som folk oppdaterer.",
+         "VENTER PÅ DATA: outcome kom inn etter forrige release og fylles etter hvert som folk "
+         "oppdaterer. Fra samme release teller også autostart, som er den vanlige veien inn — "
+         "tidligere målte histogrammet bare oppstarter noen skrev inn for hånd.",
          [(f'sum by (outcome) (sum_over_time(nav_pilot_local_ready_seconds_count{SEL}[$__interval]))', "{{outcome}}")]),
         (22, "Modeller i bruk", "piechart",
          "Skal være én. Flere betyr at noen kjører noe vi ikke har målt.",


### PR DESCRIPTION
The last hole in the local-server instrument, and the biggest one. Follows #547, which fixed the other half.

## The gap

`RecordLocalReadySeconds` was called from exactly one place: `alpha local start`, the command a developer types by hand. **Autostart — the path a launch takes, and the common one — recorded nothing at all.**

So after #547 the histogram had the right outcomes and still the wrong population: successful *and* failed starts, but only of the rare hand-typed kind. Every server started by an actual opencode launch was invisible to it.

## The seam

`internal/local` imports no telemetry package on purpose — giving it one pulls the OTel SDK into the runtime package. So `EnsureServerRunning` takes a `RecordStart` callback and the recording happens on the far side, in the package that already holds a recorder. Same three outcomes as #547: `ready`, `failed`, `interrupted`.

## Where the timer starts

After the gates, not before. Autostart refuses when the feature is off, when the wired-memory limit is too low, and when the weights are not downloaded. **None of those is a start that failed.** Recording them would drop configuration problems into a histogram of how long servers take to come up — the same mistake as the original bug, pointed the other way.

`TestAutostartRecordsNothingWhenNoStartWasAttempted` pins that boundary, because it is the one a later change is most likely to cross without noticing.

## Consequence for the dashboard

#553's "Tid til klar" and "Hvordan oppstarter endte" panels were already documented as waiting on the next release. They now also say autostart counts from that release, and that the histogram previously measured only hand-typed starts — otherwise the first person to read the panel compares it against numbers drawn from a different population and concludes something changed.

## Checks

`go build`, `go test ./...` green, and green under `DO_NOT_TRACK=1`. Dashboard regenerated; `--check` clean.