### PR TITLE
docs: dispatch to a local sub-agent requires opencode, and we never said so

### DIFF
--- a/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
+++ b/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
@@ -2192,11 +2192,19 @@ nav-pilot alpha local start`}
             hvilken du kjører.
           </BodyLong>
           <BodyLong size="small" textColor="subtle">
-            Under <strong>opencode</strong> blir bakkemodellen en underagent som heter{" "}
-            <code className="font-mono text-xs">local-worker</code>, og som hovedagenten i skyen sender avgrensede
+            Utsending til en lokal underagent krever <strong>opencode</strong>. Der blir bakkemodellen en underagent som
+            heter <code className="font-mono text-xs">local-worker</code>, og som hovedagenten i skyen sender avgrensede
             oppgaver til. Hovedagenten bestemmer fortsatt alt, og gjør selv det den vurderer at bakkemodellen ikke
-            klarer. Under <strong>Copilot CLI</strong> kjører hele økten lokalt, fordi klienten bare håndterer én
-            modelleverandør om gangen.
+            klarer.
+          </BodyLong>
+          <BodyLong size="small" textColor="subtle">
+            Under <strong>Copilot CLI</strong> finnes ingen slik underagent, og kan ikke finnes i dag. Copilot CLI er
+            standardklienten, så dette gjelder deg med mindre du har byttet. Valget der er hele økten på den lokale
+            modellen eller ingenting lokalt, fordi klienten setter modelleverandøren som en miljøvariabel for hele
+            prosessen, så én leverandør betjener hele økten. Vi har verifisert det mot Copilot CLI 1.0.83-3. Vil du ha
+            utsending, bytt med <code className="font-mono text-xs">nav-pilot config set client opencode</code>. Vi har
+            bedt GitHub om å kunne velge modelleverandør per agent i Copilot CLI, og det ligger som en feature request
+            hos dem.
           </BodyLong>
         </VStack>
 

--- a/cli/nav-pilot/internal/cli/alpha_local.go
+++ b/cli/nav-pilot/internal/cli/alpha_local.go
@@ -206,6 +206,25 @@ func cmdLocalInit() error {
 	}
 	fmt.Println()
 
+	// Said before the confirmation, and before 26 GB is spent, because on the
+	// default client this is the whole shape of what the developer is buying.
+	// It used to print after the download and after local inference was already
+	// enabled, which told people what they had only once they had it.
+	//
+	// The client is reported, not set. Writing it looks like automation and is a
+	// trap: config validation requires an opencode model in provider/model form,
+	// so setting the client on a config whose model is a bare cloud id makes
+	// every launch fail validation until someone edits the file by hand. The
+	// launch converts bare ids on its own, so nothing needs writing here.
+	if cfg, err := readConfig(); err == nil && cfg != nil && cfg.Client != nil && *cfg.Client == "copilot" {
+		fmt.Printf("  %s\n", bold("Your client is the Copilot CLI, which has no sub-agent dispatch:"))
+		fmt.Printf("    %s\n", dim("a local session runs entirely on the local model, or not at all."))
+		fmt.Printf("    %s\n", dim("The Copilot CLI takes one model provider per process, so a cloud"))
+		fmt.Printf("    %s\n", dim("main agent cannot hand scoped tasks to a local worker there."))
+		fmt.Printf("  %s\n", dim("For a cloud agent with a local worker, switch clients first:"))
+		fmt.Printf("    %s\n\n", dim("nav-pilot config set client opencode"))
+	}
+
 	// Said before the confirmation, not after it, and before anything is
 	// downloaded. Collecting more than usual during an alpha is defensible only
 	// if the developer is told what "more" means while they can still decline.
@@ -274,17 +293,6 @@ func cmdLocalInit() error {
 			return err
 		}
 		fmt.Printf("%s Wired-memory limit raised.\n", green("✓"))
-	}
-
-	// The client is reported, not set. Writing it looks like automation and is a
-	// trap: config validation requires an opencode model in provider/model form,
-	// so setting the client on a config whose model is a bare cloud id makes
-	// every launch fail validation until someone edits the file by hand. The
-	// launch converts bare ids on its own, so nothing needs writing here.
-	if cfg, err := readConfig(); err == nil && cfg != nil && cfg.Client != nil && *cfg.Client == "copilot" {
-		fmt.Printf("%s Your client is the Copilot CLI, so a local session runs entirely on the local model.\n",
-			dim("ℹ"))
-		fmt.Printf("  %s\n", dim("For a cloud agent with a local worker, switch with: nav-pilot config set client opencode"))
 	}
 
 	fmt.Printf("%s Starting the server (measured starts have been under a minute)…\n", dim("→"))

--- a/cli/nav-pilot/internal/cli/alpha_local.go
+++ b/cli/nav-pilot/internal/cli/alpha_local.go
@@ -300,7 +300,15 @@ func cmdLocalInit() error {
 		return err
 	}
 
-	fmt.Printf("\n  %s\n", bold("Ready. Run nav-pilot in a repository and it will use the local worker."))
+	// "the local worker" is only true on a client that has one. On the Copilot
+	// CLI the session either runs on the local model or does not, and telling
+	// that developer about a worker is the promise this whole change exists to
+	// stop making.
+	ready := "Ready. Run nav-pilot in a repository and it will use the local worker."
+	if cfg, err := readConfig(); err == nil && cfg != nil && cfg.Client != nil && *cfg.Client == "copilot" {
+		ready = "Ready. Run nav-pilot with a local model to put the whole session on it."
+	}
+	fmt.Printf("\n  %s\n", bold(ready))
 	fmt.Printf("  %s\n\n", dim("nav-pilot alpha local status  ·  nav-pilot alpha local off  ·  nav-pilot alpha local purge"))
 	return nil
 }

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -309,13 +309,28 @@ Av som standard, med vilje: å starte en 21 GB prosess uten å bli bedt om det e
 Ingenting av dette skjer med mindre du kjører `init` selv. Gjør du ikke det, er nav-pilot
 uendret.
 
+### Utsending til en lokal underagent krever opencode
+
 **Under opencode** blir modellen en underagent (`local-worker`) som hovedagenten i skyen
 kan sende avgrensede oppgaver til. Hovedagenten bestemmer fortsatt alt. Den sender videre
 det som er mekanisk og spesifisert, og gjør resten selv.
 
-**Under Copilot CLI** kjører hele økten lokalt, fordi klienten bare håndterer én
-modelleverandør om gangen. Det passer til arbeid som allerede er spesifisert, ikke til
-oppgaver der modellen må finne ut hva som skal gjøres.
+**Under Copilot CLI finnes ingen slik underagent, og kan ikke finnes i dag.** Copilot CLI
+er standardklienten i nav-pilot, så dette gjelder deg med mindre du har byttet. Der er
+valget hele økten på den lokale modellen eller ingenting lokalt. Grunnen er at klienten
+setter modelleverandøren som en miljøvariabel for hele prosessen, så én leverandør betjener
+hele økten. Vi har verifisert det mot Copilot CLI 1.0.83-3. Hele økten lokalt passer til
+arbeid som allerede er spesifisert, ikke til oppgaver der modellen må finne ut hva som skal
+gjøres.
+
+Vil du ha utsending, bytt klient:
+
+```bash
+nav-pilot config set client opencode
+```
+
+Vi har bedt GitHub om å kunne velge modelleverandør per agent i Copilot CLI. Det ligger som
+en feature request hos dem.
 
 ### Hva den er god og dårlig til
 

--- a/docs/news/articles/lokale-modeller-i-nav-pilot.md
+++ b/docs/news/articles/lokale-modeller-i-nav-pilot.md
@@ -19,6 +19,8 @@ For å få Nav sitt KI-token-budsjett til å strekke lenger, og for at de ivrigs
 
 Vi kaller den bakkemodellen. Hovedagenten blir i skya og bestemmer, bakkemodellen utfører. I logger og konfigurasjon heter den `local-worker`.
 
+Den arbeidsdelingen krever opencode som klient. Bare der blir bakkemodellen en underagent hovedagenten kan sende avgrensede oppgaver til. Under Copilot CLI, som er standardklienten i nav-pilot, finnes ingen slik underagent: klienten setter modelleverandøren som en miljøvariabel for hele prosessen, så én leverandør betjener hele økten. Valget der er hele økten på den lokale modellen eller ingenting lokalt. Vi har verifisert det mot Copilot CLI 1.0.83-3. Vil du ha utsending, bytt med `nav-pilot config set client opencode`. Vi har bedt GitHub om å kunne velge modelleverandør per agent i Copilot CLI, og det ligger som en feature request hos dem.
+
 ```
 nav-pilot alpha local init
 ```


### PR DESCRIPTION
A developer ran `nav-pilot alpha local init` on the default client, downloaded 26 GB, and went looking for the `local-worker` sub-agent. It is not there, and it cannot be there.

The Copilot CLI takes one model provider per process (`COPILOT_PROVIDER_BASE_URL`), so a session either runs entirely on the local model or not at all. Sub-agent dispatch works under opencode, which selects a provider per agent. Verified against Copilot CLI 1.0.83-3.

Our docs described the sub-agent design and mentioned opencode in passing. A reader on the default client, which is `copilot`, was left expecting something that cannot happen. Four surfaces now say it plainly:

- `docs/README.nav-pilot.md` gets a heading of its own: dispatch requires opencode, the Copilot CLI choice is whole-session local or nothing, and the reason.
- The news article says it where it introduces the design, instead of leaving the reader to find out later.
- The docs page carries the same two paragraphs.
- `init` says it **before** the download prompt rather than after enabling, so the developer learns what they are getting before spending 26 GB. And its closing line no longer promises a local worker on a client that has none.

No control flow changed and `init` still does not write the client setting, for the reason the comment there gives.

`go build`, `go test ./internal/cli/`, `gofmt` and `tsc --noEmit` all clean.