### PR TITLE
docs: there is no measurable difference, and we said there was

### DIFF
--- a/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
+++ b/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
@@ -2085,10 +2085,10 @@ nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først`
                       </VStack>
                     </Table.DataCell>
                     <Table.DataCell>25 GB</Table.DataCell>
-                    <Table.DataCell>3–4 av 8</Table.DataCell>
+                    <Table.DataCell>2–4 av 8</Table.DataCell>
                     <Table.DataCell>
-                      Rask og forutsigbar. Median 9 sekunder per oppgave, og 3, 3, 3, 4 og 4 av 8 over fem kjøringer.
-                      Løser mindre enn 3.8, men svarer med én gang og gjør sjelden noe uventet.
+                      Rask og forutsigbar. Median 10–12 sekunder per oppgave, og 3, 2, 4 og 4 av 8 over fire
+                      kjøringer. Ingen av de andre modellene løser målbart flere.
                     </Table.DataCell>
                   </Table.Row>
                   <Table.Row>
@@ -2096,12 +2096,13 @@ nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først`
                       <code className="font-mono text-xs">Qwen3.8-27B-4bit</code>
                     </Table.DataCell>
                     <Table.DataCell>16 GB</Table.DataCell>
-                    <Table.DataCell>5–7 av 8</Table.DataCell>
+                    <Table.DataCell>3–4 av 8</Table.DataCell>
                     <Table.DataCell>
-                      Løser mer enn standard og bruker mye lengre tid på det. Fire rene kjøringer ga 5, 5, 6 og 7 av
-                      8, mot standardens 3, 3, 3, 4 og 4 — settene overlapper ikke. Omtrent sju ganger tregere, og
-                      treffer sju-minutterstaket på rundt én av fem oppgaver. En femte kjøring er holdt utenfor fordi
-                      den ikke endret en eneste fil; det var testoppsettet, ikke modellen.
+                      Løser omtrent like mye som standard og bruker sju ganger så lang tid. Fire kjøringer ga 4, 4, 3
+                      og 4 av 8 mot standardens 3, 2, 4 og 4 — spennene overlapper, forskjellen er ikke målbar
+                      (p = 0,71). Median 58–104 sekunder, og ti treff på sju-minutterstaket mot standardens ett. Vi
+                      skrev tidligere at den løste mer; det var målt før vi oppdaget at ingen av modellene kunne
+                      kompilere.
                     </Table.DataCell>
                   </Table.Row>
                   <Table.Row>

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -279,17 +279,19 @@ Listen oppdateres når du kjører `init` eller `start` — ikke ved hver kommand
 et nettverkskall der ville lagt seg foran alt annet nav-pilot gjør. Har du nettopp hørt
 om en ny modell og ikke ser den, er `start` det som henter listen på nytt.
 
-**Qwen 3.6 er standard fordi den er rask og forutsigbar, ikke fordi den løser mest.** Over fem
-kjøringer av de samme åtte oppgavene løser den 3, 3, 3, 4 og 4. Qwen 3.8 4-bit løser 5, 5, 6 og 7
-over fire rene kjøringer — de to settene overlapper ikke i det hele tatt. Til gjengjeld bruker 3.8
-omtrent sju ganger så lang tid, median 65 sekunder mot 9, og treffer sju-minutterstaket på rundt
-én av fem oppgaver der standarden nesten aldri gjør det.
+**Qwen 3.6 er standard fordi den er rask, og fordi ingen av de andre løser flere oppgaver.**
+Over fire kjøringer av de samme åtte oppgavene løser den 3, 2, 4 og 4. Qwen 3.8 4-bit løser 4, 4,
+3 og 4. Spennene overlapper helt, og forskjellen er ikke målbar (p = 0,71). Til gjengjeld bruker
+3.8 omtrent sju ganger så lang tid — median 58–104 sekunder mot 10–12 — og traff
+sju-minutterstaket ti ganger der standarden traff det én gang.
 
-En femte 3.8-kjøring er holdt utenfor: den løste 1 av 8 uten å endre en eneste fil på noen
-oppgave, som er en feil i testoppsettet vårt og ikke i modellen. Kriteriet står skrevet ned i
+**Vi skrev tidligere at 3.8 løser mer.** Det holdt ikke. De tallene ble målt før vi oppdaget at
+sandkassen aldri ga modellene tilgang til byggverktøyene: ingen av dem kunne kompilere eller
+kjøre tester, og målet var heller ikke pinnet, så de to modellene jobbet på kodebaser fire dager
+fra hverandre. Da det ble rettet, forsvant forspranget. Hele historikken står i
 [MODELS.md](https://github.com/navikt/mlx-workspace/blob/main/MODELS.md).
 
-Valget er altså dybde mot hastighet, ikke bedre mot dårligere. `nav-pilot config explain model`
+Valget er altså hastighet mot ingenting målbart — som er en grunn til å beholde standarden. `nav-pilot config explain model`
 sier det samme kortere, og
 [MODELS.md](https://github.com/navikt/mlx-workspace/blob/main/MODELS.md) har tallene.
 

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -279,7 +279,7 @@ Listen oppdateres når du kjører `init` eller `start` — ikke ved hver kommand
 et nettverkskall der ville lagt seg foran alt annet nav-pilot gjør. Har du nettopp hørt
 om en ny modell og ikke ser den, er `start` det som henter listen på nytt.
 
-**Qwen 3.6 er standard fordi den er rask, og fordi ingen av de andre løser flere oppgaver.**
+**Qwen 3.6 er standard fordi den er rask, og fordi ingen av de andre løser målbart flere oppgaver.**
 Over fire kjøringer av de samme åtte oppgavene løser den 3, 2, 4 og 4. Qwen 3.8 4-bit løser 4, 4,
 3 og 4. Spennene overlapper helt, og forskjellen er ikke målbar (p = 0,71). Til gjengjeld bruker
 3.8 omtrent sju ganger så lang tid — median 58–104 sekunder mot 10–12 — og traff

--- a/docs/news/articles/lokale-modeller-i-nav-pilot.md
+++ b/docs/news/articles/lokale-modeller-i-nav-pilot.md
@@ -79,9 +79,12 @@ nav-pilot alpha local init
 Det vi selv lærte av dette er verdt mer enn modellvalget: **én kjøring er ikke en måling.** Alle
 konklusjonene som snudde, snudde fordi det fantes en kjøring til — ikke fordi vi tenkte oss om en
 gang til. Tabellen over var bygget på enkeltkjøringer. Denne konklusjonen snudde tre ganger: fra
-«3.8 går i loop», til «3.8 er uforutsigbar», til «3.8 løser mer enn standarden». Den siste snuen
-kom av at én kjøring viste seg å være en feil i testoppsettet og ikke i modellen. Vi krever nå
-minst fem kjøringer før et tall får styre en anbefaling.
+«3.8 går i loop», til «3.8 er uforutsigbar», til «3.8 løser mer enn standarden» — og så tilbake
+til «ingen målbar forskjell». Den siste snuen var den viktigste: vi oppdaget at sandkassen aldri
+hadde gitt modellene tilgang til byggverktøyene, så ingen av dem kunne kompilere eller kjøre
+tester. Da det ble rettet, forsvant forspranget. Vi hadde altså ikke målt modellene, vi hadde
+målt hvem som skriver best Kotlin i blinde. Vi krever nå minst fem kjøringer før et tall får
+styre en anbefaling, og at harnesset selv blir gjennomgått før tallene brukes.
 
 Deretter 200 kjøringer på én maskin med modellen vi valgte, fordelt på to klienter, seks oppgavetyper, tre refactor-strategier og tre kodebaser: en Ktor-app, en Spring-app og en frontend.
 

--- a/docs/news/articles/lokale-modeller-i-nav-pilot.md
+++ b/docs/news/articles/lokale-modeller-i-nav-pilot.md
@@ -52,23 +52,23 @@ Først prøvde vi åtte modeller og bygg på det samme oppgavesettet: elleve opp
 - **Qwen3.8-27B i 4-, 6- og 8-bit.** Ikke standard, men 4-bit og 8-bit kan nå velges. Se under.
 - **Granite 4.1 8B.** For liten. Løste 1 av 8.
 
-### Oppdatering 1. september: Qwen 3.8 kan velges
+### Oppdatering 2. september: forspranget var vårt, ikke modellens
 
-Vi skrev først at Qwen3.8 ikke ble valgt fordi den gikk i loop. Etter å ha kjørt testene på nytt
-holder ikke den beskrivelsen, og den nye er mer interessant.
+Her sto det til 2. september at Qwen3.8-27B 4-bit løste **5, 5, 6 og 7 av 8** mot
+standardmodellens **3, 3, 3, 4 og 4**, og at 3.8 dermed løser mer. Det tallet holder ikke, og
+grunnen er verdt å skrive ned.
 
-Fire rene kjøringer av det samme oppgavesettet på samme maskin: Qwen3.8-27B 4-bit løste **5, 5, 6
-og 7 av 8**, mot standardmodellens **3, 3, 3, 4 og 4** over fem. De to settene overlapper ikke i
-det hele tatt.
+Sandkassen vi kjører oppgavene i hadde aldri gitt modellene tilgang til byggverktøyene. Ingen av
+dem kunne kompilere eller kjøre en test. Vi målte altså ikke hvem som løser oppgaver, vi målte
+hvem som skriver best Kotlin i blinde. Da tilgangen kom på plass, og oppgavesettet i tillegg ble
+pinnet til én commit i stedet for å følge master, forsvant forspranget: **3,75 mot 3,25 løste
+oppgaver, p = 0,71.** Det er ingen målbar forskjell.
 
-**Qwen3.8 er altså ikke en svakere modell — den løser mer.** Til gjengjeld bruker den omtrent sju
-ganger så lang tid, median 65 sekunder mot 9, og treffer sju-minutterstaket på rundt én av fem
-oppgaver der standarden nesten aldri gjør det. En femte kjøring er holdt utenfor: den løste 1 av 8
-uten å endre en eneste fil på noen oppgave, som er en feil i testoppsettet vårt og ikke i
-modellen.
+Qwen3.8 4-bit kan fortsatt velges, og den er fortsatt omtrent sju ganger tregere, median 65
+sekunder mot 9. Men vi har ikke lenger noe belegg for at den løser mer, og de gamle tallene over
+skal ikke brukes til å velge modell. Nye kjøringer på det reparerte oppsettet pågår.
 
-Valget står altså mellom dybde og hastighet. Leser du gjennom det modellen lager og kan vente, er
-3.8 verdt å prøve. Vil du ha svar på ti sekunder, behold standarden:
+Vil du prøve den likevel:
 
 ```bash
 nav-pilot models


### PR DESCRIPTION
All three published surfaces said Qwen3.8 solves more than the model we ship as default. It does not.

## Re-measured on a repaired benchmark

| model | verified of 8 | mean | median | cap hits |
|---|---|---|---|---|
| `qwen3.6-35b-a3b-optiq` | 3, 2, 4, 4 | **3.25** | 10–12s | 1 |
| `qwen3.8-27b-4bit` | 4, 4, 3, 4 | **3.75** | 58–104s | **10** |

Exact two-sided Mann-Whitney **p = 0.71**, ranges fully overlapping. There is no measurable difference in how many tasks either solves.

## What changed was the instrument, not the models

The benchmark sandbox **never granted the toolchain**. `./gradlew` reached a mise shim, which read config outside the sandbox boundary, and the model got `Operation not permitted` — **2,672 of those across the transcripts against 2,176 mentions of gradlew**. Every attempt to compile or run a test was refused by us.

The target was not pinned either: `tasks.json` said `master` while a comment claimed SHA pinning, and the workspaces had drifted to three commits four days apart. The diff between the two models' checkouts touches a class one task threads a field into.

So we had not measured the models. We had measured which one writes better Kotlin **blind**, on two different codebases. When both faults were fixed, the gap went from 2.35 tasks to 0.5 and stopped being distinguishable from noise.

The latency figure survived unchanged, and it is now the whole basis for the default: **seven times slower, ten cap hits against one.**

## Each surface says what happened

Not just the new number — the old claim was ours, it was published, and someone may have chosen a model on it. All three now say the earlier text claimed more, that it was measured before the models could compile, and where the full history is.

## Checks

`tsc --noEmit` clean.