### PR TITLE
fix: honour the configured model, now that the manifest offers three

### DIFF
--- a/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
+++ b/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
@@ -2022,6 +2022,28 @@ nav-pilot alpha local on        # skru på igjen etter off
 nav-pilot alpha local off       # slutt å sende oppgaver dit; vektene blir liggende
 nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først`}
           </CodeBlock>
+          <LinkableHeading size="small" level="3">
+            Bytte modell
+          </LinkableHeading>
+          <BodyLong className="mt-2" size="small" style={{ color: "#475569" }}>
+            <code className="font-mono text-xs">nav-pilot models</code> viser hva som er tilgjengelig; de lokale står
+            merket <code className="font-mono text-xs">(local)</code>. Listen oppdateres når du kjører{" "}
+            <code className="font-mono text-xs">init</code> eller <code className="font-mono text-xs">start</code>, ikke
+            ved hver kommando — et nettverkskall der ville lagt seg foran alt annet nav-pilot gjør.
+          </BodyLong>
+          <CodeBlock compact>
+            {`nav-pilot models
+nav-pilot config set model mlx-community/Qwen3.8-27B-4bit
+nav-pilot alpha local init      # laster ned vektene for den nye modellen
+nav-pilot alpha local start`}
+          </CodeBlock>
+          <BodyLong className="mt-4" size="small" style={{ color: "#475569" }}>
+            Qwen 3.6 er standard, og det er ikke tilfeldig. De to Qwen 3.8-modellene ligger der fordi folk spør etter
+            dem, ikke fordi de er bedre her. På våre egne oppgaver er 3.8 tregere og mye mer ujevn: to kjøringer av de
+            samme åtte oppgavene, samme profil og samme maskin, ga median 88 og 906 sekunder. 3.6 ligger på 12–21
+            sekunder uten timeouts over åtte kjøringer. Bytter du, må vektene lastes ned én gang til — 16 GB for 3.8
+            4-bit, 30 GB for 8-bit.
+          </BodyLong>
           <BodyLong className="mt-4" size="small" style={{ color: "#475569" }}>
             Vil du slippe å starte serveren selv, kan en vanlig <code className="font-mono text-xs">nav-pilot</code>{" "}
             gjøre det for deg:

--- a/cli/nav-pilot/internal/cli/alpha_local.go
+++ b/cli/nav-pilot/internal/cli/alpha_local.go
@@ -56,6 +56,13 @@ hosted one. Off until you run init, and invisible everywhere until then.
   on        Dispatch to it again after off, without downloading anything
   off       Stop dispatching to it; the weights stay on disk
   purge     Remove the environment and the weights, after showing what and how big
+
+Switching model:
+  nav-pilot models                                  what is offered; local ones say (local)
+  nav-pilot config set model <id>                   pick one
+  nav-pilot alpha local init                        download its weights, then start
+
+The list refreshes on init and start, not on every command.
 `)
 }
 
@@ -128,14 +135,10 @@ func activeManifest() (*local.Manifest, error) {
 // needs to read the manifest.
 func localModel(m *local.Manifest) (local.Model, error) {
 	if cfg, err := readConfig(); err == nil && cfg != nil && cfg.Model != nil {
-		if entry, ok := local.Lookup(*cfg.Model); ok {
-			return entry, nil
-		}
+		local.SetSelectedModel(*cfg.Model)
 	}
-	for _, entry := range m.Models {
-		if entry.Default {
-			return entry, nil
-		}
+	if entry, ok := local.Chosen(m); ok {
+		return entry, nil
 	}
 	// Unreachable: Parse refuses a manifest without exactly one default.
 	return local.Model{}, errors.New("the local-model manifest names no default model")
@@ -749,6 +752,9 @@ func applyLocalConfig() {
 	}
 	local.SetEnabled(true)
 	local.SetAutostart(r.LocalAutostart)
+	if cfg.Model != nil {
+		local.SetSelectedModel(*cfg.Model)
+	}
 }
 
 // ─── purge ───────────────────────────────────────────────────────────────────
@@ -776,8 +782,10 @@ func cmdLocalPurge(args []string) error {
 	var model string
 	if st, ok, _ := local.LoadState(); ok {
 		model = st.Model
-	} else if m, _, err := local.Cached(); err == nil && m != nil && len(m.Models) > 0 {
-		model = m.Models[0].Model
+	} else if m, _, err := local.Cached(); err == nil && m != nil {
+		if chosen, ok := local.Chosen(m); ok {
+			model = chosen.Model
+		}
 	}
 	items := local.Removables(model)
 	if len(items) == 0 {

--- a/cli/nav-pilot/internal/local/local.go
+++ b/cli/nav-pilot/internal/local/local.go
@@ -453,6 +453,45 @@ func SetActive(m *Manifest) {
 func Active() *Manifest { return active }
 
 // Lookup returns the manifest entry for a model id.
+// selectedModel is the model id the developer configured, empty for "whatever
+// the manifest calls default". nav-pilot pushes it in the same place it pushes
+// enabled and autostart.
+var selectedModel string
+
+// SetSelectedModel records the configured model id. An id that is not in the
+// manifest is kept rather than rejected: the manifest is refetched, and a model
+// that is missing today can be offered tomorrow. [Chosen] falls back to the
+// default whenever the id does not resolve.
+func SetSelectedModel(id string) { selectedModel = id }
+
+// Chosen returns the model a start would load: the configured one when the
+// manifest offers it, otherwise the manifest's default.
+//
+// It exists because the manifest carried exactly one model until 1 September
+// 2026, which made `Models[0]` correct by accident in two places. Adding a
+// second entry made both wrong on the same day — autostart would have started
+// the default no matter what the developer configured, and purge would have
+// offered to remove the wrong weights. Neither is a bug anyone reports; they
+// are a bug people quietly work around.
+func Chosen(m *Manifest) (Model, bool) {
+	if m == nil || len(m.Models) == 0 {
+		return Model{}, false
+	}
+	if selectedModel != "" {
+		for _, e := range m.Models {
+			if e.Model == selectedModel {
+				return e, true
+			}
+		}
+	}
+	for _, e := range m.Models {
+		if e.Default {
+			return e, true
+		}
+	}
+	return Model{}, false
+}
+
 func Lookup(model string) (Model, bool) {
 	for _, m := range Active().Models {
 		if m.Model == model {

--- a/cli/nav-pilot/internal/local/local_test.go
+++ b/cli/nav-pilot/internal/local/local_test.go
@@ -443,3 +443,44 @@ func TestCachedNeverReachesTheNetwork(t *testing.T) {
 		t.Errorf("Cached() returned %q, want the cached model", m.Models[0].Model)
 	}
 }
+
+// TestChosenHonoursTheConfiguredModel is the regression test for a bug that was
+// invisible while the manifest had one entry.
+//
+// Autostart picked Models[0] and purge picked Models[0]. Both were correct by
+// accident until 1 September 2026, when two Qwen3.8 builds were offered
+// alongside the default. From that moment a developer who configured a
+// non-default model and relied on autostart would have got the default started
+// instead, with nothing on screen to say so.
+func TestChosenHonoursTheConfiguredModel(t *testing.T) {
+	m := &Manifest{Models: []Model{
+		{Key: "default-one", Model: "org/Default", Default: true},
+		{Key: "other", Model: "org/Other"},
+	}}
+	t.Cleanup(func() { SetSelectedModel("") })
+
+	SetSelectedModel("")
+	if got, ok := Chosen(m); !ok || got.Model != "org/Default" {
+		t.Errorf("with nothing configured, Chosen = %q/%v, want org/Default", got.Model, ok)
+	}
+
+	SetSelectedModel("org/Other")
+	if got, ok := Chosen(m); !ok || got.Model != "org/Other" {
+		t.Errorf("with org/Other configured, Chosen = %q/%v, want org/Other", got.Model, ok)
+	}
+
+	// A configured id the manifest does not offer falls back rather than
+	// failing: the manifest is refetched, so an id can become valid later, and
+	// refusing to start is a worse answer than starting the default.
+	SetSelectedModel("org/NotOffered")
+	if got, ok := Chosen(m); !ok || got.Model != "org/Default" {
+		t.Errorf("with an unknown model configured, Chosen = %q/%v, want the default", got.Model, ok)
+	}
+
+	// The default is not required to be first, and Models[0] was the old bug.
+	reordered := &Manifest{Models: []Model{{Key: "other", Model: "org/Other"}, {Key: "d", Model: "org/Default", Default: true}}}
+	SetSelectedModel("")
+	if got, _ := Chosen(reordered); got.Model != "org/Default" {
+		t.Errorf("with the default second, Chosen = %q, want org/Default", got.Model)
+	}
+}

--- a/cli/nav-pilot/internal/local/runtime.go
+++ b/cli/nav-pilot/internal/local/runtime.go
@@ -1408,7 +1408,11 @@ func EnsureServerRunning(ctx context.Context, announce func(string), record Reco
 	}
 	m, ok := Chosen(manifest)
 	if !ok {
-		return errors.New("the local-model manifest names no model this machine can start")
+		// Not "this machine cannot run it": Chosen only fails when the manifest
+		// is empty or names no default, which is a broken manifest rather than
+		// anything about the hardware. Parse refuses such a file, so reaching
+		// here means one was hand-assembled or the embedded copy is damaged.
+		return errors.New("the local-model manifest names no default model; it is empty or malformed")
 	}
 	if announce != nil {
 		announce(m.Model)

--- a/cli/nav-pilot/internal/local/runtime.go
+++ b/cli/nav-pilot/internal/local/runtime.go
@@ -1406,7 +1406,10 @@ func EnsureServerRunning(ctx context.Context, announce func(string), record Reco
 	if manifest == nil || len(manifest.Models) == 0 {
 		return errors.New("no local model is available in this nav-pilot's manifest")
 	}
-	m := manifest.Models[0]
+	m, ok := Chosen(manifest)
+	if !ok {
+		return errors.New("the local-model manifest names no model this machine can start")
+	}
 	if announce != nil {
 		announce(m.Model)
 	}

--- a/cli/nav-pilot/internal/local/runtime_test.go
+++ b/cli/nav-pilot/internal/local/runtime_test.go
@@ -245,10 +245,14 @@ func fastTimers(t *testing.T) {
 // wired-limit and launch paths read.
 func testModel() Model {
 	return Model{
-		Key:          "qwen",
-		Name:         "A Model",
-		Model:        okModel,
-		Backend:      "mlx-lm",
+		Key:     "qwen",
+		Name:    "A Model",
+		Model:   okModel,
+		Backend: "mlx-lm",
+		// Parse refuses a manifest without exactly one default, so a fixture
+		// without one is a shape production never sees. It went unnoticed while
+		// selection was Models[0] and every fixture had exactly one model.
+		Default:      true,
 		WeightsGB:    25,
 		MinRAMGB:     48,
 		WiredLimitGB: 36,

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -139,6 +139,31 @@ nav-pilot alpha local off       # slutt å sende oppgaver dit; vektene blir ligg
 nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først
 ```
 
+### Bytte modell
+
+`nav-pilot models` viser hva som er tilgjengelig. De lokale står merket `(local)`.
+
+```bash
+nav-pilot models
+nav-pilot config set model mlx-community/Qwen3.8-27B-4bit
+nav-pilot alpha local init      # laster ned vektene for den nye modellen
+nav-pilot alpha local start
+```
+
+Listen oppdateres når du kjører `init` eller `start` — ikke ved hver kommando, fordi
+et nettverkskall der ville lagt seg foran alt annet nav-pilot gjør. Har du nettopp hørt
+om en ny modell og ikke ser den, er `start` det som henter listen på nytt.
+
+**Qwen 3.6 er standard, og det er ikke tilfeldig.** De to Qwen 3.8-modellene ligger der
+fordi folk spør etter dem, ikke fordi de er bedre her. På våre egne oppgaver er 3.8
+tregere og mye mer ujevn: to kjøringer av de samme åtte oppgavene, samme profil og samme
+maskin, ga median 88 og 906 sekunder. 3.6 ligger på 12–21 sekunder uten timeouts over
+åtte kjøringer. `nav-pilot config explain model` sier det samme kortere, og
+[MODELS.md](https://github.com/navikt/mlx-workspace/blob/main/MODELS.md) har tallene.
+
+Bytter du modell, må vektene lastes ned én gang til — 16 GB for 3.8 4-bit, 30 GB for
+8-bit. `purge` fjerner det du ikke vil beholde.
+
 Vil du slippe å starte serveren selv, kan en vanlig `nav-pilot` gjøre det når den trenger den:
 
 ```bash


### PR DESCRIPTION
Two Qwen3.8 builds went into the served manifest this evening, opt-in, with Qwen3.6 still the default. That took the manifest from one model to three — and made a latent bug live the same hour.

## The bug

`Models[0]` was correct by accident while there was only ever one model.

**Autostart** (`internal/local/runtime.go`) picked `Models[0]`. A developer who ran `nav-pilot config set model mlx-community/Qwen3.8-27B-4bit` and relied on a launch to start the server would have got **the default started instead**, with nothing on screen to say so.

**Purge** (`internal/cli/alpha_local.go`) picked `Models[0]` too, and would have offered to remove the weights of a model the developer had not chosen.

Neither is a bug anyone reports. They are the kind people quietly work around.

## The fix

Selection lives in one place. `local.Chosen(manifest)` returns the configured model when the manifest offers it, and the manifest's default otherwise. The CLI's own picker now delegates to it instead of keeping a second copy of the rule.

A configured id the manifest does not know **falls back rather than failing** — the manifest is refetched, so an id can become valid later, and refusing to start is a worse answer than starting the default.

`TestChosenHonoursTheConfiguredModel` covers the case that was invisible: a default that is not first in the list. It also turned up a fixture building a manifest with **no** default at all — a shape `Parse` refuses, so production never sees it, and it only survived because selection used to be positional.

## Switching, documented

Verified end to end against the live manifest — all three now appear in `nav-pilot models` with the `(local)` marker:

```
nav-pilot models
nav-pilot config set model mlx-community/Qwen3.8-27B-4bit
nav-pilot alpha local init      # downloads the new weights
nav-pilot alpha local start
```

Documented in three places, because a switch nobody knows the command for is not a feature: the `alpha local` usage text, `docs/README.nav-pilot.md`, and the docs page.

All three carry the same reason 3.6 stays default, with the number rather than an adjective: **two runs of the same eight tasks, same profile, same machine, gave 3.8 a median of 88s and 906s** — against 12–21s and no timeouts across eight runs of 3.6.

They also say the list refreshes on `init` and `start` rather than on every command, since `applyLocalConfig` reads the cache deliberately — a fetch there once put a connect timeout in front of `nav-pilot config get`.

## Checks

`go build`, `go test ./...` green, and green under `DO_NOT_TRACK=1`. `tsc --noEmit` clean.