### PR TITLE
docs: list the three alpha models, and correct the news that said 3.8 was rejected

### DIFF
--- a/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
+++ b/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
@@ -115,6 +115,7 @@ const DOC_SECTIONS: TocItem[] = [
     label: "Bakkemodellen (alfa)",
     children: [
       { id: "lokal-kom-i-gang", label: "Kom i gang" },
+      { id: "lokal-modeller", label: "Modeller i alfa" },
       { id: "lokal-hva-den-klarer", label: "Hva den klarer" },
       { id: "lokal-feilsoking", label: "Når noe henger" },
     ],
@@ -2022,6 +2023,62 @@ nav-pilot alpha local on        # skru på igjen etter off
 nav-pilot alpha local off       # slutt å sende oppgaver dit; vektene blir liggende
 nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først`}
           </CodeBlock>
+          <div id="lokal-modeller">
+            <LinkableHeading size="small" level="3">
+              Modeller i alfa
+            </LinkableHeading>
+            <BodyLong className="mt-2 mb-4" size="small" style={{ color: "#475569" }}>
+              Tre modeller er tilgjengelige. Én er standard, de to andre kan velges. Tallene er fra vårt eget sett
+              på åtte oppgaver, og oppgis som spenn fordi det er spennet som skiller dem.
+            </BodyLong>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr style={{ borderBottom: "1px solid #e2e8f0" }}>
+                    <th className="text-left py-2 pr-4 font-medium">Modell</th>
+                    <th className="text-left py-2 pr-4 font-medium">Vekter</th>
+                    <th className="text-left py-2 pr-4 font-medium">Løser</th>
+                    <th className="text-left py-2 font-medium">Kort sagt</th>
+                  </tr>
+                </thead>
+                <tbody style={{ color: "#475569" }}>
+                  <tr style={{ borderBottom: "1px solid #f1f5f9" }}>
+                    <td className="py-2 pr-4 align-top">
+                      <code className="font-mono text-xs">Qwen3.6-35B-A3B-OptiQ-4bit</code>
+                      <div className="text-xs mt-1" style={{ color: "#0f6d6a" }}>standard</div>
+                    </td>
+                    <td className="py-2 pr-4 align-top">25 GB</td>
+                    <td className="py-2 pr-4 align-top">3–6 av 8</td>
+                    <td className="py-2 align-top">Rask og forutsigbar. Median rundt 10 sekunder per oppgave, og ingen loop i noen kjøring. Den du vil ha med mindre du har en grunn til noe annet.</td>
+                  </tr>
+                  <tr style={{ borderBottom: "1px solid #f1f5f9" }}>
+                    <td className="py-2 pr-4 align-top">
+                      <code className="font-mono text-xs">Qwen3.8-27B-4bit</code>
+                    </td>
+                    <td className="py-2 pr-4 align-top">16 GB</td>
+                    <td className="py-2 pr-4 align-top">1–5 av 8</td>
+                    <td className="py-2 align-top">Dyktig og ujevn. Både det beste og det dårligste enkeltresultatet vi har målt, med to timer mellom seg på samme maskin. Omtrent sju ganger tregere. Verdt å prøve på arbeid du leser gjennom etterpå.</td>
+                  </tr>
+                  <tr style={{ borderBottom: "1px solid #f1f5f9" }}>
+                    <td className="py-2 pr-4 align-top">
+                      <code className="font-mono text-xs">Qwen3.8-27B-8bit</code>
+                    </td>
+                    <td className="py-2 pr-4 align-top">30 GB</td>
+                    <td className="py-2 pr-4 align-top">ikke målt</td>
+                    <td className="py-2 align-top">Den mest omtalte, og den vi kan si minst om: de siste kjøringene ble forstyrret av en endring vi selv gjorde, så vi oppgir ingen tall. Mindre plass til kontekst enn 4-bit, 65k mot 131k.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <BodyShort size="small" className="mt-3" style={{ color: "#64748b" }}>
+              Én kjøring er ikke en måling — derfor spenn og ikke median. Alle kjøringene ligger i{" "}
+              <a href="https://github.com/navikt/mlx-workspace/blob/main/MODELS.md" style={{ textDecoration: "underline" }}>
+                MODELS.md
+              </a>
+              .
+            </BodyShort>
+          </div>
+
           <LinkableHeading size="small" level="3">
             Bytte modell
           </LinkableHeading>

--- a/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
+++ b/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
@@ -2022,6 +2022,28 @@ nav-pilot alpha local on        # skru på igjen etter off
 nav-pilot alpha local off       # slutt å sende oppgaver dit; vektene blir liggende
 nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først`}
           </CodeBlock>
+          <LinkableHeading size="small" level="3">
+            Bytte modell
+          </LinkableHeading>
+          <BodyLong className="mt-2" size="small" style={{ color: "#475569" }}>
+            <code className="font-mono text-xs">nav-pilot models</code> viser hva som er tilgjengelig; de lokale står
+            merket <code className="font-mono text-xs">(local)</code>. Listen oppdateres når du kjører{" "}
+            <code className="font-mono text-xs">init</code> eller <code className="font-mono text-xs">start</code>, ikke
+            ved hver kommando — et nettverkskall der ville lagt seg foran alt annet nav-pilot gjør.
+          </BodyLong>
+          <CodeBlock compact>
+            {`nav-pilot models
+nav-pilot config set model mlx-community/Qwen3.8-27B-4bit
+nav-pilot alpha local init      # laster ned vektene for den nye modellen
+nav-pilot alpha local start`}
+          </CodeBlock>
+          <BodyLong className="mt-4" size="small" style={{ color: "#475569" }}>
+            Qwen 3.6 er standard, og det er ikke tilfeldig. De to Qwen 3.8-modellene ligger der fordi folk spør etter
+            dem, ikke fordi de er bedre her. På våre egne oppgaver er 3.8 tregere og mye mer ujevn: to kjøringer av de
+            samme åtte oppgavene, samme profil og samme maskin, ga median 88 og 906 sekunder. 3.6 ligger på 12–21
+            sekunder uten timeouts over åtte kjøringer. Bytter du, må vektene lastes ned én gang til — 16 GB for 3.8
+            4-bit, 30 GB for 8-bit.
+          </BodyLong>
           <BodyLong className="mt-4" size="small" style={{ color: "#475569" }}>
             Vil du slippe å starte serveren selv, kan en vanlig <code className="font-mono text-xs">nav-pilot</code>{" "}
             gjøre det for deg:

--- a/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
+++ b/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
@@ -2035,10 +2035,10 @@ nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først`
               <table className="w-full text-sm">
                 <thead>
                   <tr style={{ borderBottom: "1px solid #e2e8f0" }}>
-                    <th className="text-left py-2 pr-4 font-medium">Modell</th>
-                    <th className="text-left py-2 pr-4 font-medium">Vekter</th>
-                    <th className="text-left py-2 pr-4 font-medium">Løser</th>
-                    <th className="text-left py-2 font-medium">Kort sagt</th>
+                    <th scope="col" className="text-left py-2 pr-4 font-medium">Modell</th>
+                    <th scope="col" className="text-left py-2 pr-4 font-medium">Vekter</th>
+                    <th scope="col" className="text-left py-2 pr-4 font-medium">Løser</th>
+                    <th scope="col" className="text-left py-2 font-medium">Kort sagt</th>
                   </tr>
                 </thead>
                 <tbody style={{ color: "#475569" }}>
@@ -2049,7 +2049,7 @@ nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først`
                     </td>
                     <td className="py-2 pr-4 align-top">25 GB</td>
                     <td className="py-2 pr-4 align-top">3–6 av 8</td>
-                    <td className="py-2 align-top">Rask og forutsigbar. Median rundt 10 sekunder per oppgave, og ingen loop i noen kjøring. Den du vil ha med mindre du har en grunn til noe annet.</td>
+                    <td className="py-2 align-top">Rask og forutsigbar. Rundt 10 sekunder per oppgave, og ingen loop i noen kjøring. Den du vil ha med mindre du har en grunn til noe annet.</td>
                   </tr>
                   <tr style={{ borderBottom: "1px solid #f1f5f9" }}>
                     <td className="py-2 pr-4 align-top">

--- a/cli/nav-pilot/internal/cli/alpha_local.go
+++ b/cli/nav-pilot/internal/cli/alpha_local.go
@@ -56,6 +56,13 @@ hosted one. Off until you run init, and invisible everywhere until then.
   on        Dispatch to it again after off, without downloading anything
   off       Stop dispatching to it; the weights stay on disk
   purge     Remove the environment and the weights, after showing what and how big
+
+Switching model:
+  nav-pilot models                                  what is offered; local ones say (local)
+  nav-pilot config set model <id>                   pick one
+  nav-pilot alpha local init                        download its weights, then start
+
+The list refreshes on init and start, not on every command.
 `)
 }
 
@@ -128,14 +135,10 @@ func activeManifest() (*local.Manifest, error) {
 // needs to read the manifest.
 func localModel(m *local.Manifest) (local.Model, error) {
 	if cfg, err := readConfig(); err == nil && cfg != nil && cfg.Model != nil {
-		if entry, ok := local.Lookup(*cfg.Model); ok {
-			return entry, nil
-		}
+		local.SetSelectedModel(*cfg.Model)
 	}
-	for _, entry := range m.Models {
-		if entry.Default {
-			return entry, nil
-		}
+	if entry, ok := local.Chosen(m); ok {
+		return entry, nil
 	}
 	// Unreachable: Parse refuses a manifest without exactly one default.
 	return local.Model{}, errors.New("the local-model manifest names no default model")
@@ -749,6 +752,9 @@ func applyLocalConfig() {
 	}
 	local.SetEnabled(true)
 	local.SetAutostart(r.LocalAutostart)
+	if cfg.Model != nil {
+		local.SetSelectedModel(*cfg.Model)
+	}
 }
 
 // ─── purge ───────────────────────────────────────────────────────────────────
@@ -776,8 +782,10 @@ func cmdLocalPurge(args []string) error {
 	var model string
 	if st, ok, _ := local.LoadState(); ok {
 		model = st.Model
-	} else if m, _, err := local.Cached(); err == nil && m != nil && len(m.Models) > 0 {
-		model = m.Models[0].Model
+	} else if m, _, err := local.Cached(); err == nil && m != nil {
+		if chosen, ok := local.Chosen(m); ok {
+			model = chosen.Model
+		}
 	}
 	items := local.Removables(model)
 	if len(items) == 0 {

--- a/cli/nav-pilot/internal/local/local.go
+++ b/cli/nav-pilot/internal/local/local.go
@@ -453,6 +453,45 @@ func SetActive(m *Manifest) {
 func Active() *Manifest { return active }
 
 // Lookup returns the manifest entry for a model id.
+// selectedModel is the model id the developer configured, empty for "whatever
+// the manifest calls default". nav-pilot pushes it in the same place it pushes
+// enabled and autostart.
+var selectedModel string
+
+// SetSelectedModel records the configured model id. An id that is not in the
+// manifest is kept rather than rejected: the manifest is refetched, and a model
+// that is missing today can be offered tomorrow. [Chosen] falls back to the
+// default whenever the id does not resolve.
+func SetSelectedModel(id string) { selectedModel = id }
+
+// Chosen returns the model a start would load: the configured one when the
+// manifest offers it, otherwise the manifest's default.
+//
+// It exists because the manifest carried exactly one model until 1 September
+// 2026, which made `Models[0]` correct by accident in two places. Adding a
+// second entry made both wrong on the same day — autostart would have started
+// the default no matter what the developer configured, and purge would have
+// offered to remove the wrong weights. Neither is a bug anyone reports; they
+// are a bug people quietly work around.
+func Chosen(m *Manifest) (Model, bool) {
+	if m == nil || len(m.Models) == 0 {
+		return Model{}, false
+	}
+	if selectedModel != "" {
+		for _, e := range m.Models {
+			if e.Model == selectedModel {
+				return e, true
+			}
+		}
+	}
+	for _, e := range m.Models {
+		if e.Default {
+			return e, true
+		}
+	}
+	return Model{}, false
+}
+
 func Lookup(model string) (Model, bool) {
 	for _, m := range Active().Models {
 		if m.Model == model {

--- a/cli/nav-pilot/internal/local/local_test.go
+++ b/cli/nav-pilot/internal/local/local_test.go
@@ -443,3 +443,44 @@ func TestCachedNeverReachesTheNetwork(t *testing.T) {
 		t.Errorf("Cached() returned %q, want the cached model", m.Models[0].Model)
 	}
 }
+
+// TestChosenHonoursTheConfiguredModel is the regression test for a bug that was
+// invisible while the manifest had one entry.
+//
+// Autostart picked Models[0] and purge picked Models[0]. Both were correct by
+// accident until 1 September 2026, when two Qwen3.8 builds were offered
+// alongside the default. From that moment a developer who configured a
+// non-default model and relied on autostart would have got the default started
+// instead, with nothing on screen to say so.
+func TestChosenHonoursTheConfiguredModel(t *testing.T) {
+	m := &Manifest{Models: []Model{
+		{Key: "default-one", Model: "org/Default", Default: true},
+		{Key: "other", Model: "org/Other"},
+	}}
+	t.Cleanup(func() { SetSelectedModel("") })
+
+	SetSelectedModel("")
+	if got, ok := Chosen(m); !ok || got.Model != "org/Default" {
+		t.Errorf("with nothing configured, Chosen = %q/%v, want org/Default", got.Model, ok)
+	}
+
+	SetSelectedModel("org/Other")
+	if got, ok := Chosen(m); !ok || got.Model != "org/Other" {
+		t.Errorf("with org/Other configured, Chosen = %q/%v, want org/Other", got.Model, ok)
+	}
+
+	// A configured id the manifest does not offer falls back rather than
+	// failing: the manifest is refetched, so an id can become valid later, and
+	// refusing to start is a worse answer than starting the default.
+	SetSelectedModel("org/NotOffered")
+	if got, ok := Chosen(m); !ok || got.Model != "org/Default" {
+		t.Errorf("with an unknown model configured, Chosen = %q/%v, want the default", got.Model, ok)
+	}
+
+	// The default is not required to be first, and Models[0] was the old bug.
+	reordered := &Manifest{Models: []Model{{Key: "other", Model: "org/Other"}, {Key: "d", Model: "org/Default", Default: true}}}
+	SetSelectedModel("")
+	if got, _ := Chosen(reordered); got.Model != "org/Default" {
+		t.Errorf("with the default second, Chosen = %q, want org/Default", got.Model)
+	}
+}

--- a/cli/nav-pilot/internal/local/runtime.go
+++ b/cli/nav-pilot/internal/local/runtime.go
@@ -1408,7 +1408,11 @@ func EnsureServerRunning(ctx context.Context, announce func(string), record Reco
 	}
 	m, ok := Chosen(manifest)
 	if !ok {
-		return errors.New("the local-model manifest names no model this machine can start")
+		// Not "this machine cannot run it": Chosen only fails when the manifest
+		// is empty or names no default, which is a broken manifest rather than
+		// anything about the hardware. Parse refuses such a file, so reaching
+		// here means one was hand-assembled or the embedded copy is damaged.
+		return errors.New("the local-model manifest names no default model; it is empty or malformed")
 	}
 	if announce != nil {
 		announce(m.Model)

--- a/cli/nav-pilot/internal/local/runtime.go
+++ b/cli/nav-pilot/internal/local/runtime.go
@@ -1406,7 +1406,10 @@ func EnsureServerRunning(ctx context.Context, announce func(string), record Reco
 	if manifest == nil || len(manifest.Models) == 0 {
 		return errors.New("no local model is available in this nav-pilot's manifest")
 	}
-	m := manifest.Models[0]
+	m, ok := Chosen(manifest)
+	if !ok {
+		return errors.New("the local-model manifest names no model this machine can start")
+	}
 	if announce != nil {
 		announce(m.Model)
 	}

--- a/cli/nav-pilot/internal/local/runtime_test.go
+++ b/cli/nav-pilot/internal/local/runtime_test.go
@@ -245,10 +245,14 @@ func fastTimers(t *testing.T) {
 // wired-limit and launch paths read.
 func testModel() Model {
 	return Model{
-		Key:          "qwen",
-		Name:         "A Model",
-		Model:        okModel,
-		Backend:      "mlx-lm",
+		Key:     "qwen",
+		Name:    "A Model",
+		Model:   okModel,
+		Backend: "mlx-lm",
+		// Parse refuses a manifest without exactly one default, so a fixture
+		// without one is a shape production never sees. It went unnoticed while
+		// selection was Models[0] and every fixture had exactly one model.
+		Default:      true,
 		WeightsGB:    25,
 		MinRAMGB:     48,
 		WiredLimitGB: 36,

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -155,10 +155,12 @@ et nettverkskall der ville lagt seg foran alt annet nav-pilot gjør. Har du nett
 om en ny modell og ikke ser den, er `start` det som henter listen på nytt.
 
 **Qwen 3.6 er standard, og det er ikke tilfeldig.** De to Qwen 3.8-modellene ligger der
-fordi folk spør etter dem, ikke fordi de er bedre her. På våre egne oppgaver er 3.8
-tregere og mye mer ujevn: to kjøringer av de samme åtte oppgavene, samme profil og samme
-maskin, ga median 88 og 906 sekunder. 3.6 ligger på 12–21 sekunder uten timeouts over
-åtte kjøringer. `nav-pilot config explain model` sier det samme kortere, og
+fordi folk spør etter dem, ikke fordi de er bedre her. 3.8 er ikke svakere, den er mindre
+forutsigbar: to kjøringer av de samme åtte oppgavene, samme profil og samme maskin to timer
+fra hverandre, løste **1 av 8** og deretter **5 av 8**. Den andre er det beste enkeltresultatet
+vi har målt. 3.6 ligger på 3–6 av 8 over åtte kjøringer og er omtrent sju ganger raskere.
+Vi oppgir spenn og ikke median, fordi for en modell som spenner fra 1 til 5 av 8 beskriver
+medianen ingen kjøring som faktisk har skjedd. `nav-pilot config explain model` sier det samme kortere, og
 [MODELS.md](https://github.com/navikt/mlx-workspace/blob/main/MODELS.md) har tallene.
 
 Bytter du modell, må vektene lastes ned én gang til — 16 GB for 3.8 4-bit, 30 GB for

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -139,6 +139,31 @@ nav-pilot alpha local off       # slutt å sende oppgaver dit; vektene blir ligg
 nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først
 ```
 
+### Bytte modell
+
+`nav-pilot models` viser hva som er tilgjengelig. De lokale står merket `(local)`.
+
+```bash
+nav-pilot models
+nav-pilot config set model mlx-community/Qwen3.8-27B-4bit
+nav-pilot alpha local init      # laster ned vektene for den nye modellen
+nav-pilot alpha local start
+```
+
+Listen oppdateres når du kjører `init` eller `start` — ikke ved hver kommando, fordi
+et nettverkskall der ville lagt seg foran alt annet nav-pilot gjør. Har du nettopp hørt
+om en ny modell og ikke ser den, er `start` det som henter listen på nytt.
+
+**Qwen 3.6 er standard, og det er ikke tilfeldig.** De to Qwen 3.8-modellene ligger der
+fordi folk spør etter dem, ikke fordi de er bedre her. På våre egne oppgaver er 3.8
+tregere og mye mer ujevn: to kjøringer av de samme åtte oppgavene, samme profil og samme
+maskin, ga median 88 og 906 sekunder. 3.6 ligger på 12–21 sekunder uten timeouts over
+åtte kjøringer. `nav-pilot config explain model` sier det samme kortere, og
+[MODELS.md](https://github.com/navikt/mlx-workspace/blob/main/MODELS.md) har tallene.
+
+Bytter du modell, må vektene lastes ned én gang til — 16 GB for 3.8 4-bit, 30 GB for
+8-bit. `purge` fjerner det du ikke vil beholde.
+
 Vil du slippe å starte serveren selv, kan en vanlig `nav-pilot` gjøre det når den trenger den:
 
 ```bash

--- a/docs/news/articles/lokale-modeller-i-nav-pilot.md
+++ b/docs/news/articles/lokale-modeller-i-nav-pilot.md
@@ -49,8 +49,31 @@ Først prøvde vi åtte modeller og bygg på det samme oppgavesettet: elleve opp
 - **Qwen3.6-35B-A3B, vanlig 4-bit.** Samme modell, annet bygg. Gikk i tool-loop og brukte 220 kall på én oppgave.
 - **KAT-Coder V2.5.** Løste like mange, men trengte flere kall på å komme dit.
 - **Qwen3.6-27B.** For treg. Median 113 sekunder mot 18.
-- **Qwen3.8-27B i 4-, 6- og 8-bit.** Ikke valgt. 6-bit brukte median 284 sekunder. Tallet vi publiserte for 8-bit kom fra en kjøring som stille erstattet en tidligere kjøring med et annet resultat, og vi vet ennå ikke hvilken av dem som gjelder.
+- **Qwen3.8-27B i 4-, 6- og 8-bit.** Ikke standard, men 4-bit og 8-bit kan nå velges. Se under.
 - **Granite 4.1 8B.** For liten. Løste 1 av 8.
+
+### Oppdatering 1. september: Qwen 3.8 kan velges
+
+Vi skrev først at Qwen3.8 ikke ble valgt fordi den gikk i loop. Etter å ha kjørt testene på nytt
+holder ikke den beskrivelsen, og den nye er mer interessant.
+
+To kjøringer av det samme oppgavesettet, samme maskin, to timer fra hverandre: Qwen3.8-27B 4-bit
+løste **1 av 8** i den første og **5 av 8** i den andre. Den andre er det beste enkeltresultatet
+noen modell har fått på dette settet. Qwen3.6 ligger på 3–6 av 8 over åtte kjøringer, og bruker
+omtrent en sjuendedel så lang tid.
+
+Qwen3.8 er altså ikke en svakere modell. Den er en mer uforutsigbar en. Derfor kan du velge den,
+men den er ikke standard:
+
+```bash
+nav-pilot models
+nav-pilot config set model mlx-community/Qwen3.8-27B-4bit
+nav-pilot alpha local init
+```
+
+Det vi selv lærte av dette er verdt mer enn modellvalget: **én kjøring er ikke en måling.** Alle
+konklusjonene som snudde, snudde fordi det fantes en kjøring til — ikke fordi vi tenkte oss om en
+gang til. Tabellen over var bygget på enkeltkjøringer.
 
 Deretter 200 kjøringer på én maskin med modellen vi valgte, fordelt på to klienter, seks oppgavetyper, tre refactor-strategier og tre kodebaser: en Ktor-app, en Spring-app og en frontend.
 


### PR DESCRIPTION
Stacked on #562, which added the switching instructions these build on.

## What was wrong

The docs described **one** local model. There are three, since the manifest gained two Qwen3.8 builds as opt-in.

The news article said Qwen3.8 was not chosen **because it looped**, and named a published 8-bit figure as coming from "a run that silently replaced an earlier one, and we don't yet know which applies". After re-running the suite on a repaired harness, neither statement holds.

## Docs page

New `Modeller i alfa` table under the local-model section, in the sidebar nav: weights, tasks solved **as a range**, and one honest sentence each. The default is marked. The 8-bit says `ikke målt` rather than carrying numbers.

## News article

An update section with what the re-runs actually found:

| model | run 1 | run 2 | median |
|---|---|---|---|
| Qwen3.6-35B-A3B-OptiQ | 4 of 8 | 3 of 8 | 10s |
| Qwen3.8-27B-4bit | **1 of 8** | **5 of 8** | 70s |

Two runs, same machine, two hours apart. The second is the best single result any model has recorded on this suite — including the task 3.8 was previously written up as looping on. The default sits at 3–6 of 8 across eight runs and is about seven times faster.

**So Qwen3.8 is not a weaker model, it is a less predictable one.** That is a more useful thing to tell people than the rejection was, and it is why it ships selectable but not default.

## Ranges, not medians

Both surfaces give ranges and say why: one run is not a measurement, and for a model spanning 1 to 5 of 8 the median describes no run that actually happened. The old table published medians from single runs.

Outstanding samples to reach n≥5 are tracked in #564.

## Checks

`tsc --noEmit` clean.