### PR TITLE
docs: tre former for hvor nav-pilot-artefakter installeres

### DIFF
--- a/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
+++ b/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
@@ -51,7 +51,7 @@ const DOC_SECTIONS: TocItem[] = [
     label: "Kom i gang",
     children: [
       { id: "installasjon", label: "Installasjon (5 min)" },
-      { id: "personlig-installasjon", label: "Personlig installasjon (valgfritt)" },
+      { id: "hvor-installere", label: "Hvor skal artefaktene installeres?" },
       { id: "vanlige-oppgaver", label: "Vanlige oppgaver" },
     ],
   },
@@ -741,13 +741,47 @@ nav-pilot`}
           </div>
         </div>
 
-        <div id="personlig-installasjon">
+        <div id="hvor-installere">
           <LinkableHeading size="small" level="3">
-            Personlig installasjon (valgfritt)
+            Hvor skal artefaktene installeres?
           </LinkableHeading>
           <BodyLong className="mt-2" style={{ color: "#475569" }}>
-            Du kan også installere agenter, skills og instruksjoner til hjemmemappen. De blir da tilgjengelige i{" "}
-            <em>alle</em> repoer uten å endre hvert enkelt.
+            Tre former er i bruk i Nav, og de løser ulike problemer.{" "}
+            <code className="font-mono text-xs">install</code> spør hvis du ikke svarer på forhånd med{" "}
+            <code className="font-mono text-xs">--repo</code> eller <code className="font-mono text-xs">--user</code>.
+          </BodyLong>
+          <ul className="mt-3 space-y-2 list-disc pl-5" style={{ color: "#475569" }}>
+            <li>
+              <strong>Repo</strong> (<code className="font-mono text-xs">--repo</code>, skriver til{" "}
+              <code className="font-mono text-xs">.github/</code>): hele teamet får det samme, prompts virker, og
+              Copilot på github.com ser filene fordi de er sjekket inn. Til gjengjeld ligger de i repoet og i hver
+              diff.
+            </li>
+            <li>
+              <strong>Personlig</strong> (<code className="font-mono text-xs">--user</code>, skriver til{" "}
+              <code className="font-mono text-xs">~/.copilot/</code>): følger deg på tvers av alle repoer, og
+              ingenting sjekkes inn. Den tar ikke med prompts, og når verken github.com eller resten av teamet.
+            </li>
+            <li>
+              <strong>Hub-repo</strong>: en repo-installasjon i et repo som ikke er en applikasjon, pluss teamets
+              egne skills lagt inn for hånd i det samme <code className="font-mono text-xs">.github/</code>. Konteksten
+              følger arbeidskatalogen, så den gjelder mens du står i hub-repoet.
+            </li>
+          </ul>
+          <BodyLong className="mt-3" size="small" style={{ color: "#64748b" }}>
+            Formene utelukker ikke hverandre, og{" "}
+            <code className="font-mono text-xs">nav-pilot sync</code> uten scope-flagg synker alle scope som har en
+            tilstandsfil. Avveiningene i sin helhet står i{" "}
+            <a
+              href="https://github.com/navikt/copilot/blob/main/docs/README.nav-pilot.md#hvor-skal-artefaktene-installeres"
+              className="text-blue-600 hover:underline"
+            >
+              README.nav-pilot.md
+            </a>
+            .
+          </BodyLong>
+          <BodyLong className="mt-4" style={{ color: "#475569" }}>
+            Personlig installasjon:
           </BodyLong>
           <div className="mt-4">
             <CodeBlock compact>{`nav-pilot install --user`}</CodeBlock>

--- a/apps/my-copilot/src/components/nav-pilot/interactive-setup-wizard.tsx
+++ b/apps/my-copilot/src/components/nav-pilot/interactive-setup-wizard.tsx
@@ -334,7 +334,7 @@ export function StepResult({
           </Box>
           <BodyShort textColor="subtle" size="small">
             Oppskriften installerer i dette repoet. Vil du heller ha agenter og skills på tvers av alle repoer, bytt
-            siste linje til <code>nav-pilot install --user --all</code>. Den tar ikke med prompts.{" "}
+            ut <code>install</code>-linja med <code>nav-pilot install --user --all</code>. Den tar ikke med prompts.{" "}
             <Link href="/nav-pilot/docs#hvor-installere" className="text-blue-600">
               Hvor skal artefaktene installeres?
             </Link>

--- a/apps/my-copilot/src/components/nav-pilot/interactive-setup-wizard.tsx
+++ b/apps/my-copilot/src/components/nav-pilot/interactive-setup-wizard.tsx
@@ -328,9 +328,18 @@ export function StepResult({
       </VStack>
 
       {currentResult.code && (
-        <Box background="default" borderRadius="8" padding="space-16">
-          <CodeBlock compact>{currentResult.code}</CodeBlock>
-        </Box>
+        <>
+          <Box background="default" borderRadius="8" padding="space-16">
+            <CodeBlock compact>{currentResult.code}</CodeBlock>
+          </Box>
+          <BodyShort textColor="subtle" size="small">
+            Oppskriften installerer i dette repoet. Vil du heller ha agenter og skills på tvers av alle repoer, bytt
+            siste linje til <code>nav-pilot install --user --all</code>. Den tar ikke med prompts.{" "}
+            <Link href="/nav-pilot/docs#hvor-installere" className="text-blue-600">
+              Hvor skal artefaktene installeres?
+            </Link>
+          </BodyShort>
+        </>
       )}
 
       <HStack justify="center" gap="space-16" marginBlock="space-16">

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -28,9 +28,104 @@ nav-pilot
 nav-pilot install kotlin-backend
 ```
 
-`install` spør hvor den skal installere, i repoet (`.github/`) eller i hjemmekatalogen
-(`~/.copilot/`). Svar på forhånd med `--repo`, `--user` eller `--target <mappe>` for å hoppe
-over spørsmålet.
+## Hvor skal artefaktene installeres?
+
+Tre former er i bruk i Nav, og de løser ulike problemer. `install` spør hvor den skal
+installere, i repoet (`.github/`) eller i hjemmekatalogen (`~/.copilot/`). Svar på forhånd
+med `--repo`, `--user` eller `--target <mappe>` for å hoppe over spørsmålet.
+
+| Form | Hvor | Kort sagt |
+|---|---|---|
+| Repo (`--repo`) | `<repo>/.github/` | Hele teamet får det samme, og Copilot på github.com ser det |
+| Personlig (`--user`) | `~/.copilot/` | Følger deg på tvers av alle repoer, ingenting sjekkes inn |
+| Hub-repo | ett repo med `.github/` pluss egne artefakter | Ett sted å vedlikeholde teamets egne skills |
+
+De utelukker ikke hverandre. `nav-pilot sync` uten scope-flagg synker alle scope som har en
+tilstandsfil, og de spores hver for seg.
+
+### Repo-installasjon
+
+Skriver til `<repo>/.github/`: `agents/`, `skills/`, `instructions/`, `prompts/` og
+tilstandsfila `.github/.nav-pilot-state.json`.
+
+Dette får du bare her:
+
+- **Prompts.** Brukerscopet støtter `agent`, `skill` og `instruction`, ikke `prompt`
+  (`ScopeUser()` i `cli/nav-pilot/internal/domain/domain.go`). Ber du om prompts med
+  `--user`, hopper installasjonen over dem og rapporterer dem som ikke støttet.
+- **Copilot på github.com.** Filene er sjekket inn, så det som kjører på GitHub-siden leser
+  dem. Det forutsetter at du committer og pusher, og nav-pilot gjør ingen av delene.
+- **Automatisk oppdatering uten at noen kjører CLI-et.** Den gjenbrukbare workflowen
+  `copilot-customization-sync.yml` kjører `nav-pilot sync` i Actions og åpner PR med
+  oppdateringene. Se [README.sync.md](README.sync.md).
+- **Alle på teamet, også de som ikke har nav-pilot.** Filene ligger der uansett.
+
+Hva det koster: innholdet blir liggende i repoet og dukker opp i differ og
+kodegjennomgang. `kotlin-backend` er 93 filer og rundt 490 KB målt på artefaktene i denne
+kilden. Filer teamet vil eie selv kan merkes som overrides i `.github/copilot-sync.json`,
+og blir da hoppet over ved sync.
+
+### Personlig installasjon (`--user`)
+
+```bash
+nav-pilot install --user --all
+eval "$(nav-pilot env)"
+```
+
+Skriver til `~/.copilot/`. Ingenting sjekkes inn noe sted.
+
+Dette får du bare her:
+
+- **Alle repoer på maskinen på én gang**, også repoer der du ikke vil eller kan endre
+  `.github/`.
+- **Ett sted å synce.** Repo-scopet er alltid det repoet du står i. Med repo-installasjon i
+  40 repoer må noen innom alle 40, eller sette opp sync-workflowen i alle 40. Med `--user`
+  er det én installasjon å holde fersk.
+- **`nav-pilot ignore <type> <name> --user`** for å slippe varsler om komponenter du ikke
+  vil ha. Kommandoen avviser repo-scope.
+
+Dette når den ikke:
+
+- **Prompts.** Se over.
+- **Instruksjoner uten miljøvariabel.** De havner i `~/.copilot/.github/instructions/`, og
+  leses bare når `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` peker på `~/.copilot`. Det er
+  `eval "$(nav-pilot env)"` som setter den, og det virker i Copilot CLI. Agenter og skills
+  plukkes opp uten. `nav-pilot env` sier fra hvis ingen instruksjoner er installert.
+- **GitHub-siden.** Filene ligger på din maskin, ikke i repoet.
+- **Resten av teamet.** En personlig installasjon er personlig.
+- **opencode.** Nav-konteksten til opencode materialiseres fra kilden pluss `.github/` i
+  repoet du står i, ikke fra `~/.copilot/` (`repoScopeDir()` i
+  `cli/nav-pilot/internal/provider/opencode_launch.go`).
+
+### Hub-repo
+
+Mekanisk er et hub-repo en vanlig repo-installasjon i et repo som ikke er en applikasjon,
+pluss teamets egne agenter, skills og prompts lagt inn for hånd i det samme `.github/`. Du
+kjører nav-pilot fra hub-repoet og jobber derfra.
+
+Det virker fordi begge klientene leser scopet fra arbeidskatalogen:
+
+- Copilot leser `.github/` i repoet direkte, uansett hvem som la fila der.
+- opencode materialiserer både kildeartefaktene og det som bare finnes i scopet. Det siste
+  kom med [#579](https://github.com/navikt/copilot/pull/579). Før den fikk opencode bare
+  det nav-pilot selv hadde installert: et hub-repo med 25 installerte og 3 håndlagde skills
+  så 25, uten varsel og uten feilmelding. Kjører teamet en eldre nav-pilot, mangler de tre
+  fortsatt.
+
+Skarpe kanter:
+
+- **Konteksten følger arbeidskatalogen.** nav-pilot sender ingen prosjektkatalog med til
+  cplt, så klienten arver katalogen du står i. Står du i hub-repoet, har du hub-repoets
+  artefakter og hub-repoets filer. Går du til applikasjonsrepoet for å endre kode der, har
+  du ikke lenger hub-repoets egne skills i scopet.
+- **Kilden vinner ved navnekollisjon.** En håndlagd skill med samme navn som en installert
+  taper i opencode. Se «Hva scopet ditt bidrar med» under opencode-avsnittet.
+- **Instruksjoner fra `.github/` slås ikke sammen med opencodes globale `AGENTS.md`.**
+  `nav-pilot export opencode` er veien når teamet trenger dem der.
+- **Sync i hub-repoet oppdaterer hub-repoet.** De andre repoene har fortsatt sitt eget.
+
+`AGENTS.md` og `.github/copilot-instructions.md` synces aldri, uansett form. De er alltid
+repo-spesifikke, og er stedet for det som bare gjelder ett repo.
 
 ## Sandboxing og isolasjon er påkrevd
 
@@ -243,13 +338,6 @@ parallelt.
 
 Dette er alfa. Si fra om noe henger, om en endring kompilerer men er feil, eller om
 ventetiden ikke er verdt det: `nav-pilot feedback`.
-
-## Personlig installasjon (valgfritt)
-
-```bash
-nav-pilot install --user --all
-eval "$(nav-pilot env)"
-```
 
 ## Agentpakker fra andre team
 

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -51,8 +51,9 @@ tilstandsfila `.github/.nav-pilot-state.json`.
 Dette får du bare her:
 
 - **Prompts.** Brukerscopet støtter `agent`, `skill` og `instruction`, ikke `prompt`
-  (`ScopeUser()` i `cli/nav-pilot/internal/domain/domain.go`). Ber du om prompts med
-  `--user`, hopper installasjonen over dem og rapporterer dem som ikke støttet.
+  (`ScopeUser()` i `cli/nav-pilot/internal/domain/domain.go`). Installerer du en samling med
+  `--user`, hoppes promptene over og rapporteres som ikke støttet. Ber du om én enkelt prompt
+  med `--type prompt --user`, er det en feilmelding.
 - **Copilot på github.com.** Filene er sjekket inn, så det som kjører på GitHub-siden leser
   dem. Det forutsetter at du committer og pusher, og nav-pilot gjør ingen av delene.
 - **Automatisk oppdatering uten at noen kjører CLI-et.** Den gjenbrukbare workflowen
@@ -87,10 +88,12 @@ Dette får du bare her:
 Dette når den ikke:
 
 - **Prompts.** Se over.
-- **Instruksjoner uten miljøvariabel.** De havner i `~/.copilot/.github/instructions/`, og
-  leses bare når `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` peker på `~/.copilot`. Det er
-  `eval "$(nav-pilot env)"` som setter den, og det virker i Copilot CLI. Agenter og skills
-  plukkes opp uten. `nav-pilot env` sier fra hvis ingen instruksjoner er installert.
+- **Instruksjoner utenfor nav-pilot.** De havner i `~/.copilot/.github/instructions/`, og
+  leses bare når `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` peker på `~/.copilot`. Starter du
+  klienten med `nav-pilot`, settes den for deg (`copilotEnv` i
+  `cli/nav-pilot/internal/provider/copilot_launch.go`). Starter du `copilot` eller `cplt`
+  direkte, må du sette den selv: `eval "$(nav-pilot env)"`. Agenter og skills plukkes opp
+  uansett. En staged Tier 2-pakke setter den bevisst ikke.
 - **GitHub-siden.** Filene ligger på din maskin, ikke i repoet.
 - **Resten av teamet.** En personlig installasjon er personlig.
 - **opencode.** Nav-konteksten til opencode materialiseres fra kilden pluss `.github/` i


### PR DESCRIPTION
Steg 3 i utvidbarhetsplanen i #572.

## Problemet

Tre team spurte om det samme i Slack og landet på tre ulike svar, mens kom-i-gang-siden viser én. Alle tre formene er fornuftige. Dokumentasjonen beskriver dem nå med avveiningene, uten å kåre en vinner.

## Hva er dokumentert

Nytt avsnitt «Hvor skal artefaktene installeres?» i `docs/README.nav-pilot.md`, med repo-installasjon, `--user` og hub-repo. Den gamle korte «Personlig installasjon (valgfritt)»-seksjonen er borte, innholdet er flyttet inn i det nye avsnittet.

Kom-i-gang-veiviseren ligger i dette repoet (`apps/my-copilot/src/components/nav-pilot/interactive-setup-wizard.tsx`) og foreslo bare `nav-pilot install <stack> --repo`, uten å nevne `--user`. Den nevner det nå og lenker videre. Online docs-siden (`apps/my-copilot/src/app/nav-pilot/docs/page.tsx`) har fått samme tredeling i kortform; seksjonen `#personlig-installasjon` er blitt `#hvor-installere`.

## Verifisert i koden, ikke i tråden

- **Prompts finnes bare i repo-scopet.** `ScopeUser()` i `cli/nav-pilot/internal/domain/domain.go` lister `agent`, `skill`, `instruction`. Repo-scopet har i tillegg `prompt`. `installItems` hopper over typer scopet ikke støtter og rapporterer dem som ikke støttet.
- **`--user`-instruksjoner krever miljøvariabel.** De skrives til `~/.copilot/.github/instructions/` og leses bare når `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` peker på `~/.copilot`. `cmdEnv` i `internal/cli/env.go` er det som setter den.
- **opencode leser repo-scopet, ikke brukerscopet.** `repoScopeDir()` i `internal/provider/opencode_launch.go` returnerer `<git root>/.github` for arbeidskatalogen. `~/.copilot/` er ikke med. Håndlagt innhold i scopet kom først med #579.
- **Sync er symmetrisk mellom scopene.** `cmdSyncAuto` synker begge scope som har en tilstandsfil, og `scopeStaleness` sjekker begge ved hver oppstart. Forskjellen er rekkevidde, ikke oppførsel: repo-scopet er alltid repoet du står i.
- **Arbeidskatalogen er prosjektomfanget.** Ingen launch-sti setter `cmd.Dir` (kommentar i `internal/provider/staged_launch.go`), så cplt og klienten arver katalogen du står i.
- **Kostnaden ved repo-installasjon er målt.** `kotlin-backend` er 93 filer og rundt 490 KB, summert over artefaktene manifestet peker på i denne kilden.

## Der praksis og verktøy spriker

- **Torkjel:** `--user` gir ikke alt et repo gir. Prompts følger ikke med, og instruksjonene virker bare i Copilot CLI med `nav-pilot env` satt.
- **Kristofer:** hub-repoet virket i Copilot hele tiden, men opencode så bare det nav-pilot selv hadde installert fram til #579 i går. Konteksten følger dessuten arbeidskatalogen.
- **Audun:** instruksjoner i `.github/instructions/` slås ikke sammen med opencodes globale `AGENTS.md` ved oppstart eller sync. `nav-pilot export opencode` er veien dit. `AGENTS.md` i repo-rota synces aldri og er stedet for repo-spesifikt.
- **Jakob:** innvendingen er reell og tallfestet. Til gjengjeld koster `--user` prompts og GitHub-siden.

## Verifisert

`tsc --noEmit` grønn for `apps/my-copilot`. Ingen modellkall, ingen kodeendringer.
