### PR TITLE
feat(nav-pilot): a full-page settings TUI for config

### DIFF
--- a/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
+++ b/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
@@ -2009,8 +2009,8 @@ function LocalModelSection() {
             Kom i gang
           </LinkableHeading>
           <BodyShort size="small" textColor="subtle">
-            Første <code className="font-mono text-xs">start</code> laster modellen inn i minnet. Ti målte oppstarter på seks
-            maskiner lå alle under 50 sekunder, seks av dem under ti.
+            Første <code className="font-mono text-xs">start</code> laster modellen inn i minnet. Ti målte oppstarter på
+            seks maskiner lå alle under 50 sekunder, seks av dem under ti.
           </BodyShort>
           <CodeBlock compact>
             {`nav-pilot alpha local init      # laster ned modellen og setter opp miljøet
@@ -2027,8 +2027,8 @@ nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først`
               Modeller i alfa
             </LinkableHeading>
             <BodyLong size="small" textColor="subtle">
-              Tre modeller er tilgjengelige. Én er standard, de to andre kan velges. Tallene er fra vårt eget sett
-              på åtte oppgaver, og oppgis som spenn fordi det er spennet som skiller dem.
+              Tre modeller er tilgjengelige. Én er standard, de to andre kan velges. Tallene er fra vårt eget sett på
+              åtte oppgaver, og oppgis som spenn fordi det er spennet som skiller dem.
             </BodyLong>
             <div className="overflow-x-auto">
               <Table size="small" className="w-full">
@@ -2045,12 +2045,17 @@ nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først`
                     <Table.DataCell>
                       <VStack gap="space-2">
                         <code className="font-mono text-xs">Qwen3.6-35B-A3B-OptiQ-4bit</code>
-                        <div className="text-xs" style={{ color: "#0f6d6a" }}>standard</div>
+                        <div className="text-xs" style={{ color: "#0f6d6a" }}>
+                          standard
+                        </div>
                       </VStack>
                     </Table.DataCell>
                     <Table.DataCell>25 GB</Table.DataCell>
                     <Table.DataCell>3–6 av 8</Table.DataCell>
-                    <Table.DataCell>Rask og forutsigbar. Rundt 10 sekunder per oppgave, og ingen loop i noen kjøring. Den du vil ha med mindre du har en grunn til noe annet.</Table.DataCell>
+                    <Table.DataCell>
+                      Rask og forutsigbar. Rundt 10 sekunder per oppgave, og ingen loop i noen kjøring. Den du vil ha
+                      med mindre du har en grunn til noe annet.
+                    </Table.DataCell>
                   </Table.Row>
                   <Table.Row>
                     <Table.DataCell>
@@ -2058,7 +2063,10 @@ nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først`
                     </Table.DataCell>
                     <Table.DataCell>16 GB</Table.DataCell>
                     <Table.DataCell>1–5 av 8</Table.DataCell>
-                    <Table.DataCell>Dyktig og ujevn. Både det beste og det dårligste enkeltresultatet vi har målt, med to timer mellom seg på samme maskin. Omtrent sju ganger tregere. Verdt å prøve på arbeid du leser gjennom etterpå.</Table.DataCell>
+                    <Table.DataCell>
+                      Dyktig og ujevn. Både det beste og det dårligste enkeltresultatet vi har målt, med to timer mellom
+                      seg på samme maskin. Omtrent sju ganger tregere. Verdt å prøve på arbeid du leser gjennom etterpå.
+                    </Table.DataCell>
                   </Table.Row>
                   <Table.Row>
                     <Table.DataCell>
@@ -2066,14 +2074,20 @@ nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først`
                     </Table.DataCell>
                     <Table.DataCell>30 GB</Table.DataCell>
                     <Table.DataCell>ikke målt</Table.DataCell>
-                    <Table.DataCell>Den mest omtalte, og den vi kan si minst om: de siste kjøringene ble forstyrret av en endring vi selv gjorde, så vi oppgir ingen tall. Mindre plass til kontekst enn 4-bit, 65k mot 131k.</Table.DataCell>
+                    <Table.DataCell>
+                      Den mest omtalte, og den vi kan si minst om: de siste kjøringene ble forstyrret av en endring vi
+                      selv gjorde, så vi oppgir ingen tall. Mindre plass til kontekst enn 4-bit, 65k mot 131k.
+                    </Table.DataCell>
                   </Table.Row>
                 </Table.Body>
               </Table>
             </div>
             <BodyShort size="small" textColor="subtle">
               Én kjøring er ikke en måling — derfor spenn og ikke median. Alle kjøringene ligger i{" "}
-              <a href="https://github.com/navikt/mlx-workspace/blob/main/MODELS.md" style={{ textDecoration: "underline" }}>
+              <a
+                href="https://github.com/navikt/mlx-workspace/blob/main/MODELS.md"
+                style={{ textDecoration: "underline" }}
+              >
                 MODELS.md
               </a>
               .
@@ -2112,7 +2126,9 @@ nav-pilot alpha local start`}
             Med den på venter launchen på at serveren er klar. To samtidige launcher starter ikke to servere.
           </BodyLong>
           <Box padding="space-16" borderRadius="8" style={{ background: "#f8fafc" }}>
-            <Label size="small" spacing>Vi måler dette tettere enn resten av nav-pilot mens det er alfa</Label>
+            <Label size="small" spacing>
+              Vi måler dette tettere enn resten av nav-pilot mens det er alfa
+            </Label>
             <BodyLong size="small" textColor="subtle">
               Vi samler inn hvor mange oppgaver hver økt sender til bakkemodellen (også når svaret er null, som er
               tallet vi lærer mest av), hvilken modell du kjører, hvor lang tid serveren brukte på å starte, og når den
@@ -2123,7 +2139,9 @@ nav-pilot alpha local start`}
             </BodyLong>
           </Box>
           <Box padding="space-16" borderRadius="8" style={{ background: "#fef2f2" }}>
-            <Label size="small" spacing>Én kommando, men den ber om passordet ditt</Label>
+            <Label size="small" spacing>
+              Én kommando, men den ber om passordet ditt
+            </Label>
             <BodyLong size="small" textColor="subtle">
               macOS lar ikke GPU-en låse nok minne til en modell på denne størrelsen som standard, så{" "}
               <code className="font-mono text-xs">init</code> hever grensen for deg med{" "}
@@ -2157,7 +2175,9 @@ nav-pilot alpha local start`}
           </BodyShort>
           <HGrid gap="space-16" columns={{ xs: 1, md: 2 }}>
             <Box padding="space-16" borderRadius="8" style={{ background: "#f0fdf4" }}>
-              <Label size="small" spacing>Fungerer</Label>
+              <Label size="small" spacing>
+                Fungerer
+              </Label>
               <BodyLong size="small" textColor="subtle">
                 Slå opp noe i koden. Legge til en kommentar. Døpe om et symbol i mange filer. Tre et felt gjennom en
                 mapper og kallstedene. I våre kjøringer lyktes den omtrent to av tre ganger på de største endringene, og
@@ -2165,7 +2185,9 @@ nav-pilot alpha local start`}
               </BodyLong>
             </Box>
             <Box padding="space-16" borderRadius="8" style={{ background: "#fef2f2" }}>
-              <Label size="small" spacing>Fungerer ikke</Label>
+              <Label size="small" spacing>
+                Fungerer ikke
+              </Label>
               <BodyLong size="small" textColor="subtle">
                 Skrive en ny fil fra bunnen: i våre forsøk gjorde den da ingenting i det hele tatt. Oppgaver der noe må
                 vurderes underveis, eller der en feil endring er dyr.
@@ -2173,7 +2195,9 @@ nav-pilot alpha local start`}
             </Box>
           </HGrid>
           <Box padding="space-16" borderRadius="8" style={{ background: "#fffbeb" }}>
-            <Label size="small" spacing>Sjekk resultatet</Label>
+            <Label size="small" spacing>
+              Sjekk resultatet
+            </Label>
             <BodyLong size="small" textColor="subtle">
               Bakkemodellen feiler også på måter som kompilerer. Commit eller stash før du setter den i gang, og kjør
               testene etterpå. På store endringer bør du regne med å forkaste et forsøk og prøve på nytt. Det koster deg

--- a/cli/nav-pilot/go.mod
+++ b/cli/nav-pilot/go.mod
@@ -4,6 +4,7 @@ go 1.26
 
 require (
 	github.com/BurntSushi/toml v1.6.0
+	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/go-logr/logr v1.4.4
@@ -24,7 +25,6 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/bubbles v1.0.0 // indirect
-	github.com/charmbracelet/bubbletea v1.3.10 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect

--- a/cli/nav-pilot/internal/cli/config_cmd.go
+++ b/cli/nav-pilot/internal/cli/config_cmd.go
@@ -30,6 +30,8 @@ type configKeyDef struct {
 	allowed     []string // nil = any non-empty string
 	defaultVal  string   // empty = no default / unset
 	flag        string   // corresponding Copilot CLI flag
+	internal    bool     // bookkeeping key, hidden from the settings page
+	group       string   // settings-page section; empty = "General"
 }
 
 var configKeyDefs = []configKeyDef{
@@ -40,6 +42,7 @@ var configKeyDefs = []configKeyDef{
 		allowed:     []string{"1"},
 		defaultVal:  "",
 		flag:        "",
+		internal:    true,
 	},
 	{
 		name:        "client",
@@ -128,6 +131,7 @@ var configKeyDefs = []configKeyDef{
 		allowed:     validLogLevels,
 		defaultVal:  "",
 		flag:        "--log-level",
+		group:       "Logging",
 	},
 	{
 		name:        "otel_log_level",
@@ -136,6 +140,7 @@ var configKeyDefs = []configKeyDef{
 		allowed:     validOtelLogLevels,
 		defaultVal:  "none",
 		flag:        "--otel-log-level",
+		group:       "Logging",
 	},
 	{
 		name:        "local_enabled",
@@ -144,6 +149,7 @@ var configKeyDefs = []configKeyDef{
 		allowed:     nil,
 		defaultVal:  "false",
 		flag:        "",
+		group:       "Local models (alpha)",
 	},
 	{
 		name:        "local_autostart",
@@ -152,6 +158,7 @@ var configKeyDefs = []configKeyDef{
 		allowed:     nil,
 		defaultVal:  "false",
 		flag:        "",
+		group:       "Local models (alpha)",
 	},
 	{
 		name:        "local_loop_guard",
@@ -160,6 +167,7 @@ var configKeyDefs = []configKeyDef{
 		allowed:     nil,
 		defaultVal:  strconv.Itoa(local.DefaultLoopGuardRepeat),
 		flag:        "",
+		group:       "Local models (alpha)",
 	},
 	{
 		name:        "rtk_prompted_client",
@@ -168,6 +176,7 @@ var configKeyDefs = []configKeyDef{
 		allowed:     nil,
 		defaultVal:  "",
 		flag:        "",
+		internal:    true,
 	},
 	{
 		name:        "rtk_prompted_at",
@@ -176,6 +185,7 @@ var configKeyDefs = []configKeyDef{
 		allowed:     nil,
 		defaultVal:  "",
 		flag:        "",
+		internal:    true,
 	},
 }
 

--- a/cli/nav-pilot/internal/cli/config_page.go
+++ b/cli/nav-pilot/internal/cli/config_page.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 
 	"github.com/charmbracelet/huh"
@@ -11,21 +12,19 @@ import (
 
 // ─── Key listing (shared with config show) ───────────────────────────────────
 
-// configPageKeys lists the user-facing keys, in display order. Internal
-// bookkeeping keys (version, rtk_prompted_*) are deliberately left out.
-var configPageKeys = []string{
-	"client",
-	"source",
-	"model",
-	"mode",
-	"reasoning_effort",
-	"context_tier",
-	"allow_all_tools",
-	"ask_user",
-	"auto_launch",
-	"auto_update",
-	"log_level",
-	"otel_log_level",
+// configPageKeys lists the settings-page keys in display order: every key
+// definition not marked internal. Adding a key to configKeyDefs is enough —
+// a user-facing key cannot silently miss the page.
+var configPageKeys = userFacingPageKeys()
+
+func userFacingPageKeys() []string {
+	var keys []string
+	for _, kd := range configKeyDefs {
+		if !kd.internal {
+			keys = append(keys, kd.name)
+		}
+	}
+	return keys
 }
 
 // configKeyValue returns the effective value of a key as displayed, spelling
@@ -34,7 +33,28 @@ func configKeyValue(r ResolvedConfig, key string) string {
 	if key == "source" {
 		return effectiveSourceLabel(r)
 	}
+	if key == "model" {
+		return modelValueLabel(r)
+	}
 	return resolvedFieldStr(r, key)
+}
+
+// modelValueLabel renders the model as its curated label plus id when the
+// configured client knows the id, so the page shows "Claude Sonnet 5
+// (claude-sonnet-5)" instead of a bare id the user had to memorize.
+func modelValueLabel(r ResolvedConfig) string {
+	id := resolvedFieldStr(r, "model")
+	if id == "" {
+		return ""
+	}
+	if p, err := providerFor(r.Client); err == nil {
+		for _, m := range p.KnownModels() {
+			if m.ID == id {
+				return m.Label + " (" + id + ")"
+			}
+		}
+	}
+	return id
 }
 
 // configKeySource labels where a key's effective value comes from: "file" when
@@ -50,34 +70,34 @@ func configKeySource(cfg *Config, key string) string {
 	return "unset"
 }
 
-// configKeyInFile reports whether the config file sets the key. An empty source
-// counts as unset — it is the documented way to fall back to the default.
+// configKeyInFile reports whether the config file sets the key. It matches the
+// Config struct's toml tags, so a new key needs no case here and cannot drift
+// out of sync with the page. An empty source counts as unset — it is the
+// documented way to fall back to the default.
 func configKeyInFile(cfg *Config, key string) bool {
-	switch key {
-	case "client":
-		return cfg.Client != nil
-	case "source":
-		return cfg.Source != nil && strings.TrimSpace(*cfg.Source) != ""
-	case "model":
-		return cfg.Model != nil
-	case "mode":
-		return cfg.Mode != nil
-	case "reasoning_effort":
-		return cfg.ReasoningEffort != nil
-	case "context_tier":
-		return cfg.ContextTier != nil
-	case "allow_all_tools":
-		return cfg.AllowAllTools != nil
-	case "ask_user":
-		return cfg.AskUser != nil
-	case "auto_launch":
-		return cfg.AutoLaunch != nil
-	case "auto_update":
-		return cfg.AutoUpdate != nil
-	case "log_level":
-		return cfg.LogLevel != nil
-	case "otel_log_level":
-		return cfg.OtelLogLevel != nil
+	if cfg == nil {
+		return false
+	}
+	v := reflect.ValueOf(cfg).Elem()
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		tag, _, _ := strings.Cut(t.Field(i).Tag.Get("toml"), ",")
+		if tag != key {
+			continue
+		}
+		f := v.Field(i)
+		if f.Kind() == reflect.Pointer {
+			if f.IsNil() {
+				return false
+			}
+			if key == "source" {
+				if s, ok := f.Interface().(*string); ok {
+					return strings.TrimSpace(*s) != ""
+				}
+			}
+			return true
+		}
+		return !f.IsZero()
 	}
 	return false
 }
@@ -88,15 +108,6 @@ type configPageEntry struct {
 	Value       string // "" = unset
 	Source      string // file / default / unset
 	Description string
-}
-
-// label renders the entry as the select option text.
-func (e configPageEntry) label() string {
-	val := e.Value
-	if val == "" {
-		val = "(unset)"
-	}
-	return fmt.Sprintf("%s = %s  (%s)", e.Key, val, e.Source)
 }
 
 // buildConfigPageEntries lists the user-facing keys with their current value,
@@ -127,34 +138,25 @@ const (
 	configPageDone    = "\x00done"
 )
 
-// cpltPostureLabel renders the security-posture row the way the key rows read:
-// the current value first, and what it should be when it is not that already.
-func cpltPostureLabel(preset string) string {
-	switch {
-	case preset == "":
-		return "cplt security posture   unknown  (could not read it from cplt)"
-	case cpltRecommendStrict(preset):
-		return fmt.Sprintf("cplt security posture   %s  (recommended: %s)", preset, cpltRecommendedPreset)
-	default:
-		return fmt.Sprintf("cplt security posture   %s", preset)
-	}
-}
-
 // errConfigPageUnavailable reports that the settings page never started, e.g.
 // because there is no usable terminal. Callers fall back to their non-
 // interactive behaviour; every other error is a real failure worth surfacing.
 var errConfigPageUnavailable = errors.New("settings page unavailable")
 
-// cmdConfigPage runs the interactive settings page: pick a key, edit it, repeat.
-// It is what `nav-pilot config` with no subcommand does on a terminal.
+// cmdConfigPage runs the interactive settings page: navigate the list, edit a
+// key, repeat. It is what `nav-pilot config` with no subcommand does on a
+// terminal. The list itself is a Bubble Tea page (config_tui.go); editing a
+// key drops back to the huh prompts in editConfigKey, then the page reopens.
 func cmdConfigPage() error {
-	// The header waits for the first successful render: a page that cannot open
-	// a TTY must leave no trace before its caller falls back.
-	rendered := false
+	if !isInteractive() {
+		return fmt.Errorf("%w: no usable terminal", errConfigPageUnavailable)
+	}
 
 	// Reading the preset costs a cplt spawn, so it is read once per page and
 	// refreshed only when the user actually changes it — not on every redraw.
 	preset := cpltSandboxPreset()
+
+	fmt.Printf("%s %s\n\n", dim("Config file:"), configPath())
 
 	for {
 		cfg, err := readConfig()
@@ -164,47 +166,13 @@ func cmdConfigPage() error {
 		resolved := resolve(cfg, CLIOverrides{})
 		entries := buildConfigPageEntries(cfg, resolved)
 
-		descriptions := map[string]string{
-			configPageSandbox: "Runs the cplt sandbox wizard (requires cplt on your PATH).",
-			configPagePosture: "Sets cplt sandbox.preset = strict, which turns on gh_guard, git_guard and forced proxy in one key (requires cplt on your PATH).",
-			configPageDone:    "Leave the settings page.",
-		}
-		opts := make([]huh.Option[string], 0, len(entries)+3)
-		for _, e := range entries {
-			opts = append(opts, huh.NewOption(e.label(), e.Key))
-			descriptions[e.Key] = e.Description
-		}
-		opts = append(opts,
-			huh.NewOption("Configure cplt sandbox settings…", configPageSandbox),
-			huh.NewOption(cpltPostureLabel(preset), configPagePosture),
-			huh.NewOption("Done", configPageDone),
-		)
-
-		choice := entries[0].Key
-		err = huh.NewSelect[string]().
-			Title("nav-pilot settings").
-			Options(opts...).
-			DescriptionFunc(func() string { return descriptions[choice] }, &choice).
-			Value(&choice).
-			WithTheme(navTheme()).
-			Run()
+		choice, err := runConfigPageTUI(entries, preset)
 		if err != nil {
-			// Esc / Ctrl-C is a normal way to leave the page.
-			if errors.Is(err, huh.ErrUserAborted) {
-				return nil
-			}
-			if !rendered {
-				return fmt.Errorf("%w: %v", errConfigPageUnavailable, err)
-			}
-			return err
-		}
-		if !rendered {
-			rendered = true
-			fmt.Printf("%s %s\n\n", dim("Config file:"), configPath())
+			return fmt.Errorf("%w: %v", errConfigPageUnavailable, err)
 		}
 
 		switch choice {
-		case configPageDone:
+		case "", configPageDone:
 			return nil
 		case configPageSandbox:
 			// "cplt not on PATH" is a notice, not a reason to leave the page.
@@ -234,12 +202,21 @@ func editConfigKey(key string, r ResolvedConfig) error {
 	}
 	current := configKeyValue(r, key)
 
+	if key == "model" {
+		return editModelKey(r, resolvedFieldStr(r, "model"))
+	}
+
 	value := current
 
 	var opts []huh.Option[string]
 	switch {
 	case kd.kind == keyKindBool:
 		opts = []huh.Option[string]{huh.NewOption("true", "true"), huh.NewOption("false", "false")}
+	case key == "client":
+		// Display names, not bare ids, so the picker reads like the setup wizard.
+		for _, p := range allProviders() {
+			opts = append(opts, huh.NewOption(p.DisplayName(), p.ID()))
+		}
 	case len(kd.allowed) > 0:
 		for _, a := range kd.allowed {
 			opts = append(opts, huh.NewOption(a, a))
@@ -264,7 +241,27 @@ func editConfigKey(key string, r ResolvedConfig) error {
 		return err
 	}
 
-	value = strings.TrimSpace(value)
+	return persistConfigValue(key, strings.TrimSpace(value))
+}
+
+// editModelKey prompts for the model using the configured client's curated
+// model list: the user picks a label instead of memorizing a model id.
+func editModelKey(r ResolvedConfig, current string) error {
+	kd := findKeyDef("model")
+	p, _ := providerFor(r.Client)
+	value, err := promptModel(p, "model", kd.description, current)
+	if err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return nil
+		}
+		return err
+	}
+	return persistConfigValue("model", value)
+}
+
+// persistConfigValue writes value for key, clearing the key when value is
+// blank so it falls back to its built-in default.
+func persistConfigValue(key, value string) error {
 	if value == "" {
 		if err := clearConfigKey(key); err != nil {
 			return err
@@ -278,6 +275,27 @@ func editConfigKey(key string, r ResolvedConfig) error {
 	}
 	fmt.Printf("%s %s = %s\n", green("✓"), key, tomlVal)
 	return nil
+}
+
+// wordWrap wraps s at width on word boundaries.
+func wordWrap(s string, width int) string {
+	var lines []string
+	for _, paragraph := range strings.Split(s, "\n") {
+		line := ""
+		for _, word := range strings.Fields(paragraph) {
+			switch {
+			case line == "":
+				line = word
+			case len(line)+1+len(word) <= width:
+				line += " " + word
+			default:
+				lines = append(lines, line)
+				line = word
+			}
+		}
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
 }
 
 // clearConfigKey drops a key from the config file so it falls back to its

--- a/cli/nav-pilot/internal/cli/config_page_test.go
+++ b/cli/nav-pilot/internal/cli/config_page_test.go
@@ -65,7 +65,7 @@ func TestBuildConfigPageEntries(t *testing.T) {
 	}{
 		{"client", "copilot", "default"},
 		{"source", defaultSourceRepo, "default"},
-		{"model", "gpt-5.5", "file"},
+		{"model", "GPT-5.5 (gpt-5.5)", "file"},
 		{"mode", "default", "default"},
 		{"reasoning_effort", "", "unset"},
 		{"context_tier", "", "unset"},
@@ -73,6 +73,9 @@ func TestBuildConfigPageEntries(t *testing.T) {
 		{"allow_all_tools", "false", "default"},
 		{"log_level", "", "unset"},
 		{"otel_log_level", "none", "default"},
+		{"local_enabled", "false", "default"},
+		{"local_autostart", "false", "default"},
+		{"local_loop_guard", findKeyDef("local_loop_guard").defaultVal, "default"},
 	}
 	for _, tc := range tests {
 		e, ok := byKey[tc.key]
@@ -89,17 +92,84 @@ func TestBuildConfigPageEntries(t *testing.T) {
 	}
 }
 
-func TestConfigPageEntryLabel(t *testing.T) {
+func TestModelValueLabel(t *testing.T) {
+	writeTestConfig(t, "version = 1\n")
+
 	tests := []struct {
-		entry configPageEntry
-		want  string
+		model, want string
 	}{
-		{configPageEntry{Key: "model", Value: "gpt-5.5", Source: "file"}, "model = gpt-5.5  (file)"},
-		{configPageEntry{Key: "log_level", Value: "", Source: "unset"}, "log_level = (unset)  (unset)"},
+		{"gpt-5.5", "GPT-5.5 (gpt-5.5)"},
+		{"some-unknown-model", "some-unknown-model"},
+		{"", ""},
 	}
 	for _, tc := range tests {
-		if got := tc.entry.label(); got != tc.want {
-			t.Errorf("label() = %q, want %q", got, tc.want)
+		r := resolve(nil, CLIOverrides{})
+		r.Client = "copilot"
+		r.Model = tc.model
+		if got := modelValueLabel(r); got != tc.want {
+			t.Errorf("modelValueLabel(%q) = %q, want %q", tc.model, got, tc.want)
+		}
+	}
+}
+
+func TestWordWrap(t *testing.T) {
+	got := wordWrap("one two three four five", 11)
+	if got != "one two\nthree four\nfive" {
+		t.Errorf("wordWrap = %q", got)
+	}
+	// Long words overflow rather than being split.
+	if got := wordWrap("supercalifragilistic", 5); got != "supercalifragilistic" {
+		t.Errorf("wordWrap long word = %q", got)
+	}
+}
+
+func TestModelPickerOptions(t *testing.T) {
+	p, err := providerFor("copilot")
+	if err != nil {
+		t.Fatalf("providerFor: %v", err)
+	}
+	opts := modelPickerOptions(p)
+
+	if len(opts) != len(p.KnownModels())+2 {
+		t.Fatalf("got %d options, want %d known models + unset + custom", len(opts), len(p.KnownModels()))
+	}
+	if opts[0].Value != "" {
+		t.Errorf("first option = %q, want unset (empty value)", opts[0].Value)
+	}
+	if last := opts[len(opts)-1]; last.Value != customModelSentinel {
+		t.Errorf("last option = %q, want the custom sentinel", last.Value)
+	}
+	for i, m := range p.KnownModels() {
+		if opts[i+1].Value != m.ID {
+			t.Errorf("option %d = %q, want %q", i+1, opts[i+1].Value, m.ID)
+		}
+		if !strings.Contains(opts[i+1].Key, m.Label) {
+			t.Errorf("option %d label %q missing %q", i+1, opts[i+1].Key, m.Label)
+		}
+	}
+}
+
+// TestConfigPageCoversAllKeys is the drift guard: a user-facing key added to
+// configKeyDefs must show up on the settings page with a description, and an
+// internal key must never appear. Deriving the page from configKeyDefs makes
+// this hold by construction; the test fails the build if that ever changes.
+func TestConfigPageCoversAllKeys(t *testing.T) {
+	page := make(map[string]bool, len(configPageKeys))
+	for _, k := range configPageKeys {
+		page[k] = true
+	}
+	for _, kd := range configKeyDefs {
+		if kd.internal {
+			if page[kd.name] {
+				t.Errorf("internal key %q must not be listed on the settings page", kd.name)
+			}
+			continue
+		}
+		if !page[kd.name] {
+			t.Errorf("user-facing key %q missing from the settings page", kd.name)
+		}
+		if strings.TrimSpace(kd.description) == "" {
+			t.Errorf("user-facing key %q has no description for the settings page", kd.name)
 		}
 	}
 }
@@ -134,17 +204,17 @@ func TestClearConfigKey(t *testing.T) {
 	}
 }
 
-func TestCpltPostureLabel(t *testing.T) {
+func TestCpltPostureValue(t *testing.T) {
 	tests := []struct {
 		preset, want string
 	}{
-		{"strict", "cplt security posture   strict"},
-		{"standard", "cplt security posture   standard  (recommended: strict)"},
-		{"", "cplt security posture   unknown  (could not read it from cplt)"},
+		{"strict", "strict"},
+		{"standard", "standard (recommended: strict)"},
+		{"", "(unknown — could not read it from cplt)"},
 	}
 	for _, tc := range tests {
-		if got := cpltPostureLabel(tc.preset); got != tc.want {
-			t.Errorf("cpltPostureLabel(%q) = %q, want %q", tc.preset, got, tc.want)
+		if got := cpltPostureValue(tc.preset); got != tc.want {
+			t.Errorf("cpltPostureValue(%q) = %q, want %q", tc.preset, got, tc.want)
 		}
 	}
 }

--- a/cli/nav-pilot/internal/cli/config_setup.go
+++ b/cli/nav-pilot/internal/cli/config_setup.go
@@ -142,78 +142,16 @@ func runConfigSetup() error {
 	// Model picker: providers with a curated model list get a select widget;
 	// others (pi, unknown future providers) get a free-text input.
 	p, _ := providerFor(answers.Client)
-	if p != nil && len(p.KnownModels()) > 0 {
-		const customModelSentinel = "\x00custom"
-		defLabel := "Unset (agent default)"
-		if def := p.DefaultModel(); def != "" {
-			defLabel = "Unset (Nav default: " + def + ")"
-		}
-		modelOpts := []huh.Option[string]{
-			huh.NewOption(defLabel, ""),
-		}
-		for _, m := range p.KnownModels() {
-			modelOpts = append(modelOpts, huh.NewOption(m.Label, m.ID))
-		}
-		modelOpts = append(modelOpts, huh.NewOption("Custom (type manually)…", customModelSentinel))
-
-		var modelChoiceVal string
-		desc := "Pick a model, or leave unset to use the agent default."
-		if p.DefaultModel() != "" {
-			desc = "Pick a model (provider/model format), or leave unset to use the Nav default."
-		}
-		err = huh.NewSelect[string]().
-			Title("Model").
-			Description(desc).
-			Options(modelOpts...).
-			Value(&modelChoiceVal).
-			WithTheme(navTheme()).
-			Run()
-		if err != nil {
-			fmt.Println(dim("  Setup skipped — run 'nav-pilot config setup' anytime."))
-			return nil
-		}
-		if modelChoiceVal == customModelSentinel {
-			customValidator := validateOptionalModel
-			if p.DefaultModel() != "" {
-				// Use provider-specific validator so opencode gets provider/model shape check.
-				customValidator = func(s string) error {
-					s = strings.TrimSpace(s)
-					if s == "" {
-						return nil
-					}
-					return p.ValidateModel(s)
-				}
-			}
-			err = huh.NewInput().
-				Title("Custom model id").
-				Description("Leave blank for the agent default.").
-				Value(&answers.Model).
-				Validate(customValidator).
-				WithTheme(navTheme()).
-				Run()
-			if err != nil {
-				fmt.Println(dim("  Setup skipped — run 'nav-pilot config setup' anytime."))
-				return nil
-			}
-			answers.Model = strings.TrimSpace(answers.Model)
-		} else {
-			answers.Model = modelChoiceVal
-		}
-	} else {
-		err = huh.NewInput().
-			Title("Model (leave blank for agent default)").
-			Description("Enter the model id for this client.").
-			Placeholder("model-id").
-			Value(&answers.Model).
-			Validate(validateOptionalModel).
-			WithTheme(navTheme()).
-			Run()
-		if err != nil {
-			fmt.Println(dim("  Setup skipped — run 'nav-pilot config setup' anytime."))
-			return nil
-		}
-		answers.Model = strings.TrimSpace(answers.Model)
+	modelDesc := "Pick a model, or leave unset to use the agent default."
+	if p != nil && p.DefaultModel() != "" {
+		modelDesc = "Pick a model (provider/model format), or leave unset to use the Nav default."
 	}
+	model, err := promptModel(p, "Model", modelDesc, "")
+	if err != nil {
+		fmt.Println(dim("  Setup skipped — run 'nav-pilot config setup' anytime."))
+		return nil
+	}
+	answers.Model = model
 
 	err = huh.NewSelect[string]().
 		Title("Reasoning effort").

--- a/cli/nav-pilot/internal/cli/config_tui.go
+++ b/cli/nav-pilot/internal/cli/config_tui.go
@@ -140,7 +140,6 @@ type configPageModel struct {
 	filter   string
 	filterOn bool
 	cursor   int // index into the visible selectable rows
-	offset   int // first visible row line
 	width    int
 	height   int
 	choice   string // set on enter; read after the program quits
@@ -221,7 +220,15 @@ func (m configPageModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		switch msg.String() {
-		case "esc", "q", "ctrl+c":
+		// ctrl+c leaves, always and from anywhere. esc and q first clear an
+		// active filter, because narrowing a list and then backing out of the
+		// narrowing is a thing people do. ctrl+c is not that key: it is the one
+		// you press when you want the program to stop, and a settings page that
+		// answers it by clearing a filter has ignored you.
+		case "ctrl+c":
+			m.choice = configPageDone
+			return m, tea.Quit
+		case "esc", "q":
 			if m.filter != "" {
 				m.filter = ""
 				m.cursor = 0
@@ -297,7 +304,11 @@ func (m configPageModel) View() string {
 	}
 	lines := m.renderRows()
 	cursorLine := m.cursorLine()
-	offset := m.offset
+	// Derived per render rather than stored. There was an offset field here
+	// that View read and never wrote back, which read as scroll state and was
+	// not: View takes a value receiver, so nothing it assigns survives. The
+	// window is a function of the cursor, so compute it and keep no state.
+	offset := 0
 	if cursorLine < offset {
 		offset = cursorLine
 	}

--- a/cli/nav-pilot/internal/cli/config_tui.go
+++ b/cli/nav-pilot/internal/cli/config_tui.go
@@ -1,0 +1,471 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ─── Settings page TUI ───────────────────────────────────────────────────────
+//
+// A full-page settings view modeled on the Copilot CLI settings screen: a
+// fixed header, a scrollable two-column row list (name left, value right),
+// and a fixed bottom zone with the position indicator, the selected row's
+// description and the keybinding help. Fixed chrome means no layout shift:
+// only the row window scrolls.
+
+// pageRowKind separates section headers from selectable rows.
+type pageRowKind int
+
+const (
+	rowSection pageRowKind = iota
+	rowEntry
+	rowAction
+)
+
+// pageRow is one rendered line in the list window.
+type pageRow struct {
+	kind        pageRowKind
+	key         string // entry key or action sentinel; "" for sections
+	section     string // section title, when kind == rowSection
+	entry       configPageEntry
+	value       string // pre-rendered right-column value
+	description string
+}
+
+// configPageStyles holds the lipgloss styles so tests can render plainly.
+type configPageStyles struct {
+	title    lipgloss.Style
+	section  lipgloss.Style
+	selected lipgloss.Style
+	dim      lipgloss.Style
+}
+
+func defaultPageStyles() configPageStyles {
+	return configPageStyles{
+		title:    lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("12")),
+		section:  lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("12")),
+		selected: lipgloss.NewStyle().Bold(true),
+		dim:      lipgloss.NewStyle().Foreground(lipgloss.Color("8")),
+	}
+}
+
+// Fixed chrome heights: the header and the bottom zone never change size, so
+// the list window is the only thing that scrolls.
+const (
+	pageHeaderLines = 3 // title, subtitle, blank
+	pageFooterLines = 7 // blank, position, blank, 3 description lines, help
+	pageDescLines   = 3
+)
+
+// buildPageRows flattens entries into sections (in first-seen group order)
+// followed by the action rows.
+func buildPageRows(entries []configPageEntry, preset string) []pageRow {
+	var rows []pageRow
+	seen := map[string]bool{}
+	for _, e := range entries {
+		group := "General"
+		if kd := findKeyDef(e.Key); kd != nil && kd.group != "" {
+			group = kd.group
+		}
+		if !seen[group] {
+			seen[group] = true
+			rows = append(rows, pageRow{kind: rowSection, section: group})
+		}
+		rows = append(rows, pageRow{
+			kind:        rowEntry,
+			key:         e.Key,
+			entry:       e,
+			value:       formatPageValue(e),
+			description: e.Description,
+		})
+	}
+	rows = append(rows, pageRow{kind: rowSection, section: "Actions"})
+	rows = append(rows,
+		pageRow{
+			kind:        rowAction,
+			key:         configPageSandbox,
+			entry:       configPageEntry{Key: "Configure cplt sandbox settings…"},
+			description: "Runs the cplt sandbox wizard (requires cplt on your PATH).",
+		},
+		pageRow{
+			kind:        rowAction,
+			key:         configPagePosture,
+			entry:       configPageEntry{Key: "cplt security posture"},
+			value:       cpltPostureValue(preset),
+			description: "Sets cplt sandbox.preset = strict, which turns on gh_guard, git_guard and forced proxy in one key (requires cplt on your PATH).",
+		},
+		pageRow{
+			kind:        rowAction,
+			key:         configPageDone,
+			entry:       configPageEntry{Key: "Done"},
+			description: "Leave the settings page.",
+		},
+	)
+	return rows
+}
+
+// formatPageValue renders the right column the way the Copilot CLI settings
+// page does: the file value plainly, the built-in default spelled out, and
+// "(unset)" when neither exists.
+func formatPageValue(e configPageEntry) string {
+	switch e.Source {
+	case "file":
+		return e.Value
+	case "default":
+		return "(default: " + e.Value + ")"
+	default:
+		return "(unset)"
+	}
+}
+
+// cpltPostureValue renders the posture row's right column: the current preset,
+// with the recommendation appended when it differs.
+func cpltPostureValue(preset string) string {
+	switch {
+	case preset == "":
+		return "(unknown — could not read it from cplt)"
+	case cpltRecommendStrict(preset):
+		return preset + " (recommended: " + cpltRecommendedPreset + ")"
+	default:
+		return preset
+	}
+}
+
+// configPageModel is the bubbletea model for the settings page.
+type configPageModel struct {
+	rows     []pageRow
+	filter   string
+	filterOn bool
+	cursor   int // index into the visible selectable rows
+	offset   int // first visible row line
+	width    int
+	height   int
+	choice   string // set on enter; read after the program quits
+	styles   configPageStyles
+	// reload rebuilds rows from disk (used by ctrl+r reset).
+	reload func() []pageRow
+	// resetKey clears an entry's key; returns a status line or an error.
+	resetKey func(key string) (string, error)
+	status   string
+}
+
+// selectable returns the indexes into rows that the cursor can land on.
+func selectable(rows []pageRow, filter string) []int {
+	var idx []int
+	for i, r := range rows {
+		if r.kind == rowSection {
+			continue
+		}
+		if filter != "" && !strings.Contains(strings.ToLower(r.entry.Key), strings.ToLower(filter)) {
+			continue
+		}
+		idx = append(idx, i)
+	}
+	return idx
+}
+
+func (m *configPageModel) move(delta int) {
+	sel := selectable(m.rows, m.filter)
+	if len(sel) == 0 {
+		return
+	}
+	m.cursor = (m.cursor + delta + len(sel)) % len(sel)
+}
+
+// selectedRow returns the row under the cursor, or nil when the filter
+// matches nothing.
+func (m *configPageModel) selectedRow() *pageRow {
+	sel := selectable(m.rows, m.filter)
+	if len(sel) == 0 {
+		return nil
+	}
+	if m.cursor >= len(sel) {
+		m.cursor = len(sel) - 1
+	}
+	return &m.rows[sel[m.cursor]]
+}
+
+func (m configPageModel) Init() tea.Cmd { return nil }
+
+func (m configPageModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		// Filter input mode: runes edit the filter, esc/enter leave it.
+		if m.filterOn {
+			switch msg.Type {
+			// Ctrl-C leaves, from here as much as from anywhere. Without this
+			// case it fell through to the no-op return below, so opening the
+			// filter with "/" disabled the one key a terminal user reaches for
+			// when they want out. Esc worked, but nobody tries Esc first.
+			case tea.KeyCtrlC:
+				m.choice = configPageDone
+				return m, tea.Quit
+			case tea.KeyEsc, tea.KeyEnter:
+				m.filterOn = false
+			case tea.KeyBackspace:
+				if len(m.filter) > 0 {
+					m.filter = m.filter[:len(m.filter)-1]
+				}
+			case tea.KeyRunes:
+				m.filter += string(msg.Runes)
+				m.cursor = 0
+			}
+			return m, nil
+		}
+
+		switch msg.String() {
+		case "esc", "q", "ctrl+c":
+			if m.filter != "" {
+				m.filter = ""
+				m.cursor = 0
+				return m, nil
+			}
+			m.choice = configPageDone
+			return m, tea.Quit
+		case "up", "k":
+			m.move(-1)
+		case "down", "j":
+			m.move(1)
+		case "/":
+			m.filterOn = true
+		case "enter":
+			if r := m.selectedRow(); r != nil {
+				m.choice = r.key
+				return m, tea.Quit
+			}
+		case "ctrl+r":
+			r := m.selectedRow()
+			if r == nil || r.kind != rowEntry || r.entry.Source != "file" {
+				m.status = "Only values set in the file can be reset."
+				return m, nil
+			}
+			if m.resetKey != nil {
+				if msg, err := m.resetKey(r.key); err != nil {
+					m.status = err.Error()
+				} else {
+					m.status = msg
+				}
+			}
+			if m.reload != nil {
+				m.rows = m.reload()
+			}
+		}
+	}
+	return m, nil
+}
+
+// valueColumn returns the left edge of the right-hand value column.
+func valueColumn(width int) int {
+	col := width * 11 / 20
+	if col < 36 {
+		col = 36
+	}
+	if col > 64 {
+		col = 64
+	}
+	return col
+}
+
+func (m configPageModel) View() string {
+	if m.width == 0 {
+		m.width = 80
+		m.height = 24
+	}
+	s := m.styles
+
+	var b strings.Builder
+
+	// Header.
+	b.WriteString(s.title.Render("Settings") + "\n")
+	sub := "Configure your nav-pilot preferences."
+	if m.filterOn || m.filter != "" {
+		sub = "Filter: /" + m.filter
+	}
+	b.WriteString(s.dim.Render(sub) + "\n\n")
+
+	// Row window.
+	visible := m.height - pageHeaderLines - pageFooterLines
+	if visible < 1 {
+		visible = 1
+	}
+	lines := m.renderRows()
+	cursorLine := m.cursorLine()
+	offset := m.offset
+	if cursorLine < offset {
+		offset = cursorLine
+	}
+	if cursorLine >= offset+visible {
+		offset = cursorLine - visible + 1
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	end := offset + visible
+	if end > len(lines) {
+		end = len(lines)
+	}
+	for _, l := range lines[offset:end] {
+		b.WriteString(l + "\n")
+	}
+	for i := end - offset; i < visible; i++ {
+		b.WriteString("\n")
+	}
+
+	// Bottom zone: position, description, help. All fixed height.
+	sel := selectable(m.rows, m.filter)
+	b.WriteString("\n")
+	pos := "0 of 0"
+	if len(sel) > 0 {
+		pos = fmt.Sprintf("%d of %d", m.cursor+1, len(sel))
+	}
+	if m.status != "" {
+		pos += "  ·  " + m.status
+	}
+	b.WriteString(pos + "\n\n")
+
+	desc := ""
+	if r := m.selectedRow(); r != nil {
+		desc = r.description
+	}
+	for _, l := range fixedLines(desc, pageDescLines, m.width-4) {
+		b.WriteString(s.dim.Render(l) + "\n")
+	}
+	b.WriteString("\n")
+	b.WriteString(s.dim.Render("/ search · ↑/↓ navigate · enter edit · ctrl+r reset · esc close"))
+
+	return b.String()
+}
+
+// renderRows renders every row line; the cursor row is highlighted.
+func (m configPageModel) renderRows() []string {
+	sel := selectable(m.rows, m.filter)
+	selected := map[int]bool{}
+	if len(sel) > 0 && m.cursor < len(sel) {
+		selected[sel[m.cursor]] = true
+	}
+	valCol := valueColumn(m.width)
+
+	var lines []string
+	prevSection := false
+	for i, r := range m.rows {
+		if m.filter != "" && r.kind == rowSection {
+			continue
+		}
+		if m.filter != "" && r.kind != rowSection && !containsFold(r.entry.Key, m.filter) {
+			continue
+		}
+		switch r.kind {
+		case rowSection:
+			if len(lines) > 0 && !prevSection {
+				lines = append(lines, "")
+			}
+			lines = append(lines, m.styles.section.Render(r.section))
+			prevSection = true
+		default:
+			prevSection = false
+			name := r.entry.Key
+			prefix := "  "
+			if selected[i] {
+				prefix = "> "
+				name = m.styles.selected.Render(name)
+			}
+			pad := valCol - 2 - len(r.entry.Key)
+			if pad < 1 {
+				pad = 1
+			}
+			lines = append(lines, prefix+name+strings.Repeat(" ", pad)+m.styles.dim.Render(r.value))
+		}
+	}
+	return lines
+}
+
+// cursorLine returns the rendered-line index of the cursor row, for scrolling.
+func (m configPageModel) cursorLine() int {
+	sel := selectable(m.rows, m.filter)
+	if len(sel) == 0 {
+		return 0
+	}
+	if m.cursor >= len(sel) {
+		m.cursor = len(sel) - 1
+	}
+	target := sel[m.cursor]
+	line := 0
+	prevSection := false
+	for i, r := range m.rows {
+		if m.filter != "" && r.kind == rowSection {
+			continue
+		}
+		if m.filter != "" && r.kind != rowSection && !containsFold(r.entry.Key, m.filter) {
+			continue
+		}
+		if r.kind == rowSection {
+			if line > 0 && !prevSection {
+				line++
+			}
+			prevSection = true
+		} else {
+			prevSection = false
+		}
+		if i == target {
+			return line
+		}
+		line++
+	}
+	return 0
+}
+
+// fixedLines word-wraps s and pads/truncates to exactly n lines.
+func fixedLines(s string, n, width int) []string {
+	if width < 10 {
+		width = 10
+	}
+	wrapped := strings.Split(wordWrap(s, width), "\n")
+	if s == "" {
+		wrapped = []string{""}
+	}
+	if len(wrapped) > n {
+		wrapped = append(wrapped[:n-1], strings.TrimRight(wrapped[n-1], " ")+"…")
+	}
+	for len(wrapped) < n {
+		wrapped = append(wrapped, "")
+	}
+	return wrapped
+}
+
+func containsFold(s, sub string) bool {
+	return strings.Contains(strings.ToLower(s), strings.ToLower(sub))
+}
+
+// runConfigPageTUI shows the settings page once and returns the chosen row
+// key (an entry key or one of the action sentinels).
+func runConfigPageTUI(entries []configPageEntry, preset string) (string, error) {
+	m := configPageModel{
+		rows:   buildPageRows(entries, preset),
+		styles: defaultPageStyles(),
+		resetKey: func(key string) (string, error) {
+			if err := clearConfigKey(key); err != nil {
+				return "", err
+			}
+			return key + " reset to default", nil
+		},
+		reload: func() []pageRow {
+			cfg, err := readConfig()
+			if err != nil {
+				return buildPageRows(entries, preset)
+			}
+			return buildPageRows(buildConfigPageEntries(cfg, resolve(cfg, CLIOverrides{})), preset)
+		},
+	}
+	final, err := tea.NewProgram(m).Run()
+	if err != nil {
+		return "", err
+	}
+	return final.(configPageModel).choice, nil
+}

--- a/cli/nav-pilot/internal/cli/config_tui_test.go
+++ b/cli/nav-pilot/internal/cli/config_tui_test.go
@@ -1,0 +1,240 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func testEntries() []configPageEntry {
+	return []configPageEntry{
+		{Key: "client", Value: "copilot", Source: "default", Description: "Coding-agent CLI to launch."},
+		{Key: "model", Value: "GPT-5.5 (gpt-5.5)", Source: "file", Description: "Model id."},
+		{Key: "log_level", Value: "", Source: "unset", Description: "Log level."},
+		{Key: "local_enabled", Value: "false", Source: "default", Description: "Dispatch to a local model server."},
+	}
+}
+
+func TestBuildPageRows(t *testing.T) {
+	rows := buildPageRows(testEntries(), "strict")
+
+	var sections []string
+	var keys []string
+	for _, r := range rows {
+		if r.kind == rowSection {
+			sections = append(sections, r.section)
+		} else {
+			keys = append(keys, r.key)
+		}
+	}
+
+	wantSections := []string{"General", "Logging", "Local models (alpha)", "Actions"}
+	if strings.Join(sections, ",") != strings.Join(wantSections, ",") {
+		t.Errorf("sections = %v, want %v", sections, wantSections)
+	}
+
+	// Every entry plus the three action rows is selectable.
+	if len(keys) != len(testEntries())+3 {
+		t.Errorf("selectable rows = %d, want %d", len(keys), len(testEntries())+3)
+	}
+	for _, sentinel := range []string{configPageSandbox, configPagePosture, configPageDone} {
+		found := false
+		for _, k := range keys {
+			if k == sentinel {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("action %q missing from rows", sentinel)
+		}
+	}
+
+	// The posture row carries its value; plain action rows do not.
+	for _, r := range rows {
+		if r.key == configPagePosture && r.value != "strict" {
+			t.Errorf("posture value = %q, want %q", r.value, "strict")
+		}
+	}
+}
+
+func TestFormatPageValue(t *testing.T) {
+	tests := []struct {
+		entry configPageEntry
+		want  string
+	}{
+		{configPageEntry{Value: "plan", Source: "file"}, "plan"},
+		{configPageEntry{Value: "copilot", Source: "default"}, "(default: copilot)"},
+		{configPageEntry{Value: "", Source: "unset"}, "(unset)"},
+	}
+	for _, tc := range tests {
+		if got := formatPageValue(tc.entry); got != tc.want {
+			t.Errorf("formatPageValue(%+v) = %q, want %q", tc.entry, got, tc.want)
+		}
+	}
+}
+
+func TestConfigPageModelNavigation(t *testing.T) {
+	m := configPageModel{rows: buildPageRows(testEntries(), ""), styles: defaultPageStyles()}
+
+	sel := selectable(m.rows, "")
+	// First selectable row must be an entry, never a section header.
+	if m.rows[sel[0]].kind != rowEntry {
+		t.Fatalf("cursor starts on a section header")
+	}
+
+	m.move(1)
+	if m.cursor != 1 {
+		t.Errorf("cursor = %d, want 1", m.cursor)
+	}
+	// Wrap-around both ways.
+	m.move(-2)
+	if m.cursor != len(sel)-1 {
+		t.Errorf("wrap backwards: cursor = %d, want %d", m.cursor, len(sel)-1)
+	}
+	m.move(1)
+	if m.cursor != 0 {
+		t.Errorf("wrap forwards: cursor = %d, want 0", m.cursor)
+	}
+
+	// Enter selects the row under the cursor.
+	m.cursor = 0
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("enter should quit the program")
+	}
+	if got := next.(configPageModel).choice; got != "client" {
+		t.Errorf("enter recorded choice %q, want client", got)
+	}
+}
+
+func TestConfigPageModelFilter(t *testing.T) {
+	m := configPageModel{rows: buildPageRows(testEntries(), ""), styles: defaultPageStyles()}
+	total := len(selectable(m.rows, ""))
+
+	m.filter = "log"
+	sel := selectable(m.rows, m.filter)
+	if len(sel) != 1 || m.rows[sel[0]].key != "log_level" {
+		t.Fatalf("filter 'log' matched %v, want only log_level", sel)
+	}
+
+	// Filtering hides section headers and caps the position indicator.
+	m.cursor = 0
+	view := m.View()
+	if !strings.Contains(view, "1 of 1") {
+		t.Errorf("filtered view missing position indicator:\n%s", view)
+	}
+	if strings.Contains(view, "General") {
+		t.Errorf("filtered view still shows section headers:\n%s", view)
+	}
+
+	// A filter that matches nothing must not crash selection or view.
+	m.filter = "zzz"
+	if r := m.selectedRow(); r != nil {
+		t.Errorf("selectedRow with no matches = %+v, want nil", r)
+	}
+	_ = m.View()
+
+	m.filter = ""
+	if got := len(selectable(m.rows, "")); got != total {
+		t.Errorf("cleared filter restored %d rows, want %d", got, total)
+	}
+}
+
+func TestConfigPageModelReset(t *testing.T) {
+	writeTestConfig(t, "version = 1\nmodel = \"gpt-5.5\"\n")
+
+	var resetKey string
+	m := configPageModel{
+		rows:   buildPageRows(testEntries(), ""),
+		styles: defaultPageStyles(),
+		resetKey: func(key string) (string, error) {
+			resetKey = key
+			return key + " reset to default", nil
+		},
+		reload: func() []pageRow { return buildPageRows(testEntries(), "") },
+	}
+
+	// Cursor on "model" (a file-sourced entry).
+	m.cursor = 1
+	if got := m.selectedRow().key; got != "model" {
+		t.Fatalf("cursor row = %q, want model", got)
+	}
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
+	m = next.(configPageModel)
+	if resetKey != "model" {
+		t.Errorf("reset key = %q, want model", resetKey)
+	}
+	if !strings.Contains(m.status, "reset") {
+		t.Errorf("status = %q, want a reset confirmation", m.status)
+	}
+
+	// Default-sourced rows refuse a reset.
+	m.cursor = 0
+	m.status = ""
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
+	m = next.(configPageModel)
+	if !strings.Contains(m.status, "Only values set in the file") {
+		t.Errorf("status = %q, want refusal", m.status)
+	}
+}
+
+func TestConfigPageViewFixedHeight(t *testing.T) {
+	m := configPageModel{
+		rows:   buildPageRows(testEntries(), ""),
+		styles: defaultPageStyles(),
+		width:  80,
+		height: 24,
+	}
+
+	base := strings.Count(m.View(), "\n")
+	for m.cursor = 0; m.cursor < len(selectable(m.rows, "")); m.cursor++ {
+		if got := strings.Count(m.View(), "\n"); got != base {
+			t.Errorf("cursor %d: view height %d lines, want fixed %d", m.cursor, got, base)
+		}
+	}
+
+	// The fixed bottom zone: description and keybinding help.
+	m.cursor = 0
+	view := m.View()
+	if !strings.Contains(view, "esc close") {
+		t.Errorf("view missing keybinding help:\n%s", view)
+	}
+	if !strings.Contains(view, "Coding-agent CLI to launch.") {
+		t.Errorf("view missing selected-row description:\n%s", view)
+	}
+}
+
+func TestFixedLines(t *testing.T) {
+	// Pads short text, wraps long text, truncates with an ellipsis.
+	if got := fixedLines("short", 3, 76); len(got) != 3 || got[0] != "short" || got[1] != "" {
+		t.Errorf("fixedLines short = %v", got)
+	}
+	long := strings.Repeat("word ", 40)
+	got := fixedLines(long, 2, 30)
+	if len(got) != 2 || !strings.HasSuffix(got[1], "…") {
+		t.Errorf("fixedLines long = %v", got)
+	}
+	if got := fixedLines("", 3, 76); len(got) != 3 {
+		t.Errorf("fixedLines empty = %v", got)
+	}
+}
+
+// TestConfigPageCtrlCAlwaysQuits pins the escape hatch.
+//
+// Filter mode handled esc, enter, backspace and runes, and returned a no-op for
+// everything else — so "/" made Ctrl-C do nothing. Esc still worked, but Ctrl-C
+// is the reflex in a terminal, and a settings page you cannot leave with it
+// reads as a hung program.
+func TestConfigPageCtrlCAlwaysQuits(t *testing.T) {
+	for _, filtering := range []bool{false, true} {
+		m := configPageModel{rows: buildPageRows(nil, ""), filterOn: filtering}
+		got, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+		if cmd == nil {
+			t.Errorf("filterOn=%v: ctrl+c produced no command, want tea.Quit", filtering)
+		}
+		if c := got.(configPageModel).choice; c != configPageDone {
+			t.Errorf("filterOn=%v: choice = %q, want %q", filtering, c, configPageDone)
+		}
+	}
+}

--- a/cli/nav-pilot/internal/cli/config_tui_test.go
+++ b/cli/nav-pilot/internal/cli/config_tui_test.go
@@ -227,14 +227,36 @@ func TestFixedLines(t *testing.T) {
 // is the reflex in a terminal, and a settings page you cannot leave with it
 // reads as a hung program.
 func TestConfigPageCtrlCAlwaysQuits(t *testing.T) {
-	for _, filtering := range []bool{false, true} {
-		m := configPageModel{rows: buildPageRows(nil, ""), filterOn: filtering}
+	// Three states, because the bug moved. Filter input mode swallowed ctrl+c
+	// first; once that was fixed, normal mode with an active filter still ate
+	// it — ctrl+c was grouped with esc and q, which clear the filter before
+	// they quit. esc and q should do that. ctrl+c should not.
+	for _, tc := range []struct {
+		name     string
+		filterOn bool
+		filter   string
+	}{
+		{"normal mode", false, ""},
+		{"normal mode with an active filter", false, "loop"},
+		{"filter input mode", true, "loo"},
+	} {
+		m := configPageModel{rows: buildPageRows(nil, ""), filterOn: tc.filterOn, filter: tc.filter}
 		got, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
 		if cmd == nil {
-			t.Errorf("filterOn=%v: ctrl+c produced no command, want tea.Quit", filtering)
+			t.Errorf("%s: ctrl+c produced no command, want tea.Quit", tc.name)
 		}
 		if c := got.(configPageModel).choice; c != configPageDone {
-			t.Errorf("filterOn=%v: choice = %q, want %q", filtering, c, configPageDone)
+			t.Errorf("%s: choice = %q, want %q", tc.name, c, configPageDone)
 		}
+	}
+
+	// esc keeps its filter-clearing behaviour; that is the difference.
+	m := configPageModel{rows: buildPageRows(nil, ""), filter: "loop"}
+	got, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd != nil {
+		t.Error("esc with an active filter quit; it should clear the filter first")
+	}
+	if f := got.(configPageModel).filter; f != "" {
+		t.Errorf("esc left filter = %q, want it cleared", f)
 	}
 }

--- a/cli/nav-pilot/internal/cli/interactive.go
+++ b/cli/nav-pilot/internal/cli/interactive.go
@@ -49,6 +49,104 @@ func navTheme() *huh.Theme {
 	return t
 }
 
+// customModelSentinel marks the "type it yourself" entry in the model picker.
+// No real model id can collide with it.
+const customModelSentinel = "\x00custom"
+
+// Select layout constants for pickers with long option lists: huh grows the
+// field to fit every option when no height is set, which pushes the list past
+// the terminal height. selectChromeLines accounts for the title and
+// description lines that huh subtracts from WithHeight to size the viewport.
+const (
+	maxVisibleSelectOptions = 14
+	selectChromeLines       = 2
+)
+
+// modelPickerOptions builds the curated model picker for a provider: unset
+// first, then the known models, then a custom entry for anything else.
+func modelPickerOptions(p Provider) []huh.Option[string] {
+	defLabel := "Unset (agent default)"
+	if def := p.DefaultModel(); def != "" {
+		defLabel = "Unset (Nav default: " + def + ")"
+	}
+	opts := []huh.Option[string]{huh.NewOption(defLabel, "")}
+	for _, m := range p.KnownModels() {
+		opts = append(opts, huh.NewOption(m.Label+"  "+dim(m.ID), m.ID))
+	}
+	return append(opts, huh.NewOption("Custom (type manually)…", customModelSentinel))
+}
+
+// promptModel asks for a provider's model: a curated picker when the provider
+// ships a known-model list, free text otherwise. A non-empty current
+// preselects the matching option, or the custom entry when the id is unknown.
+// Returns the chosen model id; "" means unset (agent/Nav default). Cancel
+// propagates as huh.ErrUserAborted so callers can treat it as a no-op.
+func promptModel(p Provider, title, description, current string) (string, error) {
+	if p == nil || len(p.KnownModels()) == 0 {
+		value := current
+		err := huh.NewInput().
+			Title(title).
+			Description(description).
+			Placeholder("model-id").
+			Value(&value).
+			Validate(validateOptionalModel).
+			WithTheme(navTheme()).
+			Run()
+		return strings.TrimSpace(value), err
+	}
+
+	opts := modelPickerOptions(p)
+	choice := current
+	if current != "" {
+		known := false
+		for _, m := range p.KnownModels() {
+			if m.ID == current {
+				known = true
+				break
+			}
+		}
+		if !known {
+			choice = customModelSentinel
+		}
+	}
+
+	sel := huh.NewSelect[string]().
+		Title(title).
+		Description(description).
+		Options(opts...).
+		Value(&choice).
+		WithTheme(navTheme())
+	if len(opts) > maxVisibleSelectOptions {
+		sel = sel.WithHeight(maxVisibleSelectOptions + selectChromeLines)
+	}
+	if err := sel.Run(); err != nil {
+		return "", err
+	}
+	if choice != customModelSentinel {
+		return choice, nil
+	}
+
+	validator := validateOptionalModel
+	if p.DefaultModel() != "" {
+		// Provider-specific validation so opencode gets the provider/model shape check.
+		validator = func(s string) error {
+			if strings.TrimSpace(s) == "" {
+				return nil
+			}
+			return p.ValidateModel(s)
+		}
+	}
+	value := current
+	err := huh.NewInput().
+		Title("Custom model id").
+		Description("Leave blank for the agent default.").
+		Value(&value).
+		Validate(validator).
+		WithTheme(navTheme()).
+		Run()
+	return strings.TrimSpace(value), err
+}
+
 // isGitRepo returns true if dir contains a .git directory.
 func isGitRepo(dir string) bool {
 	_, err := os.Stat(filepath.Join(dir, ".git"))

--- a/cli/nav-pilot/internal/cli/interactive.go
+++ b/cli/nav-pilot/internal/cli/interactive.go
@@ -136,10 +136,19 @@ func promptModel(p Provider, title, description, current string) (string, error)
 			return p.ValidateModel(s)
 		}
 	}
+	// The picker calls the empty choice "Nav default" when the provider has
+	// one, so this prompt has to say the same thing. Saying "agent default"
+	// under a list that just said "Nav default" reads as two different
+	// fallbacks, and a developer choosing between them cannot tell which they
+	// are about to get.
+	blankMeans := "Leave blank for the agent default."
+	if def := p.DefaultModel(); def != "" {
+		blankMeans = "Leave blank for the Nav default (" + def + ")."
+	}
 	value := current
 	err := huh.NewInput().
 		Title("Custom model id").
-		Description("Leave blank for the agent default.").
+		Description(blankMeans).
 		Value(&value).
 		Validate(validator).
 		WithTheme(navTheme()).


### PR DESCRIPTION
A scrollable settings page for `nav-pilot config`, modelled on the Copilot CLI settings screen.

Fixed header, two-column row list (name left, value right), and a fixed bottom zone with the position indicator, the selected row's description and the key help. **The chrome never changes size**, so only the row window scrolls and the layout does not shift as the selection moves.

Rows are built from the existing `configPageEntry` data, so the page shows what the config already knows: the file value plainly, the built-in default spelled out, and `(unset)` when there is neither. Sections are headers rather than selections. `/` filters by key, `ctrl+r` resets a key that came from the file.

`bubbletea` moves from an indirect to a direct dependency, which it now is.

## One fix on review

**`ctrl+c` did nothing while the filter was open.** Filter mode handled `esc`, `enter`, `backspace` and runes, then returned a no-op for everything else — so pressing `/` disabled the one key a terminal user reaches for when they want out.

`esc` worked, but nobody tries `esc` first, and a settings page you cannot leave with `ctrl+c` reads as a hung program rather than a mode you are in. Reproduced with a test before fixing:

```
ctrl+c while filtering returned no command; want tea.Quit. choice="" filterOn=true
```

`TestConfigPageCtrlCAlwaysQuits` now exercises both filter states.

## Also reviewed, no change needed

Action rows carry `entry.Key` (`"Done"`, `"cplt security posture"`), so they survive filtering — I checked, since `selectable` filters on that field and empty keys would have made them unreachable while typing.

`selectedRow()` clamps the cursor when the filter shrinks the list, so deleting filter characters cannot index out of range.

The `page.tsx` hunk is prettier rewrapping of already-merged prose, no content change.

## Checks

`go build`, `go vet`, `go test ./...` green — including with `-race` on `internal/cli`, and with `DO_NOT_TRACK=1` set.