### PR TITLE
feat(local): check the memory floor a manifest entry declares

### DIFF
--- a/cli/nav-pilot/internal/cli/config_page.go
+++ b/cli/nav-pilot/internal/cli/config_page.go
@@ -272,10 +272,18 @@ func editModelKey(r ResolvedConfig, current string) error {
 func editLocalModelKey(current string) error {
 	kd := findKeyDef("local_model")
 	opts := []huh.Option[string]{huh.NewOption("(manifest default)", "")}
+	// Marked, not hidden. A model this machine cannot hold is still worth
+	// seeing: it is what the developer with 64 GB two desks over is running,
+	// and hiding it makes the list look like the model does not exist. A
+	// machine that will not tell us its memory marks nothing.
+	ramGB, ramErr := local.MachineRAMGB()
 	for _, m := range local.Active().Models {
 		label := m.Model
 		if m.Name != "" {
 			label = m.Name + " (" + m.Model + ")"
+		}
+		if ramErr == nil && m.MinRAMGB > 0 && m.MinRAMGB > ramGB {
+			label += fmt.Sprintf("  — needs %d GB, this machine has %d", m.MinRAMGB, ramGB)
 		}
 		opts = append(opts, huh.NewOption(label, m.Model))
 	}

--- a/cli/nav-pilot/internal/local/runtime.go
+++ b/cli/nav-pilot/internal/local/runtime.go
@@ -1373,6 +1373,17 @@ func CheckWiredLimit(m Model) (WiredLimit, error) {
 	}
 	w.Sufficient = w.CurrentGB >= w.RequiredGB
 
+	// The manifest's own floor, checked rather than merely printed. Profiles
+	// are measured on one machine and shipped to a fleet with 36, 48 and 64 GB
+	// in it, and min_ram_gb is how an entry says which of those it was measured
+	// for. Until now nothing read it, so a 48 GB model on a 36 GB machine got
+	// as far as loading weights before macOS decided how it ended.
+	if m.MinRAMGB > 0 && m.MinRAMGB > w.MachineRAMGB {
+		return w, fmt.Errorf(
+			"%s needs a machine with at least %d GB of memory, and this one has %d GB.\n\n  Run `nav-pilot models` and pick an entry this machine can hold",
+			m.Model, m.MinRAMGB, w.MachineRAMGB)
+	}
+
 	if w.RequiredGB+minFreeGB > w.MachineRAMGB {
 		return w, fmt.Errorf(
 			"%s needs a %d GB wired-memory limit, which would leave %d GB of this %d GB machine for everything else — below the %d GB the rest of the system needs.\n\n  Pick a smaller model: a cap this close to physical memory is how a machine running containers and a browser loses its compositor and has to be power-cycled",
@@ -1548,4 +1559,18 @@ func RaiseWiredLimit(ctx context.Context, w WiredLimit) error {
 			err, strings.TrimSpace(out), domain.Bold(w.Command))
 	}
 	return nil
+}
+
+// MachineRAMGB is this machine's physical memory in gigabytes. Callers that
+// only need to label a list use it; anything that is about to start a model
+// should call [CheckWiredLimit], which weighs the same number against the
+// model's own floor and against what the rest of the system needs.
+func MachineRAMGB() (int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
+	defer cancel()
+	ram, err := sysctlInt(ctx, "hw.memsize")
+	if err != nil {
+		return 0, err
+	}
+	return int(ram / gib), nil
 }

--- a/cli/nav-pilot/internal/local/runtime_test.go
+++ b/cli/nav-pilot/internal/local/runtime_test.go
@@ -1333,3 +1333,53 @@ func TestServerFlagsCarryTheTunedKnobs(t *testing.T) {
 		t.Error("no params should mean no flags, so a manifest can still say nothing")
 	}
 }
+
+// A model's declared floor decides which machines may run it. The wired limit
+// alone does not: a 27 GB cap fits a 36 GB machine arithmetically, while the
+// entry was measured on 48 and says so.
+func TestCheckWiredLimitRefusesBelowDeclaredMinimum(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		minRAMGB    int
+		machineGB   int
+		wantRefusal bool
+	}{
+		{name: "below the floor", minRAMGB: 48, machineGB: 36, wantRefusal: true},
+		{name: "exactly at the floor", minRAMGB: 48, machineGB: 48},
+		{name: "above the floor", minRAMGB: 48, machineGB: 64},
+		{name: "no floor declared", minRAMGB: 0, machineGB: 36},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stubRun(t, func(name string, args []string) (string, error) {
+				if name != sysctlPath {
+					return "", errors.New("unexpected command " + name)
+				}
+				switch args[len(args)-1] {
+				case "hw.memsize":
+					return memsizeBytes(tc.machineGB), nil
+				case "iogpu.wired_limit_mb":
+					return "24576\n", nil
+				}
+				return "", errors.New("unexpected sysctl")
+			})
+
+			_, err := CheckWiredLimit(Model{Model: okModel, WeightsGB: 16, WiredLimitGB: 24, MinRAMGB: tc.minRAMGB})
+			if tc.wantRefusal {
+				if err == nil {
+					t.Fatal("CheckWiredLimit() accepted a model the manifest says needs a bigger machine")
+				}
+				// The refusal has to name both numbers, or the developer
+				// cannot tell whether it is their machine or the entry.
+				for _, want := range []string{"48 GB", "36 GB"} {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("CheckWiredLimit() error = %q, want it to mention %q", err, want)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CheckWiredLimit() errored: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`min_ram_gb` has been in the manifest since the first entry and nothing read it. It was printed on the init screen and then ignored, so the only thing between a 48 GB model and a 36 GB machine was the wired-limit arithmetic, which a small enough cap passes: a 24 GB cap fits a 36 GB machine whatever the entry was measured on.

The fleet is not one machine. It has 36, 48 and soon 64 GB in it, and `min_ram_gb` is how an entry says which of those it was measured for.

- `CheckWiredLimit` refuses below the declared floor, naming both numbers so the developer can tell whether it is their machine or the entry that is wrong.
- The `local_model` picker marks entries the machine cannot hold instead of hiding them. A hidden entry looks like one that does not exist, and it is what the developer two desks over is running. A machine that will not report its memory marks nothing.
- `local.MachineRAMGB()` is exported so the picker labels without a second sysctl read of its own.

Tested: table test over below, at, above the floor, and no floor declared. `go test ./internal/local/ ./internal/cli/` green.