### PR TITLE
fix(nav-pilot): håndlagt innhold i .github/ nådde aldri opencode

### DIFF
--- a/cli/nav-pilot/internal/artifacts/export.go
+++ b/cli/nav-pilot/internal/artifacts/export.go
@@ -113,27 +113,35 @@ func ExportOpenCode(scope *domain.InstallScope, ref, sourceRepo, cliVersion stri
 	}
 
 	sourceDir := src.Dir
+	// A repo-scope export writes <repo>/.opencode/, which only that repo reads,
+	// so what the team added by hand under .github/ belongs in it — instructions
+	// included, unlike the global materialization in [SyncOpenCodeArtifacts].
+	// The deprecated --user export writes the global config, and does not.
+	scopeDir := ""
+	if !scope.IsUser() {
+		scopeDir = scope.DstPath()
+	}
 	var totalSkills, totalCommands, totalAgents, totalInstructions int
 
-	n, err := exportSkills(sourceDir, outputDir, dryRun)
+	n, err := exportSkills(sourceDir, scopeDir, outputDir, dryRun)
 	if err != nil {
 		return fmt.Errorf("exporting skills: %w", err)
 	}
 	totalSkills = n
 
-	n, err = exportPrompts(sourceDir, outputDir, dryRun)
+	n, err = exportPrompts(sourceDir, scopeDir, outputDir, dryRun)
 	if err != nil {
 		return fmt.Errorf("exporting prompts: %w", err)
 	}
 	totalCommands = n
 
-	n, err = exportAgents(sourceDir, outputDir, dryRun)
+	n, err = exportAgents(sourceDir, scopeDir, outputDir, dryRun)
 	if err != nil {
 		return fmt.Errorf("exporting agents: %w", err)
 	}
 	totalAgents = n
 
-	n, err = exportInstructions(sourceDir, outputDir, dryRun)
+	n, err = exportInstructions(sourceDir, scopeDir, outputDir, dryRun)
 	if err != nil {
 		return fmt.Errorf("exporting instructions: %w", err)
 	}
@@ -200,8 +208,8 @@ func ExportSummary(skills, commands, agents, instructions int) string {
 	return strings.Join(parts, ", ")
 }
 
-func exportSkills(sourceDir, outputDir string, dryRun bool) (int, error) {
-	skills := source.NewSourceResolver(sourceDir).List(source.KindSkill)
+func exportSkills(sourceDir, scopeDir, outputDir string, dryRun bool) (int, error) {
+	skills := withScopeExtras(source.NewSourceResolver(sourceDir).List(source.KindSkill), scopeDir, source.KindSkill)
 	if len(skills) == 0 {
 		return 0, nil
 	}
@@ -232,8 +240,8 @@ func exportSkills(sourceDir, outputDir string, dryRun bool) (int, error) {
 	return count, nil
 }
 
-func exportPrompts(sourceDir, outputDir string, dryRun bool) (int, error) {
-	entries := source.NewSourceResolver(sourceDir).List(source.KindPrompt)
+func exportPrompts(sourceDir, scopeDir, outputDir string, dryRun bool) (int, error) {
+	entries := withScopeExtras(source.NewSourceResolver(sourceDir).List(source.KindPrompt), scopeDir, source.KindPrompt)
 	if len(entries) == 0 {
 		return 0, nil
 	}
@@ -298,8 +306,8 @@ func agentEntries(sourceDir string) []source.Resolved {
 	return slices.DeleteFunc(entries, func(e source.Resolved) bool { return e.Name == local.WorkerAgent })
 }
 
-func exportAgents(sourceDir, outputDir string, dryRun bool) (int, error) {
-	agents := agentEntries(sourceDir)
+func exportAgents(sourceDir, scopeDir, outputDir string, dryRun bool) (int, error) {
+	agents := withScopeExtras(agentEntries(sourceDir), scopeDir, source.KindAgent)
 	if len(agents) == 0 {
 		return 0, nil
 	}
@@ -385,20 +393,32 @@ type InstructionRef struct {
 	Body    []byte
 }
 
-func collectInstructionData(sourceDir string) ([]InstructionSection, []InstructionRef, error) {
-	instrEntries := source.NewSourceResolver(sourceDir).List(source.KindInstruction)
-
+// collectInstructionData gathers the instruction content for AGENTS.md. dirs is
+// the source checkout first, then any further directory whose instructions
+// belong in the same file — the installed scope, for an export that writes
+// project-local files. An empty entry is skipped, and a name the source already
+// has is not read twice, so passing only the source is what it always was.
+func collectInstructionData(dirs ...string) ([]InstructionSection, []InstructionRef, error) {
+	var instrEntries []source.Resolved
 	var globalSections []InstructionSection
-	globalInstr := filepath.Join(sourceDir, "copilot-instructions.md")
-	if data, err := os.ReadFile(globalInstr); err == nil {
+	for i, dir := range dirs {
+		if dir == "" {
+			continue
+		}
+		instrEntries = withScopeExtras(instrEntries, dir, source.KindInstruction)
+		data, err := os.ReadFile(filepath.Join(dir, "copilot-instructions.md"))
+		if err != nil {
+			continue
+		}
 		_, body, hasFM := source.SplitFrontmatter(data)
 		if !hasFM {
 			body = data
 		}
-		globalSections = append(globalSections, InstructionSection{
-			Name: "Global Instructions",
-			Body: body,
-		})
+		name := "Global Instructions"
+		if i > 0 {
+			name = "Repository Instructions"
+		}
+		globalSections = append(globalSections, InstructionSection{Name: name, Body: body})
 	}
 
 	var scopedRefs []InstructionRef
@@ -436,8 +456,8 @@ func collectInstructionData(sourceDir string) ([]InstructionSection, []Instructi
 	return globalSections, scopedRefs, nil
 }
 
-func exportInstructions(sourceDir, outputDir string, dryRun bool) (int, error) {
-	globalSections, scopedRefs, err := collectInstructionData(sourceDir)
+func exportInstructions(sourceDir, scopeDir, outputDir string, dryRun bool) (int, error) {
+	globalSections, scopedRefs, err := collectInstructionData(sourceDir, scopeDir)
 	if err != nil {
 		return 0, err
 	}

--- a/cli/nav-pilot/internal/artifacts/export_test.go
+++ b/cli/nav-pilot/internal/artifacts/export_test.go
@@ -122,7 +122,7 @@ func TestExportSkills(t *testing.T) {
 	sourceDir := setupTestSource(t)
 	outputDir := t.TempDir()
 
-	n, err := exportSkills(sourceDir, outputDir, false)
+	n, err := exportSkills(sourceDir, "", outputDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,7 +149,7 @@ func TestExportPrompts(t *testing.T) {
 	sourceDir := setupTestSource(t)
 	outputDir := t.TempDir()
 
-	n, err := exportPrompts(sourceDir, outputDir, false)
+	n, err := exportPrompts(sourceDir, "", outputDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +179,7 @@ func TestExportAgents(t *testing.T) {
 	sourceDir := setupTestSource(t)
 	outputDir := t.TempDir()
 
-	n, err := exportAgents(sourceDir, outputDir, false)
+	n, err := exportAgents(sourceDir, "", outputDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,7 +212,7 @@ func TestExportInstructions(t *testing.T) {
 	sourceDir := setupTestSource(t)
 	outputDir := t.TempDir()
 
-	n, err := exportInstructions(sourceDir, outputDir, false)
+	n, err := exportInstructions(sourceDir, "", outputDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -284,7 +284,7 @@ These apply everywhere.
 `)
 
 	outputDir := t.TempDir()
-	n, err := exportInstructions(dir, outputDir, false)
+	n, err := exportInstructions(dir, "", outputDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -305,10 +305,10 @@ func TestExportDryRun(t *testing.T) {
 	sourceDir := setupTestSource(t)
 	outputDir := t.TempDir()
 
-	for _, fn := range []func(string, string, bool) (int, error){
+	for _, fn := range []func(string, string, string, bool) (int, error){
 		exportSkills, exportPrompts, exportAgents, exportInstructions,
 	} {
-		if _, err := fn(sourceDir, outputDir, true); err != nil {
+		if _, err := fn(sourceDir, "", outputDir, true); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -325,14 +325,14 @@ func TestExportEmptySource(t *testing.T) {
 
 	for _, fn := range []struct {
 		name string
-		fn   func(string, string, bool) (int, error)
+		fn   func(string, string, string, bool) (int, error)
 	}{
 		{"skills", exportSkills},
 		{"prompts", exportPrompts},
 		{"agents", exportAgents},
 		{"instructions", exportInstructions},
 	} {
-		n, err := fn.fn(sourceDir, outputDir, false)
+		n, err := fn.fn(sourceDir, "", outputDir, false)
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", fn.name, err)
 		}
@@ -547,7 +547,7 @@ func TestExportSkills_RootLevel(t *testing.T) {
 	mustWrite(t, filepath.Join(skillDir, "SKILL.md"), "# My Skill\n")
 	mustWrite(t, filepath.Join(skillDir, "reference.md"), "## Reference\n")
 
-	n, err := exportSkills(sourceDir, outputDir, false)
+	n, err := exportSkills(sourceDir, "", outputDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -747,5 +747,49 @@ func TestWorkerAgentIsOnlyMaterializedForTheOptedIn(t *testing.T) {
 	t.Cleanup(func() { local.SetEnabled(false) })
 	if got := names(); len(got) != 2 {
 		t.Errorf("agents materialized with local dispatch on = %v, want both", got)
+	}
+}
+
+// export opencode writes <repo>/.opencode/, which only that repo reads, so the
+// scope's hand-added artifacts belong in it — instructions included.
+func TestExportScopeExtras(t *testing.T) {
+	sourceDir := setupTestSource(t)
+	scopeDir := setupTestScope(t)
+	mustWrite(t, filepath.Join(scopeDir, "copilot-instructions.md"), "Team rules for this repo.\n")
+	outputDir := t.TempDir()
+
+	if _, err := exportSkills(sourceDir, scopeDir, outputDir, false); err != nil {
+		t.Fatalf("exportSkills: %v", err)
+	}
+	if _, err := exportPrompts(sourceDir, scopeDir, outputDir, false); err != nil {
+		t.Fatalf("exportPrompts: %v", err)
+	}
+	if _, err := exportAgents(sourceDir, scopeDir, outputDir, false); err != nil {
+		t.Fatalf("exportAgents: %v", err)
+	}
+	if _, err := exportInstructions(sourceDir, scopeDir, outputDir, false); err != nil {
+		t.Fatalf("exportInstructions: %v", err)
+	}
+
+	for _, p := range []string{
+		filepath.Join("skills", "watson-setup", "SKILL.md"),
+		filepath.Join("commands", "watson-report.md"),
+		filepath.Join("agents", "watson.md"),
+		filepath.Join("instructions", "watson.md"),
+	} {
+		if _, err := os.Stat(filepath.Join(outputDir, p)); err != nil {
+			t.Errorf("hand-added %s never reached the export: %v", p, err)
+		}
+	}
+
+	data, err := os.ReadFile(filepath.Join(outputDir, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("reading AGENTS.md: %v", err)
+	}
+	if !strings.Contains(string(data), "Team rules for this repo") {
+		t.Error("the repo's own copilot-instructions.md is missing from AGENTS.md")
+	}
+	if !strings.Contains(string(data), "## Global Instructions") {
+		t.Error("the source's global instructions were dropped")
 	}
 }

--- a/cli/nav-pilot/internal/artifacts/opencode_sync.go
+++ b/cli/nav-pilot/internal/artifacts/opencode_sync.go
@@ -67,6 +67,22 @@ func ValidateOpenCodeStatePath(p string) error {
 	return fmt.Errorf("path outside allowed opencode directories: %s", p)
 }
 
+// navPilotOwns reports whether a tracked file is still byte-for-byte what
+// nav-pilot wrote, and is therefore nav-pilot's to remove. A conflicted entry
+// never is: its recorded hash is the user's own copy, so a hash comparison
+// would call it untouched.
+func navPilotOwns(outputDir string, f domain.InstalledFile) bool {
+	if f.Status == domain.FileStatusConflict {
+		return false
+	}
+	rel := filepath.Join(outputDir, f.Path)
+	current, err := source.RawArtifactHash(rel, strings.HasSuffix(f.Path, "/"))
+	if err != nil {
+		return true // already gone; removing it is a no-op
+	}
+	return current == f.Hash
+}
+
 // withScopeExtras appends the artifacts of a kind that the installed scope has
 // and the source checkout does not. Names already present in entries are left
 // alone, so the source stays authoritative and the order of the source entries
@@ -100,8 +116,12 @@ func withScopeExtras(entries []source.Resolved, scopeDir string, kind *source.Ar
 //
 // Instructions are deliberately not merged from the scope. outputDir is the
 // user's global opencode config, and AGENTS.md is always-on context: a repo's
-// instructions would follow the user into every other repo. Skills, commands
-// and agents are only loaded when invoked, so the same objection does not hold.
+// instructions would be in every prompt in every other repo until the next sync.
+// A skill or an agent from another repo is visible there too, by name and
+// description in the tool listing and the agent picker, but its body is only
+// read when it is invoked. That is a smaller price than always-on prose, which
+// is why the two are treated differently. [ExportOpenCode] writes project-local
+// files instead, and merges instructions for that reason.
 func SyncOpenCodeArtifacts(sourceDir, scopeDir, outputDir, sourceVersion, sourceSHA, sourceRepo string) (skills, commands, agents, instructions int, conflicts []string, err error) {
 	existingState, _ := ReadOpenCodeState(outputDir)
 	stateHashes := map[string]string{}
@@ -254,16 +274,23 @@ func SyncOpenCodeArtifacts(sourceDir, scopeDir, outputDir, sourceVersion, source
 		newFilesMap[f.Path] = true
 	}
 
-	// Delete old files that are not in the new file set
+	// Delete old files that are not in the new file set, but only the ones
+	// nav-pilot still owns: an entry marked conflict, or one whose bytes have
+	// changed since nav-pilot wrote them, belongs to the user now. The set
+	// shrinks for two reasons, and only one of them is a removal upstream. The
+	// other is a scope that is no longer there, which happens on every switch to
+	// another repo, so deleting on hash-blind absence would throw away a locally
+	// edited file for no better reason than the working directory.
 	if existingState != nil {
 		for _, f := range existingState.Files {
-			if !newFilesMap[f.Path] {
-				dst := filepath.Join(outputDir, f.Path)
-				if strings.HasSuffix(f.Path, "/") {
-					os.RemoveAll(dst)
-				} else {
-					os.Remove(dst)
-				}
+			if newFilesMap[f.Path] || !navPilotOwns(outputDir, f) {
+				continue
+			}
+			dst := filepath.Join(outputDir, f.Path)
+			if strings.HasSuffix(f.Path, "/") {
+				os.RemoveAll(dst)
+			} else {
+				os.Remove(dst)
 			}
 		}
 	}

--- a/cli/nav-pilot/internal/artifacts/opencode_sync.go
+++ b/cli/nav-pilot/internal/artifacts/opencode_sync.go
@@ -71,14 +71,24 @@ func ValidateOpenCodeStatePath(p string) error {
 // nav-pilot wrote, and is therefore nav-pilot's to remove. A conflicted entry
 // never is: its recorded hash is the user's own copy, so a hash comparison
 // would call it untouched.
+//
+// Note that the write path disagrees about a conflicted entry: stateHashes in
+// [SyncOpenCodeArtifacts] leaves it out, so the sync after a conflict is
+// reported treats the path as untracked and overwrites it. This function treats
+// it as the user's for good. The write path is the older half and the wrong
+// one, but it is a separate bug with its own issue, not something to change
+// under a fix for what the scope materializes.
 func navPilotOwns(outputDir string, f domain.InstalledFile) bool {
 	if f.Status == domain.FileStatusConflict {
 		return false
 	}
 	rel := filepath.Join(outputDir, f.Path)
 	current, err := source.RawArtifactHash(rel, strings.HasSuffix(f.Path, "/"))
-	if err != nil {
+	if os.IsNotExist(err) {
 		return true // already gone; removing it is a no-op
+	}
+	if err != nil {
+		return false // unreadable is not permission to delete
 	}
 	return current == f.Hash
 }
@@ -281,9 +291,20 @@ func SyncOpenCodeArtifacts(sourceDir, scopeDir, outputDir, sourceVersion, source
 	// other is a scope that is no longer there, which happens on every switch to
 	// another repo, so deleting on hash-blind absence would throw away a locally
 	// edited file for no better reason than the working directory.
+	//
+	// A file that survives stays in the state, with the hash and status it had.
+	// Dropping it would leave an untracked orphan that the next sync from the
+	// scope it came from overwrites without a word, since isConflict only knows
+	// paths the state names. Kept in state, that same sync sees the hash differ
+	// and reports a conflict instead. The state therefore grows only by files
+	// the user has edited, and `nav-pilot status` can show them.
 	if existingState != nil {
 		for _, f := range existingState.Files {
-			if newFilesMap[f.Path] || !navPilotOwns(outputDir, f) {
+			if newFilesMap[f.Path] {
+				continue
+			}
+			if !navPilotOwns(outputDir, f) {
+				files = append(files, f)
 				continue
 			}
 			dst := filepath.Join(outputDir, f.Path)

--- a/cli/nav-pilot/internal/artifacts/opencode_sync.go
+++ b/cli/nav-pilot/internal/artifacts/opencode_sync.go
@@ -67,9 +67,42 @@ func ValidateOpenCodeStatePath(p string) error {
 	return fmt.Errorf("path outside allowed opencode directories: %s", p)
 }
 
+// withScopeExtras appends the artifacts of a kind that the installed scope has
+// and the source checkout does not. Names already present in entries are left
+// alone, so the source stays authoritative and the order of the source entries
+// is unchanged.
+func withScopeExtras(entries []source.Resolved, scopeDir string, kind *source.ArtifactKind) []source.Resolved {
+	if scopeDir == "" {
+		return entries
+	}
+	seen := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		seen[e.Name] = true
+	}
+	for _, e := range source.NewSourceResolver(scopeDir).List(kind) {
+		if !seen[e.Name] {
+			entries = append(entries, e)
+		}
+	}
+	return entries
+}
+
 // SyncOpenCodeArtifacts materializes Nav context into outputDir with conflict detection
 // and state tracking. It is the state-aware counterpart to MaterializeOpenCode.
-func SyncOpenCodeArtifacts(sourceDir, outputDir, sourceVersion, sourceSHA, sourceRepo string) (skills, commands, agents, instructions int, conflicts []string, err error) {
+//
+// scopeDir is the installed scope the session runs against (a repo's .github/),
+// or "" when there is none. Skills, prompts and agents that live in the scope
+// but not in the source checkout are materialized too: a team that adds a skill
+// by hand under .github/skills/ gets it in Copilot because Copilot reads the
+// scope directly, and used to lose it in opencode because only the source was
+// read here. The source still wins on a name collision, so a scope with nothing
+// hand-added produces exactly what it did before.
+//
+// Instructions are deliberately not merged from the scope. outputDir is the
+// user's global opencode config, and AGENTS.md is always-on context: a repo's
+// instructions would follow the user into every other repo. Skills, commands
+// and agents are only loaded when invoked, so the same objection does not hold.
+func SyncOpenCodeArtifacts(sourceDir, scopeDir, outputDir, sourceVersion, sourceSHA, sourceRepo string) (skills, commands, agents, instructions int, conflicts []string, err error) {
 	existingState, _ := ReadOpenCodeState(outputDir)
 	stateHashes := map[string]string{}
 	if existingState != nil {
@@ -98,7 +131,7 @@ func SyncOpenCodeArtifacts(sourceDir, outputDir, sourceVersion, sourceSHA, sourc
 	var files []domain.InstalledFile
 	resolver := source.NewSourceResolver(sourceDir)
 
-	for _, skill := range resolver.List(source.KindSkill) {
+	for _, skill := range withScopeExtras(resolver.List(source.KindSkill), scopeDir, source.KindSkill) {
 		relPath := "skills/" + skill.Name + "/"
 		dstDir := filepath.Join(outputDir, "skills", skill.Name)
 		if isConflict(relPath, dstDir, true) {
@@ -121,7 +154,7 @@ func SyncOpenCodeArtifacts(sourceDir, outputDir, sourceVersion, sourceSHA, sourc
 		skills++
 	}
 
-	for _, entry := range resolver.List(source.KindPrompt) {
+	for _, entry := range withScopeExtras(resolver.List(source.KindPrompt), scopeDir, source.KindPrompt) {
 		if entry.IsDir {
 			continue
 		}
@@ -148,7 +181,7 @@ func SyncOpenCodeArtifacts(sourceDir, outputDir, sourceVersion, sourceSHA, sourc
 		commands++
 	}
 
-	for _, entry := range agentEntries(sourceDir) {
+	for _, entry := range withScopeExtras(agentEntries(sourceDir), scopeDir, source.KindAgent) {
 		relPath := "agents/" + entry.Name + ".md"
 		dstPath := filepath.Join(outputDir, "agents", entry.Name+".md")
 		if isConflict(relPath, dstPath, false) {

--- a/cli/nav-pilot/internal/artifacts/opencode_sync_test.go
+++ b/cli/nav-pilot/internal/artifacts/opencode_sync_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -391,9 +392,11 @@ func TestSyncOpenCodeArtifacts_ScopeExtras(t *testing.T) {
 }
 
 // A scope that holds nothing but an install of the same source must produce
-// byte-for-byte what no scope at all produces. An empty .github/ would pass
-// this trivially, so the scope is populated with a copy of the source: every
-// name collides, and the source has to win all of them.
+// byte-for-byte what no scope at all produces, which is the ordinary user with
+// nothing hand-added. An empty .github/ would pass trivially, so the scope is
+// populated with a copy of the source: the merge has to add nothing and drop
+// nothing across every kind. The copy is byte-identical, so this cannot observe
+// which side won a name collision; that is what ScopeExtras is for.
 func TestSyncOpenCodeArtifacts_InstalledScopeUnchanged(t *testing.T) {
 	sourceDir := setupTestSource(t)
 
@@ -467,5 +470,22 @@ func TestSyncOpenCodeArtifacts_KeepsEditedFileOnScopeSwitch(t *testing.T) {
 	}
 	if _, err := os.Stat(untouched); err == nil {
 		t.Error("an untouched extra was kept; only user-modified files should survive")
+	}
+
+	// Back in the first repo. The kept file must still be the user's: keeping it
+	// on the way out is worthless if the return trip overwrites it.
+	_, _, _, _, conflicts, err := SyncOpenCodeArtifacts(sourceDir, scopeDir, outputDir, "2026.06.16-120000", "abc", "")
+	if err != nil {
+		t.Fatalf("third sync: %v", err)
+	}
+	data, err = os.ReadFile(edited)
+	if err != nil {
+		t.Fatalf("locally edited file was deleted on the way back: %v", err)
+	}
+	if !strings.Contains(string(data), "Mine now") {
+		t.Error("locally edited file was overwritten by the scope copy on the way back")
+	}
+	if !slices.Contains(conflicts, "skills/watson-setup/") {
+		t.Errorf("conflicts = %v, want the edited skill reported", conflicts)
 	}
 }

--- a/cli/nav-pilot/internal/artifacts/opencode_sync_test.go
+++ b/cli/nav-pilot/internal/artifacts/opencode_sync_test.go
@@ -390,9 +390,17 @@ func TestSyncOpenCodeArtifacts_ScopeExtras(t *testing.T) {
 	}
 }
 
-// An empty scope must produce byte-for-byte what no scope produces.
-func TestSyncOpenCodeArtifacts_EmptyScopeUnchanged(t *testing.T) {
+// A scope that holds nothing but an install of the same source must produce
+// byte-for-byte what no scope at all produces. An empty .github/ would pass
+// this trivially, so the scope is populated with a copy of the source: every
+// name collides, and the source has to win all of them.
+func TestSyncOpenCodeArtifacts_InstalledScopeUnchanged(t *testing.T) {
 	sourceDir := setupTestSource(t)
+
+	installedScope := filepath.Join(t.TempDir(), ".github")
+	if err := copyDirSimple(sourceDir, installedScope); err != nil {
+		t.Fatalf("populating scope: %v", err)
+	}
 	emptyScope := filepath.Join(t.TempDir(), ".github")
 	mustMkdir(t, emptyScope)
 
@@ -419,7 +427,45 @@ func TestSyncOpenCodeArtifacts_EmptyScopeUnchanged(t *testing.T) {
 		return files
 	}
 
-	if got, want := tree(emptyScope), tree(""); !reflect.DeepEqual(got, want) {
-		t.Errorf("empty scope changed the output: got %d files, want %d", len(got), len(want))
+	baseline := tree("")
+	if len(baseline) == 0 {
+		t.Fatal("baseline output is empty; the comparison would prove nothing")
+	}
+	for _, scopeDir := range []string{emptyScope, installedScope} {
+		if got := tree(scopeDir); !reflect.DeepEqual(got, baseline) {
+			t.Errorf("scope %q changed the output: got %d files, want %d", scopeDir, len(got), len(baseline))
+		}
+	}
+}
+
+// Switching repos shrinks the file set, and the delete loop must not take a
+// locally edited file with it.
+func TestSyncOpenCodeArtifacts_KeepsEditedFileOnScopeSwitch(t *testing.T) {
+	sourceDir := setupTestSource(t)
+	scopeDir := setupTestScope(t)
+	outputDir := t.TempDir()
+
+	if _, _, _, _, _, err := SyncOpenCodeArtifacts(sourceDir, scopeDir, outputDir, "2026.06.16-120000", "abc", ""); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+
+	edited := filepath.Join(outputDir, "skills", "watson-setup", "SKILL.md")
+	mustWrite(t, edited, "---\nname: watson-setup\ndescription: Edited by hand\n---\n\nMine now.\n")
+	untouched := filepath.Join(outputDir, "agents", "watson.md")
+
+	// Second run from another repo: the extras are no longer in the file set.
+	if _, _, _, _, _, err := SyncOpenCodeArtifacts(sourceDir, "", outputDir, "2026.06.16-120000", "abc", ""); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+
+	data, err := os.ReadFile(edited)
+	if err != nil {
+		t.Fatalf("locally edited file was deleted on a scope switch: %v", err)
+	}
+	if !strings.Contains(string(data), "Mine now") {
+		t.Error("locally edited file was overwritten")
+	}
+	if _, err := os.Stat(untouched); err == nil {
+		t.Error("an untouched extra was kept; only user-modified files should survive")
 	}
 }

--- a/cli/nav-pilot/internal/artifacts/opencode_sync_test.go
+++ b/cli/nav-pilot/internal/artifacts/opencode_sync_test.go
@@ -3,6 +3,7 @@ package artifacts
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -106,7 +107,7 @@ func TestSyncOpenCodeArtifacts_FirstRun(t *testing.T) {
 	sourceDir := setupTestSource(t)
 	outputDir := t.TempDir()
 
-	skills, commands, agents, instructions, conflicts, err := SyncOpenCodeArtifacts(sourceDir, outputDir, "2026.06.16-120000", "abc123", "")
+	skills, commands, agents, instructions, conflicts, err := SyncOpenCodeArtifacts(sourceDir, "", outputDir, "2026.06.16-120000", "abc123", "")
 	if err != nil {
 		t.Fatalf("SyncOpenCodeArtifacts error: %v", err)
 	}
@@ -149,14 +150,14 @@ func TestSyncOpenCodeArtifacts_Idempotent(t *testing.T) {
 	sourceDir := setupTestSource(t)
 	outputDir := t.TempDir()
 
-	s1, c1, a1, i1, conf1, err := SyncOpenCodeArtifacts(sourceDir, outputDir, "2026.06.16-120000", "abc", "")
+	s1, c1, a1, i1, conf1, err := SyncOpenCodeArtifacts(sourceDir, "", outputDir, "2026.06.16-120000", "abc", "")
 	if err != nil {
 		t.Fatalf("SyncOpenCodeArtifacts run 1 error: %v", err)
 	}
 
 	agentsMD1, _ := os.ReadFile(filepath.Join(outputDir, "AGENTS.md"))
 
-	s2, c2, a2, i2, conf2, err := SyncOpenCodeArtifacts(sourceDir, outputDir, "2026.06.16-120000", "abc", "")
+	s2, c2, a2, i2, conf2, err := SyncOpenCodeArtifacts(sourceDir, "", outputDir, "2026.06.16-120000", "abc", "")
 	if err != nil {
 		t.Fatalf("second run error: %v", err)
 	}
@@ -178,7 +179,7 @@ func TestSyncOpenCodeArtifacts_ConflictNotOverwritten(t *testing.T) {
 	sourceDir := setupTestSource(t)
 	outputDir := t.TempDir()
 
-	if _, _, _, _, _, err := SyncOpenCodeArtifacts(sourceDir, outputDir, "2026.06.01-120000", "old", ""); err != nil {
+	if _, _, _, _, _, err := SyncOpenCodeArtifacts(sourceDir, "", outputDir, "2026.06.01-120000", "old", ""); err != nil {
 		t.Fatalf("setup SyncOpenCodeArtifacts: %v", err)
 	}
 
@@ -188,7 +189,7 @@ func TestSyncOpenCodeArtifacts_ConflictNotOverwritten(t *testing.T) {
 		t.Fatalf("writing user AGENTS.md: %v", err)
 	}
 
-	_, _, _, _, conflicts, err := SyncOpenCodeArtifacts(sourceDir, outputDir, "2026.06.16-120000", "new", "")
+	_, _, _, _, conflicts, err := SyncOpenCodeArtifacts(sourceDir, "", outputDir, "2026.06.16-120000", "new", "")
 	if err != nil {
 		t.Fatalf("second run error: %v", err)
 	}
@@ -239,12 +240,12 @@ Updated content.
 
 	outputDir := t.TempDir()
 
-	if _, _, _, _, _, err := SyncOpenCodeArtifacts(sourceV1, outputDir, "2026.06.01-120000", "v1sha", ""); err != nil {
+	if _, _, _, _, _, err := SyncOpenCodeArtifacts(sourceV1, "", outputDir, "2026.06.01-120000", "v1sha", ""); err != nil {
 		t.Fatalf("setup SyncOpenCodeArtifacts: %v", err)
 	}
 	agentV1, _ := os.ReadFile(filepath.Join(outputDir, "agents", "nav-pilot.md"))
 
-	_, _, _, _, conflicts, err := SyncOpenCodeArtifacts(sourceV2, outputDir, "2026.06.16-120000", "v2sha", "")
+	_, _, _, _, conflicts, err := SyncOpenCodeArtifacts(sourceV2, "", outputDir, "2026.06.16-120000", "v2sha", "")
 	if err != nil {
 		t.Fatalf("v2 run error: %v", err)
 	}
@@ -270,7 +271,7 @@ func TestPrintOpenCodeStatusBlock_NoError(t *testing.T) {
 	sourceDir := setupTestSource(t)
 	outputDir := t.TempDir()
 
-	if _, _, _, _, _, err := SyncOpenCodeArtifacts(sourceDir, outputDir, "2026.06.16-120000", "abc", ""); err != nil {
+	if _, _, _, _, _, err := SyncOpenCodeArtifacts(sourceDir, "", outputDir, "2026.06.16-120000", "abc", ""); err != nil {
 		t.Fatalf("sync error: %v", err)
 	}
 
@@ -296,8 +297,129 @@ func TestSyncOpenCodeArtifacts_RejectsSymlink(t *testing.T) {
 		t.Fatalf("symlink: %v", err)
 	}
 
-	_, _, _, _, _, err := SyncOpenCodeArtifacts(sourceDir, outputDir, "2026.06.16-120000", "abc", "")
+	_, _, _, _, _, err := SyncOpenCodeArtifacts(sourceDir, "", outputDir, "2026.06.16-120000", "abc", "")
 	if err == nil {
 		t.Error("SyncOpenCodeArtifacts() = nil, want error when writing through symlink")
+	}
+}
+
+// setupTestScope builds an installed repo scope (.github/) holding one artifact
+// of each kind that the source does not have, plus a skill whose name collides
+// with a source skill.
+func setupTestScope(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), ".github")
+
+	handAdded := filepath.Join(dir, "skills", "watson-setup")
+	mustMkdir(t, handAdded)
+	mustWrite(t, filepath.Join(handAdded, "SKILL.md"), "---\nname: watson-setup\ndescription: Set up Watson\n---\n\n# Watson Setup\n")
+
+	collides := filepath.Join(dir, "skills", "security-review")
+	mustMkdir(t, collides)
+	mustWrite(t, filepath.Join(collides, "SKILL.md"), "---\nname: security-review\ndescription: Scope copy\n---\n\nScope copy.\n")
+
+	mustMkdir(t, filepath.Join(dir, "prompts"))
+	mustWrite(t, filepath.Join(dir, "prompts", "watson-report.prompt.md"), "---\nmode: agent\ndescription: Watson report\n---\n\nWrite a report.\n")
+
+	mustMkdir(t, filepath.Join(dir, "agents"))
+	mustWrite(t, filepath.Join(dir, "agents", "watson.agent.md"), "---\nname: watson\ndescription: Watson expert\n---\n\nYou are Watson.\n")
+
+	mustMkdir(t, filepath.Join(dir, "instructions"))
+	mustWrite(t, filepath.Join(dir, "instructions", "watson.instructions.md"), "---\napplyTo: \"**/*.ts\"\n---\n\nTeam rules.\n")
+
+	return dir
+}
+
+func TestSyncOpenCodeArtifacts_ScopeExtras(t *testing.T) {
+	sourceDir := setupTestSource(t)
+	scopeDir := setupTestScope(t)
+	outputDir := t.TempDir()
+
+	skills, commands, agents, instructions, _, err := SyncOpenCodeArtifacts(sourceDir, scopeDir, outputDir, "2026.06.16-120000", "abc123", "")
+	if err != nil {
+		t.Fatalf("SyncOpenCodeArtifacts error: %v", err)
+	}
+	if skills != 2 {
+		t.Errorf("skills = %d, want 2 (1 source + 1 hand-added)", skills)
+	}
+	if commands != 2 {
+		t.Errorf("commands = %d, want 2", commands)
+	}
+	if agents != 3 {
+		t.Errorf("agents = %d, want 3", agents)
+	}
+	if instructions != 3 {
+		t.Errorf("instructions = %d, want 3 (scope instructions are not merged)", instructions)
+	}
+
+	for _, p := range []string{
+		filepath.Join("skills", "watson-setup", "SKILL.md"),
+		filepath.Join("commands", "watson-report.md"),
+		filepath.Join("agents", "watson.md"),
+	} {
+		if _, err := os.Stat(filepath.Join(outputDir, p)); err != nil {
+			t.Errorf("hand-added %s never reached opencode: %v", p, err)
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(outputDir, "instructions", "watson.md")); err == nil {
+		t.Error("scope instructions were merged into the global opencode config")
+	}
+
+	// A name the source also has stays the source's.
+	data, err := os.ReadFile(filepath.Join(outputDir, "skills", "security-review", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("reading materialized skill: %v", err)
+	}
+	if strings.Contains(string(data), "Scope copy") {
+		t.Error("scope copy overrode the source skill; source must stay authoritative")
+	}
+
+	state, err := ReadOpenCodeState(outputDir)
+	if err != nil || state == nil {
+		t.Fatalf("ReadOpenCodeState: %v", err)
+	}
+	var found bool
+	for _, f := range state.Files {
+		if f.Path == "skills/watson-setup/" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("hand-added skill is not tracked in the opencode state")
+	}
+}
+
+// An empty scope must produce byte-for-byte what no scope produces.
+func TestSyncOpenCodeArtifacts_EmptyScopeUnchanged(t *testing.T) {
+	sourceDir := setupTestSource(t)
+	emptyScope := filepath.Join(t.TempDir(), ".github")
+	mustMkdir(t, emptyScope)
+
+	tree := func(scopeDir string) map[string]string {
+		out := t.TempDir()
+		if _, _, _, _, _, err := SyncOpenCodeArtifacts(sourceDir, scopeDir, out, "2026.06.16-120000", "abc", ""); err != nil {
+			t.Fatalf("SyncOpenCodeArtifacts(%q): %v", scopeDir, err)
+		}
+		files := map[string]string{}
+		if err := filepath.WalkDir(out, func(p string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return err
+			}
+			rel, _ := filepath.Rel(out, p)
+			if rel == openCodeStateFileName {
+				return nil // holds a timestamp
+			}
+			data, err := os.ReadFile(p)
+			files[rel] = string(data)
+			return err
+		}); err != nil {
+			t.Fatalf("walking output: %v", err)
+		}
+		return files
+	}
+
+	if got, want := tree(emptyScope), tree(""); !reflect.DeepEqual(got, want) {
+		t.Errorf("empty scope changed the output: got %d files, want %d", len(got), len(want))
 	}
 }

--- a/cli/nav-pilot/internal/provider/opencode_launch.go
+++ b/cli/nav-pilot/internal/provider/opencode_launch.go
@@ -71,6 +71,17 @@ func openCodeNavContextDir() string {
 	return filepath.Join(home, ".config", "opencode")
 }
 
+// repoScopeDir returns the installed repo scope of the working directory
+// (<git root>/.github), or "" when the session is not inside a git repo. What a
+// team adds there by hand is part of the context the session should get.
+func repoScopeDir() string {
+	root := source.FindGitRoot(".")
+	if root == "" {
+		return ""
+	}
+	return filepath.Join(root, ".github")
+}
+
 // EnsureOpenCodeNavContext resolves the Nav artifact source and materializes
 // AGENTS.md, skills, agents, and commands into opencode's user config directory.
 // Uses SyncOpenCodeArtifacts for conflict detection and state tracking.
@@ -97,7 +108,7 @@ func EnsureOpenCodeNavContext() (string, error) {
 		recordFreshness("opencode", artifacts.OpenCodeScopeName, assessment)
 	}
 
-	skills, commands, agents, instrCount, conflicts, err := artifacts.SyncOpenCodeArtifacts(src.Dir, outputDir, src.Version, src.SHA, src.Repo)
+	skills, commands, agents, instrCount, conflicts, err := artifacts.SyncOpenCodeArtifacts(src.Dir, repoScopeDir(), outputDir, src.Version, src.SHA, src.Repo)
 	if err != nil {
 		return "", err
 	}

--- a/cli/nav-pilot/internal/provider/opencode_launch_test.go
+++ b/cli/nav-pilot/internal/provider/opencode_launch_test.go
@@ -676,3 +676,38 @@ func telemetryOn(t *testing.T) {
 	t.Setenv("DO_NOT_TRACK", "")
 	t.Setenv("NAV_PILOT_TELEMETRY_ENABLED", "")
 }
+
+func TestRepoScopeDir(t *testing.T) {
+	outside := t.TempDir()
+	t.Chdir(outside)
+	if got := repoScopeDir(); got != "" {
+		t.Errorf("outside a git repo: got %q, want \"\"", got)
+	}
+
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(repo, "cli", "nav-pilot")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(sub)
+	// Named without .github/ existing: an install may not have run yet, and the
+	// resolver treats a missing directory as no artifacts.
+	got := repoScopeDir()
+	if filepath.Base(got) != ".github" {
+		t.Fatalf("scope dir is not a .github/: %q", got)
+	}
+	// t.Chdir lands on the resolved path on macOS, where /var is a symlink.
+	resolve := func(p string) string {
+		if r, err := filepath.EvalSymlinks(p); err == nil {
+			return r
+		}
+		return p
+	}
+	got, want := resolve(filepath.Dir(got)), resolve(repo)
+	if got != want {
+		t.Errorf("from a subdirectory: git root %q, want %q", got, want)
+	}
+}

--- a/cli/nav-pilot/internal/provider/provider.go
+++ b/cli/nav-pilot/internal/provider/provider.go
@@ -320,7 +320,7 @@ func (openCodeProvider) SyncContext(ref, sourceRepo string, jsonOutput, hasPrevO
 	}
 	defer ocSrc.Cleanup()
 
-	_, _, _, _, ocConflicts, ocErr := artifacts.SyncOpenCodeArtifacts(ocSrc.Dir, ocOutputDir, ocSrc.Version, ocSrc.SHA, ocSrc.Repo)
+	_, _, _, _, ocConflicts, ocErr := artifacts.SyncOpenCodeArtifacts(ocSrc.Dir, repoScopeDir(), ocOutputDir, ocSrc.Version, ocSrc.SHA, ocSrc.Repo)
 	if ocErr != nil {
 		if !jsonOutput {
 			fmt.Fprintf(os.Stderr, "%s Opencode sync error: %v\n", domain.Yellow("⚠"), ocErr)

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -101,6 +101,28 @@ nav-pilot config set client opencode  # sett permanent
 `nav-pilot status` og `nav-pilot list --installed` viser opencode-artefaktene og om de er
 oppdaterte.
 
+##### Hva scopet ditt bidrar med
+
+Skills, prompts og agenter du har lagt inn for hånd i `.github/` i repoet du står i,
+materialiseres sammen med Nav-artefaktene. Det er slik et hub-repo får med sine egne
+skills i opencode, ikke bare de nav-pilot har installert.
+
+To ting følger ikke med, og det er med vilje:
+
+- **Instruksjoner fra `.github/`** slås ikke sammen med `AGENTS.md`. Utmappa er den
+  globale opencode-konfigurasjonen din, og `AGENTS.md` er alltid i kontekst, så
+  instruksjonene fra ett repo ville ligget i hver eneste prompt i alle andre repoer.
+  Trenger teamet dem i opencode, er `nav-pilot export opencode` veien: den skriver
+  `<repo>/.opencode/`, som bare det repoet leser, og tar instruksjonene med.
+- **Lokale endringer i en installert artefakt.** Redigerer du en installert skill i
+  `.github/`, honorerer Copilot endringen mens opencode får kildeversjonen. Kilden
+  vinner ved navnekollisjon. Vil du at opencode skal se den, gi den et eget navn.
+
+Artefakter fra et annet repo blir liggende i den globale konfigurasjonen til neste sync,
+og er synlige ved navn og beskrivelse der. De ryddes bort ved neste oppstart, med mindre
+du har endret dem selv: nav-pilot sletter bare det den selv har skrevet og som fortsatt
+er uendret.
+
 #### `export opencode` vs. automatisk materialisering
 
 Til ditt **personlige** oppsett trenger du ikke `export` i det hele tatt.

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -116,12 +116,15 @@ To ting følger ikke med, og det er med vilje:
   `<repo>/.opencode/`, som bare det repoet leser, og tar instruksjonene med.
 - **Lokale endringer i en installert artefakt.** Redigerer du en installert skill i
   `.github/`, honorerer Copilot endringen mens opencode får kildeversjonen. Kilden
-  vinner ved navnekollisjon. Vil du at opencode skal se den, gi den et eget navn.
+  vinner ved navnekollisjon. Vil du at opencode skal se den, kopier den til et eget
+  navn: både katalognavnet og `name:` i frontmatter må endres, og opencode får da både
+  originalen fra kilden og din kopi.
 
 Artefakter fra et annet repo blir liggende i den globale konfigurasjonen til neste sync,
 og er synlige ved navn og beskrivelse der. De ryddes bort ved neste oppstart, med mindre
 du har endret dem selv: nav-pilot sletter bare det den selv har skrevet og som fortsatt
-er uendret.
+er uendret. En fil du har redigert blir stående, og forblir sporet, slik at neste sync i
+repoet den kom fra melder konflikt framfor å overskrive den.
 
 #### `export opencode` vs. automatisk materialisering
 

--- a/docs/nav-pilot-changelog.md
+++ b/docs/nav-pilot-changelog.md
@@ -8,7 +8,7 @@ Endringslogg for nav-pilot agent harness — agenter, skills, instruksjoner, pro
 
 - **Scopet materialiseres nå sammen med kilden**: Opencode-artefaktene ble laget kun fra kildesjekkouten, aldri fra `.github/`. Copilot leser scopet direkte og så alt, opencode fikk bare det nav-pilot selv hadde levert. Et hub-repo med 25 installerte skills og 3 egne fikk 25, uten varsel og uten spor i tilstandsfila. Skills, prompts og agenter fra scopet blir nå med, både ved oppstart, `nav-pilot sync` og `nav-pilot export opencode` (#579).
 - **Instruksjoner slås bevisst ikke sammen ved oppstart**: Utmappa er den globale opencode-konfigurasjonen og `AGENTS.md` er alltid-på kontekst, så ett repos instruksjoner ville fulgt brukeren inn i alle andre. `export opencode` skriver `<repo>/.opencode/` og tar dem med, siden den innvendingen ikke gjelder der (#579).
-- **Slettelogikken sjekker nå hash**: Den fjernet alt som ikke lenger var i filsettet, uten å se på innholdet. Med scopet som input krymper settet hver gang du bytter repo, og en fil du selv hadde redigert i opencode-konfigurasjonen ville forsvunnet. Nav-pilot sletter nå bare det den selv har skrevet og som fortsatt er uendret (#579).
+- **Slettelogikken sjekker nå hash**: Den fjernet alt som ikke lenger var i filsettet, uten å se på innholdet. Med scopet som input krymper settet hver gang du bytter repo, og en fil du selv hadde redigert i opencode-konfigurasjonen ville forsvunnet. Nav-pilot sletter nå bare det den selv har skrevet og som fortsatt er uendret. En fil som blir stående fordi du har redigert den, forblir sporet, slik at neste sync i repoet den kom fra melder konflikt framfor å overskrive den (#579).
 
 ## 2026-08-31
 

--- a/docs/nav-pilot-changelog.md
+++ b/docs/nav-pilot-changelog.md
@@ -2,6 +2,14 @@
 
 Endringslogg for nav-pilot agent harness — agenter, skills, instruksjoner, prompts og samlinger.
 
+## 2026-09-01
+
+### opencode så aldri det teamet la inn for hånd
+
+- **Scopet materialiseres nå sammen med kilden**: Opencode-artefaktene ble laget kun fra kildesjekkouten, aldri fra `.github/`. Copilot leser scopet direkte og så alt, opencode fikk bare det nav-pilot selv hadde levert. Et hub-repo med 25 installerte skills og 3 egne fikk 25, uten varsel og uten spor i tilstandsfila. Skills, prompts og agenter fra scopet blir nå med, både ved oppstart, `nav-pilot sync` og `nav-pilot export opencode` (#579).
+- **Instruksjoner slås bevisst ikke sammen ved oppstart**: Utmappa er den globale opencode-konfigurasjonen og `AGENTS.md` er alltid-på kontekst, så ett repos instruksjoner ville fulgt brukeren inn i alle andre. `export opencode` skriver `<repo>/.opencode/` og tar dem med, siden den innvendingen ikke gjelder der (#579).
+- **Slettelogikken sjekker nå hash**: Den fjernet alt som ikke lenger var i filsettet, uten å se på innholdet. Med scopet som input krymper settet hver gang du bytter repo, og en fil du selv hadde redigert i opencode-konfigurasjonen ville forsvunnet. Nav-pilot sletter nå bare det den selv har skrevet og som fortsatt er uendret (#579).
+
 ## 2026-08-31
 
 ### Instruksjoner: én alltid-på output-style, tre agenter pensjonert


### PR DESCRIPTION
## Feilen

`SyncOpenCodeArtifacts` materialiserte opencode-artefakter fra kildesjekkouten, ikke fra scopet som faktisk er installert. Copilot leser `.github/` direkte og ser derfor alt et team legger inn for hånd. Opencode fikk bare det nav-pilot selv hadde levert.

Konkret: et hub-repo med 28 skills, 25 installert fra nav-pilot og 3 lagt inn for hånd, får 25 i opencode. De tre forsvinner uten et varsel, uten en feilmelding og uten et spor i state.

Verifisert i koden: `EnsureOpenCodeNavContext` og `openCodeProvider.SyncContext` sendte begge kun `src.Dir` inn, og hele materialiseringen går gjennom `source.NewSourceResolver(sourceDir)`. Scopet ble aldri lest. Testen som er lagt til feiler på gammel kode med nøyaktig det symptomet, og det er kontrollen for at porten faktisk kan feile.

`ExportOpenCode`, som `nav-pilot export opencode` er koblet til, hadde samme blindsone. README peker på den kommandoen som måten å sjekke Nav-kontekst inn i et prosjektrepo for hele teamet, altså nøyaktig hub-tilfellet denne PR-en finnes for.

## Løsningen

Skills, prompts og agenter som finnes i scopet, men ikke i kilden, materialiseres nå sammen med resten, både ved oppstart, ved `nav-pilot sync` og ved `export opencode`. Kilden vinner ved navnekollisjon.

Kontrollen for uendret oppførsel fyller scopet med en kopi av kilden, ikke med en tom `.github/`: alle navn kolliderer, kilden må vinne alle, og treet må bli byte-identisk med det ingen scope gir.

## Instruksjoner: forskjellig svar på de to stiene

Ved oppstart og sync slås instruksjoner ikke sammen. Utmappa er `~/.config/opencode`, brukerens globale konfig, og `AGENTS.md` er alltid-på kontekst, så ett repos instruksjoner ville ligget i hver eneste prompt i alle andre repoer.

Ved `export opencode` slås de sammen, repoets egen `copilot-instructions.md` inkludert. Utmappa der er `<repo>/.opencode/`, som bare det repoet leser, så innvendingen gjelder ikke.

En presisering av forrige formulering: skills og agenter er ikke helt fraværende før de kalles. Navn og beskrivelse ligger i verktøylista og i agentvelgeren, så et annet repos skill er synlig der til neste sync. Selve innholdet leses først ved kall. Det er fortsatt en mindre pris enn alltid-på prosa, og det er grunnen til at de to behandles ulikt.

## Slettelogikken sjekker nå hash

Løkka fjernet alt som ikke lenger var i filsettet, uten å se på innholdet. Før denne PR-en krympet settet bare når noe var fjernet oppstrøms. Med scopet som input krymper det hver gang du bytter repo, og da ville en fil du selv hadde redigert i opencode-konfigurasjonen forsvunnet. Det er akkurat det konfliktmodellen finnes for å hindre.

Nav-pilot sletter nå bare det den selv har skrevet og som fortsatt er uendret. En konfliktmarkert oppføring blir aldri rørt, siden hashen der er brukerens egen kopi og en ren hash-sammenligning ville kalt den uendret. En uleselig fil er heller ikke tillatelse til å slette: bare `os.IsNotExist` teller som borte.

En fil som blir stående legges tilbake i filsettet med hashen og statusen den hadde. Uten det var vernet bare en utsettelse på én sync: fila ble spart, men falt ut av tilstandsfila, og `isConflict` kjenner bare stier tilstanden nevner, så neste sync fra det samme scopet overskrev den uten et ord. Nå ser den hashen avvike, melder konflikt og lar fila være. Tilstanden vokser dermed bare med filer brukeren har redigert, og det er den ene mengden som trengte sporing.

Kontrollert i begge retninger: med hash-sjekken fjernet feiler `TestSyncOpenCodeArtifacts_KeepsEditedFileOnScopeSwitch` på at fila er borte etter byttet ut, og uten tilbakeleggingen feiler den på at fila er overskrevet ved retur. Testen går gjennom tre synker.

Skrivestien er uenig med `navPilotOwns` om en konfliktmarkert oppføring: `stateHashes` utelater den, så synken etter at en konflikt er meldt behandler stien som usporet og overskriver. Det er en eldre feil, ikke innført her, og den er notert i koden så neste leser ser at de to halvdelene spriker.

## Håndlagt innhold i .github/ blir ikke slettet

Endringen leser bare fra scopet. Ingenting under `.github/` blir skrevet eller slettet.

## Dokumentasjon

`docs/README.nav-pilot.md` har fått et avsnitt om hva scopet bidrar med og hva som med vilje ikke følger med, inkludert at en lokal endring i en installert skill honoreres av Copilot, men ikke av opencode. Endringsloggen har en oppføring for de tre endringene.

## Utenfor scope

`.github/hooks/` og `.github/extensions/` har nav-pilot ingen artefakttype for. Egen jobb.

`MaterializeOpenCode` har samme blindsone, men ingen kaller den utenfor testene. Ikke rørt.

## Verifisert

`mise run nav-pilot:check` grønn.
