### PR TITLE
fix(install.sh): send the token CI already gives it

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -104,14 +104,34 @@ if [[ -z "$VERSION" ]]; then
   echo "→ Fetching latest nav-pilot release..."
   # Filter by nav-pilot/ tag prefix to avoid picking up unrelated releases (e.g. skills)
   set +o pipefail
-  VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=100" \
+  # Authenticate when a token is available. Anonymous api.github.com allows 60
+  # requests per hour per IP, and a CI runner shares that IP with everyone else
+  # on the same host — so this returned 403 and the installer reported "could
+  # not determine latest version", which reads like a broken release rather
+  # than a rate limit. It blocked every pull request in this repository.
+  #
+  # Both spellings are accepted: the workflow sets GITHUB_TOKEN, the script's
+  # own error message tells people to set GH_TOKEN, and gh sets GH_TOKEN. All
+  # three were in play and none of them reached this call.
+  GH_AUTH=()
+  API_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+  if [[ -n "$API_TOKEN" ]]; then
+    GH_AUTH=(-H "Authorization: Bearer ${API_TOKEN}")
+  fi
+  VERSION=$(curl -fsSL "${GH_AUTH[@]}" "https://api.github.com/repos/${REPO}/releases?per_page=100" \
     | grep '"tag_name"' \
     | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/' \
     | grep '^nav-pilot/' \
     | head -1)
   set -o pipefail
   if [[ -z "$VERSION" ]]; then
-    echo "Error: Could not determine latest version. Use --version to specify."
+    echo "Error: Could not determine latest version."
+    if [[ -z "$API_TOKEN" ]]; then
+      echo "  No GH_TOKEN or GITHUB_TOKEN was set, so the request was anonymous."
+      echo "  Anonymous api.github.com is limited to 60 requests per hour per IP,"
+      echo "  and a shared network or CI runner reaches that quickly."
+    fi
+    echo "  Pass --version to skip the lookup entirely."
     exit 1
   fi
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -113,12 +113,15 @@ if [[ -z "$VERSION" ]]; then
   # Both spellings are accepted: the workflow sets GITHUB_TOKEN, the script's
   # own error message tells people to set GH_TOKEN, and gh sets GH_TOKEN. All
   # three were in play and none of them reached this call.
-  GH_AUTH=()
   API_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
-  if [[ -n "$API_TOKEN" ]]; then
-    GH_AUTH=(-H "Authorization: Bearer ${API_TOKEN}")
-  fi
-  VERSION=$(curl -fsSL "${GH_AUTH[@]}" "https://api.github.com/repos/${REPO}/releases?per_page=100" \
+  # The header goes in on stdin, not in the argument list. Anything passed as an
+  # argument shows up in `ps` for every user on the machine, and this script is
+  # run on shared runners.
+  auth_config() {
+    [[ -n "$API_TOKEN" ]] && printf 'header = "Authorization: Bearer %s"\n' "$API_TOKEN"
+    return 0
+  }
+  VERSION=$(auth_config | curl -fsSL -K - "https://api.github.com/repos/${REPO}/releases?per_page=100" \
     | grep '"tag_name"' \
     | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/' \
     | grep '^nav-pilot/' \


### PR DESCRIPTION
Every open pull request in this repository is red on the same job right now — #581, #576 and #586 all fail identically:

```
curl: (22) The requested URL returned error: 403
Error: Could not determine latest version. Use --version to specify.
```

## Cause

The workflow passes a token into the step:

```yaml
- name: Run install.sh
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

The curl that resolves the latest release (`scripts/install.sh:107`) **sends no Authorization header at all**. So the call is anonymous, and anonymous `api.github.com` allows **60 requests per hour per IP** — shared across every job on that runner host. The token was being handed over and dropped on the floor.

Three names were in play and none of them reached the call: the workflow sets `GITHUB_TOKEN`, the script's own error message at line 214 tells people to set `GH_TOKEN`, and `gh` sets `GH_TOKEN`.

## Fix

Use whichever is set, and keep working without either:

```bash
API_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
if [[ -n "$API_TOKEN" ]]; then
  GH_AUTH=(-H "Authorization: Bearer ${API_TOKEN}")
fi
```

Both paths tested against the live API — authenticated and anonymous each return the expected releases when not rate-limited.

## The error message was the other half

"Could not determine latest version" reads like a broken release, which is where the time goes. It now says the request was anonymous and why that runs out, and points at `--version` to skip the lookup entirely.

## Checks

`bash -n` clean, and all six `scripts/install.bats` cases pass.