### PR TITLE
config: add local_model so the served model is its own key

### DIFF
--- a/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
+++ b/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
@@ -2099,13 +2099,16 @@ nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først`
           </LinkableHeading>
           <BodyLong size="small" textColor="subtle">
             <code className="font-mono text-xs">nav-pilot models</code> viser hva som er tilgjengelig; de lokale står
-            merket <code className="font-mono text-xs">(local)</code>. Listen oppdateres når du kjører{" "}
+            merket <code className="font-mono text-xs">(local)</code>.{" "}
+            <code className="font-mono text-xs">local_model</code> velger hvilken av dem serveren laster;{" "}
+            <code className="font-mono text-xs">model</code> er modellen økten selv kjører på, og de settes hver for
+            seg. Listen oppdateres når du kjører{" "}
             <code className="font-mono text-xs">init</code> eller <code className="font-mono text-xs">start</code>, ikke
             ved hver kommando — et nettverkskall der ville lagt seg foran alt annet nav-pilot gjør.
           </BodyLong>
           <CodeBlock compact>
             {`nav-pilot models
-nav-pilot config set model mlx-community/Qwen3.8-27B-4bit
+nav-pilot config set local_model mlx-community/Qwen3.8-27B-4bit
 nav-pilot alpha local init      # laster ned vektene for den nye modellen
 nav-pilot alpha local start`}
           </CodeBlock>

--- a/cli/nav-pilot/internal/cli/alpha_local.go
+++ b/cli/nav-pilot/internal/cli/alpha_local.go
@@ -59,7 +59,7 @@ hosted one. Off until you run init, and invisible everywhere until then.
 
 Switching model:
   nav-pilot models                                  what is offered; local ones say (local)
-  nav-pilot config set model <id>                   pick one
+  nav-pilot config set local_model <id>             pick one
   nav-pilot alpha local init                        download its weights, then start
 
 The list refreshes on init and start, not on every command.
@@ -134,10 +134,16 @@ func activeManifest() (*local.Manifest, error) {
 // IsLocal — this runs before anything is enabled, which is exactly when init
 // needs to read the manifest.
 func localModel(m *local.Manifest) (local.Model, error) {
-	if cfg, err := readConfig(); err == nil && cfg != nil && cfg.Model != nil {
-		local.SetSelectedModel(*cfg.Model)
+	configured := ""
+	if cfg, err := readConfig(); err == nil && cfg != nil && cfg.LocalModel != nil {
+		configured = strings.TrimSpace(*cfg.LocalModel)
+		local.SetSelectedModel(configured)
 	}
 	if entry, ok := local.Chosen(m); ok {
+		if configured != "" && entry.Model != configured {
+			fmt.Fprintf(os.Stderr, "%s local_model is %s, which this manifest does not offer — using the default %s instead.\n",
+				yellow("⚠"), bold(configured), bold(entry.Model))
+		}
 		return entry, nil
 	}
 	// Unreachable: Parse refuses a manifest without exactly one default.
@@ -752,8 +758,8 @@ func applyLocalConfig() {
 	}
 	local.SetEnabled(true)
 	local.SetAutostart(r.LocalAutostart)
-	if cfg.Model != nil {
-		local.SetSelectedModel(*cfg.Model)
+	if cfg.LocalModel != nil {
+		local.SetSelectedModel(strings.TrimSpace(*cfg.LocalModel))
 	}
 }
 

--- a/cli/nav-pilot/internal/cli/alpha_local_test.go
+++ b/cli/nav-pilot/internal/cli/alpha_local_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/BurntSushi/toml"
 	"github.com/navikt/copilot/cli/nav-pilot/internal/local"
 	providerpkg "github.com/navikt/copilot/cli/nav-pilot/internal/provider"
 )
@@ -591,5 +592,90 @@ func TestLocalStartRefusesMissingWeights(t *testing.T) {
 	err := cmdLocalStart()
 	if err == nil || !strings.Contains(err.Error(), "not on this machine") {
 		t.Errorf("cmdLocalStart() without weights = %v, want an error naming the missing weights", err)
+	}
+}
+
+// TestLocalModelKeySelectsTheServedModel pins the split between the two keys:
+// `model` is the session model, `local_model` is what the local server loads.
+// While they were one key, a developer running a cloud main agent with a local
+// worker could not name a non-default local model at all — `model` held a cloud
+// id, Chosen found no match, and start silently loaded the manifest default.
+func TestLocalModelKeySelectsTheServedModel(t *testing.T) {
+	localTestHome(t)
+	t.Cleanup(func() { local.SetSelectedModel("") })
+
+	m := &local.Manifest{Models: []local.Model{
+		{Key: "default-one", Model: "org/Default", Default: true},
+		{Key: "other", Model: "org/Other"},
+	}}
+
+	// Nothing configured: the manifest default.
+	if got, err := localModel(m); err != nil || got.Model != "org/Default" {
+		t.Errorf("with no local_model, localModel = %q/%v, want org/Default", got.Model, err)
+	}
+
+	// A cloud session model must not steer the served model.
+	if _, err := writeConfigKey("model", "claude-opus-4.8"); err != nil {
+		t.Fatalf("writing model: %v", err)
+	}
+	if _, err := writeConfigKey("local_model", "org/Other"); err != nil {
+		t.Fatalf("writing local_model: %v", err)
+	}
+	if got, err := localModel(m); err != nil || got.Model != "org/Other" {
+		t.Errorf("with local_model = org/Other, localModel = %q/%v, want org/Other", got.Model, err)
+	}
+
+	// An id this manifest does not offer falls back to the default, and says so
+	// — silence there is how someone spends an afternoon wondering why their
+	// choice did nothing.
+	if _, err := writeConfigKey("local_model", "org/NotOffered"); err != nil {
+		t.Fatalf("writing local_model: %v", err)
+	}
+	var got local.Model
+	out := captureStderr(func() {
+		var err error
+		if got, err = localModel(m); err != nil {
+			t.Errorf("localModel: %v", err)
+		}
+	})
+	if got.Model != "org/Default" {
+		t.Errorf("with an unknown local_model, localModel = %q, want the default", got.Model)
+	}
+	if !strings.Contains(out, "org/NotOffered") || !strings.Contains(out, "org/Default") {
+		t.Errorf("no advisory naming the fallback, got: %q", out)
+	}
+}
+
+// TestLocalModelAdvisoryForASessionOnALocalModel: `model` set to a local id
+// still means "run this session locally" — it is the only way to say that — but
+// it is also what people set when they meant local_model.
+func TestLocalModelAdvisoryForASessionOnALocalModel(t *testing.T) {
+	localTestHome(t)
+	m := &local.Manifest{Models: []local.Model{{Key: "d", Model: "org/Default", Default: true}}}
+	local.SetActive(m)
+	t.Cleanup(func() { local.SetActive(nil) })
+
+	id := "org/Default"
+	warnings := configAdvisories(&Config{Version: 1, Model: &id}, toml.MetaData{})
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "local_model") {
+		t.Errorf("configAdvisories = %v, want one naming local_model", warnings)
+	}
+}
+
+// TestLocalOffLeavesLocalModelAlone: off leaves the weights on disk, and the
+// key naming which weights to load belongs with them. Resetting it would make
+// `off` then `on` quietly forget the developer's choice.
+func TestLocalOffLeavesLocalModelAlone(t *testing.T) {
+	localTestHome(t)
+	if _, err := writeConfigKey("local_model", "mlx-community/Qwen3.8-27B-4bit"); err != nil {
+		t.Fatalf("writing local_model: %v", err)
+	}
+	captureStderr(func() { captureStdout(func() { _ = cmdLocalOff() }) })
+	cfg, err := readConfig()
+	if err != nil {
+		t.Fatalf("readConfig: %v", err)
+	}
+	if cfg.LocalModel == nil || *cfg.LocalModel != "mlx-community/Qwen3.8-27B-4bit" {
+		t.Errorf("local_model = %v after off, want it untouched", cfg.LocalModel)
 	}
 }

--- a/cli/nav-pilot/internal/cli/config.go
+++ b/cli/nav-pilot/internal/cli/config.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/local"
 )
 
 // validateModelForClient validates a model identifier by delegating to the
@@ -189,6 +191,14 @@ func configAdvisories(cfg *Config, meta toml.MetaData) []string {
 	if cfg.Model == nil || validateModelValue(*cfg.Model) != nil {
 		return nil
 	}
+	// model naming a local id is legal and means "run the session locally".
+	// It is also the mistake people make when they meant to pick which model
+	// the worker loads, so it is said out loud rather than guessed at.
+	if _, ok := local.Lookup(*cfg.Model); ok {
+		return []string{fmt.Sprintf(
+			"model %q runs this session on the local model. To choose which model the local server loads, set %s instead.",
+			*cfg.Model, bold("local_model"))}
+	}
 	clientID := "copilot"
 	if cfg.Client != nil {
 		clientID = *cfg.Client
@@ -306,6 +316,9 @@ func resolve(file *Config, cli CLIOverrides) ResolvedConfig {
 		}
 		if file.LocalLoopGuard != nil {
 			r.LocalLoopGuard = *file.LocalLoopGuard
+		}
+		if file.LocalModel != nil {
+			r.LocalModel = strings.TrimSpace(*file.LocalModel)
 		}
 	}
 

--- a/cli/nav-pilot/internal/cli/config.go
+++ b/cli/nav-pilot/internal/cli/config.go
@@ -194,10 +194,18 @@ func configAdvisories(cfg *Config, meta toml.MetaData) []string {
 	// model naming a local id is legal and means "run the session locally".
 	// It is also the mistake people make when they meant to pick which model
 	// the worker loads, so it is said out loud rather than guessed at.
-	if _, ok := local.Lookup(*cfg.Model); ok {
-		return []string{fmt.Sprintf(
-			"model %q runs this session on the local model. To choose which model the local server loads, set %s instead.",
-			*cfg.Model, bold("local_model"))}
+	//
+	// Only when local_model is unset. Someone who has set both keys has already
+	// been told the difference and chosen; repeating it on every launch is a
+	// warning that fires when nothing is wrong, which is how a developer learns
+	// to stop reading warnings. It also fires immediately after they follow the
+	// "use what is running" remedy, which sets exactly this pair on purpose.
+	if cfg.LocalModel == nil {
+		if _, ok := local.Lookup(*cfg.Model); ok {
+			return []string{fmt.Sprintf(
+				"model %q runs this session on the local model. To choose which model the local server loads, set %s instead.",
+				*cfg.Model, bold("local_model"))}
+		}
 	}
 	clientID := "copilot"
 	if cfg.Client != nil {

--- a/cli/nav-pilot/internal/cli/config_cmd.go
+++ b/cli/nav-pilot/internal/cli/config_cmd.go
@@ -170,6 +170,15 @@ var configKeyDefs = []configKeyDef{
 		group:       "Local models (alpha)",
 	},
 	{
+		name:        "local_model",
+		kind:        keyKindString,
+		description: "Which local model the server loads and serves (alpha). Empty means the manifest default. Separate from model, which is the session model.",
+		allowed:     nil,
+		defaultVal:  "",
+		flag:        "",
+		group:       "Local models (alpha)",
+	},
+	{
 		name:        "rtk_prompted_client",
 		kind:        keyKindString,
 		description: "Comma-separated list of clients where the RTK setup was prompted.",
@@ -304,6 +313,12 @@ version = 1
 # nav-pilot stops them. Minimum 2.
 # Default: 8
 # local_loop_guard = 8
+
+# Which local model the server loads and serves. Unset means whatever the
+# local-model manifest calls its default. This is not the session model: the
+# model key picks that, and the two are set independently.
+# Default: unset
+# local_model = "mlx-community/Qwen3.8-27B-4bit"
 
 # Internal flag to track which client the user was last prompted to set up rtk for.
 # Default: unset
@@ -505,6 +520,8 @@ func resolvedFieldStr(r ResolvedConfig, key string) string {
 		return strconv.FormatBool(r.LocalAutostart)
 	case "local_loop_guard":
 		return strconv.Itoa(localLoopGuard(r))
+	case "local_model":
+		return r.LocalModel
 	case "rtk_prompted_client":
 		return r.RtkPromptedClient
 	case "rtk_prompted_at":
@@ -649,7 +666,11 @@ func validateKeyValue(kd *configKeyDef, value string) error {
 		}
 	}
 	// Key-specific validation beyond the generic kind/allowlist checks.
-	if kd.name == "model" {
+	// Shape only, never membership: the manifest Lookup answers from is the
+	// embedded single-model copy until local is enabled and installed, so a
+	// membership check would reject the very id the docs tell people to set.
+	// `alpha local init` and `start` fetch the real manifest and are the gate.
+	if kd.name == "model" || kd.name == "local_model" {
 		if err := validateModelValue(value); err != nil {
 			return err
 		}
@@ -825,6 +846,15 @@ func printKeyExplain(kd *configKeyDef, resolved ResolvedConfig) {
 		}
 		fmt.Printf("    Common:   %s\n", strings.Join(ids, ", "))
 		fmt.Printf("    Allowed:  any well-formed id ([A-Za-z0-9._/-], e.g. provider/model for opencode)\n")
+	} else if kd.name == "local_model" {
+		var ids []string
+		for _, m := range local.Active().Models {
+			ids = append(ids, m.Model)
+		}
+		if len(ids) > 0 {
+			fmt.Printf("    Manifest: %s\n", strings.Join(ids, ", "))
+		}
+		fmt.Printf("    Allowed:  any id the local-model manifest names; empty means its default\n")
 	} else {
 		fmt.Printf("    Allowed:  any non-empty string\n")
 	}

--- a/cli/nav-pilot/internal/cli/config_page.go
+++ b/cli/nav-pilot/internal/cli/config_page.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/huh"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/local"
 )
 
 // ─── Key listing (shared with config show) ───────────────────────────────────
@@ -206,6 +208,10 @@ func editConfigKey(key string, r ResolvedConfig) error {
 		return editModelKey(r, resolvedFieldStr(r, "model"))
 	}
 
+	if key == "local_model" {
+		return editLocalModelKey(r.LocalModel)
+	}
+
 	value := current
 
 	var opts []huh.Option[string]
@@ -257,6 +263,31 @@ func editModelKey(r ResolvedConfig, current string) error {
 		return err
 	}
 	return persistConfigValue("model", value)
+}
+
+// editLocalModelKey prompts for the served local model from the manifest's own
+// entries rather than free text: the ids are long enough that typing one from
+// memory is how you end up on the default without noticing. "(default)" clears
+// the key.
+func editLocalModelKey(current string) error {
+	kd := findKeyDef("local_model")
+	opts := []huh.Option[string]{huh.NewOption("(manifest default)", "")}
+	for _, m := range local.Active().Models {
+		label := m.Model
+		if m.Name != "" {
+			label = m.Name + " (" + m.Model + ")"
+		}
+		opts = append(opts, huh.NewOption(label, m.Model))
+	}
+	value := current
+	field := huh.NewSelect[string]().Title("local_model").Description(kd.description).Options(opts...).Value(&value)
+	if err := field.WithTheme(navTheme()).Run(); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return nil
+		}
+		return err
+	}
+	return persistConfigValue("local_model", strings.TrimSpace(value))
 }
 
 // persistConfigValue writes value for key, clearing the key when value is

--- a/cli/nav-pilot/internal/cli/models_cmd.go
+++ b/cli/nav-pilot/internal/cli/models_cmd.go
@@ -50,6 +50,7 @@ func cmdModels(jsonOutput bool) error {
 	}
 
 	fmt.Println()
+	fmt.Println(dim("  Local entries are chosen with `nav-pilot config set local_model <id>`; `model` is the session model."))
 	fmt.Println(dim("  Availability depends on your GitHub Copilot plan and organization policy."))
 	fmt.Println(dim("  Org admins manage model access at: github.com/<org>/settings/copilot/policies"))
 	fmt.Println()

--- a/cli/nav-pilot/internal/domain/domain.go
+++ b/cli/nav-pilot/internal/domain/domain.go
@@ -44,6 +44,11 @@ type Config struct {
 	// number depends on the model and the task, not because anyone should
 	// have to set it.
 	LocalLoopGuard *int `toml:"local_loop_guard"`
+	// LocalModel is which model `alpha local start` loads and serves. Empty
+	// means the manifest's default. It is separate from Model because Model is
+	// the session model: a developer running a cloud main agent with a local
+	// worker has to be able to name both.
+	LocalModel *string `toml:"local_model"`
 }
 
 // ResolvedConfig holds the final configuration after applying precedence:
@@ -73,6 +78,7 @@ type ResolvedConfig struct {
 	LocalEnabled      bool     // local inference opt-in (alpha)
 	LocalAutostart    bool     // start the local server on demand at launch
 	LocalLoopGuard    int      // identical consecutive tool calls that end a local turn; 0 = built-in default
+	LocalModel        string   // local model id to serve; empty = the manifest default
 	ExtraArgs         []string // pass-through arguments for the client
 }
 

--- a/cli/nav-pilot/internal/provider/copilot_launch.go
+++ b/cli/nav-pilot/internal/provider/copilot_launch.go
@@ -244,9 +244,10 @@ func copilotLocalWorker(sessionModel string) (local.Model, *local.Guard, error) 
 		// names, so without this the session would run on a model nobody
 		// chose and nothing would say so.
 		return local.Model{}, nil, fmt.Errorf(
-			"the local server on this machine is serving %s, and this session is configured for %s.\n\n  Use what is running:\n\n    %s\n\n  Or load the other model:\n\n    %s\n    %s",
+			"the local server on this machine is serving %s, and this session is configured for %s.\n\n  Use what is running:\n\n    %s\n\n  Or load the other model:\n\n    %s\n    %s\n    %s",
 			domain.Bold(worker.Model), domain.Bold(sessionModel),
 			domain.Bold("nav-pilot config set model "+worker.Model),
+			domain.Bold("nav-pilot config set local_model "+sessionModel),
 			domain.Bold("nav-pilot alpha local stop"),
 			domain.Bold("nav-pilot alpha local start"))
 	}

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -142,10 +142,12 @@ nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først
 ### Bytte modell
 
 `nav-pilot models` viser hva som er tilgjengelig. De lokale står merket `(local)`.
+`local_model` velger hvilken av dem serveren laster; `model` er modellen økten selv kjører på,
+og de settes hver for seg.
 
 ```bash
 nav-pilot models
-nav-pilot config set model mlx-community/Qwen3.8-27B-4bit
+nav-pilot config set local_model mlx-community/Qwen3.8-27B-4bit
 nav-pilot alpha local init      # laster ned vektene for den nye modellen
 nav-pilot alpha local start
 ```


### PR DESCRIPTION
`model` was doing two jobs, and the second one broke the arrangement the local-model feature is built around.

## The bug

`applyLocalConfig` and `localModel` both fed `local.Chosen()` from `cfg.Model`. So `model` decided both what the *session* runs on **and** which local model `alpha local start` loads.

Verified by running it:

```
with model=claude-opus-4.8, the local server would load: Qwen3.6-35B-A3B-OptiQ-4bit
to get 3.8 you must set model=mlx-community/Qwen3.8-27B-4bit — which is also your session model
```

**A developer running the intended arrangement — cloud main agent under opencode, local model as worker — could not select a non-default local model at all.** A cloud `model` finds no local match, so `Chosen()` silently falls back to the manifest default. Qwen3.8 was unreachable except by making it your session model too.

## The fix

`local_model` picks what the server loads. Two call sites now read it instead of `model`. That is the whole fix; the rest makes the key usable.

**`model` is deliberately left alone.** Setting it to a local id keeps meaning "run this session on the local model" — it is the only way to express that, both clients implement it, and the comment in `copilotLocalWorker` explains why that path gates on the session model rather than on `local.Enabled`: `init` sets `local_enabled=true`, so gating there would silently move every Copilot CLI session onto the local model. Nothing was deleted and no existing test changed.

## Around it

- keyDef in the existing "Local models (alpha)" group, so the settings TUI picks the row up from `configKeyDefs` with no page code.
- Settings-page edit path is a picker over `local.Active().Models`, not free text.
- `config explain local_model` lists the manifest ids.
- **Validation is shape-only at `config set`.** `Lookup` answers from `Active()`, which is the embedded single-model manifest until local is enabled *and* installed — a membership check would reject `local_model=Qwen3.8-27B-4bit` at exactly the moment the docs tell someone to set it, since the documented order is `config set` before `init`. `init` and `start` fetch the real manifest and are the hard gate.
- Two advisories, one line each: `localModel` says when a configured id is not in the manifest and it fell back (silent before), and setting `model` to a local id notes that this runs the session locally and points at `local_model`.
- Docs, `alpha local help`, the config template and `nav-pilot models` all updated to name the right key.

## One place the spec was wrong

The remedy string in `copilot_launch.go` sits under "Use what is running", where `sessionModel` comes from `model` — so changing it to `local_model` would have printed a command that does not clear the error. It keeps `config set model <worker>` there, and `config set local_model <sessionModel>` was added to the "or load the other model" branch instead, which is the one that needed it: stop/start reloads whatever `local_model` names.

## Checks

`go build`, `go vet`, `go test ./...`, and `DO_NOT_TRACK=1 go test ./...` all green. `tsc --noEmit` clean. Four new tests; no existing test modified.