### PR TITLE
fix: a manifest must not choose which binary nav-pilot starts

### DIFF
--- a/cli/nav-pilot/internal/local/local.go
+++ b/cli/nav-pilot/internal/local/local.go
@@ -97,7 +97,7 @@ var SupportedSchemaMajors = []string{"1"}
 // reports/alpha-status.md rather than implied by this list.
 var allowedPublishers = []string{"mlx-community", "lmstudio-community"}
 
-// allowedBackends is which inference server a manifest entry may ask for.
+// allowedBackends lists the inference servers a manifest entry may ask for.
 //
 // The field has shipped on every entry since the schema was written, always
 // "mlx-lm", and until now nothing read it and nothing checked it. That is a

--- a/cli/nav-pilot/internal/local/local.go
+++ b/cli/nav-pilot/internal/local/local.go
@@ -97,6 +97,22 @@ var SupportedSchemaMajors = []string{"1"}
 // reports/alpha-status.md rather than implied by this list.
 var allowedPublishers = []string{"mlx-community", "lmstudio-community"}
 
+// allowedBackends is which inference server a manifest entry may ask for.
+//
+// The field has shipped on every entry since the schema was written, always
+// "mlx-lm", and until now nothing read it and nothing checked it. That is a
+// wider hole than the publisher list it sits beside: a publisher decides which
+// weights are downloaded, a backend decides **which binary nav-pilot starts**,
+// and the manifest is fetched over the network from a repository outside this
+// one.
+//
+// So it is an allow-list, and an entry naming anything else is refused rather
+// than defaulted. Adding a backend means shipping the code that knows how to
+// launch it, which is a nav-pilot release, not a manifest edit. An empty value
+// is accepted as mlx-lm: entries predate the field being meaningful, and
+// refusing them would turn a forward-compatible schema into a breaking one.
+var allowedBackends = []string{"mlx-lm"}
+
 // allowedParamKey is the other half of that boundary. A model's Params become
 // the server process's environment verbatim ([Server.Start]), and an
 // environment variable decides things the publisher allow-list cannot see:
@@ -258,6 +274,12 @@ func (m *Manifest) checkModels() error {
 				"local-model manifest entry %q names model %q, which is not published by an allowed publisher (%s); "+
 					"the manifest names weights this machine downloads and runs, so allowing another publisher is a nav-pilot code change, not a manifest change",
 				where, model.Model, strings.Join(allowedPublishers, ", "))
+		}
+		if model.Backend != "" && !slices.Contains(allowedBackends, model.Backend) {
+			return fmt.Errorf(
+				"local-model manifest entry %q asks for backend %q, which nav-pilot does not know how to start (allowed: %s); "+
+					"the backend decides which binary runs on this machine, so adding one is a nav-pilot code change, not a manifest change",
+				where, model.Backend, strings.Join(allowedBackends, ", "))
 		}
 		// Same boundary as the publisher above: the allow-list decides which
 		// weights run, the environment decides where they come from and what

--- a/cli/nav-pilot/internal/local/local_test.go
+++ b/cli/nav-pilot/internal/local/local_test.go
@@ -484,3 +484,40 @@ func TestChosenHonoursTheConfiguredModel(t *testing.T) {
 		t.Errorf("with the default second, Chosen = %q, want org/Default", got.Model)
 	}
 }
+
+// TestManifestRefusesAnUnknownBackend closes the widest hole in the manifest
+// contract.
+//
+// The backend field shipped on every entry from the start, always "mlx-lm", and
+// nothing read it or checked it. It is a bigger boundary than the publisher
+// list beside it: a publisher decides which weights are downloaded, a backend
+// decides which binary nav-pilot starts — and the manifest comes over the
+// network from a repository outside this one.
+func TestManifestRefusesAnUnknownBackend(t *testing.T) {
+	entry := func(backend string) []byte {
+		return []byte(`{"schema_version":1,"channel":"alpha","models":[{
+			"key":"m","name":"M","model":"mlx-community/Thing-4bit","backend":"` + backend + `",
+			"default":true,"role":"r","expect":"e","weights_gb":1,"min_ram_gb":48,"wired_limit_gb":36,
+			"params":{"MLX_MODEL":"mlx-community/Thing-4bit"}}]}`)
+	}
+
+	for _, backend := range []string{"mlx-lm", ""} {
+		if _, err := Parse(entry(backend)); err != nil {
+			t.Errorf("Parse with backend %q = %v, want accepted", backend, err)
+		}
+	}
+
+	// An empty backend stays valid on purpose: entries predate the field being
+	// meaningful, and refusing them would make a forward-compatible schema
+	// breaking. Anything else is refused rather than defaulted.
+	for _, backend := range []string{"omlx", "vllm", "/bin/sh", "mlx-lm; rm -rf /"} {
+		_, err := Parse(entry(backend))
+		if err == nil {
+			t.Errorf("Parse accepted backend %q; a manifest must not choose which binary starts", backend)
+			continue
+		}
+		if !strings.Contains(err.Error(), "not a manifest change") {
+			t.Errorf("backend %q rejected with %q, want the message to say why widening it is a code change", backend, err)
+		}
+	}
+}


### PR DESCRIPTION
First phase of the oMLX backend work, and worth landing on its own merits — the hole it closes exists today, whether or not a second backend ever ships.

## The gap

`Backend string \`json:"backend"\`` has been on every manifest entry since the schema was written. It always says `"mlx-lm"`. **Nothing reads it and nothing validates it.**

That is a wider boundary than the publisher allow-list sitting right beside it:

| field | decides | validated before this PR |
|---|---|---|
| `model` publisher | which **weights** are downloaded | ✅ allow-list |
| `params` keys | the server process **environment** | ✅ `MLX_` namespace |
| `backend` | **which binary runs on the machine** | ❌ nothing |

And the manifest is fetched over the network, from `raw.githubusercontent.com/navikt/mlx-workspace`, a repository outside this one.

## The fix

`allowedBackends`, in the same shape and voice as its two neighbours, with an error that explains why widening it is a nav-pilot release rather than a manifest edit:

```
local-model manifest entry "m" asks for backend "omlx", which nav-pilot does not
know how to start (allowed: mlx-lm); the backend decides which binary runs on
this machine, so adding one is a nav-pilot code change, not a manifest change
```

**An empty backend stays valid**, deliberately. Entries predate the field meaning anything, and refusing them would turn a forward-compatible schema into a breaking one — the package doc is explicit that unknown fields are the contract's forward compatibility.

## Why the list has one entry

That is the point. The hole closes **before** anything new can pass through it. `"omlx"` goes in as the last line of the work that teaches nav-pilot to launch it, so every phase before that is shippable and inert.

`TestManifestRefusesAnUnknownBackend` covers both directions, including `"/bin/sh"` and `"mlx-lm; rm -rf /"`, and asserts the error explains itself rather than just failing.

## Checks

`go build`, `go test ./...` green, and green under `DO_NOT_TRACK=1`. The live manifest still parses — all three entries say `mlx-lm`.