### PR TITLE
fix: konflikt betyr at brukeren endret filen, ikke at kilden flyttet seg

### DIFF
--- a/cli/nav-pilot/internal/artifacts/state.go
+++ b/cli/nav-pilot/internal/artifacts/state.go
@@ -77,7 +77,7 @@ func WriteStateAt(path, boundary string, state *domain.StateFile) error {
 	// content and not from the order the installs happened to run in. Sorting
 	// on every write is what makes two machines that installed the same thing
 	// produce the same file.
-	slices.SortFunc(state.Files, func(a, b domain.InstalledFile) int {
+	slices.SortStableFunc(state.Files, func(a, b domain.InstalledFile) int {
 		return strings.Compare(a.Path, b.Path)
 	})
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/cli/nav-pilot/internal/artifacts/state.go
+++ b/cli/nav-pilot/internal/artifacts/state.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 
 	"github.com/navikt/copilot/cli/nav-pilot/internal/domain"
 	"github.com/navikt/copilot/cli/nav-pilot/internal/source"
@@ -71,6 +73,13 @@ func WriteStateAt(path, boundary string, state *domain.StateFile) error {
 	if err := source.CheckSymlink(path, boundary); err != nil {
 		return err
 	}
+	// A repo-scope state file is committed, so its order must come from the
+	// content and not from the order the installs happened to run in. Sorting
+	// on every write is what makes two machines that installed the same thing
+	// produce the same file.
+	slices.SortFunc(state.Files, func(a, b domain.InstalledFile) int {
+		return strings.Compare(a.Path, b.Path)
+	})
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}

--- a/cli/nav-pilot/internal/cli/add.go
+++ b/cli/nav-pilot/internal/cli/add.go
@@ -68,7 +68,7 @@ func cmdAdd(itemType, name string, scope *InstallScope, ref, sourceRepo string, 
 	// Dispatch to the appropriate installer
 	kind := kindByName[itemType]
 	resolver := resolverFor(src.Dir, pakkeFor(src, name))
-	installErr := installArtifact(resolver, scope, kind, name, dryRun, force, result)
+	installErr := installArtifact(resolver, scope, scopeStateHashes(scope), kind, name, dryRun, force, result)
 	if installErr != nil {
 		return installErr
 	}
@@ -87,8 +87,8 @@ func cmdAdd(itemType, name string, scope *InstallScope, ref, sourceRepo string, 
 	}
 
 	if result.Conflicts > 0 {
-		fmt.Printf("\n%s File already exists and differs. Use %s to overwrite.\n",
-			yellow("⚠"), bold("--force"))
+		fmt.Println()
+		printConflictHint(result.Conflicts)
 	}
 
 	if dryRun || result.Installed == 0 {

--- a/cli/nav-pilot/internal/cli/add_test.go
+++ b/cli/nav-pilot/internal/cli/add_test.go
@@ -65,7 +65,7 @@ func TestCmdAdd_Agent(t *testing.T) {
 	os.MkdirAll(filepath.Join(source, "collections"), 0o755)
 
 	result := &installResult{}
-	err := installArtifact(NewSourceResolver(source), ScopeRepo(target), KindAgent, "test-agent", false, false, result)
+	err := installArtifact(NewSourceResolver(source), ScopeRepo(target), nil, KindAgent, "test-agent", false, false, result)
 	if err != nil {
 		t.Fatalf("installArtifact agent: %v", err)
 	}
@@ -94,7 +94,7 @@ func TestCmdAdd_Skill(t *testing.T) {
 	os.MkdirAll(filepath.Join(target, ".git"), 0o755)
 
 	result := &installResult{}
-	err := installArtifact(NewSourceResolver(source), ScopeRepo(target), KindSkill, "test-skill", false, false, result)
+	err := installArtifact(NewSourceResolver(source), ScopeRepo(target), nil, KindSkill, "test-skill", false, false, result)
 	if err != nil {
 		t.Fatalf("installArtifact skill: %v", err)
 	}
@@ -121,7 +121,7 @@ func TestCmdAdd_Skill_RootLevel(t *testing.T) {
 	os.MkdirAll(filepath.Join(target, ".git"), 0o755)
 
 	result := &installResult{}
-	err := installArtifact(NewSourceResolver(source), ScopeRepo(target), KindSkill, "test-skill", false, false, result)
+	err := installArtifact(NewSourceResolver(source), ScopeRepo(target), nil, KindSkill, "test-skill", false, false, result)
 	if err != nil {
 		t.Fatalf("installArtifact skill: %v", err)
 	}
@@ -150,7 +150,7 @@ func TestCmdAdd_Skill_RootLevel_RecordsCorrectStatePath(t *testing.T) {
 	os.MkdirAll(filepath.Join(target, ".git"), 0o755)
 
 	result := &installResult{}
-	err := installArtifact(NewSourceResolver(source), ScopeRepo(target), KindSkill, "test-skill", false, false, result)
+	err := installArtifact(NewSourceResolver(source), ScopeRepo(target), nil, KindSkill, "test-skill", false, false, result)
 	if err != nil {
 		t.Fatalf("installArtifact skill: %v", err)
 	}
@@ -187,7 +187,7 @@ func TestCmdAdd_Agent_RootLevel(t *testing.T) {
 	os.MkdirAll(filepath.Join(target, ".git"), 0o755)
 
 	result := &installResult{}
-	err := installArtifact(NewSourceResolver(source), ScopeRepo(target), KindAgent, "nais", false, false, result)
+	err := installArtifact(NewSourceResolver(source), ScopeRepo(target), nil, KindAgent, "nais", false, false, result)
 	if err != nil {
 		t.Fatalf("installArtifact agent: %v", err)
 	}
@@ -216,7 +216,7 @@ func TestCmdAdd_Prompt_RootLevel(t *testing.T) {
 	os.MkdirAll(filepath.Join(target, ".git"), 0o755)
 
 	result := &installResult{}
-	err := installArtifact(NewSourceResolver(source), ScopeRepo(target), KindPrompt, "review", false, false, result)
+	err := installArtifact(NewSourceResolver(source), ScopeRepo(target), nil, KindPrompt, "review", false, false, result)
 	if err != nil {
 		t.Fatalf("installArtifact prompt: %v", err)
 	}
@@ -244,7 +244,7 @@ func TestCmdAdd_Prompt_RootDirLevel(t *testing.T) {
 	os.MkdirAll(filepath.Join(target, ".git"), 0o755)
 
 	result := &installResult{}
-	err := installArtifact(NewSourceResolver(source), ScopeRepo(target), KindPrompt, "complex", false, false, result)
+	err := installArtifact(NewSourceResolver(source), ScopeRepo(target), nil, KindPrompt, "complex", false, false, result)
 	if err != nil {
 		t.Fatalf("installArtifact prompt: %v", err)
 	}
@@ -283,7 +283,7 @@ func TestCmdAdd_AppendsToState(t *testing.T) {
 	os.WriteFile(filepath.Join(agentDir, "new-agent.agent.md"), []byte("# New Agent"), 0o644)
 
 	result := &installResult{}
-	installArtifact(NewSourceResolver(source), ScopeRepo(target), KindAgent, "new-agent", false, false, result)
+	installArtifact(NewSourceResolver(source), ScopeRepo(target), nil, KindAgent, "new-agent", false, false, result)
 
 	// Simulate what cmdAdd does: merge state
 	state, _ := readState(target)

--- a/cli/nav-pilot/internal/cli/conflict_hash_test.go
+++ b/cli/nav-pilot/internal/cli/conflict_hash_test.go
@@ -1,0 +1,289 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// driftSource builds a legacy-layout source with two collections over the same
+// two agents, so a test can install wide and then narrow.
+func driftSource(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "collections", "wide", "manifest.json"),
+		`{"name":"wide","description":"Wide","agents":["test-a","test-b"]}`)
+	mustWrite(t, filepath.Join(dir, "collections", "narrow", "manifest.json"),
+		`{"name":"narrow","description":"Narrow","agents":["test-a"]}`)
+	mustWrite(t, filepath.Join(dir, "agents", "test-a.agent.md"), "---\nname: test-a\ndescription: A\n---\nBody A\n")
+	mustWrite(t, filepath.Join(dir, "agents", "test-b.agent.md"), "---\nname: test-b\ndescription: B\n---\nBody B\n")
+	return dir
+}
+
+func localSource(dir string) *Source {
+	return &Source{Dir: dir, SHA: "abc1234", Version: "dev", Repo: defaultSourceRepo}
+}
+
+func stateEntry(t *testing.T, scope *InstallScope, path string) *InstalledFile {
+	t.Helper()
+	state, err := readScopedState(scope)
+	if err != nil || state == nil {
+		t.Fatalf("readScopedState: %v (state=%v)", err, state)
+	}
+	for i, f := range state.Files {
+		if f.Path == path {
+			return &state.Files[i]
+		}
+	}
+	return nil
+}
+
+const agentA = ".github/agents/test-a.agent.md"
+const agentB = ".github/agents/test-b.agent.md"
+
+// TestInstallSourceDriftIsNotConflict: nav-pilot's own untouched file must be
+// updated when the source moves, not reported as the user's conflict.
+func TestInstallSourceDriftIsNotConflict(t *testing.T) {
+	isolatedConfig(t)
+	srcDir := driftSource(t)
+	target := repoTarget(t)
+	scope := ScopeRepo(target)
+
+	if err := cmdInstallFromSource("narrow", localSource(srcDir), scope, false, false, false); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+
+	// Upstream moves. The user has touched nothing.
+	mustWrite(t, filepath.Join(srcDir, "agents", "test-a.agent.md"), "---\nname: test-a\ndescription: A\n---\nBody A v2\n")
+
+	if err := cmdInstallFromSource("narrow", localSource(srcDir), scope, false, false, false); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+
+	got, _ := os.ReadFile(filepath.Join(target, agentA))
+	if want := "---\nname: test-a\ndescription: A\n---\nBody A v2\n"; string(got) != want {
+		t.Errorf("untouched file was not updated:\ngot  %q\nwant %q", got, want)
+	}
+	if e := stateEntry(t, scope, agentA); e == nil || e.Status == fileStatusConflict {
+		t.Errorf("source drift recorded as a conflict: %+v", e)
+	}
+}
+
+// TestInstallUserEditIsConflict: the protection must survive the fix.
+func TestInstallUserEditIsConflict(t *testing.T) {
+	isolatedConfig(t)
+	srcDir := driftSource(t)
+	target := repoTarget(t)
+	scope := ScopeRepo(target)
+
+	if err := cmdInstallFromSource("narrow", localSource(srcDir), scope, false, false, false); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	mustWrite(t, filepath.Join(target, agentA), "my own edit\n")
+	if err := cmdInstallFromSource("narrow", localSource(srcDir), scope, false, false, false); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+
+	if got, _ := os.ReadFile(filepath.Join(target, agentA)); string(got) != "my own edit\n" {
+		t.Errorf("user edit was overwritten: %q", got)
+	}
+	if e := stateEntry(t, scope, agentA); e == nil || e.Status != fileStatusConflict {
+		t.Errorf("user edit not recorded as a conflict: %+v", e)
+	}
+}
+
+// TestInstallUntrackedHandPlacedConflicts: a foreign file nav-pilot never wrote
+// is still a conflict.
+func TestInstallUntrackedHandPlacedConflicts(t *testing.T) {
+	isolatedConfig(t)
+	srcDir := driftSource(t)
+	target := repoTarget(t)
+	scope := ScopeRepo(target)
+
+	if err := cmdInstallFromSource("narrow", localSource(srcDir), scope, false, false, false); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	// test-b was never installed; someone put their own file there.
+	mustWrite(t, filepath.Join(target, agentB), "hand placed\n")
+
+	if err := cmdInstallFromSource("wide", localSource(srcDir), scope, false, false, false); err != nil {
+		t.Fatalf("wide install: %v", err)
+	}
+	if got, _ := os.ReadFile(filepath.Join(target, agentB)); string(got) != "hand placed\n" {
+		t.Errorf("hand-placed file was overwritten: %q", got)
+	}
+	if e := stateEntry(t, scope, agentB); e == nil || e.Status != fileStatusConflict {
+		t.Errorf("hand-placed file not recorded as a conflict: %+v", e)
+	}
+}
+
+// TestInstallPreexistingConflictNotOverwritten: once a path is in conflict, a
+// later install must not adopt it silently.
+func TestInstallPreexistingConflictNotOverwritten(t *testing.T) {
+	isolatedConfig(t)
+	srcDir := driftSource(t)
+	target := repoTarget(t)
+	scope := ScopeRepo(target)
+
+	if err := cmdInstallFromSource("narrow", localSource(srcDir), scope, false, false, false); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	mustWrite(t, filepath.Join(target, agentA), "my own edit\n")
+	if err := cmdInstallFromSource("narrow", localSource(srcDir), scope, false, false, false); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	if e := stateEntry(t, scope, agentA); e == nil || e.Status != fileStatusConflict {
+		t.Fatalf("precondition: expected a recorded conflict, got %+v", e)
+	}
+
+	// Now upstream also moves. The conflict must stand.
+	mustWrite(t, filepath.Join(srcDir, "agents", "test-a.agent.md"), "---\nname: test-a\ndescription: A\n---\nBody A v2\n")
+	if err := cmdInstallFromSource("narrow", localSource(srcDir), scope, false, false, false); err != nil {
+		t.Fatalf("third install: %v", err)
+	}
+	if got, _ := os.ReadFile(filepath.Join(target, agentA)); string(got) != "my own edit\n" {
+		t.Errorf("pre-existing conflict was silently overwritten: %q", got)
+	}
+	if e := stateEntry(t, scope, agentA); e == nil || e.Status != fileStatusConflict {
+		t.Errorf("pre-existing conflict lost its status: %+v", e)
+	}
+}
+
+// TestNarrowInstallDropsWhatItDeleted: the two halves of this fix meet here.
+// removeOrphans (#615) deletes an artifact the narrower install no longer
+// ships, so the merge must not put its state entry back — a committed state
+// listing a file the tool just deleted has status report it missing and the
+// next sync report a deletion nav-pilot performed itself.
+func TestNarrowInstallDropsWhatItDeleted(t *testing.T) {
+	isolatedConfig(t)
+	srcDir := driftSource(t)
+	target := repoTarget(t)
+	scope := ScopeRepo(target)
+
+	if err := cmdInstallFromSource("wide", localSource(srcDir), scope, false, false, false); err != nil {
+		t.Fatalf("wide install: %v", err)
+	}
+	// test-b is untouched, so it is nav-pilot's to retire.
+	if err := cmdInstallFromSource("narrow", localSource(srcDir), scope, false, false, false); err != nil {
+		t.Fatalf("narrow install: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(target, agentB)); !os.IsNotExist(err) {
+		t.Fatalf("precondition: %s should have been removed from disk: %v", agentB, err)
+	}
+	if e := stateEntry(t, scope, agentB); e != nil {
+		t.Errorf("state still lists %s, which the same install deleted from disk: %+v", agentB, e)
+	}
+}
+
+// TestNarrowInstallKeepsTheUserEditItDidNotDelete: the hole #615 leaves, and
+// the only one the merge needs to fill. removeOrphans keeps an edited file on
+// disk because nav-pilot does not own it; dropping its state entry would make
+// that file invisible to every later sync.
+func TestNarrowInstallKeepsTheUserEditItDidNotDelete(t *testing.T) {
+	isolatedConfig(t)
+	srcDir := driftSource(t)
+	target := repoTarget(t)
+	scope := ScopeRepo(target)
+
+	if err := cmdInstallFromSource("wide", localSource(srcDir), scope, false, false, false); err != nil {
+		t.Fatalf("wide install: %v", err)
+	}
+	mustWrite(t, filepath.Join(target, agentB), "my own edit\n")
+
+	if err := cmdInstallFromSource("narrow", localSource(srcDir), scope, false, false, false); err != nil {
+		t.Fatalf("narrow install: %v", err)
+	}
+
+	if got, _ := os.ReadFile(filepath.Join(target, agentB)); string(got) != "my own edit\n" {
+		t.Fatalf("precondition: the edited file should still be on disk, got %q", got)
+	}
+	if e := stateEntry(t, scope, agentB); e == nil {
+		t.Errorf("the narrower install dropped %s from state while leaving it on disk; nothing can manage it now", agentB)
+	}
+}
+
+// TestInstallDoesNotUnIgnore: `ignore` keeps the recorded hash, so an untouched
+// ignored file hashes equal to it. Counting that as "nav-pilot's own, update
+// it" overwrites the file and clears the status — the user's ignore decision,
+// silently undone.
+func TestInstallDoesNotUnIgnore(t *testing.T) {
+	isolatedConfig(t)
+	srcDir := driftSource(t)
+	scope, err := ScopeUser() // ignore is a user-scope gesture
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cmdInstallFromSource("narrow", localSource(srcDir), scope, false, false, false); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	if err := cmdIgnore("agent", "test-a", scope, false); err != nil {
+		t.Fatalf("ignore: %v", err)
+	}
+	rel := scope.RelPath("agents", "test-a.agent.md")
+	onDisk := filepath.Join(scope.RootDir, rel)
+	installed, err := os.ReadFile(onDisk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Upstream moves. The ignored file must not follow it.
+	mustWrite(t, filepath.Join(srcDir, "agents", "test-a.agent.md"), "---\nname: test-a\ndescription: A\n---\nBody A v2\n")
+	if err := cmdInstallFromSource("narrow", localSource(srcDir), scope, false, false, false); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+
+	if got, _ := os.ReadFile(onDisk); string(got) != string(installed) {
+		t.Errorf("an ignored file was overwritten by the install: %q", got)
+	}
+	if e := stateEntry(t, scope, rel); e == nil || e.Status == "" {
+		t.Errorf("an ignored file came back unmanaged: %+v", e)
+	}
+}
+
+// TestMergeStateFilesCollapsesDuplicates: a prior list that already held a path
+// twice must not leave the stale copy behind — conflictStatePaths and
+// resolveSyncFiles would then disagree about the same path.
+func TestMergeStateFilesCollapsesDuplicates(t *testing.T) {
+	prior := []InstalledFile{
+		{Path: agentA, Hash: "stale", Status: fileStatusConflict},
+		{Path: agentA, Hash: "fresh"},
+	}
+	merged := mergeStateFiles(prior, nil)
+	if len(merged) != 1 {
+		t.Fatalf("duplicate path survived the merge: %+v", merged)
+	}
+	if merged[0].Hash != "fresh" || merged[0].Status == fileStatusConflict {
+		t.Errorf("the stale duplicate won: %+v", merged[0])
+	}
+}
+
+// TestMergeStateFilesKeepsForeignSource: a scope install writes entries with no
+// Source, so a path that `add --source X` tagged would lose its marker (#571).
+func TestMergeStateFilesKeepsForeignSource(t *testing.T) {
+	prior := []InstalledFile{{Path: agentA, Hash: "old", Source: "other/repo"}}
+	merged := mergeStateFiles(prior, []InstalledFile{{Path: agentA, Hash: "new"}})
+	if len(merged) != 1 || merged[0].Source != "other/repo" {
+		t.Errorf("foreign-source marker lost: %+v", merged)
+	}
+}
+
+// TestStateFilesAreWrittenSorted: the repo-scope state file is committed, so
+// its order must come from the content, not from the order the installs ran in.
+func TestStateFilesAreWrittenSorted(t *testing.T) {
+	isolatedConfig(t)
+	scope := ScopeRepo(repoTarget(t))
+	if err := writeScopedState(scope, &StateFile{Files: []InstalledFile{
+		{Path: agentB}, {Path: agentA},
+	}}); err != nil {
+		t.Fatalf("writeScopedState: %v", err)
+	}
+	state, err := readScopedState(scope)
+	if err != nil || state == nil {
+		t.Fatalf("readScopedState: %v", err)
+	}
+	if state.Files[0].Path != agentA {
+		t.Errorf("state file order follows install history, not the paths: %+v", state.Files)
+	}
+}

--- a/cli/nav-pilot/internal/cli/conflict_hash_test.go
+++ b/cli/nav-pilot/internal/cli/conflict_hash_test.go
@@ -287,3 +287,34 @@ func TestStateFilesAreWrittenSorted(t *testing.T) {
 		t.Errorf("state file order follows install history, not the paths: %+v", state.Files)
 	}
 }
+
+// TestDeselectedItemIsNotDeleted: the picker's deselected items are appended to
+// state after result.Files is built, so feeding removeOrphans the narrower set
+// makes a deselection look like an artifact the source stopped shipping — and
+// deletes a file the user explicitly chose to keep.
+func TestDeselectedItemIsNotDeleted(t *testing.T) {
+	isolatedConfig(t)
+	srcDir := driftSource(t)
+	target := repoTarget(t)
+	scope := ScopeRepo(target)
+
+	// Everything installed first, the way a picker run over an existing scope starts.
+	if err := cmdInstallFromSource("wide", localSource(srcDir), scope, false, false, false); err != nil {
+		t.Fatalf("wide install: %v", err)
+	}
+
+	// Now the user unticks test-b: the manifest carries only test-a, and test-b
+	// arrives as a deselected extra that must stay on disk.
+	narrow, err := loadManifest(srcDir, "narrow")
+	if err != nil {
+		t.Fatal(err)
+	}
+	deselected := InstalledFile{Path: agentB, Status: fileStatusIgnored}
+	if err := installAllFromSource(scope, localSource(srcDir), narrow, false, false, false, deselected); err != nil {
+		t.Fatalf("install with a deselected item: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(target, agentB)); err != nil {
+		t.Errorf("deselecting %s in the picker deleted it from disk: %v", agentB, err)
+	}
+}

--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -949,7 +949,11 @@ func installAllFromSource(scope *InstallScope, src *Source, manifest *Manifest, 
 	// install did not name. The two install paths must agree about all three.
 	if prior, err := readScopedState(scope); err == nil && prior != nil {
 		state.PreserveUnknownFrom(prior)
-		state.Files = mergeStateFiles(removeOrphans(scope, prior, result.Files), state.Files)
+		// state.Files, not result.Files: the picker's deselected items were
+		// appended above, and they are still on disk on purpose. Passing the
+		// narrower set makes removeOrphans read a deselection as an artifact
+		// the source stopped shipping, and delete a file the user chose to keep.
+		state.Files = mergeStateFiles(removeOrphans(scope, prior, state.Files), state.Files)
 	}
 
 	if err := writeScopedState(scope, state); err != nil {

--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -26,6 +26,7 @@ type installResult struct {
 // content through the resolver the active agentpakke manifest produced.
 func installItems(resolver *SourceResolver, scope *InstallScope, manifest *Manifest, dryRun, force bool) (*installResult, error) {
 	result := &installResult{}
+	stateHashes := scopeStateHashes(scope)
 
 	for _, group := range []struct {
 		label string
@@ -46,7 +47,7 @@ func installItems(resolver *SourceResolver, scope *InstallScope, manifest *Manif
 		}
 		fmt.Println(bold(fmt.Sprintf("%s (%d):", group.label, len(group.names))))
 		for _, name := range group.names {
-			if err := installArtifact(resolver, scope, group.kind, name, dryRun, force, result); err != nil {
+			if err := installArtifact(resolver, scope, stateHashes, group.kind, name, dryRun, force, result); err != nil {
 				return result, err
 			}
 		}
@@ -88,9 +89,70 @@ func pakkeContents(resolver *SourceResolver, src *Source) (*Manifest, error) {
 	return manifest, nil
 }
 
+// scopeStateHashes maps every tracked path to the hash nav-pilot recorded when
+// it last wrote that file. It is what makes "conflict" mean "the user changed
+// it" rather than "upstream moved": a file whose hash still matches the record
+// is nav-pilot's own and may be overwritten.
+//
+// Conflicted entries are deliberately left out, exactly as
+// [artifacts.SyncOpenCodeArtifacts] does: their recorded hash is the user's own
+// copy, so comparing against it would call an edited file untouched. Left out,
+// the path is treated as untracked and the byte comparison keeps the conflict.
+// An entry with no hash (a file recorded by name only) is left out for the same
+// reason.
+//
+// So is an ignored one, and for the same reason again: `ignore` keeps the
+// recorded hash, so an untouched-but-ignored file would hash equal, be
+// overwritten as an ordinary update, and come back with an empty status —
+// silently un-ignored and back under sync's management.
+func scopeStateHashes(scope *InstallScope) map[string]string {
+	hashes := map[string]string{}
+	state, err := readScopedState(scope)
+	if err != nil || state == nil {
+		return hashes
+	}
+	for _, f := range state.Files {
+		if f.Status != fileStatusConflict && f.Status != fileStatusIgnored && f.Hash != "" {
+			hashes[f.Path] = f.Hash
+		}
+	}
+	return hashes
+}
+
+// mergeStateFiles overlays the files an install just wrote onto the prior
+// entries that survived [removeOrphans], keyed by path. Replacing the list
+// instead would drop every path the narrower install did not name, and sync
+// only ever walks state.Files — so a dropped artifact becomes invisible and no
+// command can update or remove it.
+//
+// The index is built as it goes, so a prior list that already held the same
+// path twice collapses to one entry instead of leaving the stale copy behind
+// for conflictStatePaths and resolveSyncFiles to disagree over.
+//
+// A fresh entry with no Source inherits the prior one's: a scope install over a
+// path that `add --source` tagged must not drop the foreign-source marker
+// (#571).
+func mergeStateFiles(prior, files []InstalledFile) []InstalledFile {
+	merged := make([]InstalledFile, 0, len(prior)+len(files))
+	index := make(map[string]int, cap(merged))
+	for _, f := range append(append([]InstalledFile(nil), prior...), files...) {
+		i, ok := index[f.Path]
+		if !ok {
+			index[f.Path] = len(merged)
+			merged = append(merged, f)
+			continue
+		}
+		if f.Source == "" {
+			f.Source = merged[i].Source
+		}
+		merged[i] = f
+	}
+	return merged
+}
+
 // installArtifact handles the install for any artifact type.
 // Resolution, copy, hash logic are driven by the ArtifactKind.
-func installArtifact(resolver *SourceResolver, scope *InstallScope, kind *ArtifactKind, name string, dryRun, force bool, result *installResult) error {
+func installArtifact(resolver *SourceResolver, scope *InstallScope, stateHashes map[string]string, kind *ArtifactKind, name string, dryRun, force bool, result *installResult) error {
 	if err := validateName(name); err != nil {
 		return fmt.Errorf("invalid %s name: %w", kind.Name, err)
 	}
@@ -108,12 +170,29 @@ func installArtifact(resolver *SourceResolver, scope *InstallScope, kind *Artifa
 		relPath = scope.RelPath(kind.Dir, art.Name) + "/"
 	}
 
-	if c, err := checkConflict(dst, art.AbsPath, art.IsDir); err != nil {
-		return err
-	} else if c != nil && !force {
-		// File exists and differs but we're not forcing — skip the overwrite
-		// but track as conflict so it's not lost from state or reported as "new".
-		fmt.Printf("  %s %s (exists, differs — use --force to overwrite)\n", yellow("⚠"), name)
+	// A tracked file that still hashes to what nav-pilot recorded is nav-pilot's
+	// own and untouched, so a differing source is an update, not a conflict.
+	// Only an untracked path falls back to the byte comparison, where a
+	// hand-placed or foreign file genuinely is one.
+	conflicted := false
+	if storedHash, tracked := stateHashes[relPath]; tracked {
+		// An absent or unreadable file is not the user's edit either, so it is
+		// not a conflict — it is simply reinstalled.
+		current, hashErr := rawArtifactHash(dst, art.IsDir)
+		conflicted = hashErr == nil && current != storedHash
+	} else {
+		c, err := checkConflict(dst, art.AbsPath, art.IsDir)
+		if err != nil {
+			return err
+		}
+		conflicted = c != nil
+	}
+
+	if conflicted && !force {
+		// The file exists and the user changed it — skip the overwrite but
+		// track as conflict so it's not lost from state or reported as "new".
+		fmt.Printf("  %s %s (locally modified — kept; %s takes the upstream version)\n",
+			yellow("⚠"), name, bold("nav-pilot sync --apply"))
 		existingHash, hashErr := rawArtifactHash(dst, art.IsDir)
 		if hashErr == nil {
 			result.Files = append(result.Files, InstalledFile{Path: relPath, Hash: existingHash, Status: fileStatusConflict})
@@ -148,6 +227,15 @@ func installArtifact(resolver *SourceResolver, scope *InstallScope, kind *Artifa
 	result.Installed++
 
 	return nil
+}
+
+// printConflictHint says what a conflict is and how it ends. "Skipped" on its
+// own reads as permanent, and --force reads as "throw my edits away": neither
+// says that a sync --apply takes the upstream version of exactly these files.
+func printConflictHint(n int) {
+	fmt.Printf("%s %d file(s) kept as you edited them.\n", yellow("⚠"), n)
+	fmt.Printf("  %s to take the upstream version, or %s to overwrite on the next install.\n",
+		bold("nav-pilot sync --apply"), bold("--force"))
 }
 
 // ─── Commands ───────────────────────────────────────────────────────────────
@@ -426,8 +514,7 @@ func cmdInstallFromSource(collection string, src *Source, scope *InstallScope, d
 	}
 
 	if result.Conflicts > 0 {
-		fmt.Printf("%s %d file(s) skipped due to conflicts. Use %s to overwrite.\n",
-			yellow("⚠"), result.Conflicts, bold("--force"))
+		printConflictHint(result.Conflicts)
 	}
 
 	if len(result.Unsupported) > 0 {
@@ -453,10 +540,17 @@ func cmdInstallFromSource(collection string, src *Source, scope *InstallScope, d
 		Files:       result.Files,
 	}
 	// A re-install over a checked-in state file must not throw away the keys a
-	// newer nav-pilot put there; the fresh struct has none of them (#588).
-	if prior, err := readScopedState(scope); err == nil {
+	// newer nav-pilot put there; the fresh struct has none of them (#588). Nor
+	// the paths it does not name: a narrower install must not make the rest of
+	// the scope invisible to sync.
+	//
+	// The two must be decided together. removeOrphans deletes the prior paths
+	// this install did not write and nav-pilot still owns; merging every prior
+	// entry back would then commit a state that lists a file the tool has just
+	// deleted. So only what removeOrphans kept is merged.
+	if prior, err := readScopedState(scope); err == nil && prior != nil {
 		state.PreserveUnknownFrom(prior)
-		removeOrphans(scope, prior, result.Files)
+		state.Files = mergeStateFiles(removeOrphans(scope, prior, result.Files), state.Files)
 	}
 	if err := writeScopedState(scope, state); err != nil {
 		fmt.Fprintf(os.Stderr, "%s Could not write state file: %v\n", yellow("⚠"), err)
@@ -509,7 +603,7 @@ func cmdAddFromSource(itemType, name string, src *Source, scope *InstallScope, e
 
 	kind := kindByName[itemType]
 	resolver := resolverFor(src.Dir, pakkeFor(src, name))
-	installErr := installArtifact(resolver, scope, kind, name, dryRun, force, result)
+	installErr := installArtifact(resolver, scope, scopeStateHashes(scope), kind, name, dryRun, force, result)
 	if installErr != nil {
 		return installErr
 	}
@@ -531,8 +625,8 @@ func cmdAddFromSource(itemType, name string, src *Source, scope *InstallScope, e
 	}
 
 	if result.Conflicts > 0 {
-		fmt.Printf("\n%s File already exists and differs. Use %s to overwrite.\n",
-			yellow("⚠"), bold("--force"))
+		fmt.Println()
+		printConflictHint(result.Conflicts)
 	}
 
 	if dryRun || result.Installed == 0 {
@@ -811,8 +905,7 @@ func installAllFromSource(scope *InstallScope, src *Source, manifest *Manifest, 
 	}
 
 	if !jsonOutput && result.Conflicts > 0 {
-		fmt.Printf("%s %d file(s) skipped due to conflicts. Use %s to overwrite.\n",
-			yellow("⚠"), result.Conflicts, bold("--force"))
+		printConflictHint(result.Conflicts)
 	}
 
 	if jsonOutput {
@@ -851,9 +944,12 @@ func installAllFromSource(scope *InstallScope, src *Source, manifest *Manifest, 
 	}
 
 	// Same as cmdInstallFromSource: a rebuild over an existing state keeps the
-	// keys this binary does not understand (#588).
-	if prior, err := readScopedState(scope); err == nil {
+	// keys this binary does not understand (#588), retires the artifacts the
+	// source has stopped shipping (#615), and keeps the state of the paths this
+	// install did not name. The two install paths must agree about all three.
+	if prior, err := readScopedState(scope); err == nil && prior != nil {
 		state.PreserveUnknownFrom(prior)
+		state.Files = mergeStateFiles(removeOrphans(scope, prior, result.Files), state.Files)
 	}
 
 	if err := writeScopedState(scope, state); err != nil {
@@ -1168,16 +1264,23 @@ func cmdUninstall(scope *InstallScope, dryRun bool) error {
 // A file is removed only when it is byte-for-byte what nav-pilot wrote.
 // Anything the developer edited is theirs and stays, which is the same rule the
 // opencode scope has applied since it was written.
-func removeOrphans(scope *InstallScope, prior *StateFile, installed []InstalledFile) {
+//
+// It returns the prior entries it did not delete. Those are the ones whose state
+// must survive the install — deleting a file and keeping its state entry would
+// have status report it missing and the next sync report a deletion nav-pilot
+// performed itself.
+func removeOrphans(scope *InstallScope, prior *StateFile, installed []InstalledFile) []InstalledFile {
 	if prior == nil {
-		return
+		return nil
 	}
 	written := make(map[string]bool, len(installed))
 	for _, f := range installed {
 		written[f.Path] = true
 	}
+	kept := make([]InstalledFile, 0, len(prior.Files))
 	for _, f := range prior.Files {
 		if written[f.Path] || !navPilotOwns(scope.RootDir, f) {
+			kept = append(kept, f)
 			continue
 		}
 		full := filepath.Join(scope.RootDir, f.Path)
@@ -1190,8 +1293,10 @@ func removeOrphans(scope *InstallScope, prior *StateFile, installed []InstalledF
 		if err != nil && !os.IsNotExist(err) {
 			fmt.Fprintf(os.Stderr, "%s Could not remove %s, which is no longer part of the collection: %v\n",
 				yellow("⚠"), f.Path, err)
+			kept = append(kept, f)
 			continue
 		}
 		fmt.Printf("  %s %s %s\n", red("×"), f.Path, dim("(no longer in the collection)"))
 	}
+	return kept
 }

--- a/cli/nav-pilot/internal/cli/main_test.go
+++ b/cli/nav-pilot/internal/cli/main_test.go
@@ -487,7 +487,7 @@ func TestInstallAgent(t *testing.T) {
 	dstDir := t.TempDir()
 	result := &installResult{}
 
-	err := installArtifact(NewSourceResolver(srcDir), ScopeRepo(dstDir), KindAgent, "test", false, false, result)
+	err := installArtifact(NewSourceResolver(srcDir), ScopeRepo(dstDir), nil, KindAgent, "test", false, false, result)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -510,7 +510,7 @@ func TestInstallAgent_NotFound(t *testing.T) {
 	dstDir := t.TempDir()
 	result := &installResult{}
 
-	err := installArtifact(NewSourceResolver(srcDir), ScopeRepo(dstDir), KindAgent, "nonexistent", false, false, result)
+	err := installArtifact(NewSourceResolver(srcDir), ScopeRepo(dstDir), nil, KindAgent, "nonexistent", false, false, result)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -531,7 +531,7 @@ func TestInstallSkill(t *testing.T) {
 	dstDir := t.TempDir()
 	result := &installResult{}
 
-	err := installArtifact(NewSourceResolver(srcDir), ScopeRepo(dstDir), KindSkill, "my-skill", false, false, result)
+	err := installArtifact(NewSourceResolver(srcDir), ScopeRepo(dstDir), nil, KindSkill, "my-skill", false, false, result)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -558,7 +558,7 @@ func TestInstallConflictBlocked(t *testing.T) {
 	os.WriteFile(filepath.Join(dstAgents, "test.agent.md"), []byte("local modified content"), 0o644)
 
 	result := &installResult{}
-	err := installArtifact(NewSourceResolver(srcDir), ScopeRepo(dstDir), KindAgent, "test", false, false, result)
+	err := installArtifact(NewSourceResolver(srcDir), ScopeRepo(dstDir), nil, KindAgent, "test", false, false, result)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -582,7 +582,7 @@ func TestInstallConflictForced(t *testing.T) {
 	os.WriteFile(filepath.Join(dstAgents, "test.agent.md"), []byte("local modified content"), 0o644)
 
 	result := &installResult{}
-	err := installArtifact(NewSourceResolver(srcDir), ScopeRepo(dstDir), KindAgent, "test", false, true, result) // force=true
+	err := installArtifact(NewSourceResolver(srcDir), ScopeRepo(dstDir), nil, KindAgent, "test", false, true, result) // force=true
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -631,7 +631,7 @@ func TestInstallAgent_PathTraversal(t *testing.T) {
 	dstDir := t.TempDir()
 	result := &installResult{}
 
-	err := installArtifact(NewSourceResolver(srcDir), ScopeRepo(dstDir), KindAgent, "../../../etc/passwd", false, false, result)
+	err := installArtifact(NewSourceResolver(srcDir), ScopeRepo(dstDir), nil, KindAgent, "../../../etc/passwd", false, false, result)
 	if err == nil {
 		t.Fatal("expected error for path traversal attempt")
 	}
@@ -651,7 +651,7 @@ func TestInstallInstruction(t *testing.T) {
 	dstDir := t.TempDir()
 	result := &installResult{}
 
-	err := installArtifact(NewSourceResolver(srcDir), ScopeRepo(dstDir), KindInstruction, "my-instr", false, false, result)
+	err := installArtifact(NewSourceResolver(srcDir), ScopeRepo(dstDir), nil, KindInstruction, "my-instr", false, false, result)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -671,7 +671,7 @@ func TestInstallInstruction_NotFound(t *testing.T) {
 	dstDir := t.TempDir()
 	result := &installResult{}
 
-	err := installArtifact(NewSourceResolver(srcDir), ScopeRepo(dstDir), KindInstruction, "nonexistent", false, false, result)
+	err := installArtifact(NewSourceResolver(srcDir), ScopeRepo(dstDir), nil, KindInstruction, "nonexistent", false, false, result)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -689,7 +689,7 @@ func TestInstallPrompt_FlatFile(t *testing.T) {
 	dstDir := t.TempDir()
 	result := &installResult{}
 
-	err := installArtifact(NewSourceResolver(srcDir), ScopeRepo(dstDir), KindPrompt, "my-prompt", false, false, result)
+	err := installArtifact(NewSourceResolver(srcDir), ScopeRepo(dstDir), nil, KindPrompt, "my-prompt", false, false, result)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -707,7 +707,7 @@ func TestInstallPrompt_Directory(t *testing.T) {
 	dstDir := t.TempDir()
 	result := &installResult{}
 
-	err := installArtifact(NewSourceResolver(srcDir), ScopeRepo(dstDir), KindPrompt, "my-prompt", false, false, result)
+	err := installArtifact(NewSourceResolver(srcDir), ScopeRepo(dstDir), nil, KindPrompt, "my-prompt", false, false, result)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -727,7 +727,7 @@ func TestInstallPrompt_NotFound(t *testing.T) {
 	dstDir := t.TempDir()
 	result := &installResult{}
 
-	err := installArtifact(NewSourceResolver(srcDir), ScopeRepo(dstDir), KindPrompt, "nonexistent", false, false, result)
+	err := installArtifact(NewSourceResolver(srcDir), ScopeRepo(dstDir), nil, KindPrompt, "nonexistent", false, false, result)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1691,9 +1691,15 @@ func TestRun_InstallUserNoArgs(t *testing.T) {
 	forceNonInteractive = true
 	t.Cleanup(func() { forceNonInteractive = false })
 
-	// nav-pilot install --user (no collection) should call cmdInstallAll,
-	// which calls resolveSource. In test environment this will fail on source
-	// resolution. We just verify it doesn't require a collection name.
+	// isolatedConfig, or this really does install --user: the comment below is
+	// wrong about the source failing to resolve — run from the checkout it
+	// resolves to the checkout, and the install lands in the developer's own
+	// ~/.copilot. `mise run nav-pilot:check` overwrote a real user scope twice
+	// before anyone noticed what the arg-parsing test was actually doing.
+	isolatedConfig(t)
+
+	// nav-pilot install --user (no collection) should call cmdInstallAll.
+	// We just verify it doesn't require a collection name.
 	err := run([]string{"install", "--user"})
 	if err != nil && strings.Contains(err.Error(), "collection name") {
 		t.Errorf("install --user should not require collection name, got: %v", err)
@@ -1701,6 +1707,7 @@ func TestRun_InstallUserNoArgs(t *testing.T) {
 }
 
 func TestRun_InstallUserWithCollection(t *testing.T) {
+	isolatedConfig(t) // as above: without it this installs into the real home
 	// nav-pilot install --user fullstack — should still work as before
 	// (backwards compatible, dispatches to cmdInstall not cmdInstallAll)
 	err := run([]string{"install", "--user", "fullstack"})

--- a/cli/nav-pilot/internal/cli/scope_test.go
+++ b/cli/nav-pilot/internal/cli/scope_test.go
@@ -216,7 +216,7 @@ func TestInstallAgent_UserScope(t *testing.T) {
 	}
 
 	result := &installResult{}
-	err := installArtifact(NewSourceResolver(source), scope, KindAgent, "test", false, false, result)
+	err := installArtifact(NewSourceResolver(source), scope, nil, KindAgent, "test", false, false, result)
 	if err != nil {
 		t.Fatalf("installArtifact agent user scope: %v", err)
 	}

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -342,12 +342,12 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 	}
 
 	if len(conflictPaths) > 0 && !apply {
-		fmt.Printf("%s %d file(s) are in conflict state and were skipped (source: %s)\n\n",
+		fmt.Printf("%s %d file(s) hold your own edits and are left alone by a plain sync (source: %s)\n\n",
 			yellow("⚠"), len(conflictPaths), shortSHA(src.SHA))
 		for _, p := range conflictPaths {
 			fmt.Printf("  %s %s\n", dim("⊘"), p)
 		}
-		fmt.Println()
+		fmt.Printf("%s to take the upstream version of these too.\n\n", bold("nav-pilot sync --apply"))
 	}
 
 	if !apply {


### PR DESCRIPTION
## Problemet

`conflict` var definert som «ikke byte-identisk med kilden», ikke som «brukeren har endret filen».

`installArtifact` kalte `source.CheckConflict(targetPath, sourcePath)`, som bare sammenligner målfilen med kilden og aldri ser på hashen staten allerede har registrert. I det øyeblikket oppstrøms flytter seg, «avviker» altså hver eneste installerte fil, og `install` registrerer konflikt — for nav-pilots egne, urørte artefakter.

Deretter **hopper** en vanlig `sync` over konfliktfiler (`includeConflicts` er `--apply`-flagget), så det gamle innholdet blir stående uten at noen får beskjed. En bruker satt med 23 av 52 filer i konflikt uten å ha redigert noe som helst; alle 23 hashet fortsatt nøyaktig til den registrerte verdien.

Den riktige regelen fantes allerede i repoet, på OpenCode-siden: `SyncOpenCodeArtifacts` sammenligner mot `stateHashes` — det nav-pilot faktisk skrev — og `navPilotOwns` formulerer prinsippet. Den er kopiert hit, ikke funnet opp på nytt.

## De fire endringene

**1. `installArtifact` avgjør konflikt mot den registrerte hashen.** `installItems` og de to enkeltartefakt-kallerne bygger `stateHashes` fra `readScopedState(scope)` én gang, og regelen blir:

- sporet, og hashen på disk er lik den registrerte → nav-pilots egen, urørt → skriv over, dette er en oppdatering
- sporet, og avviker fra den registrerte → en ekte redigering → konflikt
- ikke sporet → dagens `CheckConflict` (en håndplassert eller fremmed fil *er* en reell konflikt)

Sammenligningen er rå mot rå (`RawArtifactHash`), siden det er den staten lagrer. Oppføringer som allerede er merket `conflict` holdes utenfor `stateHashes`, akkurat som på OpenCode-siden: den registrerte hashen deres er brukerens egen kopi, så en hash-sammenligning ville kalt en redigert fil urørt. Holdt utenfor blir stien behandlet som usporet, og konflikten står.

**2. En `ignored`-oppføring holdes utenfor på samme måte.** `ignore.go` og `sync.go` setter `Status: ignored` og *beholder* den registrerte hashen. En urørt, ignorert fil med oppstrømsdrift hashet altså likt, ble skrevet over som en helt ordinær oppdatering, og kom tilbake med tom `Status` — stille av-ignorert og tilbake under syncs forvaltning. Ingen brukerinnhold gikk tapt, men brukerens `ignore`-valg gjorde det. Én betingelse, på samme linje som konfliktsjekken.

**3. Staten flettes i stedet for å erstattes — og flettingen avgjøres sammen med `removeOrphans` (#615).** Begge install-veiene bygde `StateFile{… Files: result.Files}`, så en smalere install droppet stier fra staten. Sync går bare gjennom `state.Files`, både i oppdaterings- og slettepasset — droppede artefakter blir dermed usynlige og permanente.

Å beholde begge mekanismene hver for seg er galt: `removeOrphans` sletter `test-b` fra disk fordi nav-pilot eier den, mens en naiv fletting tar oppføringen dens med tilbake. Da lister den innsjekkede state-fila en fil verktøyet nettopp slettet, `status` teller den som borte, og neste `sync` rapporterer en sletting nav-pilot selv utførte.

`removeOrphans` returnerer derfor de forrige oppføringene den **ikke** slettet — de nav-pilot ikke eier, altså de brukeren har redigert eller som står i konflikt — og bare de flettes inn. Det er nøyaktig hullet #615 lar stå, og det eneste flettingen trenger å fylle.

`installAllFromSource` hadde ingen `removeOrphans` i det hele tatt, så de to install-veiene var uenige om pensjonerte artefakter. De gjør nå det samme.

**4. Meldingene sier hva som løser en konflikt.** «skipped» leste som permanent, og `--force` leste som «ødelegg redigeringene mine». Ingen av dem sa at `sync --apply` henter oppstrømsversjonen. Både install og sync sier det nå.

### Småting i samme sveip

- Flettingen bygger indeksen underveis, så en `prior.Files` som allerede holdt samme sti to ganger kollapser til én oppføring. Før ble den eldste stående for godt, og var den `conflict` og den ferske ikke, var `conflictStatePaths` og `resolveSyncFiles` uenige om samme sti.
- En fersk oppføring uten `Source` arver den forrige sin: en scope-install over en sti `add --source X` hadde merket, mistet ellers `#571`-markøren.
- `WriteStateAt` sorterer `Files` på sti. Den innsjekkede repo-state-fila skal få rekkefølgen sin fra innholdet, ikke fra hvilken rekkefølge installene tilfeldigvis kjørte i. Første skriving etter denne endringen gir én engangs omstokking i diffen.

## De eksisterende 23 konfliktene repareres ikke av dette

Det må sies rett ut: denne fiksen kan ikke rydde opp i konfliktene som allerede står i en brukers state. Konfliktgrenen skrev hashen til innholdet på disk *på konflikttidspunktet* over install-tidens baseline, så det finnes ikke lenger noe som skiller «redigert» fra «foreldet».

**Brukere med eksisterende konflikter må kjøre `nav-pilot sync --apply` én gang.** Etter det er baselinen igjen nav-pilots egen, og konflikt betyr det den skal bety.

## Tester

Alle er kjørt mot koden uten den aktuelle endringen først, og feiler der:

- install, la kilden flytte seg, install på nytt → **0 konflikter**
- rediger så filen, install på nytt → **1 konflikt** (vernet er korrigert, ikke fjernet)
- en usporet, håndplassert fil er fortsatt en konflikt
- en allerede registrert `conflict`-oppføring skrives ikke stille over
- `TestInstallDoesNotUnIgnore` — install `narrow`, `ignore agent test-a`, flytt kilden, install igjen: fila står urørt og beholder statusen sin. Uten betingelsen i `scopeStateHashes` blir den skrevet over og kommer tilbake med tom status.
- `TestNarrowInstallDropsWhatItDeleted` — install `wide`, så `narrow`: `test-b` er borte fra disk **og** fra staten. Med «behold begge» (`removeOrphans` pluss en fletting av hele `prior`) står oppføringen igjen, og testen feiler.
- `TestNarrowInstallKeepsTheUserEditItDidNotDelete` — samme løp, men brukeren har redigert `test-b` først: `removeOrphans` lar fila stå, og oppføringen må bli med videre. Uten fletting droppes den, og testen feiler.
- `TestMergeStateFilesCollapsesDuplicates` og `TestMergeStateFilesKeepsForeignSource` dekker de to småtingene.
- `TestStateFilesAreWrittenSorted` dekker sorteringen.

`TestNarrowInstallKeepsRetiredFileRemovable` er fjernet. Etter #615 sletter installen selv den pensjonerte fila, så testen passerte uansett hvilken løsning man valgte — den skilte ikke. De to `TestNarrowInstall…`-testene over erstatter den, og gjør det.

`TestInstallConflictBlocked` og `TestInstallArtifact_ConflictStillTracked` er uendret i oppførsel. Begge går mot et scope uten state, så stien er usporet og faller tilbake på byte-sammenligningen — som før.

## Én ting til: testsuiten installerte i utviklerens egen ~/.copilot

`mise run nav-pilot:check` skrev over det ekte brukerscopet. `TestRun_InstallUserNoArgs` og `TestRun_InstallUserWithCollection` kaller `run(["install", "--user", …])` uten å isolere `HOME`. Kommentaren i den ene sier at kilden ikke lar seg resolve i testmiljø — det stemmer ikke: kjørt fra checkouten resolver den til checkouten, og installen lander i `~/.copilot` hos den som kjører testene. 67 filer fikk ny mtime og nytt innhold, og state-fila fikk `source_repo` satt til den lokale worktreen.

Begge tester kaller nå `isolatedConfig(t)`, som resten av suiten allerede gjør. Verifisert ved å hashe `~/.copilot` og `~/.nav-pilot` før og etter en full kjøring: uendret.

## Kjørt

Rebaset på `origin/main` (`2103c52c`). Build, `go test -race ./...`, `go vet`, staticcheck, shellcheck og bats er grønne med isolert `HOME`. Eneste unntak er `TestRealCopilotProbe`, som spawner den ekte `cplt` og trenger utviklerens virkelige hjemmekatalog; den hopper over seg selv i CI, og denne grenen rører ikke `internal/provider`.
