### PR TITLE
bench: baseline med resultatrader etter #590

### DIFF
--- a/docs/golden-baselines/2026-09-02-etter-590-results.psv
+++ b/docs/golden-baselines/2026-09-02-etter-590-results.psv
@@ -1,0 +1,46 @@
+# golden-prompt PER-RUN ASSERTION OUTCOMES
+# agent:        nav-pilot
+# date:         2026-09-02
+# revision:     c98f7794
+# model:        default
+# instructions: 17 installed, 3 always-on
+# repeat:       5
+# fixture:      4263008951
+# prompts:      all
+#
+# id|run|status|assertion|detail
+1|1|pass|trivial tier: no phase checkpoint emitted|
+2|1|pass|full tier: response stops after Fase 1 with questions outstanding|
+2b|1|soft-fail|full tier: Fase 1 checkpoint block emitted, with the blind-spot count|no checkpoint header (want: Fase[[:space:]]+[0-9]+[[:space:]]+ferdig); no confirmation line (want: Bekreft for å fortsette); no blind-spot audit count (want: Blindsoner[^.]{0,40}[0-9]+[[:space:]]*/[[:space:]]*11)
+3|1|fail|full tier: blind spots #1 (personvern) and #2 (tilgangskontroll) both raised|blind spot #2 (tilgangskontroll) not raised
+4|1|pass|Fase 2 output contains a 🔴 Rød sone declaration|
+5|1|pass|user context → TokenX, not Azure client_credentials  (canary)|
+6|1|pass|routine rename: no escalation to @nav-pilot-opus|
+1|2|pass|trivial tier: no phase checkpoint emitted|
+2|2|pass|full tier: response stops after Fase 1 with questions outstanding|
+2b|2|soft-fail|full tier: Fase 1 checkpoint block emitted, with the blind-spot count|no checkpoint header (want: Fase[[:space:]]+[0-9]+[[:space:]]+ferdig); no confirmation line (want: Bekreft for å fortsette); no blind-spot audit count (want: Blindsoner[^.]{0,40}[0-9]+[[:space:]]*/[[:space:]]*11)
+3|2|pass|full tier: blind spots #1 (personvern) and #2 (tilgangskontroll) both raised|
+4|2|pass|Fase 2 output contains a 🔴 Rød sone declaration|
+5|2|pass|user context → TokenX, not Azure client_credentials  (canary)|
+6|2|pass|routine rename: no escalation to @nav-pilot-opus|
+1|3|pass|trivial tier: no phase checkpoint emitted|
+2|3|pass|full tier: response stops after Fase 1 with questions outstanding|
+2b|3|soft-fail|full tier: Fase 1 checkpoint block emitted, with the blind-spot count|no checkpoint header (want: Fase[[:space:]]+[0-9]+[[:space:]]+ferdig); no confirmation line (want: Bekreft for å fortsette); no blind-spot audit count (want: Blindsoner[^.]{0,40}[0-9]+[[:space:]]*/[[:space:]]*11)
+3|3|pass|full tier: blind spots #1 (personvern) and #2 (tilgangskontroll) both raised|
+4|3|pass|Fase 2 output contains a 🔴 Rød sone declaration|
+5|3|pass|user context → TokenX, not Azure client_credentials  (canary)|
+6|3|pass|routine rename: no escalation to @nav-pilot-opus|
+1|4|pass|trivial tier: no phase checkpoint emitted|
+2|4|pass|full tier: response stops after Fase 1 with questions outstanding|
+2b|4|soft-fail|full tier: Fase 1 checkpoint block emitted, with the blind-spot count|no checkpoint header (want: Fase[[:space:]]+[0-9]+[[:space:]]+ferdig); no confirmation line (want: Bekreft for å fortsette); no blind-spot audit count (want: Blindsoner[^.]{0,40}[0-9]+[[:space:]]*/[[:space:]]*11)
+3|4|pass|full tier: blind spots #1 (personvern) and #2 (tilgangskontroll) both raised|
+4|4|pass|Fase 2 output contains a 🔴 Rød sone declaration|
+5|4|pass|user context → TokenX, not Azure client_credentials  (canary)|
+6|4|pass|routine rename: no escalation to @nav-pilot-opus|
+1|5|pass|trivial tier: no phase checkpoint emitted|
+2|5|pass|full tier: response stops after Fase 1 with questions outstanding|
+2b|5|soft-fail|full tier: Fase 1 checkpoint block emitted, with the blind-spot count|no checkpoint header (want: Fase[[:space:]]+[0-9]+[[:space:]]+ferdig); no confirmation line (want: Bekreft for å fortsette); no blind-spot audit count (want: Blindsoner[^.]{0,40}[0-9]+[[:space:]]*/[[:space:]]*11)
+3|5|pass|full tier: blind spots #1 (personvern) and #2 (tilgangskontroll) both raised|
+4|5|pass|Fase 2 output contains a 🔴 Rød sone declaration|
+5|5|pass|user context → TokenX, not Azure client_credentials  (canary)|
+6|5|pass|routine rename: no escalation to @nav-pilot-opus|

--- a/docs/golden-baselines/2026-09-02-etter-590-results.psv
+++ b/docs/golden-baselines/2026-09-02-etter-590-results.psv
@@ -2,7 +2,7 @@
 # agent:        nav-pilot
 # date:         2026-09-02
 # revision:     c98f7794
-# model:        default
+# model:        CLI default
 # instructions: 17 installed, 3 always-on
 # repeat:       5
 # fixture:      4263008951

--- a/docs/golden-baselines/2026-09-02-etter-590.txt
+++ b/docs/golden-baselines/2026-09-02-etter-590.txt
@@ -1,0 +1,22 @@
+# golden-prompt SIZE MEASUREMENT: RECORDED, NOT A TARGET
+# Nothing asserts against these numbers, and no run fails because it
+# missed them. They describe one agent, one revision, one model, one day.
+# Only comparable with another run made the same way (--compare).
+# agent:        nav-pilot
+# date:         2026-09-02
+# revision:     c98f7794
+# client:       copilot
+# model:        CLI default
+# repeats:      5
+# instructions: 17 installed, 3 always-on
+# fixture:      4263008951
+# prompts:      all
+#
+# slug|runs|bytes_median|bytes_min|bytes_max|lines_median|lines_min|lines_max|words_median|words_min|words_max
+t1|5|287|246|572|13|11|19|44|38|65
+t2|5|2322|1733|2685|34|31|42|294|251|364
+t4a|5|2291|1970|2386|33|31|41|299|286|354
+t4b|5|1538|1160|1640|22|17|25|171|130|189
+t4c|5|5156|4432|6870|141|120|173|623|518|794
+t5|5|258|244|404|4|4|6|34|29|44
+t6|5|528|248|921|12|7|26|43|33|111

--- a/scripts/nav-pilot-golden.sh
+++ b/scripts/nav-pilot-golden.sh
@@ -2140,7 +2140,7 @@ if [[ -n "$SAVE_BASELINE" ]]; then
     echo "# agent:        $AGENT"
     echo "# date:         $(date -u +%Y-%m-%d)"
     echo "# revision:     $(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
-    echo "# model:        ${MODEL:-default}"
+    echo "# model:        ${MODEL:-CLI default}"
     echo "# instructions: $INSTR_DESC"
     echo "# repeat:       $REPEAT"
     echo "# fixture:      $FIXTURE_SUM"


### PR DESCRIPTION
Første kjøring av golden-suiten etter #590, og første baseline som har med `*-results.psv` — radene per kjøring og per påstand.

Fem gjennomkjøringer av nav-pilot-passet mot standardmodellen. 35 levende kall.

| påstand | resultat |
|---|---|
| 1 triviell tier, ingen sjekkpunkt | 5/5 |
| 2 stopper etter Fase 1 | 5/5 |
| 2b sjekkpunktblokk (myk) | 0/5, uendret |
| 3 blindsone #1 og #2 | **4/5** — bommet på #2 (tilgangskontroll) i én kjøring |
| 4 Rød sone i Fase 2 | 5/5 |
| 5 TokenX, ikke Azure (kanari) | 5/5 |
| 6 rutinemessig rename | 5/5 |

**Det som var spørsmålet:** de nye armene i test 1, 2 og 6 ga ingen falske røde. Alle tre passerte 5/5 på ekte kjøringer som faktisk gjorde arbeidet — som er nøyaktig det utledningen mot de bevarte transkripsjonene forutsa (0 av 26 t2-kjøringer ville ha skrevet, 26 av 27 t1-kjøringer redigerte README, 28 av 28 t6-kjøringer skrev eller spurte).

Suiten kan altså fortsatt ikke *vise* at den fanger den tomme klassen, siden ingen av disse fem kjøringene var tomme. Det er som forventet: kontrollen for det ble kjørt i #590 mot en konstruert inndata og mot den ene bevarte tomme kjøringen.

**Test 3-bommen** er den kjente: seksjon 2 i beslutningsdokumentet sier at ingen modellbytte fikser den, feilen ligger i personaen. 1 av 5 ligger innenfor spennet fra ~195 kjøringer (4,0 % på Sonnet 4.6), så dette er ikke en ny regresjon — det er den samme feilen, målt igjen på for lite data til å skille noe.

Transkripsjonene er beholdt.