### PR TITLE
fix(nav-pilot): en pinning fra før #597 er ikke en revisjon bak (#605)

### DIFF
--- a/cli/nav-pilot/internal/cli/declaration.go
+++ b/cli/nav-pilot/internal/cli/declaration.go
@@ -240,13 +240,19 @@ func bumpDeclarationSHA(scope *InstallScope, src *Source) {
 			yellow("⚠"), agentpakke.DeclarationPath, err)
 		return
 	}
-	// A declaration written before #597 pins seven characters, which is not a
-	// revision git can fetch — installing that repo's own pin fails. Writing it
-	// out in full is the repair, and this is where it happens, but it is not a
-	// bump: reporting it as one printed the same seven characters either side
-	// of an arrow (#605). Say what actually changed instead.
+	// An abbreviated pin is not a revision git can fetch, so installing that
+	// repo's own pin fails. No released binary ever wrote one — the declaration
+	// and the full-length SHA arrived in the same commit (#597) — but the file
+	// is documented as hand-editable and `status` prints seven characters, so a
+	// human copying one in is the reachable case. Writing it out in full is the
+	// repair, and this is where it happens. It is not a bump, and reporting it
+	// as one printed the same seven characters either side of an arrow (#605).
+	//
+	// The match is a prefix, not proof of sameness: the declared value could be
+	// any prefix a human typed. It does not matter here — the resolved revision
+	// is already on disk in full by this point, either way.
 	if sameSHA(previous, src.SHA) {
-		fmt.Printf("%s Wrote the full revision id in %s (%s). Same revision — an abbreviated one cannot be fetched. Commit it.\n",
+		fmt.Printf("%s Wrote the full revision id in %s (%s). An abbreviated pin cannot be fetched. Commit it.\n",
 			green("✓"), bold(agentpakke.DeclarationPath), shortSHA(src.SHA))
 		return
 	}

--- a/cli/nav-pilot/internal/cli/declaration.go
+++ b/cli/nav-pilot/internal/cli/declaration.go
@@ -240,6 +240,16 @@ func bumpDeclarationSHA(scope *InstallScope, src *Source) {
 			yellow("⚠"), agentpakke.DeclarationPath, err)
 		return
 	}
+	// A declaration written before #597 pins seven characters, which is not a
+	// revision git can fetch — installing that repo's own pin fails. Writing it
+	// out in full is the repair, and this is where it happens, but it is not a
+	// bump: reporting it as one printed the same seven characters either side
+	// of an arrow (#605). Say what actually changed instead.
+	if sameSHA(previous, src.SHA) {
+		fmt.Printf("%s Wrote the full revision id in %s (%s). Same revision — an abbreviated one cannot be fetched. Commit it.\n",
+			green("✓"), bold(agentpakke.DeclarationPath), shortSHA(src.SHA))
+		return
+	}
 	fmt.Printf("%s Bumped %s: %s → %s. Commit it to share the update.\n",
 		green("✓"), bold(agentpakke.DeclarationPath), shortSHA(previous), shortSHA(src.SHA))
 }

--- a/cli/nav-pilot/internal/cli/feedback.go
+++ b/cli/nav-pilot/internal/cli/feedback.go
@@ -107,11 +107,13 @@ func shortSHA(sha string) string { return domain.ShortSHA(sha) }
 // them is abbreviated.
 //
 // #597 lengthened every recorded revision from seven characters to forty,
-// because git will not fetch an abbreviated object id. But the state files and
-// declarations already on disk still hold the short form, and comparing those
-// byte for byte made every pre-upgrade pin look one revision behind — with a
-// message that printed the same seven characters on both sides and a re-fetch
-// of the revision already installed (#605).
+// because git will not fetch an abbreviated object id. But the state files
+// already on disk still hold the short form — they have since #306 — and
+// comparing those byte for byte made every pre-upgrade pin look one revision
+// behind, with a message that printed the same seven characters on both sides
+// and a re-fetch of the revision already installed (#605). A declaration can
+// hold a short one too, though only by hand: it arrived in the same commit as
+// the full-length SHA.
 //
 // The shorter side is treated as a prefix of the longer, which is what git
 // itself does with an abbreviated id. That can in principle hide a real

--- a/cli/nav-pilot/internal/cli/feedback.go
+++ b/cli/nav-pilot/internal/cli/feedback.go
@@ -103,6 +103,36 @@ func countFileIntegrity(rootDir string, state *StateFile) (ok, modified, missing
 // shortSHA returns the first 7 characters of a SHA, or the full string if shorter.
 func shortSHA(sha string) string { return domain.ShortSHA(sha) }
 
+// sameSHA reports whether two commit ids name the same revision when one of
+// them is abbreviated.
+//
+// #597 lengthened every recorded revision from seven characters to forty,
+// because git will not fetch an abbreviated object id. But the state files and
+// declarations already on disk still hold the short form, and comparing those
+// byte for byte made every pre-upgrade pin look one revision behind — with a
+// message that printed the same seven characters on both sides and a re-fetch
+// of the revision already installed (#605).
+//
+// The shorter side is treated as a prefix of the longer, which is what git
+// itself does with an abbreviated id. That can in principle hide a real
+// difference: two commits in one repository sharing the recorded prefix. It is
+// accepted, because `rev-parse --short` emitted a length git guaranteed
+// unambiguous in that repository when it was written, so hiding one needs a
+// *later* commit to land on the same prefix — and the cost of that is one
+// missed update notice, against a false one that is certain for every install
+// that exists today.
+//
+// An empty id is nobody's prefix: "" would otherwise match everything.
+func sameSHA(a, b string) bool {
+	if a == "" || b == "" {
+		return a == b
+	}
+	if len(a) > len(b) {
+		a, b = b, a
+	}
+	return strings.HasPrefix(b, a)
+}
+
 // buildFeedbackURL constructs a GitHub issue URL with pre-filled template and diagnostics.
 func buildFeedbackURL(featureRequest bool, diagnostics string) string {
 	var template, labels string

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -568,7 +568,7 @@ func syncPakkePin(scope *InstallScope, src *Source, state *StateFile, apply, jso
 		return nil
 	}
 
-	// [sameSHA], not ==: a pin recorded before #597 holds seven characters and
+	// [sameSHA], not ==: a state file written before #597 holds seven characters and
 	// this one holds forty. Comparing those byte for byte reported a newer
 	// revision that does not exist, in a sentence that printed the same seven
 	// characters on both sides, and --apply then re-fetched and re-materialized

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -568,7 +568,14 @@ func syncPakkePin(scope *InstallScope, src *Source, state *StateFile, apply, jso
 		return nil
 	}
 
-	if src.SHA == state.SourceSHA {
+	// [sameSHA], not ==: a pin recorded before #597 holds seven characters and
+	// this one holds forty. Comparing those byte for byte reported a newer
+	// revision that does not exist, in a sentence that printed the same seven
+	// characters on both sides, and --apply then re-fetched and re-materialized
+	// the revision already pinned into a second directory (#605). The recorded
+	// SHA is only ever a directory name here — nothing fetches it — so leaving
+	// it short is harmless, and the next real update writes it out in full.
+	if sameSHA(src.SHA, state.SourceSHA) {
 		if jsonOutput {
 			return outputJSON(syncResult{UpToDate: true, Source: src.SHA})
 		}

--- a/cli/nav-pilot/internal/cli/sync_pin_test.go
+++ b/cli/nav-pilot/internal/cli/sync_pin_test.go
@@ -1,0 +1,154 @@
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// ─── sync round-trips a SHA through real git ─────────────────────────────────
+
+// TestSyncApplyWritesAFetchablePin closes the seam every other sync test left
+// open. All six of them replace resolveSourceForSync with a stub that hands
+// back a fabricated SHA, so nothing on the sync path has ever round-tripped a
+// revision id back through git — which is exactly how #597 shipped an install
+// pin that git refused to fetch, behind ten green tests.
+//
+// Here the resolver is not stubbed. `sync --apply` clones the source for real
+// (RemoteURLFn points the real plumbing at a repository on disk), and the SHA
+// it writes into the repo's declaration is then proved fetchable the only way
+// that means anything: a second, fresh scope installs from it and gets the
+// content that revision holds.
+func TestSyncApplyWritesAFetchablePin(t *testing.T) {
+	isolatedConfig(t)
+	repo, first, second := gitAgentpakke(t)
+	localAgentpakkeRemote(t, repo)
+
+	scope := ScopeRepo(repoTarget(t))
+	writeDeclaration(t, scope,
+		`{"contractVersion":"1","source":"navikt/grillmester","sha":"`+first+`"}`)
+	captureStdoutFor(t, func() {
+		if err := cmdInstallAuto("grillmester", "", scope, "", "", false, false, false); err != nil {
+			t.Fatalf("install from the declared pin: %v", err)
+		}
+	})
+	if !strings.Contains(installedAgentBody(t, scope), "REVISION ONE") {
+		t.Fatal("the fixture install did not get the pinned revision")
+	}
+
+	// The resolver is left alone on purpose: this is the whole point of the test.
+	captureStdoutFor(t, func() {
+		if err := cmdSync(scope, "", "", true, false); err != nil {
+			t.Fatalf("sync --apply through the real resolver: %v", err)
+		}
+	})
+	if !strings.Contains(installedAgentBody(t, scope), "REVISION TWO") {
+		t.Error("sync --apply did not bring the scope onto the newer revision")
+	}
+
+	// The assertion the stubs could never make, and the one that comes first
+	// because it is the one that matters: what sync wrote is fetchable.
+	pinned := readDeclaration(t, scope).SHA
+	fresh := ScopeRepo(repoTarget(t))
+	writeDeclaration(t, fresh,
+		`{"contractVersion":"1","source":"navikt/grillmester","sha":"`+pinned+`"}`)
+	captureStdoutFor(t, func() {
+		if err := cmdInstallAuto("grillmester", "", fresh, "", "", false, false, false); err != nil {
+			t.Fatalf("the revision sync wrote cannot be fetched back: %v", err)
+		}
+	})
+	if !strings.Contains(installedAgentBody(t, fresh), "REVISION TWO") {
+		t.Error("installing the pin sync wrote did not produce the revision it names")
+	}
+	if pinned != second {
+		t.Errorf("sync pinned %q, want the revision git resolved to, %q", pinned, second)
+	}
+}
+
+// ─── #605: a pin recorded before #597 is seven characters ────────────────────
+
+// A Tier 2 pin written by an older binary holds an abbreviated SHA, and the
+// source now resolves to all forty characters of the same commit. Sync must
+// see one revision, not two: the old comparison reported a newer revision that
+// does not exist — printing the same seven characters on both sides of the
+// sentence — and --apply then re-fetched and re-materialized the revision
+// already pinned into a second directory under pakkerRoot().
+func TestSyncPinToleratesAnAbbreviatedRecordedSHA(t *testing.T) {
+	scope := pinEnv(t)
+	tree := tier2PinSourceTree(t)
+	const full = "abc1234def567890abcdef1234567890abcdef12"
+	short := full[:7]
+
+	old := &Source{Dir: tree, SHA: short, Version: "dev", Repo: "navikt/grillmester"}
+	if err := attachPakke(old); err != nil {
+		t.Fatal(err)
+	}
+	installPin(t, scope, old)
+
+	pinnedSyncSource(t, tree, full)
+
+	var err error
+	out := captureStdoutFor(t, func() { err = cmdSync(scope, "", "", false, false) })
+	if err != nil {
+		t.Fatalf("sync over a pre-#597 pin = %v, want up to date. Output:\n%s", err, out)
+	}
+	if strings.Contains(out, "newer revision") {
+		t.Errorf("sync announced an update to the revision already pinned:\n%s", out)
+	}
+	if !strings.Contains(out, "up to date") {
+		t.Errorf("sync did not report the pin as up to date:\n%s", out)
+	}
+
+	// --apply must not re-materialize the same commit under its long name.
+	captureStdoutFor(t, func() { err = cmdSync(scope, "", "", true, false) })
+	if err != nil {
+		t.Fatalf("sync --apply over a pre-#597 pin = %v, want nil", err)
+	}
+	if _, statErr := os.Stat(pakkeRevisionDir("navikt/grillmester", full)); !os.IsNotExist(statErr) {
+		t.Errorf("sync --apply materialized a second directory for the revision already pinned (stat err %v)", statErr)
+	}
+	if state, _ := readScopedState(scope); state == nil || state.SourceSHA != short {
+		t.Errorf("state after --apply = %+v, want the pin left at %q", state, short)
+	}
+}
+
+// The same length mismatch reaches the committed declaration, where it is worse
+// than cosmetic: the abbreviated pin there is one git cannot fetch, so it must
+// be written out in full — but the line reporting it used to claim the same
+// seven characters had changed into themselves.
+func TestSyncApplyDoesNotReportAnAbbreviatedPinAsAChange(t *testing.T) {
+	path := isolatedConfig(t)
+	mustWrite(t, path, "version = 1\n")
+	scope, srcDir := installedRepoScope(t, defaultSourceRepo) // declares sha "old1234"
+	full := "old1234" + strings.Repeat("f", 33)
+
+	syncWithSource(t, srcDir, defaultSourceRepo, full)
+	out := captureStdoutFor(t, func() { _ = cmdSync(scope, "", "", true, false) })
+
+	if strings.Contains(out, "old1234 → old1234") {
+		t.Errorf("sync reported a revision as changed into itself:\n%s", out)
+	}
+	if got := readDeclaration(t, scope).SHA; got != full {
+		t.Errorf("declaration SHA = %q, want the full %q — an abbreviated pin is not fetchable", got, full)
+	}
+}
+
+func TestSameSHA(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"abc1234", "abc1234def567890abcdef1234567890abcdef12", true},
+		{"abc1234def567890abcdef1234567890abcdef12", "abc1234", true},
+		{"abc1234", "abc1235def567890abcdef1234567890abcdef12", false},
+		{"abc1234", "abc1234", true},
+		{"", "abc1234", false}, // "" is nobody's prefix
+		{"abc1234", "", false},
+		{"", "", true},
+	}
+	for _, c := range cases {
+		if got := sameSHA(c.a, c.b); got != c.want {
+			t.Errorf("sameSHA(%q, %q) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Lukker #605. Oppfølging av #597.

## Beslutningen

Issuet ba om et valg mellom tre retninger. Valget er **normalisering på felles lengde** — én `sameSHA(a, b)` som behandler den korteste siden som prefiks av den lengste, brukt begge stedene en lagret SHA måles mot en nyoppslått.

Migrering ved lesing ble vurdert og forkastet, og grunnen er konkret: revisjonskatalogen under `pakkerRoot()` heter det tilstandsfila sier. Skriver vi `source_sha` om til førti tegn uten å døpe om katalogen, blir `pinnedRevisionOnDisk` usann, og sync svarer «pinned at X, but that revision is no longer under ~/.nav-pilot/pakker» — dårligere enn feilen den skulle rette. Å døpe om katalogen betyr å flytte et materialisert tre en kjørende sesjon kan ha åpent. Og #588/#593 viste nettopp hvor ømfintlige skrivinger i tilstandsfila er på tvers av versjoner.

Å la det stå ble forkastet fordi meldingen motsier seg selv og fordi hver bruker betaler en nedlasting og et ekstra tre for ingenting.

Prefikskollisjonen som prisen for det første alternativet er akseptert, og den er mindre enn den ser ut: `rev-parse --short` skrev en lengde git garanterte entydig i det repoet da den ble skrevet, så en kollisjon krever at en *senere* commit lander på samme prefiks. Kostnaden er da ett uteblitt oppdateringsvarsel — mot ett falskt varsel som er sikkert for hver eneste installasjon som finnes i dag.

Tilstandens SHA blir stående kort. Det er trygt fordi den bare er et katalognavn — ingenting henter den — og neste reelle oppdatering skriver den ut i full lengde av seg selv.

## Hvor lengdeforskjellen ellers biter

Hele kodebasen har nøyaktig to steder som sammenlikner SHA-er:

- `syncPakkePin` i `sync.go` — det issuet navngir.
- `bumpDeclarationSHA` i `declaration.go` — **ikke** navngitt i issuet, og verre. Deklarasjonens SHA er en fetch-ref, ikke et katalognavn, så en kort pinning der er en pinning ingen kan installere (det var #597s feil). Den må altså fortsatt skrives ut i full lengde — `sync --apply` er reparasjonen for repoer som allerede har committet en kort pinning — men linjen som meldte det skrev `old1234 → old1234`. Den sier nå hva som faktisk skjedde.

Sjekket og ikke rammet:

- **Tier 2-oppstart** (`pinnedRevision` i `pakke_launch.go`) sammenlikner ingenting; den bruker den lagrede SHA-en som katalognavn, og en kort katalog finnes.
- **Tier 1-sync** (`sync.go:311`, `sync.go:417`) skriver bare tilstanden om, uten en linje til brukeren. Den migrerer seg selv i stillhet.
- **`status` og `list --json`** (`install.go`) sender `source_sha` ut rått. Lengden varierer med installasjonens alder, men ingenting sammenlikner den.
- **`--compare` i gullharnesket** (`scripts/nav-pilot-golden.sh`) skriver `# revision:` med `rev-parse --short`, men sammenlikner den aldri — feltet er en overskriftslinje, ikke en `compat_warn`. Det leser dessuten repoets egen HEAD, ikke nav-pilots tilstand.

## Sømmen som slapp det gjennom

Dette er delen som betyr mest. Alle seks sync-testene erstattet `resolveSourceForSync` med en stubb som ga tilbake en oppdiktet `Source{SHA: "new5678"}`, så ingenting på sync-veien har noen gang sendt en revisjons-id tilbake gjennom git. Suiten hadde holdt seg grønn om `sync --apply` skrev en sju tegns pinning ingen kunne hente — som er nøyaktig det #597 rettet på installasjonssiden, bak ti grønne tester.

`TestSyncApplyWritesAFetchablePin` lar resolveren være i fred. Den kjører `sync --apply` mot et ekte git-repo med to commiter (`RemoteURLFn` peker den ekte git-plumbingen mot et repo på disk), og henter så SHA-en sync skrev ned igjen i et nytt scope. Kontrollkjøring med `getGitSHA` satt tilbake til `rev-parse --short HEAD`:

```
--- FAIL: TestSyncApplyWritesAFetchablePin (0.86s)
    sync_pin_test.go:57: the revision sync wrote cannot be fetched back:
        could not clone navikt/grillmester@e073c55 — check that the ref exists
        fatal: couldn't find remote ref e073c55
```

Porten har altså en måte å ryke på, og den ryker på nøyaktig den feilen den er satt til å fange.

## Testene mot urørt kode

De to regresjonstestene, kjørt mot koden uten rettingen:

```
--- FAIL: TestSyncPinToleratesAnAbbreviatedRecordedSHA (0.01s)
    sync_pin_test.go:93: sync over a pre-#597 pin = updates available, want up to date. Output:
        ⚠ A newer revision of grillmester is available (pinned abc1234, source abc1234).

--- FAIL: TestSyncApplyDoesNotReportAnAbbreviatedPinAsAChange (0.02s)
    sync_pin_test.go:129: sync reported a revision as changed into itself:
        ✓ Bumped .nav-pilot/agentpakke.lock.json: old1234 → old1234. Commit it to share the update.
```

Begge gjengir teksten fra issuet ordrett.

`mise run nav-pilot:check` er grønn.
