### PR TITLE
docs: at five runs the default is the weaker model, and the text said otherwise

### DIFF
--- a/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
+++ b/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
@@ -2053,8 +2053,8 @@ nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først`
                     <Table.DataCell>25 GB</Table.DataCell>
                     <Table.DataCell>3–4 av 8</Table.DataCell>
                     <Table.DataCell>
-                      Rask og forutsigbar. Rundt 10 sekunder per oppgave. Over fem kjøringer løser den 3, 3, 3, 4 og
-                      4 av 8 — den svakere modellen, men den du kan stole på uten å se etter.
+                      Rask og forutsigbar. Median 9 sekunder per oppgave, og 3, 3, 3, 4 og 4 av 8 over fem kjøringer.
+                      Løser mindre enn 3.8, men svarer med én gang og gjør sjelden noe uventet.
                     </Table.DataCell>
                   </Table.Row>
                   <Table.Row>
@@ -2062,12 +2062,12 @@ nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først`
                       <code className="font-mono text-xs">Qwen3.8-27B-4bit</code>
                     </Table.DataCell>
                     <Table.DataCell>16 GB</Table.DataCell>
-                    <Table.DataCell>1–7 av 8</Table.DataCell>
+                    <Table.DataCell>5–7 av 8</Table.DataCell>
                     <Table.DataCell>
-                      Sterkere enn standard, og mye mindre pålitelig. Over fem kjøringer løser den 1, 5, 5, 6 og 7 av
-                      8 — i snitt 4,8 mot standardens 3,4, altså rundt 41 % flere oppgaver. Den er også omtrent sju
-                      ganger tregere, og timet ut 11 ganger der standarden timet ut 2. Velg den hvis du leser gjennom
-                      det den lager.
+                      Løser mer enn standard og bruker mye lengre tid på det. Fire rene kjøringer ga 5, 5, 6 og 7 av
+                      8, mot standardens 3, 3, 3, 4 og 4 — settene overlapper ikke. Omtrent sju ganger tregere, og
+                      treffer sju-minutterstaket på rundt én av fem oppgaver. En femte kjøring er holdt utenfor fordi
+                      den ikke endret en eneste fil; det var testoppsettet, ikke modellen.
                     </Table.DataCell>
                   </Table.Row>
                   <Table.Row>
@@ -2085,7 +2085,7 @@ nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først`
               </Table>
             </div>
             <BodyShort size="small" textColor="subtle">
-              Én kjøring er ikke en måling — derfor spenn og ikke median. Alle kjøringene ligger i{" "}
+              Én kjøring er ikke en måling — derfor står alle kjøringene der, ikke bare et snitt. De ligger i{" "}
               <a
                 href="https://github.com/navikt/mlx-workspace/blob/main/MODELS.md"
                 style={{ textDecoration: "underline" }}
@@ -2112,11 +2112,8 @@ nav-pilot alpha local init      # laster ned vektene for den nye modellen
 nav-pilot alpha local start`}
           </CodeBlock>
           <BodyLong size="small" textColor="subtle">
-            Qwen 3.6 er standard, og det er ikke tilfeldig. De to Qwen 3.8-modellene ligger der fordi folk spør etter
-            dem, ikke fordi de er bedre her. På våre egne oppgaver er 3.8 tregere og mye mer ujevn: to kjøringer av de
-            samme åtte oppgavene, samme profil og samme maskin, ga median 88 og 906 sekunder. 3.6 ligger på 12–21
-            sekunder uten timeouts over åtte kjøringer. Bytter du, må vektene lastes ned én gang til — 16 GB for 3.8
-            4-bit, 30 GB for 8-bit.
+            Qwen 3.6 er standard fordi den er rask og forutsigbar, ikke fordi den løser mest. Tallene står i tabellen
+            over. Bytter du, må vektene lastes ned én gang til — 16 GB for 3.8 4-bit, 30 GB for 8-bit.
           </BodyLong>
           <BodyLong size="small" textColor="subtle">
             Vil du slippe å starte serveren selv, kan en vanlig <code className="font-mono text-xs">nav-pilot</code>{" "}

--- a/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
+++ b/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
@@ -2051,10 +2051,10 @@ nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først`
                       </VStack>
                     </Table.DataCell>
                     <Table.DataCell>25 GB</Table.DataCell>
-                    <Table.DataCell>3–6 av 8</Table.DataCell>
+                    <Table.DataCell>3–4 av 8</Table.DataCell>
                     <Table.DataCell>
-                      Rask og forutsigbar. Rundt 10 sekunder per oppgave, og ingen loop i noen kjøring. Den du vil ha
-                      med mindre du har en grunn til noe annet.
+                      Rask og forutsigbar. Rundt 10 sekunder per oppgave. Over fem kjøringer løser den 3, 3, 3, 4 og
+                      4 av 8 — den svakere modellen, men den du kan stole på uten å se etter.
                     </Table.DataCell>
                   </Table.Row>
                   <Table.Row>
@@ -2062,10 +2062,12 @@ nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først`
                       <code className="font-mono text-xs">Qwen3.8-27B-4bit</code>
                     </Table.DataCell>
                     <Table.DataCell>16 GB</Table.DataCell>
-                    <Table.DataCell>1–5 av 8</Table.DataCell>
+                    <Table.DataCell>1–7 av 8</Table.DataCell>
                     <Table.DataCell>
-                      Dyktig og ujevn. Både det beste og det dårligste enkeltresultatet vi har målt, med to timer mellom
-                      seg på samme maskin. Omtrent sju ganger tregere. Verdt å prøve på arbeid du leser gjennom etterpå.
+                      Sterkere enn standard, og mye mindre pålitelig. Over fem kjøringer løser den 1, 5, 5, 6 og 7 av
+                      8 — i snitt 4,8 mot standardens 3,4, altså rundt 41 % flere oppgaver. Den er også omtrent sju
+                      ganger tregere, og timet ut 11 ganger der standarden timet ut 2. Velg den hvis du leser gjennom
+                      det den lager.
                     </Table.DataCell>
                   </Table.Row>
                   <Table.Row>

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -157,10 +157,11 @@ om en ny modell og ikke ser den, er `start` det som henter listen på nytt.
 **Qwen 3.6 er standard, og det er ikke tilfeldig.** De to Qwen 3.8-modellene ligger der
 fordi folk spør etter dem, ikke fordi de er bedre her. 3.8 er ikke svakere, den er mindre
 forutsigbar: to kjøringer av de samme åtte oppgavene, samme profil og samme maskin to timer
-fra hverandre, løste **1 av 8** og deretter **5 av 8**. Den andre er det beste enkeltresultatet
-vi har målt. 3.6 ligger på 3–6 av 8 over åtte kjøringer og er omtrent sju ganger raskere.
-Vi oppgir spenn og ikke median, fordi for en modell som spenner fra 1 til 5 av 8 beskriver
-medianen ingen kjøring som faktisk har skjedd. `nav-pilot config explain model` sier det samme kortere, og
+løste den **1, 5, 5, 6 og 7 av 8** over fem kjøringer — i snitt 4,8 mot standardens 3,4, altså
+rundt 41 % flere oppgaver. Standarden er ikke den sterkeste modellen; den er den mest
+forutsigbare, og ligger på 3–4 av 8. 3.8 er også omtrent sju ganger tregere og timet ut 11
+ganger der standarden timet ut 2. Vi oppgir spenn og ikke median, fordi for en modell som
+spenner fra 1 til 7 av 8 beskriver medianen ingen kjøring som faktisk har skjedd. `nav-pilot config explain model` sier det samme kortere, og
 [MODELS.md](https://github.com/navikt/mlx-workspace/blob/main/MODELS.md) har tallene.
 
 Bytter du modell, må vektene lastes ned én gang til — 16 GB for 3.8 4-bit, 30 GB for

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -154,14 +154,18 @@ Listen oppdateres når du kjører `init` eller `start` — ikke ved hver kommand
 et nettverkskall der ville lagt seg foran alt annet nav-pilot gjør. Har du nettopp hørt
 om en ny modell og ikke ser den, er `start` det som henter listen på nytt.
 
-**Qwen 3.6 er standard, og det er ikke tilfeldig.** De to Qwen 3.8-modellene ligger der
-fordi folk spør etter dem, ikke fordi de er bedre her. 3.8 er ikke svakere, den er mindre
-forutsigbar: to kjøringer av de samme åtte oppgavene, samme profil og samme maskin to timer
-løste den **1, 5, 5, 6 og 7 av 8** over fem kjøringer — i snitt 4,8 mot standardens 3,4, altså
-rundt 41 % flere oppgaver. Standarden er ikke den sterkeste modellen; den er den mest
-forutsigbare, og ligger på 3–4 av 8. 3.8 er også omtrent sju ganger tregere og timet ut 11
-ganger der standarden timet ut 2. Vi oppgir spenn og ikke median, fordi for en modell som
-spenner fra 1 til 7 av 8 beskriver medianen ingen kjøring som faktisk har skjedd. `nav-pilot config explain model` sier det samme kortere, og
+**Qwen 3.6 er standard fordi den er rask og forutsigbar, ikke fordi den løser mest.** Over fem
+kjøringer av de samme åtte oppgavene løser den 3, 3, 3, 4 og 4. Qwen 3.8 4-bit løser 5, 5, 6 og 7
+over fire rene kjøringer — de to settene overlapper ikke i det hele tatt. Til gjengjeld bruker 3.8
+omtrent sju ganger så lang tid, median 65 sekunder mot 9, og treffer sju-minutterstaket på rundt
+én av fem oppgaver der standarden nesten aldri gjør det.
+
+En femte 3.8-kjøring er holdt utenfor: den løste 1 av 8 uten å endre en eneste fil på noen
+oppgave, som er en feil i testoppsettet vårt og ikke i modellen. Kriteriet står skrevet ned i
+[MODELS.md](https://github.com/navikt/mlx-workspace/blob/main/MODELS.md).
+
+Valget er altså dybde mot hastighet, ikke bedre mot dårligere. `nav-pilot config explain model`
+sier det samme kortere, og
 [MODELS.md](https://github.com/navikt/mlx-workspace/blob/main/MODELS.md) har tallene.
 
 Bytter du modell, må vektene lastes ned én gang til — 16 GB for 3.8 4-bit, 30 GB for

--- a/docs/news/articles/lokale-modeller-i-nav-pilot.md
+++ b/docs/news/articles/lokale-modeller-i-nav-pilot.md
@@ -57,13 +57,15 @@ Først prøvde vi åtte modeller og bygg på det samme oppgavesettet: elleve opp
 Vi skrev først at Qwen3.8 ikke ble valgt fordi den gikk i loop. Etter å ha kjørt testene på nytt
 holder ikke den beskrivelsen, og den nye er mer interessant.
 
-To kjøringer av det samme oppgavesettet, samme maskin, to timer fra hverandre: Qwen3.8-27B 4-bit
-løste **1 av 8** i den første og **5 av 8** i den andre. Den andre er det beste enkeltresultatet
-noen modell har fått på dette settet. Qwen3.6 ligger på 3–6 av 8 over åtte kjøringer, og bruker
-omtrent en sjuendedel så lang tid.
+Fem kjøringer av det samme oppgavesettet på samme maskin: Qwen3.8-27B 4-bit løste **1, 5, 5, 6 og
+7 av 8**. I snitt 4,8 mot standardmodellens 3,4 — rundt 41 % flere oppgaver. Standarden løser 3–4
+av 8 og er omtrent sju ganger raskere.
 
-Qwen3.8 er altså ikke en svakere modell. Den er en mer uforutsigbar en. Derfor kan du velge den,
-men den er ikke standard:
+**Qwen3.8 er altså ikke en svakere modell. Den er den sterkere, og den mer upålitelige.** Den
+timet ut 11 ganger over de fem kjøringene der standarden timet ut 2, og spennet fra 1 til 7 er på
+identisk oppsett. Valget står ikke mellom bedre og dårligere, men mellom sterkere og ujevn, eller
+svakere og forutsigbar. Leser du gjennom det modellen lager, er 3.8 verdt å prøve. Vil du stole på
+den uten å se etter, behold standarden. Derfor kan du velge den, men den er ikke standard:
 
 ```bash
 nav-pilot models
@@ -73,7 +75,9 @@ nav-pilot alpha local init
 
 Det vi selv lærte av dette er verdt mer enn modellvalget: **én kjøring er ikke en måling.** Alle
 konklusjonene som snudde, snudde fordi det fantes en kjøring til — ikke fordi vi tenkte oss om en
-gang til. Tabellen over var bygget på enkeltkjøringer.
+gang til. Tabellen over var bygget på enkeltkjøringer. Denne konklusjonen snudde to ganger: først
+fra «3.8 går i loop» til «3.8 er uforutsigbar», og så ved fem kjøringer til «3.8 er den sterkeste
+modellen vi har». Vi krever nå minst fem kjøringer før et tall får styre en anbefaling.
 
 Deretter 200 kjøringer på én maskin med modellen vi valgte, fordelt på to klienter, seks oppgavetyper, tre refactor-strategier og tre kodebaser: en Ktor-app, en Spring-app og en frontend.
 

--- a/docs/news/articles/lokale-modeller-i-nav-pilot.md
+++ b/docs/news/articles/lokale-modeller-i-nav-pilot.md
@@ -57,15 +57,18 @@ Først prøvde vi åtte modeller og bygg på det samme oppgavesettet: elleve opp
 Vi skrev først at Qwen3.8 ikke ble valgt fordi den gikk i loop. Etter å ha kjørt testene på nytt
 holder ikke den beskrivelsen, og den nye er mer interessant.
 
-Fem kjøringer av det samme oppgavesettet på samme maskin: Qwen3.8-27B 4-bit løste **1, 5, 5, 6 og
-7 av 8**. I snitt 4,8 mot standardmodellens 3,4 — rundt 41 % flere oppgaver. Standarden løser 3–4
-av 8 og er omtrent sju ganger raskere.
+Fire rene kjøringer av det samme oppgavesettet på samme maskin: Qwen3.8-27B 4-bit løste **5, 5, 6
+og 7 av 8**, mot standardmodellens **3, 3, 3, 4 og 4** over fem. De to settene overlapper ikke i
+det hele tatt.
 
-**Qwen3.8 er altså ikke en svakere modell. Den er den sterkere, og den mer upålitelige.** Den
-timet ut 11 ganger over de fem kjøringene der standarden timet ut 2, og spennet fra 1 til 7 er på
-identisk oppsett. Valget står ikke mellom bedre og dårligere, men mellom sterkere og ujevn, eller
-svakere og forutsigbar. Leser du gjennom det modellen lager, er 3.8 verdt å prøve. Vil du stole på
-den uten å se etter, behold standarden. Derfor kan du velge den, men den er ikke standard:
+**Qwen3.8 er altså ikke en svakere modell — den løser mer.** Til gjengjeld bruker den omtrent sju
+ganger så lang tid, median 65 sekunder mot 9, og treffer sju-minutterstaket på rundt én av fem
+oppgaver der standarden nesten aldri gjør det. En femte kjøring er holdt utenfor: den løste 1 av 8
+uten å endre en eneste fil på noen oppgave, som er en feil i testoppsettet vårt og ikke i
+modellen.
+
+Valget står altså mellom dybde og hastighet. Leser du gjennom det modellen lager og kan vente, er
+3.8 verdt å prøve. Vil du ha svar på ti sekunder, behold standarden:
 
 ```bash
 nav-pilot models
@@ -75,9 +78,10 @@ nav-pilot alpha local init
 
 Det vi selv lærte av dette er verdt mer enn modellvalget: **én kjøring er ikke en måling.** Alle
 konklusjonene som snudde, snudde fordi det fantes en kjøring til — ikke fordi vi tenkte oss om en
-gang til. Tabellen over var bygget på enkeltkjøringer. Denne konklusjonen snudde to ganger: først
-fra «3.8 går i loop» til «3.8 er uforutsigbar», og så ved fem kjøringer til «3.8 er den sterkeste
-modellen vi har». Vi krever nå minst fem kjøringer før et tall får styre en anbefaling.
+gang til. Tabellen over var bygget på enkeltkjøringer. Denne konklusjonen snudde tre ganger: fra
+«3.8 går i loop», til «3.8 er uforutsigbar», til «3.8 løser mer enn standarden». Den siste snuen
+kom av at én kjøring viste seg å være en feil i testoppsettet og ikke i modellen. Vi krever nå
+minst fem kjøringer før et tall får styre en anbefaling.
 
 Deretter 200 kjøringer på én maskin med modellen vi valgte, fordelt på to klienter, seks oppgavetyper, tre refactor-strategier og tre kodebaser: en Ktor-app, en Spring-app og en frontend.
 


### PR DESCRIPTION
The docs table, the README and the news article all carried numbers from **two** runs. Five runs say something different, and the difference matters to anyone choosing.

| model | verified (of 8) | mean | timeouts |
|---|---|---|---|
| `qwen3.6-35b-a3b-optiq` (default) | 3, 3, 3, 4, 4 | **3.40** | 2 |
| `qwen3.8-27b-4bit` (opt-in) | 1, 5, 5, 6, 7 | **4.80** | 11 |

**Qwen3.8 solves about 41% more tasks than the model we ship as default.** It is the stronger model, not the weaker one, and the published text understated it — it said "not weaker, less predictable", which was the honest reading at n=2 and is wrong at n=5.

It is also seven times slower, times out five times as often, and ranges 1 to 7 of 8 on identical configuration where the default sits between 3 and 4.

So all three surfaces now frame the choice as **stronger and erratic against weaker and predictable**, with a basis for picking: take 3.8 if you read through what it produces, keep the default if you want to trust it without looking.

## The part worth more than the model

The news article gains this, because it is the transferable lesson: **the conclusion reversed twice.** First from "3.8 loops and was rejected" to "3.8 is unpredictable", then at five runs to "3.8 is the strongest model we have". Both reversals came from another run existing, not from better reasoning.

Five runs is now the bar before a number informs a recommendation, and that rule is written into `MODELS.md` and `PLAN.md` in the benchmark repo.

## Checks

`tsc --noEmit` clean.