### PR TITLE
fix: behold ukjente felter når state-fila skrives om (lukker #588)

### DIFF
--- a/cli/nav-pilot/internal/artifacts/opencode_sync.go
+++ b/cli/nav-pilot/internal/artifacts/opencode_sync.go
@@ -325,6 +325,9 @@ func SyncOpenCodeArtifacts(sourceDir, scopeDir, outputDir, sourceVersion, source
 		InstalledAt: time.Now().UTC().Format("2006-01-02T15:04:05Z07:00"),
 		Files:       files,
 	}
+	// Entries carried over untouched above keep their own unknown keys; the
+	// ones this sync rebuilt do not, and neither does the top level (#588).
+	newState.PreserveUnknownFrom(existingState)
 	if wErr := WriteOpenCodeState(outputDir, newState); wErr != nil {
 		fmt.Fprintf(os.Stderr, "%s could not write opencode state: %v\n", domain.Yellow("⚠"), wErr)
 	}

--- a/cli/nav-pilot/internal/artifacts/state_unknown_test.go
+++ b/cli/nav-pilot/internal/artifacts/state_unknown_test.go
@@ -1,6 +1,7 @@
 package artifacts
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -80,36 +81,58 @@ func TestStateRewritePreservesUnknownKeys(t *testing.T) {
 	}
 }
 
+// realCommittedState is a verbatim copy of a checked-in .github/.nav-pilot-state.json
+// from a Nav repo (navikt/copilot-intern), non-ASCII collection name and all. The
+// bytes matter: this is what the byte-stability test is actually protecting.
+const realCommittedState = `{
+  "collection": "(à la carte)",
+  "version": "dev",
+  "scope": "repo",
+  "source_sha": "385e6f8",
+  "installed_at": "2026-05-06T09:41:57Z",
+  "files": [
+    {
+      "path": ".github/agents/forfatter.agent.md",
+      "hash": "4e55f4d189619dcb"
+    },
+    {
+      "path": ".github/agents/forfatter.metadata.json",
+      "hash": "415648fcdc323588"
+    }
+  ]
+}
+`
+
 // TestStateRewriteIsByteStable guards against a spurious diff in every Nav repo:
-// writing an unchanged state twice must produce identical bytes.
+// reading a state file and writing it straight back must reproduce the original
+// bytes exactly. Comparing two of our own writes would pass even if both differed
+// from what is on disk, which is the diff a colleague would actually see.
 func TestStateRewriteIsByteStable(t *testing.T) {
-	scope, path := writeStateFixture(t, stateWithUnknownKeys)
+	for _, tt := range []struct {
+		name string
+		body string
+	}{
+		{"real committed state", realCommittedState},
+		{"with unknown keys", stateWithUnknownKeys},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			scope, path := writeStateFixture(t, tt.body)
 
-	state, err := ReadScopedState(scope)
-	if err != nil {
-		t.Fatalf("read: %v", err)
-	}
-	if err := WriteScopedState(scope, state); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-	first, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	again, err := ReadScopedState(scope)
-	if err != nil {
-		t.Fatalf("re-read: %v", err)
-	}
-	if err := WriteScopedState(scope, again); err != nil {
-		t.Fatalf("re-write: %v", err)
-	}
-	second, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(first) != string(second) {
-		t.Errorf("write is not byte-stable:\n--- first ---\n%s\n--- second ---\n%s", first, second)
+			state, err := ReadScopedState(scope)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			if err := WriteScopedState(scope, state); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			out, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(out) != tt.body {
+				t.Errorf("rewrite changed the file:\n--- on disk ---\n%s\n--- rewritten ---\n%s", tt.body, out)
+			}
+		})
 	}
 }
 
@@ -145,4 +168,69 @@ func TestStatePredatingPerFileSourceRoundTrips(t *testing.T) {
 	if string(out) != old {
 		t.Errorf("round trip changed the file:\n--- want ---\n%s\n--- got ---\n%s", old, out)
 	}
+}
+
+// TestSyncOpenCodeArtifactsKeepsUnknownKeys is #588 through the opencode sync:
+// every nav-pilot-owned entry is rebuilt from the source on each run, so a
+// per-file key on a path the sync still owns — and the top-level one — has to be
+// carried over from the state being replaced.
+func TestSyncOpenCodeArtifactsKeepsUnknownKeys(t *testing.T) {
+	sourceDir := setupTestSource(t)
+	outputDir := t.TempDir()
+
+	if _, _, _, _, _, err := SyncOpenCodeArtifacts(sourceDir, "", outputDir, "1.0.0", "abc123", ""); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+
+	// Stamp the written state the way a newer nav-pilot would have.
+	path := filepath.Join(outputDir, ".nav-pilot-state.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatal(err)
+	}
+	doc["schema_version"] = json.RawMessage(`2`)
+	var files []map[string]json.RawMessage
+	if err := json.Unmarshal(doc["files"], &files); err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatal("first sync recorded no files")
+	}
+	stamped := string(files[0]["path"])
+	files[0]["installed_by"] = json.RawMessage(`"2.0.0"`)
+	if doc["files"], err = json.Marshal(files); err != nil {
+		t.Fatal(err)
+	}
+	if raw, err = json.Marshal(doc); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, _, _, _, err := SyncOpenCodeArtifacts(sourceDir, "", outputDir, "1.0.1", "def456", ""); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+
+	state, err := ReadOpenCodeState(outputDir)
+	if err != nil || state == nil {
+		t.Fatalf("ReadOpenCodeState = (%v, %v)", state, err)
+	}
+	if _, ok := state.Unknown["schema_version"]; !ok {
+		t.Errorf("sync dropped the top-level schema_version key: %+v", state.Unknown)
+	}
+	for _, f := range state.Files {
+		if `"`+f.Path+`"` != stamped {
+			continue
+		}
+		if _, ok := f.Unknown["installed_by"]; !ok {
+			t.Errorf("sync dropped installed_by from %s, an entry it rebuilt: %+v", f.Path, f.Unknown)
+		}
+		return
+	}
+	t.Errorf("the stamped path %s is gone from the state entirely", stamped)
 }

--- a/cli/nav-pilot/internal/artifacts/state_unknown_test.go
+++ b/cli/nav-pilot/internal/artifacts/state_unknown_test.go
@@ -1,0 +1,148 @@
+package artifacts
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/domain"
+)
+
+// stateWithUnknownKeys is a repo-scope state file as a newer nav-pilot would
+// write it: a top-level key and a per-file key that this binary does not know.
+const stateWithUnknownKeys = `{
+  "collection": "all",
+  "version": "1.2.3",
+  "scope": "repo",
+  "source_repo": "navikt/copilot",
+  "source_sha": "abc123",
+  "installed_at": "2026-01-01T00:00:00Z",
+  "files": [
+    {
+      "path": ".github/agents/foo.md",
+      "hash": "sha256:aaa",
+      "source": "navikt/annen-pakke",
+      "installed_by": "2.0.0"
+    }
+  ],
+  "schema_version": 2
+}
+`
+
+func writeStateFixture(t *testing.T, body string) (*domain.InstallScope, string) {
+	t.Helper()
+	dir := t.TempDir()
+	scope := domain.ScopeRepo(dir)
+	path := scope.StatePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return scope, path
+}
+
+// TestStateRewritePreservesUnknownKeys is the #588 regression: a read-modify-write
+// cycle must not drop keys the running binary does not understand, neither inside
+// a files entry nor at the top level.
+func TestStateRewritePreservesUnknownKeys(t *testing.T) {
+	scope, path := writeStateFixture(t, stateWithUnknownKeys)
+
+	state, err := ReadScopedState(scope)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	// A mutation of the kind sync/ignore/add make.
+	state.SourceSHA = "def456"
+	state.Files[0].Status = domain.FileStatusIgnored
+	if err := WriteScopedState(scope, state); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		`"source": "navikt/annen-pakke"`,
+		`"installed_by": "2.0.0"`,
+		`"schema_version": 2`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("rewritten state lost %s\n%s", want, got)
+		}
+	}
+	if !strings.Contains(got, `"source_sha": "def456"`) || !strings.Contains(got, `"status": "ignored"`) {
+		t.Errorf("rewritten state lost the mutation\n%s", got)
+	}
+}
+
+// TestStateRewriteIsByteStable guards against a spurious diff in every Nav repo:
+// writing an unchanged state twice must produce identical bytes.
+func TestStateRewriteIsByteStable(t *testing.T) {
+	scope, path := writeStateFixture(t, stateWithUnknownKeys)
+
+	state, err := ReadScopedState(scope)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if err := WriteScopedState(scope, state); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	first, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	again, err := ReadScopedState(scope)
+	if err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	if err := WriteScopedState(scope, again); err != nil {
+		t.Fatalf("re-write: %v", err)
+	}
+	second, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != string(second) {
+		t.Errorf("write is not byte-stable:\n--- first ---\n%s\n--- second ---\n%s", first, second)
+	}
+}
+
+// TestStatePredatingPerFileSourceRoundTrips is the other half of #588: state as an
+// older nav-pilot wrote it (no source key anywhere) must survive untouched.
+func TestStatePredatingPerFileSourceRoundTrips(t *testing.T) {
+	const old = `{
+  "collection": "all",
+  "version": "1.0.0",
+  "scope": "repo",
+  "source_sha": "abc123",
+  "installed_at": "2026-01-01T00:00:00Z",
+  "files": [
+    {
+      "path": ".github/agents/foo.md",
+      "hash": "sha256:aaa"
+    }
+  ]
+}
+`
+	scope, path := writeStateFixture(t, old)
+	state, err := ReadScopedState(scope)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if err := WriteScopedState(scope, state); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != old {
+		t.Errorf("round trip changed the file:\n--- want ---\n%s\n--- got ---\n%s", old, out)
+	}
+}

--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -386,6 +386,11 @@ func cmdInstallFromSource(collection string, src *Source, scope *InstallScope, d
 		InstalledAt: timeNow().UTC().Format("2006-01-02T15:04:05Z07:00"),
 		Files:       result.Files,
 	}
+	// A re-install over a checked-in state file must not throw away the keys a
+	// newer nav-pilot put there; the fresh struct has none of them (#588).
+	if prior, err := readScopedState(scope); err == nil {
+		state.PreserveUnknownFrom(prior)
+	}
 	if err := writeScopedState(scope, state); err != nil {
 		fmt.Fprintf(os.Stderr, "%s Could not write state file: %v\n", yellow("⚠"), err)
 	}
@@ -765,6 +770,12 @@ func installAllFromSource(scope *InstallScope, src *Source, manifest *Manifest, 
 	// Append items the user explicitly deselected in the picker as ignored.
 	if len(extraStateFiles) > 0 {
 		state.Files = append(state.Files, extraStateFiles...)
+	}
+
+	// Same as cmdInstallFromSource: a rebuild over an existing state keeps the
+	// keys this binary does not understand (#588).
+	if prior, err := readScopedState(scope); err == nil {
+		state.PreserveUnknownFrom(prior)
 	}
 
 	if err := writeScopedState(scope, state); err != nil {

--- a/cli/nav-pilot/internal/cli/pakke_install.go
+++ b/cli/nav-pilot/internal/cli/pakke_install.go
@@ -479,6 +479,7 @@ func pinRevision(scope *InstallScope, src *Source, jsonOutput bool) (string, err
 		SourceSHA:   src.SHA,
 		InstalledAt: timeNow().UTC().Format("2006-01-02T15:04:05Z07:00"),
 	}
+	state.PreserveUnknownFrom(existing) // #588: the pin replaces the state, not the keys it carried
 	if err := writeScopedState(scope, state); err != nil {
 		return "", fmt.Errorf("writing state: %w", err)
 	}

--- a/cli/nav-pilot/internal/cli/pakke_install.go
+++ b/cli/nav-pilot/internal/cli/pakke_install.go
@@ -479,7 +479,14 @@ func pinRevision(scope *InstallScope, src *Source, jsonOutput bool) (string, err
 		SourceSHA:   src.SHA,
 		InstalledAt: timeNow().UTC().Format("2006-01-02T15:04:05Z07:00"),
 	}
-	state.PreserveUnknownFrom(existing) // #588: the pin replaces the state, not the keys it carried
+	// #588: the pin replaces the state, not the keys it carried — but only
+	// when the state still describes the same source. Switching a scope from
+	// repo A to repo B makes A's keys describe nothing: they were written
+	// about A's install, and a newer binary reading them off B's state would
+	// trust a claim nobody made about B.
+	if existing != nil && sameSourceRepo(existing.SourceRepo, src.Repo) {
+		state.PreserveUnknownFrom(existing)
+	}
 	if err := writeScopedState(scope, state); err != nil {
 		return "", fmt.Errorf("writing state: %w", err)
 	}

--- a/cli/nav-pilot/internal/cli/state_unknown_install_test.go
+++ b/cli/nav-pilot/internal/cli/state_unknown_install_test.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// stateWithUnknownKeys is a repo state file as a newer nav-pilot wrote it: a
+// top-level key and a per-file key this binary does not know, on the two paths
+// legacySourceTree installs.
+const stateWithUnknownKeys = `{
+  "collection": "fullstack",
+  "version": "dev",
+  "scope": "repo",
+  "source_repo": "navikt/copilot",
+  "source_sha": "old1234",
+  "installed_at": "2026-01-01T00:00:00Z",
+  "files": [
+    {
+      "path": ".github/agents/test-a.agent.md",
+      "hash": "sha256:aaa",
+      "installed_by": "2.0.0"
+    },
+    {
+      "path": ".github/skills/test-s/",
+      "hash": "sha256:bbb"
+    }
+  ],
+  "schema_version": 2
+}
+`
+
+func seedState(t *testing.T, scope *InstallScope, body string) {
+	t.Helper()
+	path := scope.StatePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertStateKeeps(t *testing.T, scope *InstallScope, want ...string) {
+	t.Helper()
+	out, err := os.ReadFile(scope.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, w := range want {
+		if !strings.Contains(string(out), w) {
+			t.Errorf("rewritten state lost %s\n%s", w, out)
+		}
+	}
+}
+
+// TestInstallOverExistingStateKeepsUnknownKeys is #588 through `install`: the
+// state is rebuilt from scratch, not read-modify-written, so the keys a newer
+// nav-pilot recorded have to be carried over explicitly.
+func TestInstallOverExistingStateKeepsUnknownKeys(t *testing.T) {
+	isolatedConfig(t)
+	srcDir := legacySourceTree(t)
+	scope := ScopeRepo(repoTarget(t))
+	seedState(t, scope, stateWithUnknownKeys)
+
+	src := &Source{Dir: srcDir, SHA: "abc1234", Version: "dev", Repo: defaultSourceRepo}
+	if err := attachPakke(src); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmdInstallFromSource("fullstack", src, scope, false, true, false); err != nil {
+		t.Fatalf("cmdInstallFromSource: %v", err)
+	}
+	assertStateKeeps(t, scope, `"schema_version": 2`, `"installed_by": "2.0.0"`)
+}
+
+// TestInstallAllOverExistingStateKeepsUnknownKeys is the same for `install`
+// without a collection, which builds its StateFile at a second site.
+func TestInstallAllOverExistingStateKeepsUnknownKeys(t *testing.T) {
+	isolatedConfig(t)
+	srcDir := legacySourceTree(t)
+	scope := ScopeRepo(repoTarget(t))
+	seedState(t, scope, stateWithUnknownKeys)
+
+	src := &Source{Dir: srcDir, SHA: "abc1234", Version: "dev", Repo: defaultSourceRepo}
+	if err := attachPakke(src); err != nil {
+		t.Fatal(err)
+	}
+	if err := installAllFromSource(scope, src, nil, false, true, false); err != nil {
+		t.Fatalf("installAllFromSource: %v", err)
+	}
+	assertStateKeeps(t, scope, `"schema_version": 2`, `"installed_by": "2.0.0"`)
+}
+
+// TestPinRevisionKeepsUnknownKeys covers the Tier 2 pin: it reads the state it
+// replaces for the source-switch cleanup, and used to throw the rest away.
+func TestPinRevisionKeepsUnknownKeys(t *testing.T) {
+	scope := pinEnv(t)
+	seedState(t, scope, `{
+  "collection": "grillmester",
+  "version": "dev",
+  "scope": "user",
+  "source_repo": "navikt/grillmester",
+  "source_sha": "old1234",
+  "installed_at": "2026-01-01T00:00:00Z",
+  "schema_version": 2
+}
+`)
+
+	src := &Source{Dir: tier2SourceTree(t), SHA: "abc1234", Version: "dev", Repo: "navikt/grillmester"}
+	if err := attachPakke(src); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pinRevision(scope, src, true); err != nil {
+		t.Fatalf("pinRevision: %v", err)
+	}
+	assertStateKeeps(t, scope, `"schema_version": 2`)
+}

--- a/cli/nav-pilot/internal/cli/state_unknown_install_test.go
+++ b/cli/nav-pilot/internal/cli/state_unknown_install_test.go
@@ -117,3 +117,38 @@ func TestPinRevisionKeepsUnknownKeys(t *testing.T) {
 	}
 	assertStateKeeps(t, scope, `"schema_version": 2`)
 }
+
+// TestPinRevisionDropsUnknownKeysOnSourceSwitch is the other half of #588's
+// rule: keys survive a rewrite, but not a change of what the state describes.
+// A key an older nav-pilot wrote about repo A's install says nothing about
+// repo B, and carrying it over would let a newer binary trust a claim nobody
+// made.
+func TestPinRevisionDropsUnknownKeysOnSourceSwitch(t *testing.T) {
+	scope := pinEnv(t)
+	seedState(t, scope, `{
+  "collection": "grillmester",
+  "version": "dev",
+  "scope": "user",
+  "source_repo": "navikt/grillmester",
+  "source_sha": "old1234",
+  "installed_at": "2026-01-01T00:00:00Z",
+  "schema_version": 2
+}
+`)
+
+	src := &Source{Dir: tier2SourceTree(t), SHA: "abc1234", Version: "dev", Repo: "navikt/annen-pakke"}
+	if err := attachPakke(src); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pinRevision(scope, src, true); err != nil {
+		t.Fatalf("pinRevision: %v", err)
+	}
+
+	out, err := os.ReadFile(scope.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(out), "schema_version") {
+		t.Errorf("a key written about navikt/grillmester survived the switch to navikt/annen-pakke\n%s", out)
+	}
+}

--- a/cli/nav-pilot/internal/domain/domain.go
+++ b/cli/nav-pilot/internal/domain/domain.go
@@ -516,10 +516,18 @@ func knownJSONKeys(v any) map[string]bool {
 	t := reflect.TypeOf(v)
 	keys := make(map[string]bool, t.NumField())
 	for i := range t.NumField() {
-		name, _, _ := strings.Cut(t.Field(i).Tag.Get("json"), ",")
-		if name != "" && name != "-" {
-			keys[name] = true
+		f := t.Field(i)
+		name, _, _ := strings.Cut(f.Tag.Get("json"), ",")
+		if name == "-" {
+			continue
 		}
+		// An empty tag name is not "no key": encoding/json still matches the
+		// field by its Go name, so leaving it out here would file a known
+		// field under the unknown keys and duplicate it on the way out.
+		if name == "" {
+			name = f.Name
+		}
+		keys[name] = true
 	}
 	return keys
 }
@@ -559,6 +567,33 @@ func appendUnknownKeys(b []byte, unknown map[string]json.RawMessage) []byte {
 		out = append(out, unknown[k]...)
 	}
 	return append(out, '}')
+}
+
+// PreserveUnknownFrom carries the unknown keys of the state being replaced over
+// to s: the top-level ones, and the per-file ones for every path still tracked.
+//
+// The read-modify-write paths (sync, add, ignore) get this for free from the
+// struct copy. Every path that builds a fresh StateFile over an existing one —
+// install, pinRevision, the opencode sync — has to ask for it, or it drops
+// exactly the keys #588 is about.
+func (s *StateFile) PreserveUnknownFrom(prior *StateFile) {
+	if s == nil || prior == nil {
+		return
+	}
+	if s.Unknown == nil {
+		s.Unknown = prior.Unknown
+	}
+	perFile := make(map[string]map[string]json.RawMessage, len(prior.Files))
+	for _, f := range prior.Files {
+		if len(f.Unknown) > 0 {
+			perFile[f.Path] = f.Unknown
+		}
+	}
+	for i, f := range s.Files {
+		if f.Unknown == nil {
+			s.Files[i].Unknown = perFile[f.Path]
+		}
+	}
 }
 
 // FileStatusIgnored marks a file as intentionally excluded by the user.

--- a/cli/nav-pilot/internal/domain/domain.go
+++ b/cli/nav-pilot/internal/domain/domain.go
@@ -581,7 +581,7 @@ func (s *StateFile) PreserveUnknownFrom(prior *StateFile) {
 		return
 	}
 	if s.Unknown == nil {
-		s.Unknown = prior.Unknown
+		s.Unknown = maps.Clone(prior.Unknown)
 	}
 	perFile := make(map[string]map[string]json.RawMessage, len(prior.Files))
 	for _, f := range prior.Files {
@@ -591,7 +591,9 @@ func (s *StateFile) PreserveUnknownFrom(prior *StateFile) {
 	}
 	for i, f := range s.Files {
 		if f.Unknown == nil {
-			s.Files[i].Unknown = perFile[f.Path]
+			// Clone: two entries in s can share a path, and prior is not ours
+			// to alias into a struct the caller keeps.
+			s.Files[i].Unknown = maps.Clone(perFile[f.Path])
 		}
 	}
 }

--- a/cli/nav-pilot/internal/domain/domain.go
+++ b/cli/nav-pilot/internal/domain/domain.go
@@ -1,11 +1,15 @@
 package domain
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -423,6 +427,10 @@ type StateFile struct {
 	SourceSHA   string          `json:"source_sha"`
 	InstalledAt string          `json:"installed_at"`
 	Files       []InstalledFile `json:"files"`
+	// Unknown carries every top-level key this binary does not understand, so a
+	// read-modify-write does not silently drop what a newer nav-pilot wrote.
+	// See [InstalledFile.Unknown].
+	Unknown map[string]json.RawMessage `json:"-"`
 }
 
 // InstalledFile records a single installed file with its content hash.
@@ -435,6 +443,122 @@ type InstalledFile struct {
 	// every state file written before per-file origins says about all of its
 	// files — so they keep syncing exactly as they did.
 	Source string `json:"source,omitempty"`
+	// Unknown carries every key of this entry that the running binary does not
+	// understand, and writes it back out unchanged.
+	//
+	// The repo-scope state file is committed and shared across a team, so a
+	// colleague on an older nav-pilot rewrites it on every sync, ignore or add.
+	// Without this, the decoder drops what it does not know: that is how
+	// per-file `source` (#571) went missing and the next sync deleted the file
+	// as "gone upstream" (#588). Keeping unknown keys fixes that for every
+	// field added after this binary was built, not just for `source`.
+	Unknown map[string]json.RawMessage `json:"-"`
+}
+
+// The alias types below borrow the struct tags without the JSON methods, so the
+// custom marshalling can lean on encoding/json for the known fields.
+type (
+	stateFileFields     StateFile
+	installedFileFields InstalledFile
+)
+
+var (
+	stateFileKnownKeys     = knownJSONKeys(StateFile{})
+	installedFileKnownKeys = knownJSONKeys(InstalledFile{})
+)
+
+func (s *StateFile) UnmarshalJSON(b []byte) error {
+	var known stateFileFields
+	if err := json.Unmarshal(b, &known); err != nil {
+		return err
+	}
+	unknown, err := unknownJSONKeys(b, stateFileKnownKeys)
+	if err != nil {
+		return err
+	}
+	*s = StateFile(known)
+	s.Unknown = unknown
+	return nil
+}
+
+func (s StateFile) MarshalJSON() ([]byte, error) {
+	b, err := json.Marshal(stateFileFields(s))
+	if err != nil {
+		return nil, err
+	}
+	return appendUnknownKeys(b, s.Unknown), nil
+}
+
+func (f *InstalledFile) UnmarshalJSON(b []byte) error {
+	var known installedFileFields
+	if err := json.Unmarshal(b, &known); err != nil {
+		return err
+	}
+	unknown, err := unknownJSONKeys(b, installedFileKnownKeys)
+	if err != nil {
+		return err
+	}
+	*f = InstalledFile(known)
+	f.Unknown = unknown
+	return nil
+}
+
+func (f InstalledFile) MarshalJSON() ([]byte, error) {
+	b, err := json.Marshal(installedFileFields(f))
+	if err != nil {
+		return nil, err
+	}
+	return appendUnknownKeys(b, f.Unknown), nil
+}
+
+// knownJSONKeys is the set of JSON names a struct type declares.
+func knownJSONKeys(v any) map[string]bool {
+	t := reflect.TypeOf(v)
+	keys := make(map[string]bool, t.NumField())
+	for i := range t.NumField() {
+		name, _, _ := strings.Cut(t.Field(i).Tag.Get("json"), ",")
+		if name != "" && name != "-" {
+			keys[name] = true
+		}
+	}
+	return keys
+}
+
+// unknownJSONKeys returns the members of a JSON object that known does not name.
+func unknownJSONKeys(b []byte, known map[string]bool) (map[string]json.RawMessage, error) {
+	var all map[string]json.RawMessage
+	if err := json.Unmarshal(b, &all); err != nil {
+		return nil, err
+	}
+	for k := range all {
+		if known[k] {
+			delete(all, k)
+		}
+	}
+	if len(all) == 0 {
+		return nil, nil
+	}
+	return all, nil
+}
+
+// appendUnknownKeys puts the preserved keys back at the end of the object, in a
+// fixed order: the same state must always serialise to the same bytes, or every
+// checked-in state file picks up a spurious diff on the next sync.
+func appendUnknownKeys(b []byte, unknown map[string]json.RawMessage) []byte {
+	if len(unknown) == 0 {
+		return b
+	}
+	out := b[:len(b)-1] // drop the closing brace
+	for _, k := range slices.Sorted(maps.Keys(unknown)) {
+		if len(out) > 1 {
+			out = append(out, ',')
+		}
+		key, _ := json.Marshal(k)
+		out = append(out, key...)
+		out = append(out, ':')
+		out = append(out, unknown[k]...)
+	}
+	return append(out, '}')
 }
 
 // FileStatusIgnored marks a file as intentionally excluded by the user.

--- a/cli/nav-pilot/internal/domain/domain_test.go
+++ b/cli/nav-pilot/internal/domain/domain_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -432,5 +433,69 @@ func TestAgentFrontmatterModelsAreKnown(t *testing.T) {
 		if got := OpenCodeModelForLabel(string(m[1])); got == "" {
 			t.Errorf("%s declares model %q, which maps to no Copilot model", filepath.Base(f), m[1])
 		}
+	}
+}
+
+// legacyFile stands in for a nav-pilot built before per-file `source` (#571)
+// but with the unknown-key preservation of #588 in place. It is how we check
+// the claim that matters: such a binary rewrites a state file it does not fully
+// understand without losing the stamp a newer one put there.
+type legacyFile struct {
+	Path    string `json:"path"`
+	Hash    string `json:"hash"`
+	Status  string `json:"status,omitempty"`
+	Unknown map[string]json.RawMessage
+}
+
+func (f *legacyFile) UnmarshalJSON(b []byte) error {
+	type fields legacyFile
+	var known fields
+	if err := json.Unmarshal(b, &known); err != nil {
+		return err
+	}
+	unknown, err := unknownJSONKeys(b, knownJSONKeys(legacyFile{}))
+	if err != nil {
+		return err
+	}
+	*f = legacyFile(known)
+	f.Unknown = unknown
+	return nil
+}
+
+func (f legacyFile) MarshalJSON() ([]byte, error) {
+	type fields legacyFile
+	b, err := json.Marshal(fields(f))
+	if err != nil {
+		return nil, err
+	}
+	return appendUnknownKeys(b, f.Unknown), nil
+}
+
+// TestOlderDecoderKeepsPerFileSource is the #588 scenario from the other side:
+// the older binary is the one that rewrites the shared state file.
+func TestOlderDecoderKeepsPerFileSource(t *testing.T) {
+	const stamped = `{"path":".github/agents/foo.md","hash":"sha256:aaa","source":"navikt/annen-pakke"}`
+
+	var f legacyFile
+	if err := json.Unmarshal([]byte(stamped), &f); err != nil {
+		t.Fatal(err)
+	}
+	f.Status = FileStatusIgnored // the mutation an `ignore` run makes
+
+	out, err := json.Marshal(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The stamp must still be there, and still readable as a Source.
+	var back InstalledFile
+	if err := json.Unmarshal(out, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.Source != "navikt/annen-pakke" {
+		t.Errorf("older decoder dropped the source stamp: %s", out)
+	}
+	if back.Status != FileStatusIgnored || back.Hash != "sha256:aaa" {
+		t.Errorf("older decoder lost known fields: %s", out)
 	}
 }

--- a/cli/nav-pilot/internal/domain/domain_test.go
+++ b/cli/nav-pilot/internal/domain/domain_test.go
@@ -441,9 +441,9 @@ func TestAgentFrontmatterModelsAreKnown(t *testing.T) {
 // the claim that matters: such a binary rewrites a state file it does not fully
 // understand without losing the stamp a newer one put there.
 type legacyFile struct {
-	Path    string `json:"path"`
-	Hash    string `json:"hash"`
-	Status  string `json:"status,omitempty"`
+	Path    string                     `json:"path"`
+	Hash    string                     `json:"hash"`
+	Status  string                     `json:"status,omitempty"`
 	Unknown map[string]json.RawMessage `json:"-"`
 }
 
@@ -497,5 +497,28 @@ func TestOlderDecoderKeepsPerFileSource(t *testing.T) {
 	}
 	if back.Status != FileStatusIgnored || back.Hash != "sha256:aaa" {
 		t.Errorf("older decoder lost known fields: %s", out)
+	}
+}
+
+// TestKnownJSONKeysUntaggedField guards the fallback in knownJSONKeys: a field
+// with no json name is still matched by encoding/json under its Go name, so
+// treating it as unknown would duplicate it on every write. A `json:"-"` field
+// is skipped, because encoding/json never writes it at all.
+func TestKnownJSONKeysUntaggedField(t *testing.T) {
+	type sample struct {
+		Tagged   string `json:"tagged"`
+		Untagged string
+		OmitOnly string `json:",omitempty"`
+		Skipped  string `json:"-"`
+	}
+
+	keys := knownJSONKeys(sample{})
+	for _, want := range []string{"tagged", "Untagged", "OmitOnly"} {
+		if !keys[want] {
+			t.Errorf("knownJSONKeys did not report %q as known; encoding/json matches it", want)
+		}
+	}
+	if keys["Skipped"] || keys["-"] {
+		t.Errorf(`a json:"-" field must not be known under any name: %v`, keys)
 	}
 }

--- a/cli/nav-pilot/internal/domain/domain_test.go
+++ b/cli/nav-pilot/internal/domain/domain_test.go
@@ -444,7 +444,7 @@ type legacyFile struct {
 	Path    string `json:"path"`
 	Hash    string `json:"hash"`
 	Status  string `json:"status,omitempty"`
-	Unknown map[string]json.RawMessage
+	Unknown map[string]json.RawMessage `json:"-"`
 }
 
 func (f *legacyFile) UnmarshalJSON(b []byte) error {


### PR DESCRIPTION
Lukker #588. Oppfølging av #586.

## Problemet

Repo-scopets `.github/.nav-pilot-state.json` er sjekket inn og delt i teamet. En kollega på en nav-pilot fra før #586 kjører `sync --apply`, `ignore` eller `add`. Go-dekoderen dropper den ukjente `source`-nøkkelen, staten skrives tilbake uten den, og stempelet er borte. Neste `sync --apply` fra en oppdatert binær ser en ustemplet fil som scopets egen kilde ikke har, leser det som «slettet oppstrøms», og sletter den — nøyaktig datatapet #571/#586 skulle stoppe.

## Løsningen

`StateFile` og `InstalledFile` har fått et `Unknown map[string]json.RawMessage` med egne `MarshalJSON`/`UnmarshalJSON`. Hver nøkkel binæren ikke kjenner blir liggende og skrives ut igjen uendret.

Valgt framfor skjemaversjon eller en svakere slettelogikk i `sync` fordi det løser problemet én gang for alle framtidige felter: en nav-pilot bygget i dag mister heller ikke et felt som legges til neste år. `json.RawMessage` på hele fil-oppføringen ble vraket, den ville tvunget hver eneste mutasjonsvei i `sync.go`, `add.go` og `ignore.go` til å pakke ut og pakke inn igjen.

Toppnivået i `StateFile` er behandlet likt som `Files`-oppføringene, og med samme begrunnelse: et framtidig toppnivåfelt (en skjemaversjon, en scope-innstilling) er nøyaktig like utsatt, og mekanismen var allerede skrevet.

Feltrekkefølgen ligger fast: kjente felter i strukturens rekkefølge, bevarte nøkler sist, sortert. En uendret state-fil gir dermed identiske bytes ved neste skriving, så ingen Nav-repo får en spøkelsesdiff.

## Veiene som bygger staten på nytt

Les-endre-skriv (`sync`, `add`, `ignore`) får bevaringen gratis: `Unknown` er med i struct-kopien. Det gjelder ikke der en `StateFile` bygges fersk over en som allerede fantes — der er kartet tomt, og nøklene forsvinner like sikkert som i #588, bare gjennom en annen kommando. En kollega som kjører `nav-pilot install` i et repo med en innsjekket state fra en nyere nav-pilot mistet stempelet på stedet.

`StateFile.PreserveUnknownFrom` flytter toppnivånøklene og de per-fil nøklene for hver sti som fortsatt spores. Den kalles fire steder:

- `cmdInstallFromSource` og `installAllFromSource` — begge leste ingen tidligere state i det hele tatt; de leser den nå, kun for å bevare.
- `pinRevision` — hadde allerede den forrige staten i hånda for opprydding ved kildebytte, og kastet resten.
- `SyncOpenCodeArtifacts` — verst av dem, fordi det er en synk: urørte oppføringer bæres videre ordrett og beholder sine egne nøkler, men hver oppføring nav-pilot eier bygges fersk hver kjøring, så per-fil nøkler forsvant for nøyaktig de filene synken faktisk synker — pluss toppnivået.

## Kjente begrensninger

- **Duplikatnøkler som bare skiller seg i store/små bokstaver** (`"version"` og `"Version"` i samme objekt) spretter fram og tilbake mellom rundturer. `encoding/json` matcher case-insensitivt, så den ene blir kjent og den andre bevart. Patologisk input som nav-pilot aldri skriver selv; ikke forsøkt løst.
- **Bevarte nøkler legges sist.** Skriver en nyere binær et nytt felt midt i strukturen, gir en eldre binær som skriver fila om en to-linjers diff (nøkkelen flyttet til slutten). Strengt bedre enn datatapet det erstatter, og den billige fiksen finnes ikke.

## Tester

`TestStateRewritePreservesUnknownKeys` feiler uten endringen. Mot uendret kode:

```
--- FAIL: TestStateRewritePreservesUnknownKeys (0.00s)
    state_unknown_test.go:75: rewritten state lost "installed_by": "2.0.0"
    state_unknown_test.go:75: rewritten state lost "schema_version": 2
```

Én regresjonstest per nybygg-vei, alle fire feiler uten kallet til `PreserveUnknownFrom`:

```
--- FAIL: TestInstallOverExistingStateKeepsUnknownKeys (0.02s)
    state_unknown_install_test.go:75: rewritten state lost "schema_version": 2
    state_unknown_install_test.go:75: rewritten state lost "installed_by": "2.0.0"
--- FAIL: TestInstallAllOverExistingStateKeepsUnknownKeys (0.01s)
    state_unknown_install_test.go:93: rewritten state lost "schema_version": 2
    state_unknown_install_test.go:93: rewritten state lost "installed_by": "2.0.0"
--- FAIL: TestPinRevisionKeepsUnknownKeys (0.00s)
    state_unknown_install_test.go:118: rewritten state lost "schema_version": 2
--- FAIL: TestSyncOpenCodeArtifactsKeepsUnknownKeys (0.01s)
    state_unknown_test.go:224: sync dropped the top-level schema_version key: map[]
    state_unknown_test.go:231: sync dropped installed_by from skills/security-review/, an entry it rebuilt: map[]
```

I tillegg:

- `TestStateRewriteIsByteStable` — leser en ordrett kopi av en ekte innsjekket state-fil (fra navikt/copilot-intern, med ikke-ASCII kolleksjonsnavn), skriver den, og krever nøyaktig de samme bytene tilbake. Den sammenlignet tidligere to av våre egne skrivinger mot hverandre, som ville passert selv om begge avvek fra det som lå på disk — altså nøyaktig den diffen en kollega ville sett.
- `TestStatePredatingPerFileSourceRoundTrips` — state fra før `source`, uten noen `source`-nøkkel, kommer uendret ut.
- `TestOlderDecoderKeepsPerFileSource` — en dekoder som ikke kjenner `source` i det hele tatt leser en stemplet oppføring, setter `status: ignored`, skriver den ut, og stempelet er fortsatt der.

`knownJSONKeys` hoppet over felter med tomt navn i json-taggen, mens `encoding/json` matcher dem på Go-navnet. Ingenting var feilklassifisert — alle felt har eksplisitt navn — men det var fella testfixturen `legacyFile` gikk i, som skrev en bokstavelig `"Unknown"`-nøkkel ved siden av den ekte. Begge deler rettet.

`mise run nav-pilot:check` er grønn.
