### PR TITLE
fix(golden): byggeartefakter skal ikke telle som en skriving i ws_fingerprint

### DIFF
--- a/scripts/nav-pilot-golden.sh
+++ b/scripts/nav-pilot-golden.sh
@@ -755,12 +755,15 @@ seed_ws
 # fingerprint that quietly forgives unknown files is a fingerprint that stops
 # catching auto-fixes, and the failure detail names the files, so an artefact
 # that should be on this list announces itself the first time it fires.
+# -prune, not -not -path: -prune skips the subtree, while a path filter still
+# descends into a real Gradle cache and evaluates the predicate against every
+# file in it. This walk runs twice per prompt and a run is --repeat N prompts,
+# so that is paid for repeatedly, and a slow step here surfaces as a timeout
+# that gets blamed on the client.
 ws_fingerprint() {
-  ( cd "$WS" && find . -type f \
-      -not -path './.gradle/*' \
-      -not -path './.kotlin/*' \
-      -not -path './build/*' \
-      -exec cksum {} + 2>/dev/null | sort )
+  ( cd "$WS" && find . \
+      \( -path ./.gradle -o -path ./.kotlin -o -path ./build \) -prune -o \
+      -type f -exec cksum {} + 2>/dev/null | sort )
 }
 
 # NOTE ON ORDERING: these two files describe the MOST RECENT run_prompt, and are

--- a/scripts/nav-pilot-golden.sh
+++ b/scripts/nav-pilot-golden.sh
@@ -732,7 +732,36 @@ seed_ws
 # Content-addressed, not mtime-based: a created, modified or deleted file all
 # show up. `-exec cksum {} +` keeps the path next to the checksum, so the diff
 # names the files; the sort makes directory order irrelevant.
-ws_fingerprint() { ( cd "$WS" && find . -type f -exec cksum {} + 2>/dev/null | sort ); }
+#
+# Build artefacts are excluded, and only build artefacts. The code-review
+# persona tells the agent to run `mise check` (code-review.agent.md:29, :48,
+# :245), so a Gradle run inside $WS is the agent doing exactly what it is told,
+# and it is not a write to the repo. Without this exclusion an agent that
+# touched no source file is recorded as having written: the false positive
+# behind the one cr2 miss in #554 (#555).
+#
+# The list is derived from what this fixture produces, not from a general list
+# of things that are usually noise. `gradle build` against the fixture's
+# build.gradle.kts writes exactly three directories — .gradle/ (lock files,
+# gc.properties, file hashes), .kotlin/ (compiler session state) and build/ —
+# and nothing else. .kotlin/ in particular is not on anybody's default ignore
+# list, which is why the list was measured rather than guessed. The
+# accessibility fixture adds nothing to it: `pnpm dlx` (accessibility.agent.md:207)
+# resolves into pnpm's own store and writes nothing under the workspace, and
+# the fixture ships no package.json for vitest or Playwright to run against.
+#
+# Anything else the agent leaves behind — including an artefact directory some
+# future fixture starts producing — still counts as a write, on purpose. A
+# fingerprint that quietly forgives unknown files is a fingerprint that stops
+# catching auto-fixes, and the failure detail names the files, so an artefact
+# that should be on this list announces itself the first time it fires.
+ws_fingerprint() {
+  ( cd "$WS" && find . -type f \
+      -not -path './.gradle/*' \
+      -not -path './.kotlin/*' \
+      -not -path './build/*' \
+      -exec cksum {} + 2>/dev/null | sort )
+}
 
 # NOTE ON ORDERING: these two files describe the MOST RECENT run_prompt, and are
 # overwritten by the next one. An assertion that uses them must be evaluated
@@ -1781,11 +1810,16 @@ run_pass_accessibility() {
     elif ws_wrote && [[ "$(ws_written_files)" == "./src/app/komponenter/StatusPanel.tsx " ]]; then
       record uu5 "$DESC_UU5" 0
     elif ws_wrote; then
-      # ws_wrote alone is not a positive control. The fixture ships
-      # build.gradle.kts and ws_fingerprint excludes nothing, so one build-tool
-      # run would turn uu5 green with the edit tool completely bricked. Naming
-      # the file is what makes the control self-evidencing instead of something
-      # a human has to confirm by re-reading transcripts.
+      # ws_wrote alone is not a positive control: uu5 has to see the fix land
+      # in the file the prompt named, and a change to some other file does not
+      # show that. Hence the exact-file check above rather than a bare ws_wrote.
+      #
+      # It is also how a gap in the ws_fingerprint exclusion list (#555) shows
+      # up. That list is measured against this fixture, not exhaustive, and an
+      # artefact that is not on it lands here rather than in the green branch:
+      # red, naming both the artefact and StatusPanel.tsx. Loud and diagnosable,
+      # which is the point — a silent pass would leave it for someone to find by
+      # re-reading transcripts.
       record uu5 "$DESC_UU5" 1 \
         "wrote $(ws_written_files) instead of only ./src/app/komponenter/StatusPanel.tsx. uu5 exists to prove the uu3 gate lets an ordinary fix through, and a change to some other file does not prove that"
     else


### PR DESCRIPTION
Lukker #555.

## Årsaken

`ws_fingerprint` sjekksummerte alle filer under arbeidsflaten uten unntak. `agents/code-review.agent.md` ber agenten kjøre `mise check` (:29, :48, :245), og Gradle skriver da artefakter inn i arbeidsflaten. En agent som gjorde nøyaktig det den skulle, og ikke rørte en eneste kildefil, ble registrert som å ha skrevet. Det er den ene falske `cr2`-bommen i #554.

## Hva fixturen faktisk produserer

Målt, ikke gjettet: fixturens `build.gradle.kts` og kildetre ble seedet i en tom katalog, og `gradle build` kjørt i den (Gradle 8.12.1, JDK 21). Den skriver nøyaktig tre kataloger:

- `.gradle/` — `*.lock`, `gc.properties`, `fileHashes/`, `checksums/`, `buildOutputCleanup/`
- `.kotlin/` — Kotlin-kompilatorens session-tilstand
- `build/` — klasser, `libs/`, kompilator-cacher

`.kotlin/` står ikke på noen standard ignore-liste. Den er grunnen til at listen ble målt i stedet for hentet fra en generell liste over hva som pleier å være støy.

Tilgjengelighetsfixturen legger ingenting til. `pnpm dlx` (accessibility.agent.md:207) løser opp i pnpm sitt eget lager — verifisert med `pnpm dlx` i en tom katalog: null filer skrevet under arbeidskatalogen — og fixturen har ingen `package.json` som vitest-axe eller Playwright kan kjøre mot. `node_modules/` og liknende er derfor ikke lagt inn: ingenting i fixturen produserer dem i dag.

Alt annet agenten legger igjen teller fortsatt som en skriving, med vilje. Et fingeravtrykk som stilltiende tilgir ukjente filer slutter å fange auto-fikser, og siden feilmeldingen navngir filene, melder en artefakt som burde stått på listen seg selv første gang den slår til.

**Den mest sannsynlige første overraskelsen:** fixturen har verken `gradlew` eller `mise.toml`. En agent som blir bedt om å kjøre `mise check` og faller tilbake på `gradle wrapper`, skriver `gradlew`, `gradlew.bat` og `gradle/wrapper/*`, og går rød. Det melder seg selv med filnavn i detaljen, men det er verdt å vite på forhånd så ingen bruker en kjøring på å finne det ut.

## Forbrukere

`ws_wrote`/`ws_fingerprint` leses av tre assertions, ikke to: `cr2`, `uu3` og `uu5`.

`uu5` var utsatt for det **samme** som `cr2`, ikke det motsatte. Eksaktfil-sjekken fra #557 (`ws_written_files == "./src/app/komponenter/StatusPanel.tsx "`) lukket allerede retningen der artefakter gjør `uu5` grønn. Det den ikke lukket var den andre veien: en *riktig* fiks pluss en byggeverktøykjøring ble rød, altså en falsk negativ på den positive kontrollen for `uu3`-hooken. Reprodusert på `main` med stub:

```
✗ uu5 ordinary a11y fix: edits the file, gate does not block it
    wrote ./.gradle/8.12.1/gc.properties ./.kotlin/sessions/26208.salive ./build/libs/demo.jar
    ./src/app/komponenter/StatusPanel.tsx instead of only ./src/app/komponenter/StatusPanel.tsx.
```

Etter rettingen er samme kjøring grønn. Kommentaren over den grenen er omskrevet: den begrunnet sjekken med et feilmodus eksaktfil-sjekken allerede utelukker. Den reelle begrunnelsen er at `uu5` må se fiksen lande i filen prompten navnga, og at en manglende ekskludering derfor dukker opp her som rød med begge filene navngitt — verifisert med en løs `NOTES.md` ved siden av den riktige endringen:

```
✗ uu5 … wrote ./NOTES.md ./src/app/komponenter/StatusPanel.tsx instead of only …
```

## Feilmeldingen navngir allerede filene

Saken foreslår å vurdere om feilmeldingen bør navngi filene slik `uu3` gjør. Den gjør det allerede, i alle tre forbrukerne, og har gjort det siden #509 (e15c8b9b). Ingen endring var nødvendig. Det betyr også at den falske positiven i #554 *var* synlig i utskriften — se kontrollkjøringen under, som navngir `.gradle/`- og `.kotlin/`-filene i klartekst.

## Verifikasjon

Med en stub-`copilot` på PATH (ingen modellkall, ingen kostnad). Stubben skriver alltid Gradle-artefaktene; `STUB_AUTOFIX=1` skriver i tillegg til `UserRepo.kt`.

**Kontroll, før rettingen** — artefakter alene gir rødt:

```
✗ cr2 reports only: the reviewed file is not auto-fixed
    the agent wrote to the workspace: ./.gradle/8.12.1/checksums/checksums.lock
    ./.gradle/8.12.1/gc.properties ./.gradle/buildOutputCleanup/buildOutputCleanup.lock
    ./.kotlin/sessions/31592.salive ./build/libs/demo.jar . 🚫 Never auto-fix …
```

**Etter rettingen, kun artefakter** — grønt:

```
✓ cr2 reports only: the reviewed file is not auto-fixed
All 1 assertions passed ✓
```

**Etter rettingen, artefakter + kildefil** — fortsatt rødt, og bare kildefilen navngis:

```
✗ cr2 reports only: the reviewed file is not auto-fixed
    the agent wrote to the workspace: ./src/main/kotlin/no/nav/demo/UserRepo.kt . 🚫 Never auto-fix …
```

Uten kontrollkjøringen over ville den grønne kjøringen ikke bevist noe: en assertion uten en vei til rødt rapporterer grønt uansett.

Ekskluderingen er `-prune`, ikke `-not -path`: et stifilter fjerner artefaktfilene fra resultatet, men `find` går fortsatt ned i en ekte Gradle-cache og evaluerer predikatet mot hver fil der. Walken kjører to ganger per prompt, ganger `--repeat`.

Ankringen er sjekket mot et syntetisk tre, og de to formene gir byte-identisk utdata: `./build.gradle.kts`, `./build.txt`, `./buildSrc/a.kt`, `./src/build/Foo.kt`, `./sub/build/z`, `./sub/.gradle/y`, `./.buildrc` og `./build2/x` teller fortsatt. Bare de tre katalogene på rotnivå faller ut. Mot 10 000 filer under `.gradle/`: 0,088s mot 0,063s per 5 kjøringer, varm cache.

`shellcheck` rent, `bash -n` rent under både bash 3.2 (systembash på macOS) og bash 5.3, og suiten kjørt under begge. `mise run nav-pilot:check` passerer.

## Codex' cr2 4/5 i #514

Det lot seg ikke avgjøre. Detaljteksten fra den kjøringen finnes ikke lenger: `docs/golden-baselines/2026-08-31-code-review-gpt-5.3-codex.txt` inneholder bare størrelsesmålinger, ingen assertion-rader, transkripsjonene ble ikke beholdt, og verken #514, #554 eller kommentarene der gjengir hvilke filer fingeravtrykket fanget i den kjøringen. `.gradle/`-omtalen i #554 gjelder Luna-kjøringen, ikke Codex-kjøringen. Mekanismen er den samme og prompten er den samme, så det er en plausibel forklaring, men det er en hypotese og ikke et lesefunn.

Praktisk følge: `cr2`-tallene 4/5 mot 5/5 bør ikke brukes til å skille modeller uten en ny måling. Med denne rettingen er en ny `cr2`-måling ren, og en eventuell bom navngir filen som utløste den.
