### PR TITLE
fix(local): stop refusing weights that are already on the machine

### DIFF
--- a/cli/nav-pilot/internal/local/runtime.go
+++ b/cli/nav-pilot/internal/local/runtime.go
@@ -623,9 +623,23 @@ func modelCacheDir(model string) string {
 // Face cache.
 //
 // "Fully" is the point. An interrupted download leaves the snapshot in place
-// with .incomplete blobs beside it, so a directory-exists check answers yes for
-// a model that cannot load, and the developer gets the failure from mlx-lm
-// several minutes later instead of from here.
+// with the missing pieces as .incomplete blobs, so a directory-exists check
+// answers yes for a model that cannot load, and the developer gets the failure
+// from mlx-lm several minutes later instead of from here.
+//
+// The completeness test is whether the snapshot's own files resolve. Each one
+// is a symlink into blobs/, and a piece that never finished downloading has no
+// blob for its symlink to point at, so a stat that follows the link is the
+// question "is this file here" asked directly.
+//
+// Scanning for .incomplete blobs instead is what this used to do, and it was
+// wrong in the direction that hurts: the cache keeps a partial as
+// <blob>.<id>.incomplete, and a later successful download writes the finished
+// blob without removing the abandoned partial. A model downloaded across two
+// attempts therefore ends up complete on disk with stale .incomplete files
+// beside it. Reported from a machine where init downloaded 25 GB, printed
+// "Weights downloaded", and then refused to start on weights it had just
+// fetched, with seven stale partials and every snapshot symlink resolving.
 func WeightsPresent(model string) (bool, error) {
 	dir := modelCacheDir(model)
 	snapshots, err := os.ReadDir(filepath.Join(dir, "snapshots"))
@@ -635,24 +649,26 @@ func WeightsPresent(model string) (bool, error) {
 		}
 		return false, fmt.Errorf("reading the model cache at %s: %w", dir, err)
 	}
-	blobs, err := os.ReadDir(filepath.Join(dir, "blobs"))
-	if err != nil && !os.IsNotExist(err) {
-		return false, fmt.Errorf("reading the model cache at %s: %w", dir, err)
-	}
-	for _, b := range blobs {
-		if strings.HasSuffix(b.Name(), ".incomplete") {
-			return false, nil
-		}
-	}
 	for _, snap := range snapshots {
-		files, err := os.ReadDir(filepath.Join(dir, "snapshots", snap.Name()))
+		snapDir := filepath.Join(dir, "snapshots", snap.Name())
+		files, err := os.ReadDir(snapDir)
 		if err != nil {
 			continue
 		}
 		var weights, config bool
 		for _, f := range files {
-			weights = weights || strings.HasSuffix(f.Name(), ".safetensors")
-			config = config || f.Name() == "config.json"
+			name := f.Name()
+			isWeights := strings.HasSuffix(name, ".safetensors")
+			if !isWeights && name != "config.json" {
+				continue
+			}
+			// os.Stat follows the symlink; os.ReadDir did not. A dangling
+			// link is a piece the download never finished.
+			if _, err := os.Stat(filepath.Join(snapDir, name)); err != nil {
+				return false, nil
+			}
+			weights = weights || isWeights
+			config = config || name == "config.json"
 		}
 		if weights && config {
 			return true, nil

--- a/cli/nav-pilot/internal/local/runtime_test.go
+++ b/cli/nav-pilot/internal/local/runtime_test.go
@@ -357,34 +357,57 @@ func TestEnsureEnvRefusesAWrongInterpreter(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestWeightsPresent(t *testing.T) {
+	// The real cache stores every file once under blobs/ and gives the
+	// snapshot a symlink to it, so the seeds here do the same: a file that
+	// downloaded is a link with a blob behind it, and one that did not is a
+	// link pointing at nothing.
 	tests := []struct {
 		name  string
 		files map[string]string // path under the hub dir -> contents
+		links map[string]string // snapshot path -> blob name (may be absent)
 		want  bool
 	}{
 		{name: "nothing in the cache", want: false},
 		{
-			name: "a complete snapshot",
-			files: map[string]string{
-				"snapshots/abc123/config.json":       "{}",
-				"snapshots/abc123/model.safetensors": "weights",
+			name:  "a complete snapshot",
+			files: map[string]string{"blobs/aaa": "{}", "blobs/bbb": "weights"},
+			links: map[string]string{
+				"snapshots/abc123/config.json":       "aaa",
+				"snapshots/abc123/model.safetensors": "bbb",
 			},
 			want: true,
 		},
 		{
 			// The case a directory-exists check gets wrong: the snapshot is
-			// there, the blobs are not, and mlx-lm discovers it minutes later.
-			name: "an interrupted download",
-			files: map[string]string{
-				"snapshots/abc123/config.json":       "{}",
-				"snapshots/abc123/model.safetensors": "weights",
-				"blobs/deadbeef.incomplete":          "partial",
+			// there, a shard is not, and mlx-lm discovers it minutes later.
+			name:  "an interrupted download",
+			files: map[string]string{"blobs/aaa": "{}", "blobs/bbb.1234.incomplete": "partial"},
+			links: map[string]string{
+				"snapshots/abc123/config.json":       "aaa",
+				"snapshots/abc123/model.safetensors": "bbb",
 			},
 			want: false,
 		},
 		{
+			// A download that finished on the second attempt. The cache keeps
+			// the abandoned partial from the first, and the model is complete
+			// anyway. Refusing here sent a developer back to `init` for
+			// weights that were already on the machine.
+			name: "a stale partial beside a complete snapshot",
+			files: map[string]string{
+				"blobs/aaa": "{}", "blobs/bbb": "weights",
+				"blobs/bbb.1234.incomplete": "abandoned",
+			},
+			links: map[string]string{
+				"snapshots/abc123/config.json":       "aaa",
+				"snapshots/abc123/model.safetensors": "bbb",
+			},
+			want: true,
+		},
+		{
 			name:  "metadata without weights",
-			files: map[string]string{"snapshots/abc123/config.json": "{}"},
+			files: map[string]string{"blobs/aaa": "{}"},
+			links: map[string]string{"snapshots/abc123/config.json": "aaa"},
 			want:  false,
 		},
 		{
@@ -403,6 +426,15 @@ func TestWeightsPresent(t *testing.T) {
 					t.Fatalf("seeding the cache: %v", err)
 				}
 				if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+					t.Fatalf("seeding the cache: %v", err)
+				}
+			}
+			for rel, blob := range tc.links {
+				path := filepath.Join(dir, rel)
+				if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+					t.Fatalf("seeding the cache: %v", err)
+				}
+				if err := os.Symlink(filepath.Join("..", "..", "blobs", blob), path); err != nil {
 					t.Fatalf("seeding the cache: %v", err)
 				}
 			}


### PR DESCRIPTION
Reported from a run of `nav-pilot alpha local init`: it downloaded 25 GB, printed "Weights downloaded", and then refused to start with

    Error: the weights for mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit are not on this machine.
      Download them first:
        nav-pilot alpha local init

The advice was to run the command that had just succeeded.

`WeightsPresent` refused as soon as it saw any `.incomplete` blob in the model's cache directory. The Hugging Face cache stores a partial as `<blob>.<id>.incomplete`, and a later successful download writes the finished blob **without removing the abandoned partial**. A model fetched across two attempts is therefore complete on disk with stale partials beside it. The machine that reported this had seven, and every snapshot symlink resolved.

Completeness is now asked of the snapshot's own files: each is a symlink into `blobs/`, and a piece that never finished downloading has no blob to point at, so a `stat` that follows the link answers the question directly. An interrupted download is still refused, which is the case the `.incomplete` scan was written for.

The test seeded plain files where the real cache has symlinks, so it could not tell a finished download from an interrupted one. It now seeds symlinks and covers the stale partial.

`go test ./internal/local/ ./internal/cli/` green.