### PR TITLE
feat(local): restart, and say when the server is not serving the model you chose

### DIFF
--- a/cli/nav-pilot/internal/cli/alpha_local.go
+++ b/cli/nav-pilot/internal/cli/alpha_local.go
@@ -50,8 +50,9 @@ hosted one. Off until you run init, and invisible everywhere until then.
 
   init      Set it all up: environment, weights, memory limit, and a running server
   start     Start the server and wait until it answers a real completion
+  restart   Stop the server and start one on the model local_model names now
   stop      Stop the server
-  status    Model, health, resident memory, the wired-memory limit and what it has done
+  status    Model, health, resident memory, the wired-memory limit, the log and what it has done
   ask       Put one question straight to the local model: ask -p "..." (or pipe stdin)
   on        Dispatch to it again after off, without downloading anything
   off       Stop dispatching to it; the weights stay on disk
@@ -86,6 +87,8 @@ func cmdAlpha(args []string) error {
 		return cmdLocalStart()
 	case "stop":
 		return cmdLocalStop()
+	case "restart":
+		return cmdLocalRestart()
 	case "status":
 		return cmdLocalStatus()
 	case "on":
@@ -100,7 +103,7 @@ func cmdAlpha(args []string) error {
 		alphaUsage()
 		return nil
 	default:
-		if hint := suggest(sub, []string{"init", "start", "stop", "status", "ask", "on", "off", "purge"}); hint != "" {
+		if hint := suggest(sub, []string{"init", "start", "restart", "stop", "status", "ask", "on", "off", "purge"}); hint != "" {
 			return fmt.Errorf("unknown command: nav-pilot alpha local %s. Did you mean %s?", sub, hint)
 		}
 		return fmt.Errorf("unknown command: nav-pilot alpha local %s. Run %s for usage", sub, bold("nav-pilot alpha help"))
@@ -510,6 +513,21 @@ func currentWiredLabel(w local.WiredLimit) string {
 
 // ─── stop ────────────────────────────────────────────────────────────────────
 
+// cmdLocalRestart stops a running server and starts one on the model the
+// config names now. Changing local_model does not move a server that is
+// already up, and there was no single command for it: stop, then start, with
+// nothing to say the second half failed.
+func cmdLocalRestart() error {
+	if _, running, err := local.LoadState(); err == nil && running {
+		if err := cmdLocalStop(); err != nil {
+			return err
+		}
+	} else {
+		fmt.Printf("%s No server was running.\n", dim("\u2192"))
+	}
+	return cmdLocalStart()
+}
+
 func cmdLocalStop() error {
 	st, ok, err := local.LoadState()
 	if err != nil {
@@ -557,6 +575,13 @@ func cmdLocalStatus() error {
 		defer printLocalStats(stats)
 	}
 	fmt.Printf("  Model        %s\n", bold(st.Model))
+	// A server keeps serving what it loaded. Changing local_model under a
+	// running one leaves the config and the process disagreeing, and every
+	// answer comes from the old model with nothing on screen to say so.
+	if want, ok := local.Chosen(local.Active()); ok && want.Model != st.Model {
+		fmt.Printf("               %s local_model is %s now. Run %s to serve it.\n",
+			yellow("⚠"), bold(want.Model), bold("nav-pilot alpha local restart"))
+	}
 	fmt.Printf("  Server       %s, %s\n", healthColour(health), dim(healthMeaning(health)))
 	fmt.Printf("  Process      pid %d, up %s, listening on %s\n",
 		st.PID, timeNow().Sub(st.Started).Round(time.Second), local.ServerURL())
@@ -564,6 +589,12 @@ func cmdLocalStatus() error {
 		fmt.Printf("  Resident     %.1f GB\n", float64(rss)/1024)
 	} else {
 		fmt.Printf("  Resident     %s\n", dim("unreadable"))
+	}
+	// Everything the server printed is here, and it is where a hang or a
+	// refusal to load explains itself. Naming it in status saves the developer
+	// finding out that nav-pilot keeps one at all.
+	if lp := local.LogPath(); lp != "" {
+		fmt.Printf("  Log          %s\n", dim(lp))
 	}
 
 	// The wired limit is per model and measured, so it is only meaningful for a

--- a/cli/nav-pilot/internal/cli/alpha_local_test.go
+++ b/cli/nav-pilot/internal/cli/alpha_local_test.go
@@ -43,7 +43,10 @@ func TestAlphaDispatch(t *testing.T) {
 		{name: "help prints usage", args: []string{"help"}},
 		{name: "local with no subcommand prints usage", args: []string{"local"}},
 		{name: "an unknown group", args: []string{"quantum"}, wantErr: "unknown alpha group"},
-		{name: "an unknown subcommand", args: []string{"local", "restart"}, wantErr: "unknown command"},
+		// Deliberately a word nobody will implement. "restart" used to stand
+		// here, and the day it became a real subcommand this test stopped and
+		// started the server on whatever machine ran it.
+		{name: "an unknown subcommand", args: []string{"local", "frobnicate"}, wantErr: "unknown command"},
 		{name: "a near miss is suggested", args: []string{"local", "statuss"}, wantErr: "Did you mean"},
 	}
 	for _, tt := range tests {

--- a/cli/nav-pilot/internal/cli/config_cmd.go
+++ b/cli/nav-pilot/internal/cli/config_cmd.go
@@ -543,6 +543,9 @@ func cmdConfigSet(key, value string) error {
 		return nil
 	}
 	fmt.Printf("%s %s = %s\n", green("✓"), key, tomlVal)
+	if key == "local_model" {
+		warnServerServesSomethingElse(value)
+	}
 	return nil
 }
 
@@ -874,4 +877,28 @@ func printKeyExplain(kd *configKeyDef, resolved ResolvedConfig) {
 		fmt.Printf("    Current:  %s\n", val)
 	}
 	fmt.Printf("    To set:   nav-pilot config set %s <value>\n", kd.name)
+}
+
+// warnServerServesSomethingElse says so when the server that is up is not
+// serving the model just chosen.
+//
+// A running server keeps the weights it loaded. Without this the config and the
+// process disagree in silence: every answer still comes from the old model, and
+// the only way to notice is to read the status output closely enough to compare
+// two model ids.
+func warnServerServesSomethingElse(chosen string) {
+	st, running, err := local.LoadState()
+	if err != nil || !running {
+		return
+	}
+	// The process read the config before this write, so the selection it holds
+	// is the previous one. Ask about the value that was just written instead,
+	// which is also what resolves an empty value to the manifest default.
+	local.SetSelectedModel(chosen)
+	want, ok := local.Chosen(local.Active())
+	if !ok || want.Model == st.Model {
+		return
+	}
+	fmt.Printf("\n%s The server that is running still serves %s.\n", yellow("⚠"), bold(st.Model))
+	fmt.Printf("  Load the one you just chose:\n\n    %s\n\n", bold("nav-pilot alpha local restart"))
 }


### PR DESCRIPTION
Three gaps, all from one question: what happens when `local_model` changes while a server is running. Nothing did. The config said one model, the process kept serving what it had loaded, and every answer came from the old weights with nothing on screen to say so.

- `nav-pilot config set local_model <id>` now warns when the running server serves something else, and names the command that fixes it.
- `nav-pilot alpha local restart` exists. Before this it was `stop` and then `start`, with nothing to report that the second half failed.
- `status` carries the same warning under the model line, and names the log file (`~/.nav-pilot/local/server.log`). Nothing told a developer nav-pilot keeps one, and it is where a hang or a refusal to load explains itself.

```
  Model        mlx-community/Qwen3.8-27B-8bit
               ⚠ local_model is mlx-community/Qwen3.8-27B-4bit now. Run nav-pilot alpha local restart to serve it.
  Server       ready, answered a real completion
  Log          /Users/hans/.nav-pilot/local/server.log
```

One test fixture had to change: `TestAlphaDispatch` used `restart` as its example of an unknown subcommand, and it calls `cmdAlpha` for real. The day `restart` became a command, that test stopped and started the local server on whatever machine ran it. It now names a word nobody will implement.