### PR TITLE
fix(install): delete artifacts the source has stopped shipping

### DIFF
--- a/cli/nav-pilot/internal/artifacts/opencode_sync.go
+++ b/cli/nav-pilot/internal/artifacts/opencode_sync.go
@@ -67,7 +67,7 @@ func ValidateOpenCodeStatePath(p string) error {
 	return fmt.Errorf("path outside allowed opencode directories: %s", p)
 }
 
-// navPilotOwns reports whether a tracked file is still byte-for-byte what
+// NavPilotOwns reports whether a tracked file is still byte-for-byte what
 // nav-pilot wrote, and is therefore nav-pilot's to remove. A conflicted entry
 // never is: its recorded hash is the user's own copy, so a hash comparison
 // would call it untouched.
@@ -78,7 +78,7 @@ func ValidateOpenCodeStatePath(p string) error {
 // it as the user's for good. The write path is the older half and the wrong
 // one, but it is a separate bug with its own issue, not something to change
 // under a fix for what the scope materializes.
-func navPilotOwns(outputDir string, f domain.InstalledFile) bool {
+func NavPilotOwns(outputDir string, f domain.InstalledFile) bool {
 	if f.Status == domain.FileStatusConflict {
 		return false
 	}
@@ -303,7 +303,7 @@ func SyncOpenCodeArtifacts(sourceDir, scopeDir, outputDir, sourceVersion, source
 			if newFilesMap[f.Path] {
 				continue
 			}
-			if !navPilotOwns(outputDir, f) {
+			if !NavPilotOwns(outputDir, f) {
 				files = append(files, f)
 				continue
 			}

--- a/cli/nav-pilot/internal/cli/aliases.go
+++ b/cli/nav-pilot/internal/cli/aliases.go
@@ -217,6 +217,8 @@ var (
 	// behind it become unreachable, and it happens on four separate install
 	// paths — a shared write is one place to get it right instead of four
 	// places to forget it.
+	navPilotOwns = artifacts.NavPilotOwns
+
 	writeScopedState = func(scope *InstallScope, state *StateFile) error {
 		releasePin(scope, state)
 		return artifacts.WriteScopedState(scope, state)

--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -456,6 +456,7 @@ func cmdInstallFromSource(collection string, src *Source, scope *InstallScope, d
 	// newer nav-pilot put there; the fresh struct has none of them (#588).
 	if prior, err := readScopedState(scope); err == nil {
 		state.PreserveUnknownFrom(prior)
+		removeOrphans(scope, prior, result.Files)
 	}
 	if err := writeScopedState(scope, state); err != nil {
 		fmt.Fprintf(os.Stderr, "%s Could not write state file: %v\n", yellow("⚠"), err)
@@ -1149,4 +1150,48 @@ func cmdUninstall(scope *InstallScope, dryRun bool) error {
 		fmt.Printf("%s Removed %d items.\n", green("✓"), removed)
 	}
 	return nil
+}
+
+// removeOrphans deletes files the previous install put on disk that this one
+// did not write.
+//
+// State is rebuilt from what the install produced, so a file the source has
+// stopped shipping simply falls out of it. Nothing then deletes it, and nothing
+// can: sync walks the state, so a path it no longer names is invisible to every
+// later run. The file stays installed for the life of the machine.
+//
+// Reported after the local worker agent was renamed from lokal-arbeider to
+// local-worker. Both were listed in Copilot CLI's agent picker for three days,
+// and the stale one showed "inherit (default behavior)" — a worker agent that
+// would have run on the cloud model, which is the one thing it exists not to do.
+//
+// A file is removed only when it is byte-for-byte what nav-pilot wrote.
+// Anything the developer edited is theirs and stays, which is the same rule the
+// opencode scope has applied since it was written.
+func removeOrphans(scope *InstallScope, prior *StateFile, installed []InstalledFile) {
+	if prior == nil {
+		return
+	}
+	written := make(map[string]bool, len(installed))
+	for _, f := range installed {
+		written[f.Path] = true
+	}
+	for _, f := range prior.Files {
+		if written[f.Path] || !navPilotOwns(scope.RootDir, f) {
+			continue
+		}
+		full := filepath.Join(scope.RootDir, f.Path)
+		var err error
+		if strings.HasSuffix(f.Path, "/") {
+			err = os.RemoveAll(full)
+		} else {
+			err = os.Remove(full)
+		}
+		if err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "%s Could not remove %s, which is no longer part of the collection: %v\n",
+				yellow("⚠"), f.Path, err)
+			continue
+		}
+		fmt.Printf("  %s %s %s\n", red("×"), f.Path, dim("(no longer in the collection)"))
+	}
 }

--- a/cli/nav-pilot/internal/cli/install_orphan_test.go
+++ b/cli/nav-pilot/internal/cli/install_orphan_test.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/domain"
+	"github.com/navikt/copilot/cli/nav-pilot/internal/source"
+)
+
+// An artifact renamed upstream used to stay installed forever: state is rebuilt
+// from what the install wrote, so the old path fell out of it, and sync only
+// walks the state. Copilot CLI listed both lokal-arbeider and local-worker for
+// three days because of this.
+func TestRemoveOrphansDeletesWhatTheSourceStoppedShipping(t *testing.T) {
+	root := t.TempDir()
+	write := func(rel, body string) string {
+		full := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		h, err := source.RawArtifactHash(full, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return h
+	}
+
+	renamedAway := write("agents/lokal-arbeider.agent.md", "the old name")
+	edited := write("agents/kafka.agent.md", "the developer changed this")
+	kept := write("agents/local-worker.agent.md", "the new name")
+
+	prior := &StateFile{Files: []domain.InstalledFile{
+		{Path: "agents/lokal-arbeider.agent.md", Hash: renamedAway},
+		// Recorded with the hash it had when nav-pilot wrote it, which is not
+		// what is on disk now.
+		{Path: "agents/kafka.agent.md", Hash: "sha256:something-else"},
+		{Path: "agents/local-worker.agent.md", Hash: kept},
+	}}
+	_ = edited
+
+	scope := &InstallScope{RootDir: root}
+	removeOrphans(scope, prior, []domain.InstalledFile{
+		{Path: "agents/local-worker.agent.md", Hash: kept},
+	})
+
+	if _, err := os.Stat(filepath.Join(root, "agents/lokal-arbeider.agent.md")); !os.IsNotExist(err) {
+		t.Error("the renamed-away artifact is still installed")
+	}
+	for _, keep := range []string{"agents/kafka.agent.md", "agents/local-worker.agent.md"} {
+		if _, err := os.Stat(filepath.Join(root, keep)); err != nil {
+			t.Errorf("%s should have been left alone: %v", keep, err)
+		}
+	}
+}


### PR DESCRIPTION
Reported from a Copilot CLI agent list:

    kafka-agent      user  preferred  gpt-5.3-codex (default model)  No  On
  ❯ lokal-arbeider   user  preferred  inherit (default behavior)     No  On
    nais-agent       user  preferred  gpt-5.3-codex (default model)  No  On

The worker agent was renamed from `lokal-arbeider` to `local-worker` on 31 August. The old file has been installed on that machine ever since, and `inherit (default behavior)` means it would run on the cloud model, which is the one thing a local worker exists not to do.

`install` rebuilds the state file from what it just wrote, so a path the source no longer ships falls out of state. Nothing deletes it then, and nothing can: `sync` walks the state, so a path it does not name is invisible to every later run. The file stays installed for the life of the machine, and any rename in this repo silently leaves one behind on every machine that had the old name.

Install now removes what the previous state listed and this install did not write, and only when the file is byte-for-byte what nav-pilot wrote. Anything the developer edited is theirs and stays. That guard already existed for the opencode scope; it is exported now and both paths use it.

Test covers all three cases: renamed away (deleted), edited by the developer (kept), still shipped (kept).