### PR TITLE
fix(nav-pilot): add --source overlevde ikke neste sync (#571)

### DIFF
--- a/cli/nav-pilot/DESIGN.md
+++ b/cli/nav-pilot/DESIGN.md
@@ -459,6 +459,15 @@ Konsekvenser:
   sammenlignes symlink-oppløst (`resolvedSourcePath`), så en symlink og
   checkouten bak den er én kilde. Ferskhetssjekken i rot-TUI-en hopper over
   scope som ikke kommer fra `navikt/copilot`: release-feeden beskriver bare den.
+- **Opphav per fil (#571):** `InstalledFile.source` navngir agentpakken en fil kom
+  fra når det ikke er scopets egen. `add`/`install` av ett artefakt med `--source`
+  stempler fila og sier fra i utskriften; sync hopper over slike filer i stedet
+  for å lese fraværet i scopets kilde som «slettet oppstrøms», som er det som
+  slettet det `add --source` nettopp installerte. Tomt felt betyr «scopets egen
+  kilde», som er det alle state-filer skrevet før dette sier om alle filene sine —
+  derfor synker de nøyaktig som før. En fremmed fil oppdateres ved å legges til på
+  nytt fra sin egen kilde; sync trenger aldri å nå den, så offline sletter ingenting.
+
 - **Tier 2 ennå ikke støttet:** en agentpakke uten `layout`, med klienter som har
   `payloads`, avvises med sin egen begrunnelse i stedet for en misvisende
   «mangler agenter»-feil.

--- a/cli/nav-pilot/internal/cli/add.go
+++ b/cli/nav-pilot/internal/cli/add.go
@@ -101,7 +101,7 @@ func cmdAdd(itemType, name string, scope *InstallScope, ref, sourceRepo string, 
 	}
 
 	fmt.Printf("\n%s Added %s %q.\n", green("✓"), itemType, name)
-	noteForeignSource(scope, foreign, fmt.Sprintf("nav-pilot add %s %s --source %s", itemType, name, foreign))
+	noteForeignSource(scope, foreign, fmt.Sprintf("nav-pilot install %s --type %s --source %s --force", name, itemType, foreign))
 	return nil
 }
 
@@ -113,11 +113,18 @@ func cmdAdd(itemType, name string, scope *InstallScope, ref, sourceRepo string, 
 // file is absent from it, sync reads that as "deleted upstream", and the next
 // `sync --apply` removes what `add --source` just installed (#571).
 //
-// Only an explicit --source can make a file foreign. Without the flag the scope
-// either resolves its own source or is refused by guardScopeSource, so an
-// auto-detected local checkout (whose label is an absolute path) must not be
-// mistaken for another agentpakke. And a foreign add leaves the scope's
-// SourceSHA alone: that SHA describes the scope's own source, not this file's.
+// An auto-detected local checkout is not foreign. Running from a checkout gives
+// the source an absolute path as its label, which never equals the scope's
+// repo id, and stamping it would make sync skip the file forever — in a scope
+// whose own source it is. Only a path the user asked for by name can be foreign
+// that way, so an absolute label counts as foreign only with an explicit
+// --source. Every other differing label still stamps: guardScopeSource does not
+// fire when the config source is unset, so a plain add into a scope installed
+// from elsewhere does resolve the default source, and that file must be stamped
+// or the next sync deletes it.
+//
+// A foreign add also leaves the scope's SourceSHA alone: that SHA describes the
+// scope's own source, not this file's.
 //
 // A scope with no state yet takes this source as its own, so its files need no
 // stamp. A scope whose state predates source tracking keeps its unset
@@ -138,8 +145,9 @@ func recordAddedFiles(scope *InstallScope, src *Source, result *installResult, e
 			SourceSHA:   src.SHA,
 			InstalledAt: timeNow().UTC().Format("2006-01-02T15:04:05Z07:00"),
 		}
-	} else if explicitSource != "" && !sameSourceRepo(scopeSourceRepo(state), sourceLabelFor(src)) {
-		foreign = sourceLabelFor(src)
+	} else if label := sourceLabelFor(src); !sameSourceRepo(scopeSourceRepo(state), label) &&
+		(explicitSource != "" || !filepath.IsAbs(label)) {
+		foreign = label
 	}
 	if foreign == "" {
 		state.SourceSHA = src.SHA

--- a/cli/nav-pilot/internal/cli/add.go
+++ b/cli/nav-pilot/internal/cli/add.go
@@ -95,7 +95,7 @@ func cmdAdd(itemType, name string, scope *InstallScope, ref, sourceRepo string, 
 		return nil
 	}
 
-	foreign, err := recordAddedFiles(scope, src, result)
+	foreign, err := recordAddedFiles(scope, src, result, sourceRepo)
 	if err != nil {
 		return err
 	}
@@ -113,11 +113,17 @@ func cmdAdd(itemType, name string, scope *InstallScope, ref, sourceRepo string, 
 // file is absent from it, sync reads that as "deleted upstream", and the next
 // `sync --apply` removes what `add --source` just installed (#571).
 //
+// Only an explicit --source can make a file foreign. Without the flag the scope
+// either resolves its own source or is refused by guardScopeSource, so an
+// auto-detected local checkout (whose label is an absolute path) must not be
+// mistaken for another agentpakke. And a foreign add leaves the scope's
+// SourceSHA alone: that SHA describes the scope's own source, not this file's.
+//
 // A scope with no state yet takes this source as its own, so its files need no
 // stamp. A scope whose state predates source tracking keeps its unset
 // SourceRepo — sync's adoption path owns that question — and its files are
 // compared against the default source, which is where they must have come from.
-func recordAddedFiles(scope *InstallScope, src *Source, result *installResult) (string, error) {
+func recordAddedFiles(scope *InstallScope, src *Source, result *installResult, explicitSource string) (string, error) {
 	state, err := readScopedState(scope)
 	if err != nil {
 		return "", fmt.Errorf("reading existing state: %w", err)
@@ -132,10 +138,12 @@ func recordAddedFiles(scope *InstallScope, src *Source, result *installResult) (
 			SourceSHA:   src.SHA,
 			InstalledAt: timeNow().UTC().Format("2006-01-02T15:04:05Z07:00"),
 		}
-	} else if !sameSourceRepo(scopeSourceRepo(state), sourceLabelFor(src)) {
+	} else if explicitSource != "" && !sameSourceRepo(scopeSourceRepo(state), sourceLabelFor(src)) {
 		foreign = sourceLabelFor(src)
 	}
-	state.SourceSHA = src.SHA
+	if foreign == "" {
+		state.SourceSHA = src.SHA
+	}
 	if state.Version == "" {
 		state.Version = src.Version
 	}

--- a/cli/nav-pilot/internal/cli/add.go
+++ b/cli/nav-pilot/internal/cli/add.go
@@ -95,48 +95,83 @@ func cmdAdd(itemType, name string, scope *InstallScope, ref, sourceRepo string, 
 		return nil
 	}
 
-	// Append to state file if one exists, otherwise create a minimal one
+	foreign, err := recordAddedFiles(scope, src, result)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("\n%s Added %s %q.\n", green("✓"), itemType, name)
+	noteForeignSource(scope, foreign, fmt.Sprintf("nav-pilot add %s %s --source %s", itemType, name, foreign))
+	return nil
+}
+
+// recordAddedFiles merges freshly installed files into the scope's state, and
+// stamps each one with where it came from when that is not the scope's own
+// source.
+//
+// Without the stamp the scope's SourceRepo is the only origin sync knows: the
+// file is absent from it, sync reads that as "deleted upstream", and the next
+// `sync --apply` removes what `add --source` just installed (#571).
+//
+// A scope with no state yet takes this source as its own, so its files need no
+// stamp. A scope whose state predates source tracking keeps its unset
+// SourceRepo — sync's adoption path owns that question — and its files are
+// compared against the default source, which is where they must have come from.
+func recordAddedFiles(scope *InstallScope, src *Source, result *installResult) (string, error) {
 	state, err := readScopedState(scope)
 	if err != nil {
-		return fmt.Errorf("reading existing state: %w", err)
+		return "", fmt.Errorf("reading existing state: %w", err)
 	}
+	foreign := ""
 	if state == nil {
 		state = &StateFile{
 			Collection:  "(à la carte)",
 			Scope:       scope.Name,
 			Version:     src.Version,
+			SourceRepo:  sourceLabelFor(src),
 			SourceSHA:   src.SHA,
 			InstalledAt: timeNow().UTC().Format("2006-01-02T15:04:05Z07:00"),
 		}
+	} else if !sameSourceRepo(scopeSourceRepo(state), sourceLabelFor(src)) {
+		foreign = sourceLabelFor(src)
 	}
 	state.SourceSHA = src.SHA
 	if state.Version == "" {
 		state.Version = src.Version
 	}
 
-	// Merge new files into state, avoiding duplicates
-	existing := make(map[string]bool)
-	for _, f := range state.Files {
-		existing[f.Path] = true
+	index := make(map[string]int, len(state.Files))
+	for i, f := range state.Files {
+		index[f.Path] = i
 	}
 	for _, f := range result.Files {
-		if !existing[f.Path] {
-			state.Files = append(state.Files, f)
-		} else {
-			// Update hash and clear ignored status for existing entry
-			for i, sf := range state.Files {
-				if sf.Path == f.Path {
-					state.Files[i].Hash = f.Hash
-					state.Files[i].Status = ""
-					break
-				}
-			}
+		f.Source = foreign
+		if i, ok := index[f.Path]; ok {
+			state.Files[i] = f
+			continue
 		}
+		index[f.Path] = len(state.Files)
+		state.Files = append(state.Files, f)
 	}
 	if err := writeScopedState(scope, state); err != nil {
 		fmt.Fprintf(os.Stderr, "%s Could not write state file: %v\n", yellow("⚠"), err)
 	}
+	return foreign, nil
+}
 
-	fmt.Printf("\n%s Added %s %q.\n", green("✓"), itemType, name)
-	return nil
+// noteForeignSource says that the file just added does not belong to the scope's
+// agentpakke, and how to keep it current. Adding it silently is what made
+// `add --source` a trap: it looked like every other file until a sync
+// disagreed.
+//
+// The update gesture is the add again, not a sync from the other source: a
+// `sync --source` re-points the whole scope, which is how the scope's own files
+// would go the way this file used to.
+func noteForeignSource(scope *InstallScope, foreign, updateCmd string) {
+	if foreign == "" {
+		return
+	}
+	state, _ := readScopedState(scope)
+	fmt.Printf("\n%s It comes from %s, not this scope's %s. `nav-pilot sync` leaves it alone —\n  re-run %s to update it.\n",
+		dim("ℹ"), bold(foreign), bold(scopeSourceRepo(state)), bold(updateCmd))
 }

--- a/cli/nav-pilot/internal/cli/agentpakke.go
+++ b/cli/nav-pilot/internal/cli/agentpakke.go
@@ -336,6 +336,16 @@ func noteRecordedSourceWins(stateRepo string) {
 		bold("nav-pilot install --source "+configured+" <name>"))
 }
 
+// scopeSourceRepo is the source a scope's files belong to unless a file says
+// otherwise. A state that predates source tracking records nothing and came
+// from the default source — the same reading as [tracksDefaultSource].
+func scopeSourceRepo(state *StateFile) string {
+	if state == nil || state.SourceRepo == "" {
+		return defaultSourceRepo
+	}
+	return state.SourceRepo
+}
+
 // tracksDefaultSource reports whether a scope's install came from the default
 // source, which is the only source nav-pilot's own release feed describes.
 //

--- a/cli/nav-pilot/internal/cli/agentpakke_test.go
+++ b/cli/nav-pilot/internal/cli/agentpakke_test.go
@@ -1198,7 +1198,7 @@ func TestCancelledInteractiveInstallDoesNotPersistSource(t *testing.T) {
 
 	// finishInstall is what run() wraps every install in: it must turn the
 	// sentinel into a clean exit and persist nothing.
-	if err := finishInstall(err, "navikt/grillmester", false); err != nil {
+	if err := finishInstall(err, "navikt/grillmester", false, true); err != nil {
 		t.Errorf("finishInstall(cancelled) = %v, want nil (clean exit)", err)
 	}
 	if got, _ := configuredSourceRepo(); got != "" {
@@ -1431,4 +1431,26 @@ func captureStdoutFor(t *testing.T, fn func()) string {
 	out := <-done
 	r.Close()
 	return out
+}
+
+// TestFinishInstall_SingleArtifactDoesNotPersistSource: pulling one artifact
+// out of another agentpakke with `install <name> --type <t> --source X` does
+// not make X the scope's agentpakke. Persisting it would refuse every later
+// plain add (B3) and let sync adopt X for a pre-tracking scope.
+func TestFinishInstall_SingleArtifactDoesNotPersistSource(t *testing.T) {
+	isolatedConfig(t)
+
+	if err := finishInstall(nil, "navikt/grillmester", false, false); err != nil {
+		t.Fatalf("finishInstall = %v, want nil", err)
+	}
+	if got, _ := configuredSourceRepo(); got != "" {
+		t.Errorf("single-artifact install persisted source = %q, want none", got)
+	}
+
+	if err := finishInstall(nil, "navikt/grillmester", false, true); err != nil {
+		t.Fatalf("finishInstall = %v, want nil", err)
+	}
+	if got, _ := configuredSourceRepo(); got != "navikt/grillmester" {
+		t.Errorf("scope-defining install persisted %q, want %q", got, "navikt/grillmester")
+	}
 }

--- a/cli/nav-pilot/internal/cli/cli.go
+++ b/cli/nav-pilot/internal/cli/cli.go
@@ -559,7 +559,7 @@ func run(args []string) error {
 	case "install":
 		return runWithCommandTelemetry("install", telemetryMode(), scope.Name, func() error {
 			install := func(err error) error {
-				return finishInstall(err, sourceRepo, dryRun)
+				return finishInstall(err, sourceRepo, dryRun, installType == "")
 			}
 			if userScope && (len(positional) == 0 || installAll) {
 				return install(cmdInstallAll(scope, ref, sourceRepo, dryRun, force, jsonOutput))

--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
@@ -452,52 +453,13 @@ func cmdAddFromSource(itemType, name string, src *Source, scope *InstallScope, d
 		return nil
 	}
 
-	// Append to state file if one exists, otherwise create a minimal one
-	state, err := readScopedState(scope)
+	foreign, err := recordAddedFiles(scope, src, result)
 	if err != nil {
-		return fmt.Errorf("reading existing state: %w", err)
-	}
-	if state == nil {
-		state = &StateFile{
-			Collection:  "(à la carte)",
-			Scope:       scope.Name,
-			Version:     src.Version,
-			SourceRepo:  src.Repo,
-			SourceSHA:   src.SHA,
-			InstalledAt: timeNow().UTC().Format("2006-01-02T15:04:05Z07:00"),
-		}
-	}
-	state.SourceSHA = src.SHA
-	if state.SourceRepo == "" {
-		state.SourceRepo = src.Repo
-	}
-	if state.Version == "" {
-		state.Version = src.Version
-	}
-
-	// Merge new files into state, avoiding duplicates
-	existing := make(map[string]bool)
-	for _, f := range state.Files {
-		existing[f.Path] = true
-	}
-	for _, f := range result.Files {
-		if !existing[f.Path] {
-			state.Files = append(state.Files, f)
-		} else {
-			for i, sf := range state.Files {
-				if sf.Path == f.Path {
-					state.Files[i].Hash = f.Hash
-					state.Files[i].Status = ""
-					break
-				}
-			}
-		}
-	}
-	if err := writeScopedState(scope, state); err != nil {
-		fmt.Fprintf(os.Stderr, "%s Could not write state file: %v\n", yellow("⚠"), err)
+		return err
 	}
 
 	fmt.Printf("\n%s Installed %s %q.\n", green("✓"), itemType, name)
+	noteForeignSource(scope, foreign, fmt.Sprintf("nav-pilot install %s --type %s --source %s", name, itemType, foreign))
 	return nil
 }
 
@@ -953,6 +915,26 @@ func cmdListInstalledScoped(scope *InstallScope, _ bool, jsonOutput bool) error 
 	return nil
 }
 
+// foreignFileCounts counts a scope's files per agentpakke they came from,
+// leaving out the scope's own (which record no source). A file that sync
+// deliberately skips should say so somewhere the user looks before wondering
+// why it never updates.
+func foreignFileCounts(state *StateFile) ([]string, map[string]int) {
+	counts := map[string]int{}
+	var sources []string
+	for _, f := range state.Files {
+		if f.Source == "" {
+			continue
+		}
+		if counts[f.Source] == 0 {
+			sources = append(sources, f.Source)
+		}
+		counts[f.Source]++
+	}
+	sort.Strings(sources)
+	return sources, counts
+}
+
 func printStatusBlock(scope *InstallScope, state *StateFile) {
 	ok, modified, missing, ignored, modifiedPaths := countFileIntegrity(scope.RootDir, state)
 
@@ -977,6 +959,12 @@ func printStatusBlock(scope *InstallScope, state *StateFile) {
 
 	for _, p := range modifiedPaths {
 		fmt.Printf("  %s %s (modified locally)\n", yellow("~"), p)
+	}
+
+	foreignSources, foreignCounts := foreignFileCounts(state)
+	for _, fs := range foreignSources {
+		fmt.Printf("  %s %d file(s) from %s (synced with its own source, not this one)\n",
+			dim("↗"), foreignCounts[fs], fs)
 	}
 
 	statusLine := fmt.Sprintf("\n  %s %d ok, %s %d modified, %s %d missing",

--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -255,7 +255,7 @@ func cmdInstallAuto(name, itemType string, scope *InstallScope, ref, sourceRepo 
 	}
 
 	if len(matchedKinds) == 1 {
-		return cmdAddFromSource(matchedKinds[0].Name, name, src, scope, dryRun, force, jsonOutput)
+		return cmdAddFromSource(matchedKinds[0].Name, name, src, scope, sourceRepo, dryRun, force, jsonOutput)
 	}
 
 	// Not found — suggest closest match
@@ -400,7 +400,7 @@ func cmdInstallFromSource(collection string, src *Source, scope *InstallScope, d
 
 // cmdAddFromSource installs a single artifact from an already-resolved source.
 // It preserves the à-la-carte state semantics from cmdAdd.
-func cmdAddFromSource(itemType, name string, src *Source, scope *InstallScope, dryRun, force bool, jsonOutput bool) error {
+func cmdAddFromSource(itemType, name string, src *Source, scope *InstallScope, explicitSource string, dryRun, force bool, jsonOutput bool) error {
 	if !scope.SupportsType(itemType) {
 		return fmt.Errorf("type %q is not supported in user scope. Only agents, skills, and instructions can be installed to ~/.copilot", itemType)
 	}
@@ -453,13 +453,13 @@ func cmdAddFromSource(itemType, name string, src *Source, scope *InstallScope, d
 		return nil
 	}
 
-	foreign, err := recordAddedFiles(scope, src, result)
+	foreign, err := recordAddedFiles(scope, src, result, explicitSource)
 	if err != nil {
 		return err
 	}
 
 	fmt.Printf("\n%s Installed %s %q.\n", green("✓"), itemType, name)
-	noteForeignSource(scope, foreign, fmt.Sprintf("nav-pilot install %s --type %s --source %s", name, itemType, foreign))
+	noteForeignSource(scope, foreign, fmt.Sprintf("nav-pilot add %s %s --source %s", itemType, name, foreign))
 	return nil
 }
 
@@ -963,7 +963,7 @@ func printStatusBlock(scope *InstallScope, state *StateFile) {
 
 	foreignSources, foreignCounts := foreignFileCounts(state)
 	for _, fs := range foreignSources {
-		fmt.Printf("  %s %d file(s) from %s (synced with its own source, not this one)\n",
+		fmt.Printf("  %s %d file(s) from %s (`sync` leaves these alone — re-add to update)\n",
 			dim("↗"), foreignCounts[fs], fs)
 	}
 

--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -155,14 +155,22 @@ func installArtifact(resolver *SourceResolver, scope *InstallScope, kind *Artifa
 // actually succeeded (and validated, which resolveSource does). A cancelled
 // prompt installed nothing, so it persists nothing — and it is still a clean
 // exit, not an error the user has to read.
-func finishInstall(err error, flagSource string, dryRun bool) error {
+//
+// Only a scope-defining install persists. `install <name> --type <t> --source X`
+// pulls one artifact out of another agentpakke; it does not make X the scope's
+// agentpakke, and writing it to the config would refuse every later plain add
+// (B3) and let sync adopt X for a pre-tracking scope. The file is stamped with
+// its origin instead, which is what keeps it current.
+func finishInstall(err error, flagSource string, dryRun, scopeDefining bool) error {
 	if errors.Is(err, errInstallCancelled) {
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	persistInstalledSource(flagSource, dryRun)
+	if scopeDefining {
+		persistInstalledSource(flagSource, dryRun)
+	}
 	return nil
 }
 
@@ -459,7 +467,7 @@ func cmdAddFromSource(itemType, name string, src *Source, scope *InstallScope, e
 	}
 
 	fmt.Printf("\n%s Installed %s %q.\n", green("✓"), itemType, name)
-	noteForeignSource(scope, foreign, fmt.Sprintf("nav-pilot add %s %s --source %s", itemType, name, foreign))
+	noteForeignSource(scope, foreign, fmt.Sprintf("nav-pilot install %s --type %s --source %s --force", name, itemType, foreign))
 	return nil
 }
 

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -237,6 +237,11 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 		fmt.Println()
 	}
 
+	// Counts in the summary describe what this source was asked about. A file
+	// from another agentpakke was skipped above without being compared, so
+	// counting it as "up to date" claims a check that never happened.
+	checked := len(files) - len(foreignPaths)
+
 	result := syncResult{
 		UpToDate:  len(updates) == 0 && len(deletedPaths) == 0 && len(syncErrors) == 0 && (apply || len(conflictPaths) == 0),
 		Source:    src.SHA,
@@ -271,7 +276,7 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 
 	if result.UpToDate {
 		fmt.Printf("%s All %d files up to date (source: %s)\n",
-			green("✓"), len(files), src.SHA)
+			green("✓"), checked, src.SHA)
 		// Bump state version so staleness check won't re-trigger for this release
 		if src.Version != "" {
 			if state, err := readScopedState(scope); err == nil && state != nil {
@@ -291,7 +296,7 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 	// Report updates
 	if len(updates) > 0 {
 		fmt.Printf("%s %d of %d files have updates available (source: %s)\n\n",
-			yellow("⚠"), len(updates), len(files), src.SHA)
+			yellow("⚠"), len(updates), checked, src.SHA)
 		for _, u := range updates {
 			fmt.Printf("  %s %s\n", yellow("~"), u.Path)
 		}

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -17,6 +17,7 @@ type syncResult struct {
 	Errors    []string     `json:"errors,omitempty"`
 	Overrides []string     `json:"overrides,omitempty"`
 	Ignored   []string     `json:"ignored,omitempty"`
+	Foreign   []string     `json:"foreign,omitempty"`
 	Conflicts []string     `json:"conflicts,omitempty"`
 }
 
@@ -174,11 +175,23 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 	var deletedPaths []string
 	var syncErrors []string
 	var ignoredPaths []string
+	var foreignPaths []string
 	for _, sf := range files {
 		// Check if local file exists; if missing, treat as intentional deletion
 		localFull := filepath.Join(scope.RootDir, sf.localPath)
 		if _, statErr := os.Stat(localFull); os.IsNotExist(statErr) {
 			ignoredPaths = append(ignoredPaths, sf.localPath)
+			continue
+		}
+
+		// A file from another agentpakke is not this source's to judge. It is
+		// absent here because it was never here, and reading that as "deleted
+		// upstream" is what removed files that `add --source` had just
+		// installed (#571). Such a file is updated by adding it again from its
+		// own source, which never has to be reachable from this run — being
+		// offline must not delete anything.
+		if sf.source != "" && !sameSourceRepo(sf.source, sourceLabelFor(src)) {
+			foreignPaths = append(foreignPaths, sf.localPath)
 			continue
 		}
 
@@ -217,6 +230,13 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 		}
 	}
 
+	if !jsonOutput && len(foreignPaths) > 0 {
+		for _, p := range foreignPaths {
+			fmt.Printf("  %s %s (from another agentpakke — not synced from here)\n", dim("⊘"), p)
+		}
+		fmt.Println()
+	}
+
 	result := syncResult{
 		UpToDate:  len(updates) == 0 && len(deletedPaths) == 0 && len(syncErrors) == 0 && (apply || len(conflictPaths) == 0),
 		Source:    src.SHA,
@@ -225,6 +245,7 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 		Errors:    syncErrors,
 		Overrides: overriddenPaths,
 		Ignored:   ignoredPaths,
+		Foreign:   foreignPaths,
 		Conflicts: conflictPaths,
 	}
 	tMode := telemetryMode()
@@ -632,6 +653,7 @@ type syncFile struct {
 	localPath  string // relative path in target repo (e.g. ".github/agents/nais.agent.md")
 	sourcePath string // relative path in source repo (same unless remapped)
 	isDir      bool
+	source     string // agentpakke this file came from; empty means the scope's own
 }
 
 // resolveSyncFiles determines which files to sync.
@@ -658,6 +680,7 @@ func resolveSyncFiles(scope *InstallScope, resolver *SourceResolver, includeConf
 				localPath:  f.Path,
 				sourcePath: sp,
 				isDir:      strings.HasSuffix(f.Path, "/"),
+				source:     f.Source,
 			})
 		}
 		return files, state.Collection, nil

--- a/cli/nav-pilot/internal/cli/sync_test.go
+++ b/cli/nav-pilot/internal/cli/sync_test.go
@@ -1178,3 +1178,40 @@ func TestAdd_ForeignSourceKeepsScopeSHA(t *testing.T) {
 		t.Errorf("foreign add rewrote SourceSHA to %q, want %q", state.SourceSHA, "own-sha")
 	}
 }
+
+// TestAdd_PlainAddIntoForeignScopeIsStamped is the hole the first attempt at
+// the local-checkout fix opened: guardScopeSource does not fire when the config
+// source is unset, so a plain `add` into a scope installed from another
+// agentpakke resolves the default source. That file is not the scope's, and an
+// unstamped one is deleted by the next sync --apply.
+func TestAdd_PlainAddIntoForeignScopeIsStamped(t *testing.T) {
+	isolatedConfig(t)
+	dir := t.TempDir()
+	defaultSource := t.TempDir()
+
+	os.MkdirAll(filepath.Join(dir, ".git"), 0o755)
+	os.MkdirAll(filepath.Join(defaultSource, "agents"), 0o755)
+	os.WriteFile(filepath.Join(defaultSource, "agents", "nais.agent.md"), []byte("# Nais"), 0o644)
+
+	scope := ScopeRepo(dir)
+	writeState(dir, &StateFile{Collection: "(à la carte)", SourceRepo: "team/agentpakke", SourceSHA: "team-sha"})
+
+	origResolve := resolveSource
+	t.Cleanup(func() { resolveSource = origResolve })
+	resolveSource = func(ref, sourceRepo string) (*Source, error) {
+		return &source.Source{Dir: defaultSource, SHA: "default-sha", Repo: "navikt/copilot"}, nil
+	}
+	if err := cmdAdd("agent", "nais", scope, "", "", false, false, false); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	state, _ := readScopedState(scope)
+	for _, f := range state.Files {
+		if f.Path == ".github/agents/nais.agent.md" && f.Source != "navikt/copilot" {
+			t.Fatalf("file from the default source stamped %q, want %q", f.Source, "navikt/copilot")
+		}
+	}
+	if state.SourceSHA != "team-sha" {
+		t.Errorf("SourceSHA = %q, want the scope's own %q", state.SourceSHA, "team-sha")
+	}
+}

--- a/cli/nav-pilot/internal/cli/sync_test.go
+++ b/cli/nav-pilot/internal/cli/sync_test.go
@@ -992,3 +992,121 @@ func TestSync_DirectoryPromptAndLocalSource(t *testing.T) {
 		t.Fatalf("sync check failed: %v", err)
 	}
 }
+
+// TestSync_ForeignSourceFileSurvivesApply is #571: `add --source <other>`
+// installed a file the scope's own source has never had, and the next
+// `sync --apply` read that absence as an upstream deletion and removed it.
+func TestSync_ForeignSourceFileSurvivesApply(t *testing.T) {
+	isolatedConfig(t)
+	dir := t.TempDir()
+	ownSource := t.TempDir()
+	otherSource := t.TempDir()
+
+	os.MkdirAll(filepath.Join(dir, ".git"), 0o755)
+	os.MkdirAll(filepath.Join(ownSource, "agents"), 0o755)
+	os.WriteFile(filepath.Join(ownSource, "agents", "nais.agent.md"), []byte("# Nais"), 0o644)
+	os.MkdirAll(filepath.Join(otherSource, "agents"), 0o755)
+	os.WriteFile(filepath.Join(otherSource, "agents", "teamting.agent.md"), []byte("# Teamting"), 0o644)
+
+	scope := ScopeRepo(dir)
+	os.MkdirAll(filepath.Join(dir, ".github", "agents"), 0o755)
+	os.WriteFile(filepath.Join(dir, ".github", "agents", "nais.agent.md"), []byte("# Nais"), 0o644)
+	ownHash, _ := fileHash(filepath.Join(dir, ".github", "agents", "nais.agent.md"))
+	writeState(dir, &StateFile{
+		Collection: "kotlin-backend",
+		SourceRepo: "navikt/copilot",
+		Files:      []InstalledFile{{Path: ".github/agents/nais.agent.md", Hash: ownHash}},
+	})
+
+	origResolve := resolveSource
+	t.Cleanup(func() { resolveSource = origResolve })
+	resolveSource = func(ref, sourceRepo string) (*Source, error) {
+		return &source.Source{Dir: otherSource, SHA: "other-sha", Repo: "team/agentpakke"}, nil
+	}
+	if err := cmdAdd("agent", "teamting", scope, "", "team/agentpakke", false, false, false); err != nil {
+		t.Fatalf("add --source: %v", err)
+	}
+
+	added := filepath.Join(dir, ".github", "agents", "teamting.agent.md")
+	if _, err := os.Stat(added); err != nil {
+		t.Fatalf("add did not install the file: %v", err)
+	}
+	state, _ := readScopedState(scope)
+	var foreign string
+	for _, f := range state.Files {
+		if f.Path == ".github/agents/teamting.agent.md" {
+			foreign = f.Source
+		}
+	}
+	if foreign != "team/agentpakke" {
+		t.Fatalf("state records source %q, want %q", foreign, "team/agentpakke")
+	}
+
+	origSync := resolveSourceForSync
+	t.Cleanup(func() { resolveSourceForSync = origSync })
+	resolveSourceForSync = func(ref, sourceRepo string) (*Source, error) {
+		return &source.Source{Dir: ownSource, SHA: "own-sha", Repo: "navikt/copilot"}, nil
+	}
+	if err := cmdSync(scope, "", "", true, false); err != nil {
+		t.Fatalf("sync --apply: %v", err)
+	}
+
+	if _, err := os.Stat(added); err != nil {
+		t.Fatalf("sync deleted a file from another source: %v", err)
+	}
+	state, _ = readScopedState(scope)
+	found := false
+	for _, f := range state.Files {
+		if f.Path == ".github/agents/teamting.agent.md" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("sync dropped the foreign file from state")
+	}
+}
+
+// TestSync_StatePredatingPerFileSource is the upgrade path: a state file
+// written before InstalledFile had a source records none for any file, which
+// must keep meaning "this scope's source" rather than "belongs to nothing".
+func TestSync_StatePredatingPerFileSource(t *testing.T) {
+	isolatedConfig(t)
+	dir := t.TempDir()
+	sourceDir := t.TempDir()
+
+	os.MkdirAll(filepath.Join(sourceDir, "agents"), 0o755)
+	os.WriteFile(filepath.Join(sourceDir, "agents", "nais.agent.md"), []byte("# Nais"), 0o644)
+	os.MkdirAll(filepath.Join(dir, ".github", "agents"), 0o755)
+	os.WriteFile(filepath.Join(dir, ".github", "agents", "nais.agent.md"), []byte("# Nais"), 0o644)
+	hash, _ := fileHash(filepath.Join(dir, ".github", "agents", "nais.agent.md"))
+
+	// Written by hand in the pre-change shape: no "source" key anywhere.
+	statePath := ScopeRepo(dir).StatePath()
+	os.MkdirAll(filepath.Dir(statePath), 0o755)
+	os.WriteFile(statePath, []byte(`{
+  "collection": "kotlin-backend",
+  "version": "2026.06",
+  "source_repo": "navikt/copilot",
+  "source_sha": "old-sha",
+  "installed_at": "2026-06-01T00:00:00Z",
+  "files": [{"path": ".github/agents/nais.agent.md", "hash": "`+hash+`"}]
+}`), 0o644)
+
+	origSync := resolveSourceForSync
+	t.Cleanup(func() { resolveSourceForSync = origSync })
+	resolveSourceForSync = func(ref, sourceRepo string) (*Source, error) {
+		return &source.Source{Dir: sourceDir, SHA: "new-sha", Repo: "navikt/copilot"}, nil
+	}
+
+	scope := ScopeRepo(dir)
+	if err := cmdSync(scope, "", "", true, false); err != nil {
+		t.Fatalf("sync --apply over a pre-source state: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".github", "agents", "nais.agent.md")); err != nil {
+		t.Fatalf("sync deleted a file from a state that predates per-file sources: %v", err)
+	}
+	state, _ := readScopedState(scope)
+	if state == nil || len(state.Files) != 1 {
+		t.Fatalf("state after sync = %+v, want the one file kept", state)
+	}
+}

--- a/cli/nav-pilot/internal/cli/sync_test.go
+++ b/cli/nav-pilot/internal/cli/sync_test.go
@@ -960,7 +960,7 @@ func TestSync_DirectoryPromptAndLocalSource(t *testing.T) {
 
 	// 2. Install directory prompt to target
 	targetScope := ScopeRepo(dir)
-	err = cmdAddFromSource("prompt", "my-prompt", src, targetScope, false, false, false)
+	err = cmdAddFromSource("prompt", "my-prompt", src, targetScope, src.Repo, false, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1108,5 +1108,73 @@ func TestSync_StatePredatingPerFileSource(t *testing.T) {
 	state, _ := readScopedState(scope)
 	if state == nil || len(state.Files) != 1 {
 		t.Fatalf("state after sync = %+v, want the one file kept", state)
+	}
+}
+
+// TestAdd_LocalCheckoutIsNotForeign guards the other half of #571: without an
+// explicit --source, an add resolves the scope's own source, and a dev running
+// from a local checkout gets an absolute path as the source label. Stamping
+// that as foreign would make sync skip the file forever, in a scope whose own
+// source it actually is.
+func TestAdd_LocalCheckoutIsNotForeign(t *testing.T) {
+	isolatedConfig(t)
+	dir := t.TempDir()
+	checkout := t.TempDir()
+
+	os.MkdirAll(filepath.Join(dir, ".git"), 0o755)
+	os.MkdirAll(filepath.Join(checkout, "agents"), 0o755)
+	os.WriteFile(filepath.Join(checkout, "agents", "teamting.agent.md"), []byte("# Teamting"), 0o644)
+
+	scope := ScopeRepo(dir)
+	writeState(dir, &StateFile{Collection: "kotlin-backend", SourceRepo: "navikt/copilot"})
+
+	origResolve := resolveSource
+	t.Cleanup(func() { resolveSource = origResolve })
+	resolveSource = func(ref, sourceRepo string) (*Source, error) {
+		return &source.Source{Dir: checkout, SHA: "local-sha", Repo: checkout}, nil
+	}
+	if err := cmdAdd("agent", "teamting", scope, "", "", false, false, false); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	state, _ := readScopedState(scope)
+	for _, f := range state.Files {
+		if f.Path == ".github/agents/teamting.agent.md" && f.Source != "" {
+			t.Fatalf("local checkout stamped as foreign source %q", f.Source)
+		}
+	}
+	if state.SourceSHA != "local-sha" {
+		t.Errorf("SourceSHA = %q, want the scope's own %q", state.SourceSHA, "local-sha")
+	}
+}
+
+// TestAdd_ForeignSourceKeepsScopeSHA is the Copilot review comment on #586: a
+// foreign add must not overwrite the scope's SourceSHA with another repo's,
+// which would leave status and the Tier 2 launch pin pointing at a revision
+// this scope's source has never had.
+func TestAdd_ForeignSourceKeepsScopeSHA(t *testing.T) {
+	isolatedConfig(t)
+	dir := t.TempDir()
+	otherSource := t.TempDir()
+
+	os.MkdirAll(filepath.Join(dir, ".git"), 0o755)
+	os.MkdirAll(filepath.Join(otherSource, "agents"), 0o755)
+	os.WriteFile(filepath.Join(otherSource, "agents", "teamting.agent.md"), []byte("# Teamting"), 0o644)
+
+	scope := ScopeRepo(dir)
+	writeState(dir, &StateFile{Collection: "kotlin-backend", SourceRepo: "navikt/copilot", SourceSHA: "own-sha"})
+
+	origResolve := resolveSource
+	t.Cleanup(func() { resolveSource = origResolve })
+	resolveSource = func(ref, sourceRepo string) (*Source, error) {
+		return &source.Source{Dir: otherSource, SHA: "other-sha", Repo: "team/agentpakke"}, nil
+	}
+	if err := cmdAdd("agent", "teamting", scope, "", "team/agentpakke", false, false, false); err != nil {
+		t.Fatalf("add --source: %v", err)
+	}
+
+	state, _ := readScopedState(scope)
+	if state.SourceSHA != "own-sha" {
+		t.Errorf("foreign add rewrote SourceSHA to %q, want %q", state.SourceSHA, "own-sha")
 	}
 }

--- a/cli/nav-pilot/internal/domain/domain.go
+++ b/cli/nav-pilot/internal/domain/domain.go
@@ -424,6 +424,11 @@ type InstalledFile struct {
 	Path   string `json:"path"`
 	Hash   string `json:"hash"`
 	Status string `json:"status,omitempty"` // "" = active, FileStatusIgnored = intentionally excluded, FileStatusConflict = exists with local modifications
+	// Source names the agentpakke this file came from, when that is not the
+	// scope's own SourceRepo. Empty means "this scope's source", which is what
+	// every state file written before per-file origins says about all of its
+	// files — so they keep syncing exactly as they did.
+	Source string `json:"source,omitempty"`
 }
 
 // FileStatusIgnored marks a file as intentionally excluded by the user.


### PR DESCRIPTION
Lukker #571. Steg 4 i #572.

## Feilen

`nav-pilot add <kind> <navn> --source <annet-repo>` lyktes, og neste `sync --apply` slettet fila. `InstalledFile` hadde bare `path`, `hash` og `status`, så synken sammenlignet hver fil mot scopets `source_repo`, fant den fremmede fila der ikke, og presenterte slettingen som opprydding etter noe som var fjernet oppstrøms.

Verifisert på main før endringen, og reprodusert i test (testen feiler uten fiksen).

## Løsningen

Kilde per fil, ikke nektelse — samme felt komposisjonen i #572 trenger.

- `InstalledFile.source` navngir agentpakken fila kom fra når det ikke er scopets egen.
- **Bakoverkompatibilitet:** tomt felt betyr «scopets egen kilde». Alle state-filer skrevet før dette har tomt felt på alle filer, så de synker byte for byte som før. Ingen migrering, ingen versjonsbump.
- **Fremmede filer i sync:** hoppes over, med én linje i utskriften og et `foreign`-felt i `--json`. De sammenlignes ikke mot sin egen kilde under en sync av scopets kilde — synken trenger da aldri å nå den andre kilden, og offline kan ikke slette noe. Oppdatering skjer ved å legge fila til på nytt fra sin egen kilde. (`sync --source <annen>` er bevisst *ikke* rådet: det ville pekt hele scopet dit, og sendt scopets egne filer samme vei som denne fila pleide å gå.)
- **`add`/`install` sier fra:** én linje som sier hvilken kilde fila kom fra, hvilken scopet har, og hvordan den oppdateres. Stillheten var halve fella.
- **`list`/status:** «↗ N file(s) from <kilde> (synced with its own source, not this one)».

Søsterstien `install <artefakt> --source` (`cmdAddFromSource`) hadde samme feil og bruker nå samme kode. Den sluttet samtidig å adoptere en fremmed kilde som *hele* scopets `source_repo` når scopet ikke hadde noen — det ville sendt alle scopets øvrige filer i samme felle. `adoptSyncSource` eier fortsatt det spørsmålet.

## Bevis

Tre kjøringer med ekte binær mot lokale kilder, og tilsvarende tester:

1. **Fella er borte:** `add --source other` → `sync --apply` → fila lever, og står fortsatt i state. (`TestSync_ForeignSourceFileSurvivesApply` — feiler uten fiksen, verifisert.)
2. **Normalstien er urørt:** en fil fra scopets egen kilde som ble fjernet oppstrøms slettes fortsatt. (`TestSync_RemoteDeletions`, uendret.)
3. **Oppgraderingsstien:** en håndskrevet state-fil uten `source`-nøkkel noe sted synker uten å slette noe. (`TestSync_StatePredatingPerFileSource`.)

`mise run nav-pilot:check` er grønn.

## Fra beskrivelsen i saken

Alt i #571 stemte. Ett tillegg den ikke nevnte: `add --source` inn i et *tomt* scope var samme felle langs en annen vei — state ble skrevet uten `source_repo`, og synken adopterte den konfigurerte kilden i stedet. Nytt state fra `add` registrerer nå kilden det faktisk ble installert fra.