### PR TITLE
fix(my-copilot): nav-pilot/docs krasjet i produksjon, og ingenting kunne fange det

### DIFF
--- a/.github/workflows/my-copilot.yaml
+++ b/.github/workflows/my-copilot.yaml
@@ -41,6 +41,7 @@ jobs:
       docker-context: '../..'
       mise-setup-tasks: '["install"]'
       mise-tasks: '["lint", "check"]'
+      mise-task-build: 'smoke'
       deploys-to-nais: true
       deploy-pr-to-dev: true
       nais-team: copilot

--- a/apps/my-copilot/.mise.toml
+++ b/apps/my-copilot/.mise.toml
@@ -41,6 +41,11 @@ description = "Run Jest tests"
 run = "pnpm build"
 description = "Build Next.js production bundle"
 
+[tasks.smoke]
+run = "bash hack/smoke.sh"
+depends = ["build"]
+description = "Start the built server and load every route, failing on render errors"
+
 [tasks.dev]
 run = "fnox exec -- pnpm dev"
 description = "Start Next.js development server (secrets from Keychain)"

--- a/apps/my-copilot/hack/smoke.sh
+++ b/apps/my-copilot/hack/smoke.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Røyktest: start den bygde standalone-serveren og hent hver rute i src/app.
+#
+# Hvorfor: `next build --experimental-build-mode compile` hopper over
+# prerendering, og `tsc` ser ikke render-feil. En side som kaster under render
+# svarer likevel 200 — Next sender skjelettet i Suspense-fallbacken og merker
+# grensen med `data-dgst`, digesten til feilen serveren kastet, og klienten
+# bytter skjelettet ut med error.tsx («Noe gikk galt»). Statuskoden alene
+# fanger altså ingenting; vi må se etter digesten i kroppen. Next bruker samme
+# mekanisme til vanlig kontrollflyt — `redirect()` og `notFound()` gir en
+# `NEXT_*`-digest — så det er bare digestene uten det prefikset som er feil.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+[ -f .next/standalone/server.js ] || { echo "smoke: mangler .next/standalone — kjør build først" >&2; exit 1; }
+
+rm -rf .next/standalone/.next/static .next/standalone/public
+cp -r .next/static .next/standalone/.next/static
+cp -r public .next/standalone/public
+
+PORT="${SMOKE_PORT:-3999}"
+NODE_ENV=production PORT="$PORT" HOSTNAME=127.0.0.1 node .next/standalone/server.js >/tmp/smoke-server.log 2>&1 &
+server=$!
+trap 'kill "$server" 2>/dev/null || true' EXIT
+
+for _ in $(seq 1 60); do
+  curl -sf -o /dev/null "http://127.0.0.1:$PORT/" && break
+  sleep 1
+done
+
+failed=0
+while read -r page; do
+  route=${page#src/app}
+  route=${route%/page.tsx}
+  route=$(printf '%s' "$route" | sed 's|/([^/)]*)||g')
+  [ -z "$route" ] && route=/
+  case "$route" in *"["*) continue;; esac
+
+  body=$(mktemp)
+  status=$(curl -s -o "$body" -w '%{http_code}' "http://127.0.0.1:$PORT$route")
+  if [ "$status" -ge 400 ]; then
+    echo "FAIL $route: HTTP $status"
+    failed=1
+  elif [ "$status" -lt 300 ] && grep -oE 'data-dgst="[^"]*"' "$body" | grep -qv 'NEXT_'; then
+    echo "FAIL $route: siden kastet under render (React-feilgrense i HTML-en)"
+    failed=1
+  else
+    echo "ok   $route ($status)"
+  fi
+  rm -f "$body"
+done < <(find src/app -name page.tsx | sort)
+
+if [ "$failed" -ne 0 ]; then
+  echo "--- serverlogg ---"
+  tail -40 /tmp/smoke-server.log
+  exit 1
+fi

--- a/apps/my-copilot/package.json
+++ b/apps/my-copilot/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build --experimental-build-mode compile",
     "start": "node .next/standalone/server.js",
-    "check": "eslint . --fix && tsc --noEmit && prettier --write . --list-different && NODE_OPTIONS='--experimental-require-module' knip && vitest run",
+    "check": "eslint . --fix && tsc --noEmit && prettier --check . && NODE_OPTIONS='--experimental-require-module' knip && vitest run",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write . --list-different",

--- a/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
+++ b/apps/my-copilot/src/app/nav-pilot/docs/page.tsx
@@ -1,4 +1,5 @@
-import { Heading, BodyShort, BodyLong, Box, HGrid, Label, Table, VStack, Tag } from "@navikt/ds-react";
+import { Heading, BodyShort, BodyLong, Box, HGrid, Label, VStack, Tag } from "@navikt/ds-react";
+import { Table, TableHeader, TableBody, TableRow, TableHeaderCell, TableDataCell } from "@/components/aksel-table";
 import { CodeBlock } from "@/components/code-block";
 import { AltInstall } from "@/components/alt-install";
 import { FileExplorer } from "@/components/file-explorer";
@@ -746,32 +747,30 @@ nav-pilot`}
             Hvor skal artefaktene installeres?
           </LinkableHeading>
           <BodyLong className="mt-2" style={{ color: "#475569" }}>
-            Tre former er i bruk i Nav, og de løser ulike problemer.{" "}
-            <code className="font-mono text-xs">install</code> spør hvis du ikke svarer på forhånd med{" "}
-            <code className="font-mono text-xs">--repo</code> eller <code className="font-mono text-xs">--user</code>.
+            Tre former er i bruk i Nav, og de løser ulike problemer. <code className="font-mono text-xs">install</code>{" "}
+            spør hvis du ikke svarer på forhånd med <code className="font-mono text-xs">--repo</code> eller{" "}
+            <code className="font-mono text-xs">--user</code>.
           </BodyLong>
           <ul className="mt-3 space-y-2 list-disc pl-5" style={{ color: "#475569" }}>
             <li>
               <strong>Repo</strong> (<code className="font-mono text-xs">--repo</code>, skriver til{" "}
               <code className="font-mono text-xs">.github/</code>): hele teamet får det samme, prompts virker, og
-              Copilot på github.com ser filene fordi de er sjekket inn. Til gjengjeld ligger de i repoet og i hver
-              diff.
+              Copilot på github.com ser filene fordi de er sjekket inn. Til gjengjeld ligger de i repoet og i hver diff.
             </li>
             <li>
               <strong>Personlig</strong> (<code className="font-mono text-xs">--user</code>, skriver til{" "}
-              <code className="font-mono text-xs">~/.copilot/</code>): følger deg på tvers av alle repoer, og
-              ingenting sjekkes inn. Den tar ikke med prompts, og når verken github.com eller resten av teamet.
+              <code className="font-mono text-xs">~/.copilot/</code>): følger deg på tvers av alle repoer, og ingenting
+              sjekkes inn. Den tar ikke med prompts, og når verken github.com eller resten av teamet.
             </li>
             <li>
-              <strong>Hub-repo</strong>: en repo-installasjon i et repo som ikke er en applikasjon, pluss teamets
-              egne skills lagt inn for hånd i det samme <code className="font-mono text-xs">.github/</code>. Konteksten
+              <strong>Hub-repo</strong>: en repo-installasjon i et repo som ikke er en applikasjon, pluss teamets egne
+              skills lagt inn for hånd i det samme <code className="font-mono text-xs">.github/</code>. Konteksten
               følger arbeidskatalogen, så den gjelder mens du står i hub-repoet.
             </li>
           </ul>
           <BodyLong className="mt-3" size="small" style={{ color: "#64748b" }}>
-            Formene utelukker ikke hverandre, og{" "}
-            <code className="font-mono text-xs">nav-pilot sync</code> uten scope-flagg synker alle scope som har en
-            tilstandsfil. Avveiningene i sin helhet står i{" "}
+            Formene utelukker ikke hverandre, og <code className="font-mono text-xs">nav-pilot sync</code> uten
+            scope-flagg synker alle scope som har en tilstandsfil. Avveiningene i sin helhet står i{" "}
             <a
               href="https://github.com/navikt/copilot/blob/main/docs/README.nav-pilot.md#hvor-skal-artefaktene-installeres"
               className="text-blue-600 hover:underline"
@@ -2066,57 +2065,56 @@ nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først`
             </BodyLong>
             <div className="overflow-x-auto">
               <Table size="small" className="w-full">
-                <Table.Header>
-                  <Table.Row>
-                    <Table.HeaderCell scope="col">Modell</Table.HeaderCell>
-                    <Table.HeaderCell scope="col">Vekter</Table.HeaderCell>
-                    <Table.HeaderCell scope="col">Løser</Table.HeaderCell>
-                    <Table.HeaderCell scope="col">Kort sagt</Table.HeaderCell>
-                  </Table.Row>
-                </Table.Header>
-                <Table.Body>
-                  <Table.Row>
-                    <Table.DataCell>
+                <TableHeader>
+                  <TableRow>
+                    <TableHeaderCell scope="col">Modell</TableHeaderCell>
+                    <TableHeaderCell scope="col">Vekter</TableHeaderCell>
+                    <TableHeaderCell scope="col">Løser</TableHeaderCell>
+                    <TableHeaderCell scope="col">Kort sagt</TableHeaderCell>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  <TableRow>
+                    <TableDataCell>
                       <VStack gap="space-2">
                         <code className="font-mono text-xs">Qwen3.6-35B-A3B-OptiQ-4bit</code>
                         <div className="text-xs" style={{ color: "#0f6d6a" }}>
                           standard
                         </div>
                       </VStack>
-                    </Table.DataCell>
-                    <Table.DataCell>25 GB</Table.DataCell>
-                    <Table.DataCell>2–4 av 8</Table.DataCell>
-                    <Table.DataCell>
-                      Rask og forutsigbar. Median 10–12 sekunder per oppgave, og 3, 2, 4 og 4 av 8 over fire
-                      kjøringer. Ingen av de andre modellene løser målbart flere.
-                    </Table.DataCell>
-                  </Table.Row>
-                  <Table.Row>
-                    <Table.DataCell>
+                    </TableDataCell>
+                    <TableDataCell>25 GB</TableDataCell>
+                    <TableDataCell>2–4 av 8</TableDataCell>
+                    <TableDataCell>
+                      Rask og forutsigbar. Median 10–12 sekunder per oppgave, og 3, 2, 4 og 4 av 8 over fire kjøringer.
+                      Ingen av de andre modellene løser målbart flere.
+                    </TableDataCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableDataCell>
                       <code className="font-mono text-xs">Qwen3.8-27B-4bit</code>
-                    </Table.DataCell>
-                    <Table.DataCell>16 GB</Table.DataCell>
-                    <Table.DataCell>3–4 av 8</Table.DataCell>
-                    <Table.DataCell>
-                      Løser omtrent like mye som standard og bruker sju ganger så lang tid. Fire kjøringer ga 4, 4, 3
-                      og 4 av 8 mot standardens 3, 2, 4 og 4 — spennene overlapper, forskjellen er ikke målbar
-                      (p = 0,71). Median 58–104 sekunder, og ti treff på sju-minutterstaket mot standardens ett. Vi
-                      skrev tidligere at den løste mer; det var målt før vi oppdaget at ingen av modellene kunne
-                      kompilere.
-                    </Table.DataCell>
-                  </Table.Row>
-                  <Table.Row>
-                    <Table.DataCell>
+                    </TableDataCell>
+                    <TableDataCell>16 GB</TableDataCell>
+                    <TableDataCell>3–4 av 8</TableDataCell>
+                    <TableDataCell>
+                      Løser omtrent like mye som standard og bruker sju ganger så lang tid. Fire kjøringer ga 4, 4, 3 og
+                      4 av 8 mot standardens 3, 2, 4 og 4 — spennene overlapper, forskjellen er ikke målbar (p = 0,71).
+                      Median 58–104 sekunder, og ti treff på sju-minutterstaket mot standardens ett. Vi skrev tidligere
+                      at den løste mer; det var målt før vi oppdaget at ingen av modellene kunne kompilere.
+                    </TableDataCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableDataCell>
                       <code className="font-mono text-xs">Qwen3.8-27B-8bit</code>
-                    </Table.DataCell>
-                    <Table.DataCell>30 GB</Table.DataCell>
-                    <Table.DataCell>ikke målt</Table.DataCell>
-                    <Table.DataCell>
+                    </TableDataCell>
+                    <TableDataCell>30 GB</TableDataCell>
+                    <TableDataCell>ikke målt</TableDataCell>
+                    <TableDataCell>
                       Den mest omtalte, og den vi kan si minst om: de siste kjøringene ble forstyrret av en endring vi
                       selv gjorde, så vi oppgir ingen tall. Mindre plass til kontekst enn 4-bit, 65k mot 131k.
-                    </Table.DataCell>
-                  </Table.Row>
-                </Table.Body>
+                    </TableDataCell>
+                  </TableRow>
+                </TableBody>
               </Table>
             </div>
             <BodyShort size="small" textColor="subtle">
@@ -2139,9 +2137,9 @@ nav-pilot alpha local purge     # fjern alt igjen, viser hva og hvor mye først`
             merket <code className="font-mono text-xs">(local)</code>.{" "}
             <code className="font-mono text-xs">local_model</code> velger hvilken av dem serveren laster;{" "}
             <code className="font-mono text-xs">model</code> er modellen økten selv kjører på, og de settes hver for
-            seg. Listen oppdateres når du kjører{" "}
-            <code className="font-mono text-xs">init</code> eller <code className="font-mono text-xs">start</code>, ikke
-            ved hver kommando — et nettverkskall der ville lagt seg foran alt annet nav-pilot gjør.
+            seg. Listen oppdateres når du kjører <code className="font-mono text-xs">init</code> eller{" "}
+            <code className="font-mono text-xs">start</code>, ikke ved hver kommando — et nettverkskall der ville lagt
+            seg foran alt annet nav-pilot gjør.
           </BodyLong>
           <CodeBlock compact>
             {`nav-pilot models

--- a/apps/my-copilot/src/components/aksel-table.tsx
+++ b/apps/my-copilot/src/components/aksel-table.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { Table } from "@navikt/ds-react";
+
+// Table er et klientkomponent i @navikt/ds-react. Et serverkomponent som gjør
+// `import { Table }` får bare en klientreferanse, og statiske felter på den —
+// `Table.Header`, `Table.Body`, … — er `undefined`. React kaster da #130
+// («Element type is invalid … got: undefined») midt i render, og siden havner i
+// error.tsx. Her, innenfor "use client", er Table den ekte funksjonen, så
+// delkomponentene kan plukkes ut og eksporteres som egne klientreferanser.
+export { Table };
+export const TableHeader = Table.Header;
+export const TableBody = Table.Body;
+export const TableRow = Table.Row;
+export const TableHeaderCell = Table.HeaderCell;
+export const TableDataCell = Table.DataCell;

--- a/apps/my-copilot/src/components/nav-pilot/interactive-setup-wizard.tsx
+++ b/apps/my-copilot/src/components/nav-pilot/interactive-setup-wizard.tsx
@@ -333,8 +333,8 @@ export function StepResult({
             <CodeBlock compact>{currentResult.code}</CodeBlock>
           </Box>
           <BodyShort textColor="subtle" size="small">
-            Oppskriften installerer i dette repoet. Vil du heller ha agenter og skills på tvers av alle repoer, bytt
-            ut <code>install</code>-linja med <code>nav-pilot install --user --all</code>. Den tar ikke med prompts.{" "}
+            Oppskriften installerer i dette repoet. Vil du heller ha agenter og skills på tvers av alle repoer, bytt ut{" "}
+            <code>install</code>-linja med <code>nav-pilot install --user --all</code>. Den tar ikke med prompts.{" "}
             <Link href="/nav-pilot/docs#hvor-installere" className="text-blue-600">
               Hvor skal artefaktene installeres?
             </Link>


### PR DESCRIPTION
Produksjonssiden https://ki-utvikling.nav.no/nav-pilot/docs viste Navs generiske feilside. Faro og serverloggen sier React #130: `Element type is invalid ... but got: undefined`.

## Årsaken

`Table` i `@navikt/ds-react` ligger bak `"use client"`. En **server**-komponent som gjør `import { Table }` får bare en klientreferanse, og de statiske feltene som henger på den — `Table.Header`, `Table.Body`, `Table.Row`, `Table.HeaderCell`, `Table.DataCell` — er `undefined` på serveren. React kaster da midt i renderingen.

Bevis, fra en produksjonsbygging av `origin/main` servert lokalt:

- Serverlogg: `⨯ Error: Element type is invalid ... got: undefined { digest: "719703786" }`
- HTML-en for ruta: status **200**, kroppen bare skjeletter, med `<!--$!-->` og `data-dgst="719703786"`. Produksjons-HTML-en har nøyaktig samme form med en annen digest — altså samme feil, annen bygging. Bildet som kjører *er* bygget fra main; ingenting er utdatert.
- En probe-rute i en server-komponent skrev `ds.Table=function`, men `Table.Header=undefined`. `node -e "require(\"@navikt/ds-react\").Table"` viser alle statikkene til stede. Det er altså ikke `optimizePackageImports` — slått av, og subkomponentene var fortsatt `undefined`.

Kom inn med `6e74e45b` (#573). `git log -S"Table.Header"` på fila gir nøyaktig den commiten. De to andre tabellene i appen bruker `Table.*` også, men er selv `"use client"`, og har derfor aldri feilet.

**Rettelsen** er `src/components/aksel-table.tsx`, en seks linjers `"use client"`-modul som destrukturerer subkomponentene der `Table` er den ekte funksjonen, og eksporterer dem.

## Hvorfor ingenting fanget det

Dette er den delen som betyr mest.

- `tsc --noEmit` passerer: typene har statikkene.
- CI bygger med `next build --experimental-build-mode compile`, som **hopper over prerendering helt**.
- En vitest-rendering av siden **passerer** — testmiljøet har ingen RSC-grense.
- Sida svarer **200**. En statuskodesjekk fanger ingenting.

## Porten

`hack/smoke.sh` starter standalone-serveren etter byggingen og henter hver rute fra `src/app/**/page.tsx`. Den feiler på HTTP ≥ 400, og på `data-dgst` i kroppen når digesten ikke er en `NEXT_*`-kontrollflyt-digest (`redirect()` og `notFound()` bruker samme mekanisme; det unntaket fjernet en falsk positiv på `/ordliste`).

Kjørt som `[tasks.smoke]` med `depends = ["build"]`, og `mise-task-build: "smoke"` i workflowen, så den rir på byggejobben som allerede finnes. Ingen ekstra bygging i CI.

**Vist rød med rettelsen reversert**, alt annet likt:

```
FAIL /nav-pilot/docs: siden kastet under render (React-feilgrense i HTML-en)
smoke exit=1        (19 andre ruter ok)
```

Med rettelsen: 20/20 ok, exit 0.

## Sjekken som ikke kunne feile

`check` kjørte `prettier --write` — den retter og avslutter med 0. Den kan altså aldri feile. Nå `prettier --check`. Første kjøring feilet på drift som allerede lå på main i `page.tsx` og `interactive-setup-wizard.tsx`; begge er formatert.

## Verdt å vite

- **Ingenting annet på main feiler på samme måte.** Alle 20 statiske ruter passerer. Dynamiske ruter (`[slug]`, `[id]`) dekkes ikke — skriptet hopper over dem, siden det ikke har noen måte å velge en gyldig parameter på.
- En full `next build` fullfører ikke på main i det hele tatt: den dør tidligere på `/personvern` med en Cache Components-feil om ucachet data utenfor `<Suspense>`. Preeksisterende, egen sak, ikke rørt her.