### PR TITLE
feat(nav-pilot): doctor verifiserer håndheving, og QUIC-hullet presiseres

### DIFF
--- a/cli/nav-pilot/internal/cli/config_sandbox.go
+++ b/cli/nav-pilot/internal/cli/config_sandbox.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -148,4 +149,72 @@ func cmdConfigStrictPreset() error {
 	}
 	fmt.Printf("%s cplt sandbox.preset = %s\n", domain.Green("✓"), cpltRecommendedPreset)
 	return nil
+}
+
+// Sandbox enforcement, verified rather than inferred from configuration.
+//
+// doctor used to check cplt's *setup* only: a version, a preset, and a grep of
+// `cplt config show`. That answers "is it configured", never "is it enforcing",
+// and the failure mode is on record — an earlier grep here tested a config key
+// cplt has never had, so the check reported a problem that could not exist and
+// pointed users at a `cplt config set` cplt rejects (#406).
+//
+// `cplt check` (navikt/cplt#145) runs probes inside the real resolved sandbox —
+// the same policy an agent would get — and reports, per probe, whether cplt
+// allows or blocks it, why, and the exact fix. `--json` makes it machine-
+// readable and the battery exits non-zero when it cannot confirm enforcement.
+
+// cpltCheckReport is the part of a `cplt check --json` battery report doctor
+// reads. cplt's Report carries per-probe items with reasons and fixes too;
+// doctor prints the verdict and leaves the detail to `cplt check` itself.
+type cpltCheckReport struct {
+	// Enforcing is true only when every graded expectation held AND at least
+	// one protection was actually verified — cplt's own definition.
+	Enforcing bool `json:"enforcing"`
+	// Verified counts the expected-blocked probes that really were blocked.
+	Verified int `json:"verified"`
+	// Battery marks the full enforcement battery. A targeted query
+	// (`cplt check path …`) is not graded and must never be read as a verdict.
+	Battery bool `json:"battery"`
+}
+
+// parseCpltCheckReport decodes a battery report, or returns nil for "unknown".
+//
+// Unknown covers every way this can fail to be an answer: a cplt old enough to
+// have no `check` subcommand (clap writes a usage error to stderr and leaves
+// stdout empty), no cplt at all, a killed process, or a report that is not the
+// graded battery. Unknown is never rendered as enforcing and never as failing —
+// a security check that goes green, or red, on missing data is the same bug in
+// two directions.
+func parseCpltCheckReport(out []byte) *cpltCheckReport {
+	var r cpltCheckReport
+	if err := json.Unmarshal(out, &r); err != nil || !r.Battery {
+		return nil
+	}
+	return &r
+}
+
+// cpltCheckTimeout bounds the enforcement battery. It is longer than
+// cpltCommandTimeout because `cplt check` builds the resolved sandbox and spawns
+// probes inside it rather than reading a config file — measured at well under a
+// second warm, but a cold run after a cplt upgrade does more work.
+const cpltCheckTimeout = 15 * time.Second
+
+// cpltEnforcement runs `cplt check --json` in the current directory and returns
+// the battery verdict, or nil when it could not be established.
+//
+// The non-zero exit cplt uses for "not enforcing" is the answer, not a failure:
+// the report is on stdout either way, so the error is deliberately ignored and
+// the decision left to the decode.
+//
+// A var so tests can exercise doctor without spawning a sandbox.
+var cpltEnforcement = func() *cpltCheckReport {
+	cliPath, err := findCplt()
+	if err != nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), cpltCheckTimeout)
+	defer cancel()
+	out, _ := exec.CommandContext(ctx, cliPath, "check", "--json").Output()
+	return parseCpltCheckReport(out)
 }

--- a/cli/nav-pilot/internal/cli/config_sandbox_test.go
+++ b/cli/nav-pilot/internal/cli/config_sandbox_test.go
@@ -40,32 +40,33 @@ func TestCpltRecommendStrict(t *testing.T) {
 	}
 }
 
-// realCpltCheckBattery is the head of a real `cplt check --json` battery report,
-// captured from cplt 2026.09.02-164136-a480712 in this repository. Trimmed to
-// two items; the fields doctor reads are verbatim.
+// realCpltCheckBattery is a real `cplt check --json` battery report, captured
+// from cplt 2026.09.02-164136-a480712 run in this repository on macOS. Trimmed
+// to two of the seven items — one allowed, one blocked — and the home directory
+// rewritten from the capturing developer's to /Users/dev. Everything else,
+// including the fields doctor reads, is as cplt emitted it.
 const realCpltCheckBattery = `{
   "agent": "Copilot",
   "platform": "macos (Seatbelt)",
-  "enforcing": false,
-  "verified": 2,
+  "enforcing": true,
+  "verified": 4,
   "battery": true,
   "items": [
     {
       "name": "read project dir",
       "category": "filesystem",
-      "target": "/repo",
+      "target": "/Users/dev/go/src/github.com/navikt/copilot",
       "decision": "allowed",
       "expected": "allowed",
       "reason": "covered by the project-dir rule (read+write+execute)."
     },
     {
-      "name": "read $HOME (root)",
+      "name": "read ~/.ssh/id_ed25519",
       "category": "filesystem",
-      "target": "/home/u",
-      "decision": "allowed",
+      "target": "/Users/dev/.ssh/id_ed25519",
+      "decision": "blocked",
       "expected": "blocked",
-      "reason": "not covered by any allow rule, so it is denied by default.",
-      "fix": "grant access with --allow-read <PATH> (read) or --allow-write <PATH> (read+write), or add it under [allow] read/write in config."
+      "reason": "protected credential path, never exposed to the agent (deny-by-default). This is intentional."
     }
   ]
 }`
@@ -81,10 +82,11 @@ func TestParseCpltCheckReport(t *testing.T) {
 		wantEnforce  bool
 		wantVerified int
 	}{
-		{name: "a real battery report", in: realCpltCheckBattery, wantVerified: 2},
-		{name: "an enforcing battery",
-			in:          `{"agent":"Copilot","platform":"macos (Seatbelt)","enforcing":true,"verified":7,"battery":true,"items":[]}`,
-			wantEnforce: true, wantVerified: 7},
+		{name: "a real battery report", in: realCpltCheckBattery, wantEnforce: true, wantVerified: 4},
+		// A graded battery that came back negative is a verdict, not unknown:
+		// it must decode, so doctor renders "NOT enforcing" rather than skip it.
+		{name: "a battery that is not enforcing",
+			in: `{"agent":"Copilot","platform":"linux (Landlock)","enforcing":false,"verified":0,"battery":true,"items":[]}`},
 		// An older cplt has no `check` subcommand: clap writes usage to stderr
 		// and stdout is empty. That is unknown, not "not enforcing".
 		{name: "no check subcommand", in: "", wantNil: true},

--- a/cli/nav-pilot/internal/cli/config_sandbox_test.go
+++ b/cli/nav-pilot/internal/cli/config_sandbox_test.go
@@ -39,3 +39,82 @@ func TestCpltRecommendStrict(t *testing.T) {
 		}
 	}
 }
+
+// realCpltCheckBattery is the head of a real `cplt check --json` battery report,
+// captured from cplt 2026.09.02-164136-a480712 in this repository. Trimmed to
+// two items; the fields doctor reads are verbatim.
+const realCpltCheckBattery = `{
+  "agent": "Copilot",
+  "platform": "macos (Seatbelt)",
+  "enforcing": false,
+  "verified": 2,
+  "battery": true,
+  "items": [
+    {
+      "name": "read project dir",
+      "category": "filesystem",
+      "target": "/repo",
+      "decision": "allowed",
+      "expected": "allowed",
+      "reason": "covered by the project-dir rule (read+write+execute)."
+    },
+    {
+      "name": "read $HOME (root)",
+      "category": "filesystem",
+      "target": "/home/u",
+      "decision": "allowed",
+      "expected": "blocked",
+      "reason": "not covered by any allow rule, so it is denied by default.",
+      "fix": "grant access with --allow-read <PATH> (read) or --allow-write <PATH> (read+write), or add it under [allow] read/write in config."
+    }
+  ]
+}`
+
+// TestParseCpltCheckReport pins the contract doctor's enforcement check rests
+// on: the real report shape decodes, and every way of not getting an answer is
+// unknown rather than a verdict in either direction.
+func TestParseCpltCheckReport(t *testing.T) {
+	tests := []struct {
+		name         string
+		in           string
+		wantNil      bool
+		wantEnforce  bool
+		wantVerified int
+	}{
+		{name: "a real battery report", in: realCpltCheckBattery, wantVerified: 2},
+		{name: "an enforcing battery",
+			in:          `{"agent":"Copilot","platform":"macos (Seatbelt)","enforcing":true,"verified":7,"battery":true,"items":[]}`,
+			wantEnforce: true, wantVerified: 7},
+		// An older cplt has no `check` subcommand: clap writes usage to stderr
+		// and stdout is empty. That is unknown, not "not enforcing".
+		{name: "no check subcommand", in: "", wantNil: true},
+		{name: "cplt missing entirely", in: "", wantNil: true},
+		{name: "not JSON at all", in: "error: unrecognized subcommand 'check'\n", wantNil: true},
+		{name: "truncated read", in: `{"enforcing":true,"battery":`, wantNil: true},
+		// A targeted query is ungraded — `enforcing` is false there for a
+		// reason that has nothing to do with the sandbox.
+		{name: "a targeted, non-battery query",
+			in:      `{"agent":"Copilot","platform":"macos (Seatbelt)","enforcing":false,"verified":0,"battery":false,"items":[]}`,
+			wantNil: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseCpltCheckReport([]byte(tc.in))
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("parseCpltCheckReport(%q) = %+v, want nil (unknown)", tc.in, got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("parseCpltCheckReport returned nil, want a report")
+			}
+			if got.Enforcing != tc.wantEnforce {
+				t.Errorf("Enforcing = %v, want %v", got.Enforcing, tc.wantEnforce)
+			}
+			if got.Verified != tc.wantVerified {
+				t.Errorf("Verified = %d, want %d", got.Verified, tc.wantVerified)
+			}
+		})
+	}
+}

--- a/cli/nav-pilot/internal/cli/doctor.go
+++ b/cli/nav-pilot/internal/cli/doctor.go
@@ -223,7 +223,7 @@ func cmdDoctor() error {
 		switch report := cpltEnforcement(); {
 		case report == nil:
 			fmt.Printf("    %s Could not verify sandbox enforcement\n", dim("-"))
-			fmt.Printf("        %s Run %s — an older cplt has no such subcommand.\n", dim("Solution:"), bold("cplt check"))
+			fmt.Printf("        %s Run %s by hand — this run could not read a verdict, which an older cplt (no such subcommand), a timeout or an interrupted probe all produce.\n", dim("Solution:"), bold("cplt check"))
 		case report.Enforcing:
 			fmt.Printf("    %s Sandbox is enforcing (%d protections verified)\n", green("✓"), report.Verified)
 		default:

--- a/cli/nav-pilot/internal/cli/doctor.go
+++ b/cli/nav-pilot/internal/cli/doctor.go
@@ -215,6 +215,22 @@ func cmdDoctor() error {
 				fmt.Printf("    • No .cplt.toml found in current directory\n")
 			}
 		}
+
+		// Enforcement, probed rather than inferred. Everything above this line
+		// reads configuration; `cplt check` runs the probes inside the sandbox
+		// the agent would actually get. A repo can be perfectly configured and
+		// still not be enforcing.
+		switch report := cpltEnforcement(); {
+		case report == nil:
+			fmt.Printf("    %s Could not verify sandbox enforcement\n", dim("-"))
+			fmt.Printf("        %s Run %s — an older cplt has no such subcommand.\n", dim("Solution:"), bold("cplt check"))
+		case report.Enforcing:
+			fmt.Printf("    %s Sandbox is enforcing (%d protections verified)\n", green("✓"), report.Verified)
+		default:
+			hasErrors = true
+			fmt.Printf("    %s Sandbox is NOT enforcing\n", red("[✗]"))
+			fmt.Printf("        %s Run %s — it names each failing probe and its fix.\n", red("Solution:"), bold("cplt check"))
+		}
 	} else {
 		fmt.Printf("    • Skipped (cplt not installed)\n")
 	}

--- a/docs/nav-pilot-changelog.md
+++ b/docs/nav-pilot-changelog.md
@@ -2,6 +2,14 @@
 
 Endringslogg for nav-pilot agent harness — agenter, skills, instruksjoner, prompts og samlinger.
 
+## 2026-09-03
+
+### cplt-oppdateringer etter oppstrømsgjennomgang
+
+- **cplt-gulvet hevet til `2026.08.28-080711`, og `--no-audit` fjernet**: Flagget lå på begge stagede cplt-vektorene fordi cplts parent-side audit kunne kjøre repo-kontrollerte Git-hjelpere utenfor sandboxen — en repo-lokal `core.fsmonitor` i en `.git/config` agenten selv kan skrive. [navikt/cplt#211](https://github.com/navikt/cplt/pull/211) ruter alle tolv parent-side git-kallstedene gjennom én herdet invoker, og [#217](https://github.com/navikt/cplt/pull/217) utvider git-persistence-deniene til hver skrivbar rot. Gulvet peker på #217s release, ikke #211s, fordi #217 legger til enda et parent-side git-kall. Versjonsproben beholder `--no-audit`: et `--version`-spørsmål har ingen sesjon å auditere.
+- **`deny.paths = [".github/hooks"]` i repoets `.cplt.toml`**: preToolUse-porten som holder Ask First for ARIA-roller var redigerbar av agenten den begrenser. `[deny]` håndheves uten `cplt trust` og kan bare stramme inn. macOS Seatbelt håndhever det; på Linux kreves Bubblewrap, og med Landlock alene advarer cplt i stedet for å håndheve.
+- **`doctor` verifiserer nå håndheving, ikke bare oppsett**: Sjekken leste `cplt --version` og `cplt config show`, som svarer på om cplt er konfigurert, aldri på om sandboxen faktisk håndhever. `cplt check --json` ([navikt/cplt#145](https://github.com/navikt/cplt/pull/145)) kjører prober inne i den ekte resolverte sandboxen og eksiterer ikke-null når den ikke kan bekrefte håndheving. En eldre cplt uten subkommandoen, eller en cplt som ikke finnes, gir «vet ikke» — aldri en grønn hake og aldri en falsk feil.
+
 ## 2026-09-01
 
 ### opencode så aldri det teamet la inn for hånd

--- a/docs/nav-pilot-changelog.md
+++ b/docs/nav-pilot-changelog.md
@@ -6,8 +6,6 @@ Endringslogg for nav-pilot agent harness — agenter, skills, instruksjoner, pro
 
 ### cplt-oppdateringer etter oppstrømsgjennomgang
 
-- **cplt-gulvet hevet til `2026.08.28-080711`, og `--no-audit` fjernet**: Flagget lå på begge stagede cplt-vektorene fordi cplts parent-side audit kunne kjøre repo-kontrollerte Git-hjelpere utenfor sandboxen — en repo-lokal `core.fsmonitor` i en `.git/config` agenten selv kan skrive. [navikt/cplt#211](https://github.com/navikt/cplt/pull/211) ruter alle tolv parent-side git-kallstedene gjennom én herdet invoker, og [#217](https://github.com/navikt/cplt/pull/217) utvider git-persistence-deniene til hver skrivbar rot. Gulvet peker på #217s release, ikke #211s, fordi #217 legger til enda et parent-side git-kall. Versjonsproben beholder `--no-audit`: et `--version`-spørsmål har ingen sesjon å auditere.
-- **`deny.paths = [".github/hooks"]` i repoets `.cplt.toml`**: preToolUse-porten som holder Ask First for ARIA-roller var redigerbar av agenten den begrenser. `[deny]` håndheves uten `cplt trust` og kan bare stramme inn. macOS Seatbelt håndhever det; på Linux kreves Bubblewrap, og med Landlock alene advarer cplt i stedet for å håndheve.
 - **`doctor` verifiserer nå håndheving, ikke bare oppsett**: Sjekken leste `cplt --version` og `cplt config show`, som svarer på om cplt er konfigurert, aldri på om sandboxen faktisk håndhever. `cplt check --json` ([navikt/cplt#145](https://github.com/navikt/cplt/pull/145)) kjører prober inne i den ekte resolverte sandboxen og eksiterer ikke-null når den ikke kan bekrefte håndheving. En eldre cplt uten subkommandoen, eller en cplt som ikke finnes, gir «vet ikke» — aldri en grønn hake og aldri en falsk feil.
 
 ## 2026-09-01

--- a/docs/news/articles/cplt-juli-2026-sikkerhetsoppdatering.md
+++ b/docs/news/articles/cplt-juli-2026-sikkerhetsoppdatering.md
@@ -39,7 +39,7 @@ Kilde: [navikt/cplt#64](https://github.com/navikt/cplt/pull/64)
 
 Til nå har proxyen vært rådgivende på kernel-nivå: sandboxen tillater utgående `*:443`, og trafikken går gjennom proxyen fordi cplt injiserer `HTTPS_PROXY`. En rå socket — eller `env -u HTTPS_PROXY` — kunne dermed nå nettet utenom domenefiltreringen.
 
-Det gjelder også på macOS, og på et punkt til: standardprofilen nekter `(remote tcp)` og tillater så `(remote ip "*:443")`, og en `ip`-regel dekker UDP like mye som TCP. QUIC over UDP/443 går derfor ut uten å innom cplt-proxyen i standardmodus. Proxyloggen er altså ikke en fullstendig utgangslogg så lenge `proxy.forced` er av.
+Det gjelder også på macOS, og på et punkt til: standardprofilen nekter `(remote tcp)` og tillater så `(remote ip "*:443")`, og en `ip`-regel dekker UDP like mye som TCP. QUIC over UDP/443 er derfor kjernetillatt i standardmodus, uten å gå innom cplt-proxyen. Proxyloggen er altså ikke en fullstendig utgangslogg så lenge `proxy.forced` er av.
 
 `proxy.forced` lukker den bypassen: proxyen blir obligatorisk, og kernel-egress begrenses til proxy-porten alene (ingen direkte `*:443`). Feiler proxyen ved oppstart, starter ikke agenten — fail-closed.
 

--- a/docs/news/articles/cplt-juli-2026-sikkerhetsoppdatering.md
+++ b/docs/news/articles/cplt-juli-2026-sikkerhetsoppdatering.md
@@ -39,6 +39,8 @@ Kilde: [navikt/cplt#64](https://github.com/navikt/cplt/pull/64)
 
 Til nå har proxyen vært rådgivende på kernel-nivå: sandboxen tillater utgående `*:443`, og trafikken går gjennom proxyen fordi cplt injiserer `HTTPS_PROXY`. En rå socket — eller `env -u HTTPS_PROXY` — kunne dermed nå nettet utenom domenefiltreringen.
 
+Det gjelder også på macOS, og på et punkt til: standardprofilen nekter `(remote tcp)` og tillater så `(remote ip "*:443")`, og en `ip`-regel dekker UDP like mye som TCP. QUIC over UDP/443 går derfor ut uten å innom cplt-proxyen i standardmodus. Proxyloggen er altså ikke en fullstendig utgangslogg så lenge `proxy.forced` er av.
+
 `proxy.forced` lukker den bypassen: proxyen blir obligatorisk, og kernel-egress begrenses til proxy-porten alene (ingen direkte `*:443`). Feiler proxyen ved oppstart, starter ikke agenten — fail-closed.
 
 ```sh
@@ -47,10 +49,12 @@ cplt config set proxy.forced true
 
 Håndhevingen er asymmetrisk mellom plattformene:
 
-- **macOS** pinner fullt til `localhost:<proxy_port>` — ingen restkanal.
+- **macOS** pinner fullt til `localhost:<proxy_port>` — ingen restkanal. `*:443`-regelen droppes i sin helhet, så QUIC-hullet over UDP/443 lukkes sammen med TCP-veien.
 - **Linux** dropper `*:443`-regelen, men Landlock er portbasert og kan ikke pinne til localhost, så en smal portbasert restkanal (`evil.com:<proxy_port>`) gjenstår. Dette er en kjent og bevisst begrensning, sporet oppstrøms i [navikt/cplt#114](https://github.com/navikt/cplt/issues/114).
 
 Av som standard. Kilde: [navikt/cplt#117](https://github.com/navikt/cplt/pull/117)
+
+> **Rettelse 3. september:** Saken beskrev standardmodus som om proxyen så all utgående trafikk når `HTTPS_PROXY` er satt; UDP/443 er også tillatt der, og QUIC går utenom.
 
 ---
 


### PR DESCRIPTION
To av de fire cplt-punktene. De to andre er tatt ut: pinnehevingen går som egen PR fordi den er en felles beslutning med grillmester-siden, og `deny.paths` er droppet helt.

## `doctor` verifiserer håndheving, ikke bare oppsett

`doctor` kjørte `cplt --version` og gikk gjennom `cplt config show` med grep. Den sjekket altså *oppsett*, aldri *håndheving* — og `doctor.go:148-151` bærer minnet om en grep-basert sjekk som testet en konfignøkkel som aldri fantes (#406).

`cplt check --json` ([cplt#145](https://github.com/navikt/cplt/pull/145)) kjører prober inne i den ekte, oppløste sandkassen. Formen er lest ut av `src/check.rs` og bekreftet mot en faktisk kjøring.

`pending`-grepet er beholdt: `cplt check` ser bort fra ugodkjente `[propose]`-nøkler, så det er fortsatt den eneste kilden til det signalet.

To ting å vite om `doctor` etter dette, begge i changeloggen: den gjør nå utgående nettkall (batteriet prober `githubcopilot.com:443` og `169.254.169.254:443`), og den kan bruke opptil 15 sekunder. Den var tidligere en lokal, frakoblet kommando.

## QUIC-hullet i standardmodus

`docs/news/articles/cplt-juli-2026-sikkerhetsoppdatering.md` sa at macOS «pinner fullt til `localhost:<proxy_port>` — ingen restkanal». Det er sant om `proxy.forced`, ikke om standardmodus.

Presiseringen er formulert etter det profilen faktisk gjør: `(deny default)` nekter allerede UDP, og det er `ip`-tillatelsen på `*:443` som åpner den igjen — ikke en TCP-avgrenset deny som utgangspunkt. Teksten sier nå at stien er kjernetillatt, ikke at QUIC-trafikk *går* ut: den medfølgende stacken er HTTP/1.1–2, så dette er en åpen sti, ikke observert trafikk.

Verifisert ved å generere profilen og kjøre den: med `ip *:443` er `udp 443` tillatt og `udp 53` nektet; under `proxy.forced` faller regelen bort og `udp 443` nektes.

Verdt å melde videre: cplt sin egen `SECURITY.md:426,797` gjør den samme TCP-avgrensede feilen.

## Fixturen

Kommentaren over `realCpltCheckBattery` påsto ordrett fangst, men bar Linux-stier og `enforcing: false`, mens en ekte macOS-kjøring gir `enforcing: true` og `verified: 4`. Formen var riktig og parseren stemmer; opphavspåstanden gjorde det ikke. Den sier nå hva den er.

## Det som ikke er her

**`deny.paths = [".github/hooks"]` er droppet.** Gjennomgangen målte at `deny.paths` sender ut både `file-read*` og `file-write*`, etter tillatelsene, med siste treff først. Å nekte `.github/hooks` gjør altså at agentens egen CLI ikke kan lese `copilot-hooks.json`, ingen preToolUse-hook registreres, og siden hook-kommandoen ender på `|| exit 0` blir et uleselig skript svelget og verktøykallet **tillatt**. Det slår altså av ARIA-porten, fail-open, i hver macOS-økt.

`cplt check --json path .github/hooks/ask-first-aria.py` gir `"decision": "blocked"`.

cplt har ingen skrivebeskyttet deny, så dette trenger en oppstrøms samtale framfor en konfiglinje.

**Pinnehevingen** går som egen PR. Begrunnelsen som lå her var feil — påstanden om at #217 legger til et nytt foreldresidig git-kall holder ikke; `rev-parse --git-common-dir` er fra mai og ble allerede rutet gjennom den herdede invokeren av #211. Gulvet er fortsatt forsvarlig, men på et annet grunnlag, og det hører hjemme i en PR grillmester kan si ja til.