### PR TITLE
fix: the manifest's tuned parameters never reached the server

### DIFF
--- a/cli/nav-pilot/internal/local/runtime.go
+++ b/cli/nav-pilot/internal/local/runtime.go
@@ -953,6 +953,51 @@ func (s *Server) URL() string {
 // The manifest entry's MLX_* params go in as environment, unchanged and
 // untyped, so a knob the generator adds reaches the server without a nav-pilot
 // release.
+// serverFlags turns manifest params into mlx_lm.server command-line flags.
+//
+// This exists because passing them as environment variables did nothing. mlx-lm
+// reads exactly one variable in its entire package, MLXLM_USE_MODELSCOPE
+// (utils.py:27), so every tuned knob in the manifest was inert in the field
+// while the benchmarks that produced those knobs ran through a harness that
+// translates the same variables into flags. The two were never the same
+// configuration, and the comment above this function used to claim they were.
+//
+// The most expensive one was silent: without --chat-template-args the
+// {"enable_thinking": false} in every profile never applied, so served models
+// ran with thinking on. The second was worse in kind: mlx-lm defaults --temp to
+// 0.0, which is greedy decoding, and greedy is what makes a local model repeat
+// a tool call until something outside it intervenes. The loop guard was built
+// for runs of 203 and 220 identical calls measured in exactly this state.
+//
+// The mapping is explicit rather than generic on purpose. Params come from a
+// file fetched over the network, and a loop that turned any key into a flag
+// would let that file pass arbitrary arguments to a process on the developer's
+// machine. A key that is not on this list reaches the server only as an
+// environment variable, which is inert, which is the safe direction to fail.
+func serverFlags(params map[string]string) []string {
+	// param name, flag, and whether a value equal to the mlx-lm default is
+	// worth passing anyway. Order is fixed so a launch is reproducible.
+	spec := []struct{ key, flag string }{
+		{"MLX_TEMP", "--temp"},
+		{"MLX_TOP_P", "--top-p"},
+		{"MLX_TOP_K", "--top-k"},
+		{"MLX_MIN_P", "--min-p"},
+		{"MLX_MAX_TOKENS", "--max-tokens"},
+		{"MLX_CACHE_SIZE", "--prompt-cache-size"},
+		{"MLX_CACHE_BYTES", "--prompt-cache-bytes"},
+		{"MLX_CHAT_TEMPLATE_ARGS", "--chat-template-args"},
+	}
+	var args []string
+	for _, s := range spec {
+		v := strings.TrimSpace(params[s.key])
+		if v == "" {
+			continue
+		}
+		args = append(args, s.flag, v)
+	}
+	return args
+}
+
 func (s *Server) Start(ctx context.Context, model Model) error {
 	s.mu.Lock()
 	if s.proc != nil && s.exit == nil {
@@ -995,11 +1040,16 @@ func (s *Server) Start(ctx context.Context, model Model) error {
 	for k, v := range model.Params {
 		env = append(env, k+"="+v)
 	}
-	p, err := startProcess(ctx, venvBin("mlx_lm.server"), []string{
+	// Env as well as flags: MLX_OPENCODE_* are read by nav-pilot itself rather
+	// than by the server, and a future param may be picked up by mlx-lm without
+	// a nav-pilot release. Flags are what actually configure this process.
+	args := []string{
 		"--model", model.Model,
 		"--host", "127.0.0.1",
 		"--port", strconv.Itoa(port),
-	}, env)
+	}
+	args = append(args, serverFlags(model.Params)...)
+	p, err := startProcess(ctx, venvBin("mlx_lm.server"), args, env)
 	if err != nil {
 		return fmt.Errorf("starting the local %s server: %w", model.Model, err)
 	}

--- a/cli/nav-pilot/internal/local/runtime.go
+++ b/cli/nav-pilot/internal/local/runtime.go
@@ -950,9 +950,12 @@ func (s *Server) URL() string {
 // gets a nil error has a server that has loaded the model, and one this process
 // started.
 //
-// The manifest entry's MLX_* params go in as environment, unchanged and
-// untyped, so a knob the generator adds reaches the server without a nav-pilot
-// release.
+// The manifest entry's MLX_* params reach the server as command-line flags, and
+// only the ones [serverFlags] names. A key outside that list is still exported
+// into the environment, where mlx-lm will not read it — so a genuinely new knob
+// does need a nav-pilot release, which is the opposite of what this comment
+// claimed until the flags existed.
+
 // serverFlags turns manifest params into mlx_lm.server command-line flags.
 //
 // This exists because passing them as environment variables did nothing. mlx-lm
@@ -975,8 +978,11 @@ func (s *Server) URL() string {
 // machine. A key that is not on this list reaches the server only as an
 // environment variable, which is inert, which is the safe direction to fail.
 func serverFlags(params map[string]string) []string {
-	// param name, flag, and whether a value equal to the mlx-lm default is
-	// worth passing anyway. Order is fixed so a launch is reproducible.
+	// Fixed order, so two launches of the same profile produce the same command
+	// line and a difference in behaviour is never a difference in argument
+	// order. Values are passed as the manifest states them, including ones that
+	// match an mlx-lm default: restating a default costs nothing and keeps the
+	// launch readable in `ps` without cross-referencing mlx-lm's own defaults.
 	spec := []struct{ key, flag string }{
 		{"MLX_TEMP", "--temp"},
 		{"MLX_TOP_P", "--top-p"},

--- a/cli/nav-pilot/internal/local/runtime_test.go
+++ b/cli/nav-pilot/internal/local/runtime_test.go
@@ -1297,16 +1297,23 @@ func TestServerFlagsCarryTheTunedKnobs(t *testing.T) {
 		"MLX_CHAT_TEMPLATE_ARGS": `{"enable_thinking": false}`,
 		"MLX_OPENCODE_CONTEXT":   "65536",
 	})
-	joined := strings.Join(got, " ")
-
-	for _, want := range []string{
-		"--temp 0.6", "--top-k 20", "--top-p 0.95", "--max-tokens 32768",
-		"--prompt-cache-size 3", `--chat-template-args {"enable_thinking": false}`,
-	} {
-		if !strings.Contains(joined, want) {
-			t.Errorf("serverFlags omitted %q; got %v", want, got)
-		}
+	// Exact equality rather than substring matching. serverFlags is
+	// deterministic, so the order is part of the contract, and a substring
+	// check would pass on a duplicated flag — which is how a doubled
+	// device_id attribute reached a commit earlier the same week.
+	want := []string{
+		"--temp", "0.6",
+		"--top-p", "0.95",
+		"--top-k", "20",
+		"--max-tokens", "32768",
+		"--prompt-cache-size", "3",
+		"--chat-template-args", `{"enable_thinking": false}`,
 	}
+	if !slices.Equal(got, want) {
+		t.Errorf("serverFlags =\n  %v\nwant\n  %v", got, want)
+	}
+
+	joined := strings.Join(got, " ")
 
 	// Keys the server does not take must not become flags. Params come from a
 	// file fetched over the network, so a generic key-to-flag loop would let

--- a/cli/nav-pilot/internal/local/runtime_test.go
+++ b/cli/nav-pilot/internal/local/runtime_test.go
@@ -1274,3 +1274,51 @@ func TestLockfilePinsTheVersionsTheCodeNames(t *testing.T) {
 		t.Error("requirements.txt carries no hashes, so --require-hashes buys nothing")
 	}
 }
+
+// TestServerFlagsCarryTheTunedKnobs pins the fix for a silent production bug.
+//
+// The manifest's params were passed to mlx_lm.server as environment variables,
+// and mlx-lm reads exactly one variable in its whole package. So every profile
+// shipped {"enable_thinking": false} and a tuned sampler, and the server ran
+// with thinking on and mlx-lm's own defaults — including --temp 0.0, greedy
+// decoding, which is what makes a local model repeat a tool call forever. The
+// benchmarks that produced those values ran through a harness that translates
+// the same variables into flags, so the numbers described a configuration no
+// developer was running.
+func TestServerFlagsCarryTheTunedKnobs(t *testing.T) {
+	got := serverFlags(map[string]string{
+		"MLX_MODEL":              "org/Model",
+		"MLX_SERVER_TYPE":        "mlx-lm",
+		"MLX_TEMP":               "0.6",
+		"MLX_TOP_K":              "20",
+		"MLX_TOP_P":              "0.95",
+		"MLX_MAX_TOKENS":         "32768",
+		"MLX_CACHE_SIZE":         "3",
+		"MLX_CHAT_TEMPLATE_ARGS": `{"enable_thinking": false}`,
+		"MLX_OPENCODE_CONTEXT":   "65536",
+	})
+	joined := strings.Join(got, " ")
+
+	for _, want := range []string{
+		"--temp 0.6", "--top-k 20", "--top-p 0.95", "--max-tokens 32768",
+		"--prompt-cache-size 3", `--chat-template-args {"enable_thinking": false}`,
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("serverFlags omitted %q; got %v", want, got)
+		}
+	}
+
+	// Keys the server does not take must not become flags. Params come from a
+	// file fetched over the network, so a generic key-to-flag loop would let
+	// that file pass arbitrary arguments to a process on the developer's
+	// machine. Failing closed means an unknown key stays inert.
+	for _, unwanted := range []string{"MLX_MODEL", "MLX_SERVER_TYPE", "MLX_OPENCODE_CONTEXT", "org/Model"} {
+		if strings.Contains(joined, unwanted) {
+			t.Errorf("serverFlags leaked %q into the command line: %v", unwanted, got)
+		}
+	}
+
+	if len(serverFlags(map[string]string{})) != 0 {
+		t.Error("no params should mean no flags, so a manifest can still say nothing")
+	}
+}


### PR DESCRIPTION
Found while checking something else. Every tuned parameter nav-pilot serves in the local-model manifest has been inert in the field since the alpha shipped.

## What happened

`Server.Start` launched `mlx_lm.server` with `--model`, `--host` and `--port`, and passed the manifest's params as **environment variables**:

```go
env := os.Environ()
for k, v := range model.Params { env = append(env, k+"="+v) }
```

mlx-lm reads exactly one environment variable in its entire package — `MLXLM_USE_MODELSCOPE` (`utils.py:27`). Nothing else. The `MLX_*` → flag translation lives in the benchmark harness (`.mise/tasks/server` in `navikt/mlx-workspace`), which nav-pilot does not use.

So the benchmarks that produced these values ran through a harness that applies them, and the fleet ran without them. **They were never the same configuration.** The comment above the launch claimed a knob the generator adds "reaches the server"; it did not.

## The two that matter

**`--chat-template-args` never arrived.** Every profile carries `{"enable_thinking": false}`. Served models have been running with **thinking on** since day one. Our own measurement puts that at roughly 2.3× on routine operations.

**`--temp` defaults to 0.0 in mlx-lm — greedy decoding.** The note in our harness explains why we never benchmark that way: greedy reinforces a high-probability token pattern until the model cannot escape it. nav-pilot's loop guard exists because we measured runs of **203 and 220 identical consecutive tool calls**. The field has been running greedy the entire time.

That is not proof the guard was built for a symptom our own serving configuration causes. It is now the first thing to check.

Also inert: `--top-k`, `--top-p`, `--min-p`, `--max-tokens` (mlx-lm defaults to **512**), and both prompt-cache settings.

## The fix

`serverFlags` maps params to flags as an **explicit list**, not a loop. These values come from a file fetched over the network; turning any key into a flag would let that file pass arbitrary arguments to a process on a developer's machine. An unrecognised key stays an environment variable, which is inert — the safe direction to fail.

Env vars are still passed, because `MLX_OPENCODE_*` are read by nav-pilot itself rather than the server.

`TestServerFlagsCarryTheTunedKnobs` pins both halves: the tuned knobs become flags, and `MLX_MODEL`, `MLX_SERVER_TYPE` and `MLX_OPENCODE_*` never reach the command line.

## What this means for the numbers

Every benchmark result we have describes a configuration no developer was running — including the `expect` text shipped in the manifest hours ago. Fresh runs against the fixed configuration are queued tonight, and the reports get corrected against those rather than against the old ones.

## Also here

`reasoning_effort` is now pinned to `medium` in both Qwen3.8 profiles (in the mlx-workspace manifest, not this repo). Qwen3.8's template calls `raise_exception` on anything outside `xhigh`/`medium`/`low`, and nav-pilot accepts six values — `none`, `high` and `max` would make it refuse the request. Qwen3.6 ignores the field entirely, so the asymmetry arrived with the profiles added last night. With this PR, `--chat-template-args` finally applies, which is what makes pinning it work at all.

## Checks

`go build`, `go test ./...` green, and green under `DO_NOT_TRACK=1`.