### PR TITLE
docs: agenter som kjører nav-pilot-binæren skal isolere HOME

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -469,3 +469,14 @@ mise all
 ```
 
 This runs all checks across all applications to ensure nothing is broken.
+
+## Running the nav-pilot binary
+
+`nav-pilot` writes to `~/.copilot/`, `~/.nav-pilot/` and the repository you are
+standing in. Never run it — or a test that calls `run()` — against a real home
+directory. Set `HOME` to a temporary directory (`nav-pilot` does **not** read
+`COPILOT_HOME`), along with `NAV_PILOT_CONFIG` and `XDG_CONFIG_HOME`, and check
+`~/.copilot` and `~/.nav-pilot` afterwards for changes you did not intend. In Go
+tests, use `isolatedConfig(t)`.
+
+Isolation that is set up wrong looks exactly like isolation until someone checks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,21 +41,28 @@ After editing an app, run `mise check` in that app's directory. Run `mise all` w
 - Do not commit secrets.
 - Do not push unless explicitly asked.
 
-## Å kjøre nav-pilot-binæren under testing
+## Running the nav-pilot binary in tests or verification
 
-`nav-pilot` skriver til brukerens eget miljø: `~/.copilot/`, `~/.nav-pilot/` og
-det repoet du står i. En verifisering som kjører den ekte binæren uten isolasjon
-endrer utviklerens faktiske oppsett — og det har skjedd: en installasjon under
-testing pekte et brukerscope mot en midlertidig worktree og etterlot 23 av 52
-filer i konflikt, som `sync` deretter hoppet over i det stille.
+`nav-pilot` writes to the developer's own environment: `~/.copilot/`,
+`~/.nav-pilot/` and the repository you are standing in. A verification that runs
+the real binary without isolation changes a real setup, and it has: an install
+run during testing pointed a user scope at a temporary worktree and left 23 of 52
+files in conflict, which `sync` then silently skipped. Nothing had been edited by
+hand.
 
-Derfor, hver gang du kjører binæren for å sjekke oppførsel:
+Whenever you run the binary — directly, or through a test that calls `run()`:
 
-- Sett `HOME` og `COPILOT_HOME` til en midlertidig katalog. Ikke stol på at
-  kommandoen «bare leser» — `install`, `sync`, `config` og oppstartsveiene
-  skriver alle sammen.
-- Ta en kopi av `~/.copilot` og `~/.nav-pilot` før kjøringen, sammenlign etterpå,
-  og rapporter enhver forskjell. Isolasjon som er satt opp feil ser ut som
-  isolasjon helt til noen ser etter.
-- Rapporter det høyt hvis du likevel rørte noe. En stille endring i et
-  brukeroppsett er verre enn en feilet test.
+- Set `HOME` to a temporary directory. That is the one that matters, because
+  everything resolves through `os.UserHomeDir`. `nav-pilot` does **not** read
+  `COPILOT_HOME`. Also set `NAV_PILOT_CONFIG` (relocates
+  `~/.nav-pilot/config.toml`, see `internal/cli/config.go`) and
+  `XDG_CONFIG_HOME` (honoured on the opencode export path, see
+  `internal/provider/opencode_launch.go`). In Go tests, `isolatedConfig(t)` does
+  this for you — use it.
+- Do not assume a command only reads. `install`, `sync`, `config` and the launch
+  paths all write.
+- Hash `~/.copilot` and `~/.nav-pilot` before and after, and report any
+  difference. Isolation that is set up wrong looks exactly like isolation until
+  someone checks.
+- Say so loudly if you did touch something. A silent change to a developer's
+  setup is worse than a failed test.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,22 @@ After editing an app, run `mise check` in that app's directory. Run `mise all` w
 - In `my-copilot`, use Aksel spacing tokens, not Tailwind `p-*/m-*` utilities.
 - Do not commit secrets.
 - Do not push unless explicitly asked.
+
+## Å kjøre nav-pilot-binæren under testing
+
+`nav-pilot` skriver til brukerens eget miljø: `~/.copilot/`, `~/.nav-pilot/` og
+det repoet du står i. En verifisering som kjører den ekte binæren uten isolasjon
+endrer utviklerens faktiske oppsett — og det har skjedd: en installasjon under
+testing pekte et brukerscope mot en midlertidig worktree og etterlot 23 av 52
+filer i konflikt, som `sync` deretter hoppet over i det stille.
+
+Derfor, hver gang du kjører binæren for å sjekke oppførsel:
+
+- Sett `HOME` og `COPILOT_HOME` til en midlertidig katalog. Ikke stol på at
+  kommandoen «bare leser» — `install`, `sync`, `config` og oppstartsveiene
+  skriver alle sammen.
+- Ta en kopi av `~/.copilot` og `~/.nav-pilot` før kjøringen, sammenlign etterpå,
+  og rapporter enhver forskjell. Isolasjon som er satt opp feil ser ut som
+  isolasjon helt til noen ser etter.
+- Rapporter det høyt hvis du likevel rørte noe. En stille endring i et
+  brukeroppsett er verre enn en feilet test.


### PR DESCRIPTION
En verifisering i går kjørte den ekte `nav-pilot`-binæren uten isolert `HOME`. Resultatet i utviklerens eget oppsett:

- brukerscopet ble pekt mot en midlertidig worktree (`source_repo` satt til en `copilot-610`-sti som forsvinner)
- 23 av 52 filer ble stående med `status: conflict`
- `sync` hoppet deretter over dem i det stille, så tre agenter viste modeller som ble endret oppstrøms i #506

Brukeren hadde ikke redigert en eneste fil manuelt.

`AGENTS.md` sier nå at en agent som kjører binæren skal sette `HOME` og `COPILOT_HOME` til en midlertidig katalog, sammenlikne `~/.copilot` og `~/.nav-pilot` før og etter, og rapportere enhver forskjell. Sistnevnte fordi isolasjon som er satt opp feil ser ut som isolasjon helt til noen ser etter.

Selve konflikt-oppførselen er en egen sak: `install` uten `--force` merker nav-pilots *egne* artefakter som konflikt når de avviker fra kilden, uten å se på hashen den selv har lagret, og `sync` hopper så over dem. Den analysen kommer for seg.