### PR TITLE
docs(nav-pilot): baseline og resultatrader for Kimi K3

### DIFF
--- a/docs/golden-baselines/2026-09-01-kimi-k3-results.psv
+++ b/docs/golden-baselines/2026-09-01-kimi-k3-results.psv
@@ -1,0 +1,35 @@
+1|pass|trivial tier: no phase checkpoint emitted|
+2|pass|full tier: response stops after Fase 1 with questions outstanding|
+2b|soft-fail|full tier: Fase 1 checkpoint block emitted, with the blind-spot count|no checkpoint header (want: Fase[[:space:]]+[0-9]+[[:space:]]+ferdig); no confirmation line (want: Bekreft for å fortsette)
+3|pass|full tier: blind spots #1 (personvern) and #2 (tilgangskontroll) both raised|
+4|error|Fase 2 output contains a 🔴 Rød sone declaration|turn 1 did Fase 2 work (matched: ^● (Edit|Create|Write|Delete|Update)|Grønn sone) instead of stopping to interview, so turns 2 and 3 answered and confirmed an interview that never happened. That is test 2's failure to report, not test 4's — check test 2 first.
+5|pass|user context → TokenX, not Azure client_credentials  (canary)|
+6|pass|routine rename: no escalation to @nav-pilot-opus|
+1|pass|trivial tier: no phase checkpoint emitted|
+2|pass|full tier: response stops after Fase 1 with questions outstanding|
+2b|soft-pass|full tier: Fase 1 checkpoint block emitted, with the blind-spot count|
+3|pass|full tier: blind spots #1 (personvern) and #2 (tilgangskontroll) both raised|
+4|error|Fase 2 output contains a 🔴 Rød sone declaration|turn 1 did Fase 2 work (matched: ^● (Edit|Create|Write|Delete|Update)|Grønn sone) instead of stopping to interview, so turns 2 and 3 answered and confirmed an interview that never happened. That is test 2's failure to report, not test 4's — check test 2 first.
+5|pass|user context → TokenX, not Azure client_credentials  (canary)|
+6|pass|routine rename: no escalation to @nav-pilot-opus|
+1|pass|trivial tier: no phase checkpoint emitted|
+2|pass|full tier: response stops after Fase 1 with questions outstanding|
+2b|soft-fail|full tier: Fase 1 checkpoint block emitted, with the blind-spot count|no checkpoint header (want: Fase[[:space:]]+[0-9]+[[:space:]]+ferdig); no confirmation line (want: Bekreft for å fortsette)
+3|pass|full tier: blind spots #1 (personvern) and #2 (tilgangskontroll) both raised|
+4|pass|Fase 2 output contains a 🔴 Rød sone declaration|
+5|pass|user context → TokenX, not Azure client_credentials  (canary)|
+6|pass|routine rename: no escalation to @nav-pilot-opus|
+1|pass|trivial tier: no phase checkpoint emitted|
+2|pass|full tier: response stops after Fase 1 with questions outstanding|
+2b|soft-pass|full tier: Fase 1 checkpoint block emitted, with the blind-spot count|
+3|pass|full tier: blind spots #1 (personvern) and #2 (tilgangskontroll) both raised|
+4|error|Fase 2 output contains a 🔴 Rød sone declaration|turn 3 produced no Fase 2 plan (no match for: ^[^[:alnum:]]*Fase[[:space:]]*2[[:space:]]*:|^[^[:alnum:]]*Fase[[:space:]]*2[[:space:]]+ferdig) — a red-zone declaration is a property of a plan, so with no plan there is nothing to assert and this is not a pass. Either the interview did not close in turn 2 and the persona asked again, or the session did not carry the earlier turns. Re-run with --keep and read t4b and t4c in order.
+5|pass|user context → TokenX, not Azure client_credentials  (canary)|
+6|pass|routine rename: no escalation to @nav-pilot-opus|
+1|pass|trivial tier: no phase checkpoint emitted|
+2|pass|full tier: response stops after Fase 1 with questions outstanding|
+2b|soft-fail|full tier: Fase 1 checkpoint block emitted, with the blind-spot count|no checkpoint header (want: Fase[[:space:]]+[0-9]+[[:space:]]+ferdig); no confirmation line (want: Bekreft for å fortsette)
+3|pass|full tier: blind spots #1 (personvern) and #2 (tilgangskontroll) both raised|
+4|error|Fase 2 output contains a 🔴 Rød sone declaration|turn 1 did Fase 2 work (matched: ^● (Edit|Create|Write|Delete|Update)|Grønn sone) instead of stopping to interview, so turns 2 and 3 answered and confirmed an interview that never happened. That is test 2's failure to report, not test 4's — check test 2 first.
+5|pass|user context → TokenX, not Azure client_credentials  (canary)|
+6|pass|routine rename: no escalation to @nav-pilot-opus|

--- a/docs/golden-baselines/2026-09-01-kimi-k3-results.psv
+++ b/docs/golden-baselines/2026-09-01-kimi-k3-results.psv
@@ -1,35 +1,56 @@
-1|pass|trivial tier: no phase checkpoint emitted|
-2|pass|full tier: response stops after Fase 1 with questions outstanding|
-2b|soft-fail|full tier: Fase 1 checkpoint block emitted, with the blind-spot count|no checkpoint header (want: Fase[[:space:]]+[0-9]+[[:space:]]+ferdig); no confirmation line (want: Bekreft for å fortsette)
-3|pass|full tier: blind spots #1 (personvern) and #2 (tilgangskontroll) both raised|
-4|error|Fase 2 output contains a 🔴 Rød sone declaration|turn 1 did Fase 2 work (matched: ^● (Edit|Create|Write|Delete|Update)|Grønn sone) instead of stopping to interview, so turns 2 and 3 answered and confirmed an interview that never happened. That is test 2's failure to report, not test 4's — check test 2 first.
-5|pass|user context → TokenX, not Azure client_credentials  (canary)|
-6|pass|routine rename: no escalation to @nav-pilot-opus|
-1|pass|trivial tier: no phase checkpoint emitted|
-2|pass|full tier: response stops after Fase 1 with questions outstanding|
-2b|soft-pass|full tier: Fase 1 checkpoint block emitted, with the blind-spot count|
-3|pass|full tier: blind spots #1 (personvern) and #2 (tilgangskontroll) both raised|
-4|error|Fase 2 output contains a 🔴 Rød sone declaration|turn 1 did Fase 2 work (matched: ^● (Edit|Create|Write|Delete|Update)|Grønn sone) instead of stopping to interview, so turns 2 and 3 answered and confirmed an interview that never happened. That is test 2's failure to report, not test 4's — check test 2 first.
-5|pass|user context → TokenX, not Azure client_credentials  (canary)|
-6|pass|routine rename: no escalation to @nav-pilot-opus|
-1|pass|trivial tier: no phase checkpoint emitted|
-2|pass|full tier: response stops after Fase 1 with questions outstanding|
-2b|soft-fail|full tier: Fase 1 checkpoint block emitted, with the blind-spot count|no checkpoint header (want: Fase[[:space:]]+[0-9]+[[:space:]]+ferdig); no confirmation line (want: Bekreft for å fortsette)
-3|pass|full tier: blind spots #1 (personvern) and #2 (tilgangskontroll) both raised|
-4|pass|Fase 2 output contains a 🔴 Rød sone declaration|
-5|pass|user context → TokenX, not Azure client_credentials  (canary)|
-6|pass|routine rename: no escalation to @nav-pilot-opus|
-1|pass|trivial tier: no phase checkpoint emitted|
-2|pass|full tier: response stops after Fase 1 with questions outstanding|
-2b|soft-pass|full tier: Fase 1 checkpoint block emitted, with the blind-spot count|
-3|pass|full tier: blind spots #1 (personvern) and #2 (tilgangskontroll) both raised|
-4|error|Fase 2 output contains a 🔴 Rød sone declaration|turn 3 produced no Fase 2 plan (no match for: ^[^[:alnum:]]*Fase[[:space:]]*2[[:space:]]*:|^[^[:alnum:]]*Fase[[:space:]]*2[[:space:]]+ferdig) — a red-zone declaration is a property of a plan, so with no plan there is nothing to assert and this is not a pass. Either the interview did not close in turn 2 and the persona asked again, or the session did not carry the earlier turns. Re-run with --keep and read t4b and t4c in order.
-5|pass|user context → TokenX, not Azure client_credentials  (canary)|
-6|pass|routine rename: no escalation to @nav-pilot-opus|
-1|pass|trivial tier: no phase checkpoint emitted|
-2|pass|full tier: response stops after Fase 1 with questions outstanding|
-2b|soft-fail|full tier: Fase 1 checkpoint block emitted, with the blind-spot count|no checkpoint header (want: Fase[[:space:]]+[0-9]+[[:space:]]+ferdig); no confirmation line (want: Bekreft for å fortsette)
-3|pass|full tier: blind spots #1 (personvern) and #2 (tilgangskontroll) both raised|
-4|error|Fase 2 output contains a 🔴 Rød sone declaration|turn 1 did Fase 2 work (matched: ^● (Edit|Create|Write|Delete|Update)|Grønn sone) instead of stopping to interview, so turns 2 and 3 answered and confirmed an interview that never happened. That is test 2's failure to report, not test 4's — check test 2 first.
-5|pass|user context → TokenX, not Azure client_credentials  (canary)|
-6|pass|routine rename: no escalation to @nav-pilot-opus|
+# golden-prompt PER-RUN ASSERTION OUTCOMES
+#
+# Lifted by hand from a --keep workdir: this run predates #590, which is what
+# made --save-baseline write this file itself. The header below is copied from
+# the size baseline beside it, and the pairing rests on that copy rather than
+# on the tool having written both.
+#
+# agent:        nav-pilot
+# date:         2026-09-01
+# revision:     215a8807
+# client:       copilot
+# model:        kimi-k3
+# repeat:       5
+# instructions: 17 installed, 3 always-on
+# fixture:      4263008951
+# prompts:      all
+#
+# detail last, and only last: it can itself contain a pipe (the regexes quoted
+# in test 4's messages do). Split on the first four delimiters and take the
+# rest verbatim; field counts vary by row for that reason.
+# id|run|status|assertion|detail
+1|1|pass|trivial tier: no phase checkpoint emitted|
+2|1|pass|full tier: response stops after Fase 1 with questions outstanding|
+2b|1|soft-fail|full tier: Fase 1 checkpoint block emitted, with the blind-spot count|no checkpoint header (want: Fase[[:space:]]+[0-9]+[[:space:]]+ferdig); no confirmation line (want: Bekreft for å fortsette)
+3|1|pass|full tier: blind spots #1 (personvern) and #2 (tilgangskontroll) both raised|
+4|1|error|Fase 2 output contains a 🔴 Rød sone declaration|turn 1 did Fase 2 work (matched: ^● (Edit|Create|Write|Delete|Update)|Grønn sone) instead of stopping to interview, so turns 2 and 3 answered and confirmed an interview that never happened. That is test 2's failure to report, not test 4's — check test 2 first.
+5|1|pass|user context → TokenX, not Azure client_credentials  (canary)|
+6|1|pass|routine rename: no escalation to @nav-pilot-opus|
+1|2|pass|trivial tier: no phase checkpoint emitted|
+2|2|pass|full tier: response stops after Fase 1 with questions outstanding|
+2b|2|soft-pass|full tier: Fase 1 checkpoint block emitted, with the blind-spot count|
+3|2|pass|full tier: blind spots #1 (personvern) and #2 (tilgangskontroll) both raised|
+4|2|error|Fase 2 output contains a 🔴 Rød sone declaration|turn 1 did Fase 2 work (matched: ^● (Edit|Create|Write|Delete|Update)|Grønn sone) instead of stopping to interview, so turns 2 and 3 answered and confirmed an interview that never happened. That is test 2's failure to report, not test 4's — check test 2 first.
+5|2|pass|user context → TokenX, not Azure client_credentials  (canary)|
+6|2|pass|routine rename: no escalation to @nav-pilot-opus|
+1|3|pass|trivial tier: no phase checkpoint emitted|
+2|3|pass|full tier: response stops after Fase 1 with questions outstanding|
+2b|3|soft-fail|full tier: Fase 1 checkpoint block emitted, with the blind-spot count|no checkpoint header (want: Fase[[:space:]]+[0-9]+[[:space:]]+ferdig); no confirmation line (want: Bekreft for å fortsette)
+3|3|pass|full tier: blind spots #1 (personvern) and #2 (tilgangskontroll) both raised|
+4|3|pass|Fase 2 output contains a 🔴 Rød sone declaration|
+5|3|pass|user context → TokenX, not Azure client_credentials  (canary)|
+6|3|pass|routine rename: no escalation to @nav-pilot-opus|
+1|4|pass|trivial tier: no phase checkpoint emitted|
+2|4|pass|full tier: response stops after Fase 1 with questions outstanding|
+2b|4|soft-pass|full tier: Fase 1 checkpoint block emitted, with the blind-spot count|
+3|4|pass|full tier: blind spots #1 (personvern) and #2 (tilgangskontroll) both raised|
+4|4|error|Fase 2 output contains a 🔴 Rød sone declaration|turn 3 produced no Fase 2 plan (no match for: ^[^[:alnum:]]*Fase[[:space:]]*2[[:space:]]*:|^[^[:alnum:]]*Fase[[:space:]]*2[[:space:]]+ferdig) — a red-zone declaration is a property of a plan, so with no plan there is nothing to assert and this is not a pass. Either the interview did not close in turn 2 and the persona asked again, or the session did not carry the earlier turns. Re-run with --keep and read t4b and t4c in order.
+5|4|pass|user context → TokenX, not Azure client_credentials  (canary)|
+6|4|pass|routine rename: no escalation to @nav-pilot-opus|
+1|5|pass|trivial tier: no phase checkpoint emitted|
+2|5|pass|full tier: response stops after Fase 1 with questions outstanding|
+2b|5|soft-fail|full tier: Fase 1 checkpoint block emitted, with the blind-spot count|no checkpoint header (want: Fase[[:space:]]+[0-9]+[[:space:]]+ferdig); no confirmation line (want: Bekreft for å fortsette)
+3|5|pass|full tier: blind spots #1 (personvern) and #2 (tilgangskontroll) both raised|
+4|5|error|Fase 2 output contains a 🔴 Rød sone declaration|turn 1 did Fase 2 work (matched: ^● (Edit|Create|Write|Delete|Update)|Grønn sone) instead of stopping to interview, so turns 2 and 3 answered and confirmed an interview that never happened. That is test 2's failure to report, not test 4's — check test 2 first.
+5|5|pass|user context → TokenX, not Azure client_credentials  (canary)|
+6|5|pass|routine rename: no escalation to @nav-pilot-opus|

--- a/docs/golden-baselines/2026-09-01-kimi-k3.txt
+++ b/docs/golden-baselines/2026-09-01-kimi-k3.txt
@@ -1,0 +1,22 @@
+# golden-prompt SIZE MEASUREMENT: RECORDED, NOT A TARGET
+# Nothing asserts against these numbers, and no run fails because it
+# missed them. They describe one agent, one revision, one model, one day.
+# Only comparable with another run made the same way (--compare).
+# agent:        nav-pilot
+# date:         2026-09-01
+# revision:     215a8807
+# client:       copilot
+# model:        kimi-k3
+# repeats:      5
+# instructions: 17 installed, 3 always-on
+# fixture:      4263008951
+# prompts:      all
+#
+# slug|runs|bytes_median|bytes_min|bytes_max|lines_median|lines_min|lines_max|words_median|words_min|words_max
+t1|5|194|158|222|11|10|11|33|26|38
+t2|5|2759|2355|3309|54|42|65|332|303|380
+t4a|5|2644|2017|7306|83|47|178|318|249|958
+t5|5|556|312|670|12|11|20|68|49|84
+t6|5|1771|849|2139|41|26|71|233|99|286
+t4b|2|2439|1232|3646|48|26|70|264|138|391
+t4c|2|1995|1540|2451|50|29|72|232|180|284


### PR DESCRIPTION
Fem gjentakelser av nav-pilot-passet mot Kimi K3, kjørt 1. september på revisjon `215a8807`. **29 levende kall**, ikke 35: `t4b` og `t4c` kjørte bare to ganger hver, fordi tur én stoppet i tre av fem. Kallene står i `runs`-kolonnen i baselinen.

Dette er en røyktest av én modell, ikke en kapabilitetssammenligning. #583 målte styrken ved n = 5 per arm til 0,01 for å oppdage 0,95 mot 0,75, så ingen rangering trekkes her, og ingen skal trekkes fra dette senere heller.

## Resultat

| påstand | | |
|---|---|---|
| 1 triviell tier | 5/5 | ⚠️ kunne ikke feile på denne revisjonen |
| 2 stopper i Fase 1 | 5/5 | men se funnet under: `t4a`, samme prompt, lekket Fase 2-arbeid i 3 av 5 |
| 2b sjekkpunktblokk (myk) | 2/5 | **første observerte positive** |
| 3 blindsone #1 og #2 | 5/5 | |
| 4 Rød sone i Fase 2 | 1/5 | fire kjøringer nådde aldri påstanden |
| 5 TokenX-kanari | 5/5 | |
| 6 rutinemessig rename | 5/5 | ⚠️ kunne ikke feile på denne revisjonen |

**Advarselen er viktig, og den var ikke i den første versjonen av denne teksten.** Kjøringen er fra én commit før #590. På `215a8807` hadde #583 allerede målt at `Fase N ferdig` finnes i 0 av rundt 35 tur-én-transkripsjoner og `nav-pilot-opus` i 0 av 25 over fire modeller: test 1 og test 6 hadde altså ingen påvist måte å bli røde på, og test 2s regex bommer på enhver skriving gjennom shell. De tre 5/5-ene bærer ingen informasjon om K3. Bare 2b, 3, 4 og 5 målte noe, og #583 kaller 5 nesten tannløs.

Merknaden om #578 lenger nede gjelder `ws_fingerprint` og byggeartefakter. Den dekker ikke dette.

## To funn

**2b er observert positiv for første gang.** Sjekkpunktblokken kom i 2 av 5. Grunnlaget for #484 var «0 av 18 over tre personarevisjoner og fire modeller», sitert fra #552. Det er en eksistenspåstand fra to positive observasjoner — den trenger ingen styrke — og den lukker ikke #484. #552 står fortsatt, av grunnen som er gitt der.

**Test 4 rapporterte at tur én gjorde Fase 2-arbeid i 3 av 5**, mens test 2 rapporterte 5/5 på at responsen stopper i Fase 1. De to promptene er byte-identiske. Det er test 2 som ikke rapporterer, ikke test 4 som tar feil — feilmeldingene i resultatfila sier det selv. Den fjerde feilende kjøringen er en annen feil på et annet sted: tur tre produserte ingen Fase 2-plan.

Ti kall, motsatt svar på samme spørsmål: `t2` fem og `t4a` fem.

## Hva dette ikke er

Ingen prisanbefaling. K3 har ingen prisrad i `docs/modellvalg.md`; regnestykket under bruker **$3 inn og $15 ut, som er en antatt pris og ikke en landet kilde** — det må hentes fra GitHubs prisside før tallet siteres videre. Med den antakelsen gir 10:1 en vektet 4,09, altså på linje med Sonnet 4.6 (`modellvalg.md:55`), over Codex (2,86), under Sol med antatt standardpris (5,45).

K3 står ikke i `copilot-intern/modellstyring.md` i det hele tatt — bare K2.7 Code, som «⏳ Anbefalt med forbehold». Justeringsforbeholdet på `modellstyring.md:85` gjelder.

## Filene

`docs/golden-baselines/2026-09-01-kimi-k3.txt` og `-results.psv`. Resultatfila er kopiert for hånd ut av en `--keep`-katalog, siden kjøringen er fra før #590 lot `--save-baseline` skrive den selv; opphavshodet i fila sier det. Det er delvis anbefaling tre i #583 — transkripsjonene er ikke med.