### PR TITLE
docs: ikke-underlegenhet for test 3, regnet og skrevet ned

### DIFF
--- a/docs/nav-pilot-benchmark-og-beslutninger-2026-08.md
+++ b/docs/nav-pilot-benchmark-og-beslutninger-2026-08.md
@@ -39,6 +39,66 @@ sikkerhet ikke skiller kandidatene, er det ingenting igjen som gjør det.
 Ikke les tabellen som en rangering. Punktestimatene ser ut som en rangering, men
 usikkerheten dekker hele spennet.
 
+### Ikke-underlegenhet, regnet i etterkant
+
+Seksjon 1 sier at ingen forskjell er signifikant. Det er et fravær av bevis for en
+forskjell, og det er ikke det samme som bevis for at kandidatene er gode nok. Det
+spørsmålet stilles med en ikke-underlegenhetstest, og det er den [#584](https://github.com/navikt/copilot/issues/584)
+setter først i køen fordi den ikke koster et eneste kall: dataene finnes allerede.
+
+**Spørsmålet:** er kandidatens passrate på test 3 dårligere enn den sittende
+modellens med mer enn en margin vi på forhånd sier vi kan leve med? Marginen er
+satt til **δ = 0,10**, altså ti prosentpoeng. Kandidaten er ikke-underlegen hvis
+den **nedre** grensen for differansen `kandidat − referanse` ligger over **−δ**.
+
+**Metode:** Newcombe hybrid score-intervall for differansen mellom to andeler,
+bygget på Wilson-intervallene for hver arm, altså samme metode som tabellen over.
+Ensidig 95 prosent, `z = 1,6449`. Ensidig, fordi hypotesen bare handler om én
+retning: vi bryr oss om at kandidaten er *dårligere*, ikke om at den er bedre.
+Regnestykket ligger i [`scripts/ikke-underlegenhet.py`](../scripts/ikke-underlegenhet.py)
+og kjøres uten nettverk.
+
+Inndata er tabellen over, snudd fra feil til bestått:
+
+| Arm | Bestått | Kjøringer | Passrate | Wilson, ensidig 95 % |
+|---|---|---|---|---|
+| Claude Sonnet 4.6 (referanse) | 48 | 50 | 96,0 % | 88,6 til 98,7 % |
+| GPT-5.6 Sol | 49 | 50 | 98,0 % | 91,5 til 99,6 % |
+| GPT-5.6 Luna | 49 | 50 | 98,0 % | 91,5 til 99,6 % |
+| GPT-5.6 Terra | 40 | 45 | 88,9 % | 78,9 til 94,5 % |
+
+Resultatet:
+
+| Kandidat | Differanse | Newcombe-intervall | Nedre grense mot −δ | Ikke-underlegen? |
+|---|---|---|---|---|
+| GPT-5.6 Sol | +2,0 pp | −5,0 til +9,6 pp | −5,0 > −10,0 | **ja** |
+| GPT-5.6 Luna | +2,0 pp | −5,0 til +9,6 pp | −5,0 > −10,0 | **ja** |
+| GPT-5.6 Terra | −7,1 pp | −17,5 til +2,2 pp | −17,5 < −10,0 | **nei** |
+
+Sol og Luna er altså ikke-underlegne den sittende modellen på test 3 ved
+δ = 0,10. Terra er det ikke: intervallet strekker seg til 17,5 prosentpoeng
+dårligere, og det er mer enn marginen tillater.
+
+**Tre presiseringer, fordi denne testen er lett å lese feil.**
+
+Tallene −5,0, −5,0 og −17,5 er **negative nedre grenser**, ikke gevinster. En
+tidligere muntlig gjengivelse av dette resultatet oppga dem uten fortegn, som
+«Sol +5,0, Luna +5,0, Terra +17,5». Det er samme tall, men motsatt fortegn, og med
+fortegnet borte gir Terra-raden ingen mening: en kandidat som ligger 17,5
+prosentpoeng *over* referansen kan ikke stryke på en ikke-underlegenhetstest.
+Fortegnet er hele testen.
+
+At Terra ikke består, er **ikke** det samme som at Terra er underlegen. Testen
+har ett utfall til, og det er Terras: *ubesluttet*. Intervallet dekker både −10 og
+0. Dataene utelukker verken at Terra er like god eller at den er ti prosentpoeng
+dårligere. Det svarer til Fisher p = 0,25 i tabellen over og motsier ikke
+seksjon 4.2: Terra er fortsatt ikke bevist dårligere, den er nå også ikke bevist
+god nok. Det er 45 kjøringer som er for få, ikke Terra som er avslørt.
+
+Testen gjelder **én påstand**, blindsone-assertionen i test 3, og ikke suiten som
+helhet. Se avsnittet under: test 3 er den eneste påstanden i suiten som har n nok
+til at et slikt regnestykke betyr noe.
+
 ### Den metodiske lærdommen
 
 Denne kostet ekte penger å lære, så den står her eksplisitt.
@@ -56,12 +116,47 @@ Konsekvenser for framtidige sammenligninger på en sjelden hendelse:
 - En liten runde kan avkrefte at noe er *veldig* galt. Den kan ikke rangere
   kandidater som ligger nær hverandre, og den skal ikke brukes til det.
 
+Gjennomgangen av hele conformance-suiten i
+[#583](https://github.com/navikt/copilot/issues/583) satte to tall på det samme,
+og begge hører hjemme i et beslutningsdokument.
+
+**Styrken ved n = 5 per arm til å oppdage 0,95 mot 0,75 etterlevelse er 0,01.**
+Det er ikke et svakt eksperiment, det er ikke noe eksperiment. Nitti-ni av hundre
+ganger ville en reell forskjell av den størrelsen gå upåaktet hen. Vi har likevel
+argumentert pinningsbeslutninger fra 4 av 5 mot 5 av 5. For 80 prosent styrke på
+den samme forskjellen trengs rundt 50 kjøringer per arm, som for nav-pilot er 140
+til 350 kall per modell.
+
+**Suiten har aldri skilt to modeller på noen påstand, unntatt gjennom
+artefakter.** Hver gang den så ut til å gjøre det, ble forskjellen sporet tilbake
+til noe annet enn modellen: cr2 4/5 mot 5/5 var byggeartefakter i
+fingeravtrykket ([#578](https://github.com/navikt/copilot/pull/578)), cr3-hellingen
+i [#554](https://github.com/navikt/copilot/pull/554) var regnet på et regex som
+måler norsk ordforråd og ikke forklaring, og uu3-forskjellen etter hooken måler
+hooken. Tre av seks nav-pilot-påstander kan ikke feile mot noen modell vi har
+observert.
+
+Test 3 er unntaket, og det er derfor ikke-underlegenhetstesten over kunne regnes i
+det hele tatt: n = 50 per arm er den eneste tilstrekkelig kraftige sammenligningen
+i repoet. Den skal ikke generaliseres til de øvrige påstandene, og et grønt
+suite-resultat er fortsatt en røyktest på at personaen framkaller den grove formen
+av oppførselen, ikke et belegg for at modell X er like god som modell Y for Nav.
+
 ### Forbehold om sporbarhet
 
 Baseline-filene under `docs/golden-baselines/` inneholder
 **størrelsesmålinger**, ikke bestått/ikke-bestått per kjøring. Tallene i tabellen
 over er talt opp under selve kjøringen og er ikke gjenskapbare fra de commitede
 filene alene. Gjentas benchmarken, bør rådataene for assertions logges også.
+
+Dette gjelder ikke-underlegenhetstesten over med. Passtallene 48/50, 49/50, 49/50
+og 40/45 er de samme tallene som feiltabellen, snudd. Regnestykket er
+reproduserbart fra tallene, og skriptet ligger i repoet; **tallene er ikke
+reproduserbare fra de commitede filene**. Fra og med
+[#590](https://github.com/navikt/copilot/pull/590) skriver `--save-baseline` også
+en `*-results.psv` med rader per kjøring og per påstand. Skal denne testen kjøres
+mot nye data, er det den fila som må ligge ved siden av baselinen; uten den er
+neste analyse like uetterrettelig som denne.
 
 ## 2. Funnet som betyr mer enn modellvalget
 
@@ -173,6 +268,12 @@ kostnadsbeinet i argumentet over faller bort. Beslutningen blir stående som den
 er: den ble tatt på det grunnlaget som stod her, og punktestimatene i seksjon 1
 er ikke en rangering. Om prisen alene nå taler for Terra, er det en ny
 beslutning som må tas for seg, ikke en omskriving av denne.
+
+**Tillegg:** ikke-underlegenhetstesten i seksjon 1 gir beslutningen et bein til.
+Terra er den eneste kandidaten som ikke består den ved δ = 0,10. Det er fortsatt
+ikke et bevis på at Terra er dårligere — utfallet er *ubesluttet*, ikke
+*underlegen* — men det er heller ikke et belegg for at den er god nok, og et
+argument *for* Terra må i så fall komme fra en måling som finnes.
 
 ### 4.3 nav-pilot styrer standard klientkonfigurasjon
 
@@ -367,3 +468,10 @@ stedet man glemmer.
 - [#500](https://github.com/navikt/copilot/issues/500): vilkårene for å skrive
   klientkonfigurasjon
 - `cli/nav-pilot/internal/artifacts/export.go`: `transformAgent` og `openCodeAgentModel`
+- `scripts/ikke-underlegenhet.py`: ikke-underlegenhetstesten for test 3
+- [#583](https://github.com/navikt/copilot/issues/583): hva conformance-suiten
+  faktisk måler, styrke og ikke-separasjon
+- [#584](https://github.com/navikt/copilot/issues/584): arbeidskøen som følger av
+  #583, der ikke-underlegenhet stod først
+- [#590](https://github.com/navikt/copilot/pull/590): `results.psv` ved siden av
+  hver baseline

--- a/docs/nav-pilot-benchmark-og-beslutninger-2026-08.md
+++ b/docs/nav-pilot-benchmark-og-beslutninger-2026-08.md
@@ -46,14 +46,23 @@ forskjell, og det er ikke det samme som bevis for at kandidatene er gode nok. De
 spørsmålet stilles med en ikke-underlegenhetstest, og det er den [#584](https://github.com/navikt/copilot/issues/584)
 setter først i køen fordi den ikke koster et eneste kall: dataene finnes allerede.
 
+**Marginen er satt i etterkant, og det må stå her.** Overskriften sier «regnet i
+etterkant», og δ ble valgt etter at tallene forelå. Det betyr at δ, ikke dataene,
+avgjør den ene omstridte armen: Terra stryker ved δ = 0,10 og består ved
+δ ≥ 0,175. En protokoll som fastsetter δ, ensidig nivå og minste n *før* neste
+måling er oppgaven i #584, og til den finnes skal denne testen leses som en
+etterhåndsanalyse.
+
 **Spørsmålet:** er kandidatens passrate på test 3 dårligere enn den sittende
 modellens med mer enn en margin vi på forhånd sier vi kan leve med? Marginen er
 satt til **δ = 0,10**, altså ti prosentpoeng. Kandidaten er ikke-underlegen hvis
 den **nedre** grensen for differansen `kandidat − referanse` ligger over **−δ**.
 
 **Metode:** Newcombe hybrid score-intervall for differansen mellom to andeler,
-bygget på Wilson-intervallene for hver arm, altså samme metode som tabellen over.
-Ensidig 95 prosent, `z = 1,6449`. Ensidig, fordi hypotesen bare handler om én
+bygget på Wilson-intervallene for hver arm, altså samme metode som tabellen over,
+men ikke samme konstant: tabellen i seksjon 1 er tosidig 95 prosent
+(`z = 1,96`), denne er ensidig 95 prosent (`z = 1,6449`). Snur du seksjon 1
+bokstavelig, får du 86,5 til 98,9 prosent for referansen, ikke 88,6 til 98,7. Ensidig, fordi hypotesen bare handler om én
 retning: vi bryr oss om at kandidaten er *dårligere*, ikke om at den er bedre.
 Regnestykket ligger i [`scripts/ikke-underlegenhet.py`](../scripts/ikke-underlegenhet.py)
 og kjøres uten nettverk.
@@ -90,7 +99,9 @@ Fortegnet er hele testen.
 
 At Terra ikke består, er **ikke** det samme som at Terra er underlegen. Testen
 har ett utfall til, og det er Terras: *ubesluttet*. Intervallet dekker både −10 og
-0. Dataene utelukker verken at Terra er like god eller at den er ti prosentpoeng
+0. (Å bruke den øvre grensen slik er strengt tatt en tosidig 90 prosent-uttalelse,
+siden bare den nedre grensen bærer den ensidige garantien. Konklusjonen står
+uansett: ved tosidig 95 prosent er intervallet −19,8 til +4,2, som dekker begge.) Dataene utelukker verken at Terra er like god eller at den er ti prosentpoeng
 dårligere. Det svarer til Fisher p = 0,25 i tabellen over og motsier ikke
 seksjon 4.2: Terra er fortsatt ikke bevist dårligere, den er nå også ikke bevist
 god nok. Det er 45 kjøringer som er for få, ikke Terra som er avslørt.
@@ -124,8 +135,15 @@ og begge hører hjemme i et beslutningsdokument.
 Det er ikke et svakt eksperiment, det er ikke noe eksperiment. Nitti-ni av hundre
 ganger ville en reell forskjell av den størrelsen gå upåaktet hen. Vi har likevel
 argumentert pinningsbeslutninger fra 4 av 5 mot 5 av 5. For 80 prosent styrke på
-den samme forskjellen trengs rundt 50 kjøringer per arm, som for nav-pilot er 140
-til 350 kall per modell.
+den samme forskjellen trengs rundt 50 kjøringer per arm. For nav-pilot er det 350
+kall per modell: `scripts/nav-pilot-golden.sh` bruker sju levende kall per
+gjennomkjøring. (#583 oppgir spennet «140 til 350». Den nedre enden er ikke
+utledet noe sted og svarer ikke til noen agent i harnesset — accessibility bruker
+fire kall, code-review to — så den bør ikke siteres videre uten et regnestykke.)
+
+Tallet er dessuten en nedre grense på Fishers eksakte test: normaltilnærmingen
+gir 48,8 per arm, mens Fisher krysser 80 prosent styrke først et sted mellom
+n = 50 (0,748) og n = 60 (0,845).
 
 **Suiten har aldri skilt to modeller på noen påstand, unntatt gjennom
 artefakter.** Hver gang den så ut til å gjøre det, ble forskjellen sporet tilbake
@@ -133,8 +151,9 @@ til noe annet enn modellen: cr2 4/5 mot 5/5 var byggeartefakter i
 fingeravtrykket ([#578](https://github.com/navikt/copilot/pull/578)), cr3-hellingen
 i [#554](https://github.com/navikt/copilot/pull/554) var regnet på et regex som
 måler norsk ordforråd og ikke forklaring, og uu3-forskjellen etter hooken måler
-hooken. Tre av seks nav-pilot-påstander kan ikke feile mot noen modell vi har
-observert.
+hooken. Tre av seks nav-pilot-påstander kunne ikke feile mot noen modell vi hadde
+observert; [#590](https://github.com/navikt/copilot/pull/590) rettet test 1, 2 og
+6, som var de tre.
 
 Test 3 er unntaket, og det er derfor ikke-underlegenhetstesten over kunne regnes i
 det hele tatt: n = 50 per arm er den eneste tilstrekkelig kraftige sammenligningen

--- a/scripts/ikke-underlegenhet.py
+++ b/scripts/ikke-underlegenhet.py
@@ -51,4 +51,9 @@ def main():
 if __name__ == "__main__":
     main()
     # Selvsjekk: tallene som staar i benchmark-dokumentet.
-    assert [round(newcombe(x, n, 48, 50)[1] * 100, 1) for _, x, n in KANDIDATER] == [-5.0, -5.0, -17.5]
+    # Referansearmen leses fra REFERANSE, ikke skrevet inn paa nytt: ellers er
+    # den ene armen hvis tall ogsaa staar i dokumentets inndatatabell den ene
+    # armen selvsjekken ikke dekker.
+    _, x_ref, n_ref = REFERANSE
+    assert (x_ref, n_ref) == (48, 50)
+    assert [round(newcombe(x, n, x_ref, n_ref)[1] * 100, 1) for _, x, n in KANDIDATER] == [-5.0, -5.0, -17.5]

--- a/scripts/ikke-underlegenhet.py
+++ b/scripts/ikke-underlegenhet.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Ensidig ikke-underlegenhetstest for test 3 i golden-suiten.
+
+Newcombe hybrid score-intervall for differansen mellom to andeler, ensidig 95 %
+(z = 1,6449), mot en margin paa delta = 0,10. Tallene som mates inn staar i
+tabellen i docs/nav-pilot-benchmark-og-beslutninger-2026-08.md, seksjon 1, og er
+talt opp under selve kjoeringen. De er ikke gjenskapbare fra baseline-filene
+alene; se forbeholdet i samme seksjon.
+
+Kjoer: python3 scripts/ikke-underlegenhet.py
+"""
+import math
+
+Z = 1.6449  # ensidig 95 %
+DELTA = 0.10
+
+REFERANSE = ("Claude Sonnet 4.6", 48, 50)  # bestaatt, kjoeringer
+KANDIDATER = [("GPT-5.6 Sol", 49, 50), ("GPT-5.6 Luna", 49, 50), ("GPT-5.6 Terra", 40, 45)]
+
+
+def wilson(x, n, z=Z):
+    p = x / n
+    nevner = 1 + z * z / n
+    senter = p + z * z / (2 * n)
+    halv = z * math.sqrt(p * (1 - p) / n + z * z / (4 * n * n))
+    return (senter - halv) / nevner, (senter + halv) / nevner
+
+
+def newcombe(x1, n1, x2, n2, z=Z):
+    """Nedre og oevre grense for p1 - p2 (kandidat minus referanse)."""
+    p1, p2 = x1 / n1, x2 / n2
+    l1, u1 = wilson(x1, n1, z)
+    l2, u2 = wilson(x2, n2, z)
+    d = p1 - p2
+    return d, d - math.sqrt((p1 - l1) ** 2 + (u2 - p2) ** 2), d + math.sqrt((u1 - p1) ** 2 + (p2 - l2) ** 2)
+
+
+def main():
+    navn_ref, x_ref, n_ref = REFERANSE
+    print(f"Referanse: {navn_ref} {x_ref}/{n_ref} = {x_ref / n_ref:.3f}\n")
+    for navn, x, n in KANDIDATER:
+        d, lo, hi = newcombe(x, n, x_ref, n_ref)
+        ok = lo > -DELTA
+        print(
+            f"{navn:16s} {x}/{n} = {x / n:.3f}  diff {d * 100:+6.2f} pp"
+            f"  [{lo * 100:+6.2f}, {hi * 100:+6.2f}] pp"
+            f"  ikke-underlegen ved delta={DELTA:.2f}: {'ja' if ok else 'nei'}"
+        )
+
+
+if __name__ == "__main__":
+    main()
+    # Selvsjekk: tallene som staar i benchmark-dokumentet.
+    assert [round(newcombe(x, n, 48, 50)[1] * 100, 1) for _, x, n in KANDIDATER] == [-5.0, -5.0, -17.5]

--- a/scripts/ikke-underlegenhet.py
+++ b/scripts/ikke-underlegenhet.py
@@ -54,6 +54,13 @@ if __name__ == "__main__":
     # Referansearmen leses fra REFERANSE, ikke skrevet inn paa nytt: ellers er
     # den ene armen hvis tall ogsaa staar i dokumentets inndatatabell den ene
     # armen selvsjekken ikke dekker.
+    # raise, ikke assert: `python -O` fjerner assert, og en selvsjekk som
+    # forsvinner under et flagg er verre enn ingen selvsjekk.
     _, x_ref, n_ref = REFERANSE
-    assert (x_ref, n_ref) == (48, 50)
-    assert [round(newcombe(x, n, x_ref, n_ref)[1] * 100, 1) for _, x, n in KANDIDATER] == [-5.0, -5.0, -17.5]
+    dokumentert = [-5.0, -5.0, -17.5]
+    regnet = [round(newcombe(x, n, x_ref, n_ref)[1] * 100, 1) for _, x, n in KANDIDATER]
+    if (x_ref, n_ref) != (48, 50) or regnet != dokumentert:
+        raise SystemExit(
+            f"selvsjekk feilet: referanse {x_ref}/{n_ref} (dok: 48/50), "
+            f"nedre grenser {regnet} (dok: {dokumentert})"
+        )


### PR DESCRIPTION
Første punkt i køen i #584: «Regn om test 3 som ensidig ikke-underlegenhet. Null
kall. Data finnes.» Ingen modellkall brukt — alt er regnet fra tallene som
allerede står i benchmark-dokumentet.

## Hva som er regnet

Newcombe hybrid score-intervall for differansen mellom to andeler, bygget på
Wilson-intervallene for hver arm, ensidig 95 prosent (`z = 1,6449`), mot en
margin på δ = 0,10. Referanse er den sittende modellen, Claude Sonnet 4.6.

Inndata er feiltabellen i seksjon 1, snudd fra feil til bestått:

| Arm | Bestått | Kjøringer | Passrate |
|---|---|---|---|
| Claude Sonnet 4.6 (referanse) | 48 | 50 | 96,0 % |
| GPT-5.6 Sol | 49 | 50 | 98,0 % |
| GPT-5.6 Luna | 49 | 50 | 98,0 % |
| GPT-5.6 Terra | 40 | 45 | 88,9 % |

| Kandidat | Differanse | Newcombe-intervall | Ikke-underlegen ved δ = 0,10 |
|---|---|---|---|
| Sol | +2,0 pp | −5,0 til +9,6 pp | ja |
| Luna | +2,0 pp | −5,0 til +9,6 pp | ja |
| Terra | −7,1 pp | −17,5 til +2,2 pp | nei |

## Fortegnet

Resultatet ble gjengitt muntlig som «Sol +5,0, Luna +5,0, Terra +17,5». Magnituden
stemmer på alle tre, fortegnet ikke: dette er **negative nedre grenser**, ikke
gevinster. Uten fortegnet gir Terra-raden ingen mening — en kandidat som ligger
17,5 prosentpoeng over referansen kan ikke stryke på en ikke-underlegenhetstest.
Presiseringen står i dokumentet, sammen med at Terras utfall er *ubesluttet* og
ikke *underlegen*.

## Reproduserbarhet

Regnestykket ligger i `scripts/ikke-underlegenhet.py`, kjører uten nettverk, og
har en selvsjekk som feiler om tallene i dokumentet og skriptet skiller lag.

Inndataene er derimot ikke reproduserbare fra repoet: baseline-filene under
`docs/golden-baselines/` inneholder bare størrelsesmålinger, og passtallene ble
talt opp under selve kjøringen. Forbeholdet som allerede stod om feiltabellen er
utvidet til å dekke denne testen med, og peker på `results.psv` fra #590 som det
som må ligge ved siden av baselinen neste gang.

## To funn fra #583 foldet inn

Begge hører hjemme i et beslutningsdokument og stod ikke der:

- Styrken ved n = 5 per arm til å oppdage 0,95 mot 0,75 er **0,01**.
- Suiten har **aldri** skilt to modeller på noen påstand, unntatt gjennom
  artefakter — cr2 var byggeartefakter (#578), cr3-hellingen var regex (#554),
  uu3 måler hooken. Test 3 er unntaket, og det er derfor denne testen lot seg
  regne i det hele tatt.

Seksjon 4.2 har fått et tillegg om hva testen betyr for Terra-beslutningen.
Beslutningen står.

Refs #583, #584, #590
