### PR TITLE
fix(mcp-onboarding): avvis ukjent client_id i /oauth/authorize

### DIFF
--- a/apps/mcp-onboarding/dcr_test.go
+++ b/apps/mcp-onboarding/dcr_test.go
@@ -237,7 +237,7 @@ func TestHandleAuthorize_MissingClientID(t *testing.T) {
 	}
 }
 
-func TestHandleAuthorize_UnregisteredClientID_Allowed(t *testing.T) {
+func TestHandleAuthorize_UnregisteredClientID_Rejected(t *testing.T) {
 	server := newTestOAuthServer()
 
 	req := httptest.NewRequest("GET", "/oauth/authorize?client_id=unknown&redirect_uri=http://127.0.0.1:33418&state=abc", nil)
@@ -245,8 +245,18 @@ func TestHandleAuthorize_UnregisteredClientID_Allowed(t *testing.T) {
 
 	server.handleAuthorize(w, req)
 
-	if w.Code != http.StatusFound {
-		t.Fatalf("expected 302 redirect, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+	// invalid_client is what makes an MCP client re-run Dynamic Client
+	// Registration after the in-memory store has been emptied by a restart.
+	if resp["error"] != "invalid_client" {
+		t.Fatalf("expected error 'invalid_client', got %q", resp["error"])
 	}
 }
 

--- a/apps/mcp-onboarding/oauth.go
+++ b/apps/mcp-onboarding/oauth.go
@@ -110,7 +110,7 @@ func (s *OAuthServer) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 		// Unknown client_id — normally the in-memory store lost it on restart.
 		// Tell the client to re-register rather than trusting an unregistered
 		// client's redirect_uri (GHSA-7hwf-488h-59x8).
-		slog.Warn("unknown client_id", "client_id", clientID)
+		slog.Warn("unknown client_id", "client_id", logSafe(clientID))
 		recordOAuthFlow("authorize", "invalid_client")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
@@ -246,16 +246,22 @@ func (s *OAuthServer) handleCallback(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleTokenOptions answers the CORS preflight without granting any origin.
-// /oauth/token deliberately sends no Access-Control-Allow-Origin: all supported
-// clients (VS Code and other IDE extensions) redeem the code from a native
-// process, not from a web page, and a wildcard grant here let any page read a
-// token response in the victim's browser (GHSA-7hwf-488h-59x8).
+//
+// /oauth/token deliberately sends no Access-Control-Allow-Origin. Every
+// supported client (VS Code and the other IDE extensions) redeems the code from
+// a native process rather than a web page, so none of them needs the header. A
+// wildcard grant let any page read a token response in the victim's browser
+// (GHSA-7hwf-488h-59x8).
 func (s *OAuthServer) handleTokenOptions(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *OAuthServer) handleToken(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
+	// RFC 6749 §5.1: a token response carries credentials and must not be
+	// stored by any intermediary or by the browser's back/forward cache.
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
 
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MB
 	if err := r.ParseForm(); err != nil {

--- a/apps/mcp-onboarding/oauth.go
+++ b/apps/mcp-onboarding/oauth.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -92,12 +93,12 @@ func (s *OAuthServer) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 	codeChallengeMethod := r.URL.Query().Get("code_challenge_method")
 
 	slog.Debug("authorize request received",
-		"client_id", clientID,
-		"redirect_uri", redirectURI,
+		"client_id", logSafe(clientID),
+		"redirect_uri", logSafe(redirectURI),
 		"has_state", clientState != "",
 		"has_pkce", codeChallenge != "",
-		"code_challenge_method", codeChallengeMethod,
-		"user_agent", r.UserAgent(),
+		"code_challenge_method", logSafe(codeChallengeMethod),
+		"user_agent", logSafe(r.UserAgent()),
 	)
 
 	if clientID == "" {
@@ -112,19 +113,14 @@ func (s *OAuthServer) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 		// client's redirect_uri (GHSA-7hwf-488h-59x8).
 		slog.Warn("unknown client_id", "client_id", logSafe(clientID))
 		recordOAuthFlow("authorize", "invalid_client")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		_ = json.NewEncoder(w).Encode(map[string]string{
-			"error":             "invalid_client",
-			"error_description": "Unknown client_id, please register again",
-		})
+		writeUnknownClient(w, r)
 		return
 	}
 
 	if !isRegisteredRedirectURI(reg.RedirectURIs, redirectURI) { // also rejects ""
 		slog.Warn("redirect_uri not registered",
-			"client_id", clientID,
-			"redirect_uri", redirectURI,
+			"client_id", logSafe(clientID),
+			"redirect_uri", logSafe(redirectURI),
 		)
 		http.Error(w, "redirect_uri does not match registered URIs", http.StatusBadRequest)
 		return
@@ -148,8 +144,8 @@ func (s *OAuthServer) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 	s.Store.SaveAuthSession(internalState, session)
 
 	slog.Info("starting oauth flow",
-		"client_id", clientID,
-		"redirect_uri", redirectURI,
+		"client_id", logSafe(clientID),
+		"redirect_uri", logSafe(redirectURI),
 		"has_pkce", codeChallenge != "",
 	)
 	recordOAuthFlow("authorize", "started")
@@ -163,6 +159,52 @@ func (s *OAuthServer) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 	)
 
 	http.Redirect(w, r, githubURL, http.StatusFound)
+}
+
+// unknownClientPage is what a person sees when their browser lands on the
+// invalid_client error from /oauth/authorize.
+//
+// Client registrations live in memory and the app runs a single replica, so
+// every deploy drops every client_id. The editor extension then re-authorises
+// with the one it cached, gets rejected here, and sits blocked on its loopback
+// callback without ever reading the response body. The browser tab is the only
+// place a human is told what happened, so it has to say how to recover.
+const unknownClientPage = `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Unknown client - sign in again</title></head>
+<body>
+<h1>This server no longer knows your editor's registration</h1>
+<p>Client registrations are kept in memory, so a deploy or a restart of this server clears
+them all. Your editor is still sending a <code>client_id</code> from before that, and the
+server cannot accept it (<code>invalid_client</code>).</p>
+<h2>How to recover</h2>
+<p>Remove the cached MCP registration and tokens for this server in your editor, then sign in
+again. The editor registers itself anew and the sign-in goes through.</p>
+<ul>
+<li>VS Code: open the Accounts menu, sign out of this MCP server, and reconnect it.</li>
+<li>Other clients: delete the stored OAuth registration for this server and reconnect.</li>
+</ul>
+<p>Nothing is wrong with your account, and you do not need to report this.</p>
+</body>
+</html>
+`
+
+// writeUnknownClient answers an unregistered client_id. Machine clients that
+// parse the body keep the RFC 6749 JSON error; a browser gets a page it can act
+// on, because it is the browser that the person is looking at.
+func writeUnknownClient(w http.ResponseWriter, r *http.Request) {
+	if strings.Contains(r.Header.Get("Accept"), "text/html") {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(unknownClientPage))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"error":             "invalid_client",
+		"error_description": "Unknown client_id. Clear the cached MCP registration and tokens for this server, then sign in again to re-register.",
+	})
 }
 
 func (s *OAuthServer) handleCallback(w http.ResponseWriter, r *http.Request) {

--- a/apps/mcp-onboarding/oauth.go
+++ b/apps/mcp-onboarding/oauth.go
@@ -105,8 +105,23 @@ func (s *OAuthServer) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	reg, _ := s.Store.GetClientRegistration(clientID)
-	if reg != nil && redirectURI != "" && !isRegisteredRedirectURI(reg.RedirectURIs, redirectURI) {
+	reg, err := s.Store.GetClientRegistration(clientID)
+	if err != nil {
+		// Unknown client_id — normally the in-memory store lost it on restart.
+		// Tell the client to re-register rather than trusting an unregistered
+		// client's redirect_uri (GHSA-7hwf-488h-59x8).
+		slog.Warn("unknown client_id", "client_id", clientID)
+		recordOAuthFlow("authorize", "invalid_client")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":             "invalid_client",
+			"error_description": "Unknown client_id, please register again",
+		})
+		return
+	}
+
+	if !isRegisteredRedirectURI(reg.RedirectURIs, redirectURI) { // also rejects ""
 		slog.Warn("redirect_uri not registered",
 			"client_id", clientID,
 			"redirect_uri", redirectURI,
@@ -230,13 +245,16 @@ func (s *OAuthServer) handleCallback(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, callbackURL, http.StatusFound)
 }
 
+// handleTokenOptions answers the CORS preflight without granting any origin.
+// /oauth/token deliberately sends no Access-Control-Allow-Origin: all supported
+// clients (VS Code and other IDE extensions) redeem the code from a native
+// process, not from a web page, and a wildcard grant here let any page read a
+// token response in the victim's browser (GHSA-7hwf-488h-59x8).
 func (s *OAuthServer) handleTokenOptions(w http.ResponseWriter, _ *http.Request) {
-	s.setCORSHeaders(w)
 	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *OAuthServer) handleToken(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w)
 	w.Header().Set("Content-Type", "application/json")
 
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MB
@@ -288,12 +306,12 @@ func (s *OAuthServer) handleAuthorizationCodeGrant(w http.ResponseWriter, r *htt
 		return
 	}
 
-	if clientID != "" && authCode.ClientID != "" && authCode.ClientID != clientID {
-		slog.Warn("client_id mismatch in token exchange",
+	if clientID == "" || clientID != authCode.ClientID {
+		slog.Warn("client_id missing or mismatched in token exchange",
 			"expected", authCode.ClientID,
 			"got", clientID,
 		)
-		s.writeTokenError(w, "invalid_client", "client_id mismatch")
+		s.writeTokenError(w, "invalid_client", "client_id missing or does not match the authorization code")
 		return
 	}
 

--- a/apps/mcp-onboarding/oauth_security_test.go
+++ b/apps/mcp-onboarding/oauth_security_test.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newChainTestServer wires the real route table (RegisterRoutes) against a
+// stubbed GitHub, so the tests below drive the whole authorize -> callback ->
+// token chain through the mux rather than calling handlers directly.
+func newChainTestServer(t *testing.T) (*http.ServeMux, *OAuthServer) {
+	t.Helper()
+
+	github := newGitHubMock(t, map[string]http.HandlerFunc{
+		"POST /login/oauth/access_token": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token":  "gho_victim",
+				"refresh_token": "ghr_victim",
+				"expires_in":    28800,
+				"token_type":    "bearer",
+			})
+		},
+		"GET /user": func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(GitHubUser{ID: 42, Login: "victim"})
+		},
+		"GET /user/orgs": func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode([]GitHubOrg{{ID: 1, Login: "navikt"}})
+		},
+	})
+
+	oauth := NewOAuthServer("http://localhost:8080", newTestGitHubClient(github), NewTokenStore(), "navikt")
+	mux := http.NewServeMux()
+	oauth.RegisterRoutes(mux)
+	return mux, oauth
+}
+
+func do(mux *http.ServeMux, req *http.Request) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	return w
+}
+
+// registerClient runs Dynamic Client Registration through the mux and returns
+// the issued client_id.
+func registerClient(t *testing.T, mux *http.ServeMux, redirectURI string) string {
+	t.Helper()
+	b, _ := json.Marshal(map[string]any{
+		"client_name":   "test client",
+		"redirect_uris": []string{redirectURI},
+	})
+	w := do(mux, httptest.NewRequest("POST", "/register", bytes.NewReader(b)))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("register: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var reg ClientRegistration
+	if err := json.NewDecoder(w.Body).Decode(&reg); err != nil {
+		t.Fatalf("register: decode: %v", err)
+	}
+	return reg.ClientID
+}
+
+// runChain drives authorize -> callback -> token and returns the recorders for
+// each step. Steps after a non-redirecting authorize are skipped (nil).
+func runChain(t *testing.T, mux *http.ServeMux, clientID, redirectURI string) (authorize, callback, token *httptest.ResponseRecorder) {
+	t.Helper()
+
+	authorize = do(mux, httptest.NewRequest("GET", "/oauth/authorize?client_id="+url.QueryEscape(clientID)+
+		"&redirect_uri="+url.QueryEscape(redirectURI)+"&state=client-state", nil))
+	if authorize.Code != http.StatusFound {
+		return authorize, nil, nil
+	}
+
+	// The redirect goes to GitHub; the internal state is what ties the session
+	// to the callback.
+	ghURL, err := url.Parse(authorize.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("authorize: bad Location: %v", err)
+	}
+	internalState := ghURL.Query().Get("state")
+
+	callback = do(mux, httptest.NewRequest("GET", "/oauth/callback?code=gh-code&state="+url.QueryEscape(internalState), nil))
+	if callback.Code != http.StatusFound {
+		return authorize, callback, nil
+	}
+
+	cbURL, err := url.Parse(callback.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("callback: bad Location: %v", err)
+	}
+	form := url.Values{
+		"grant_type":   {"authorization_code"},
+		"code":         {cbURL.Query().Get("code")},
+		"client_id":    {clientID},
+		"redirect_uri": {redirectURI},
+	}
+	req := httptest.NewRequest("POST", "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	token = do(mux, req)
+	return authorize, callback, token
+}
+
+// TestOAuthChain_RegisteredClient_IssuesToken is the control: it proves the
+// harness can actually reach an access token, so the rejection asserted by
+// TestOAuthChain_UnregisteredClientID_Rejected means something.
+func TestOAuthChain_RegisteredClient_IssuesToken(t *testing.T) {
+	mux, _ := newChainTestServer(t)
+	redirectURI := "http://127.0.0.1:33418/callback"
+	clientID := registerClient(t, mux, redirectURI)
+
+	authorize, callback, token := runChain(t, mux, clientID, redirectURI)
+
+	if authorize.Code != http.StatusFound {
+		t.Fatalf("authorize: expected 302, got %d: %s", authorize.Code, authorize.Body.String())
+	}
+	if callback.Code != http.StatusFound {
+		t.Fatalf("callback: expected 302, got %d: %s", callback.Code, callback.Body.String())
+	}
+	if got := callback.Header().Get("Location"); !strings.HasPrefix(got, redirectURI+"?code=") {
+		t.Fatalf("callback: expected redirect to %s with code, got %q", redirectURI, got)
+	}
+	if token.Code != http.StatusOK {
+		t.Fatalf("token: expected 200, got %d: %s", token.Code, token.Body.String())
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(token.Body).Decode(&resp); err != nil {
+		t.Fatalf("token: decode: %v", err)
+	}
+	if resp["access_token"] == nil || resp["access_token"] == "" {
+		t.Fatalf("token: expected an access_token, got %v", resp)
+	}
+}
+
+// TestOAuthChain_UnregisteredClientID_Rejected covers GHSA-7hwf-488h-59x8: an
+// unregistered client_id must not carry an attacker-chosen redirect_uri
+// through the chain.
+func TestOAuthChain_UnregisteredClientID_Rejected(t *testing.T) {
+	mux, oauth := newChainTestServer(t)
+	attackerURI := "https://attacker.example/cb"
+
+	authorize, callback, token := runChain(t, mux, "never-registered", attackerURI)
+
+	if authorize.Code != http.StatusBadRequest {
+		t.Fatalf("authorize: expected 400 for unregistered client_id, got %d (Location=%q)",
+			authorize.Code, authorize.Header().Get("Location"))
+	}
+	var errResp map[string]string
+	if err := json.NewDecoder(authorize.Body).Decode(&errResp); err != nil {
+		t.Fatalf("authorize: expected a JSON error body, got %q (%v)", authorize.Body.String(), err)
+	}
+	if errResp["error"] != "invalid_client" {
+		t.Fatalf("authorize: expected error=invalid_client so the client re-runs DCR, got %v", errResp)
+	}
+	if callback != nil || token != nil {
+		t.Fatal("chain continued past authorize")
+	}
+
+	// No session may have been created with the attacker's redirect_uri.
+	oauth.Store.mu.RLock()
+	sessions := len(oauth.Store.authSessions)
+	oauth.Store.mu.RUnlock()
+	if sessions != 0 {
+		t.Fatalf("expected no auth session for a rejected client_id, got %d", sessions)
+	}
+}
+
+// TestHandleAuthorize_EmptyRedirectURI_Rejected: an empty redirect_uri must be
+// rejected too, not fall through the validation.
+func TestHandleAuthorize_EmptyRedirectURI_Rejected(t *testing.T) {
+	mux, _ := newChainTestServer(t)
+	clientID := registerClient(t, mux, "http://127.0.0.1:33418/callback")
+
+	w := do(mux, httptest.NewRequest("GET", "/oauth/authorize?client_id="+clientID+"&state=abc", nil))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty redirect_uri, got %d (Location=%q)", w.Code, w.Header().Get("Location"))
+	}
+}
+
+// TestTokenEndpoint_MissingClientID_Rejected: omitting client_id entirely must
+// not bypass the client_id check (oauth.go compared only when both sides were
+// non-empty).
+func TestTokenEndpoint_MissingClientID_Rejected(t *testing.T) {
+	mux, oauth := newChainTestServer(t)
+
+	oauth.Store.SaveAuthCode("stolen-code", &AuthCode{
+		ClientID:    "legit-client",
+		RedirectURI: "http://127.0.0.1:33418/callback",
+		UserLogin:   "victim",
+		UserID:      42,
+		CreatedAt:   time.Now(),
+	})
+
+	form := url.Values{
+		"grant_type":   {"authorization_code"},
+		"code":         {"stolen-code"},
+		"redirect_uri": {"http://127.0.0.1:33418/callback"},
+		// no client_id at all
+	}
+	req := httptest.NewRequest("POST", "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := do(mux, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 when client_id is omitted, got %d: %s", w.Code, w.Body.String())
+	}
+	var errResp map[string]string
+	_ = json.NewDecoder(w.Body).Decode(&errResp)
+	if errResp["error"] != "invalid_client" {
+		t.Fatalf("expected error=invalid_client, got %v", errResp)
+	}
+}
+
+// TestTokenEndpoint_NoWildcardCORS: /oauth/token must not hand a wildcard CORS
+// grant to arbitrary web pages; that is what let a code be redeemed from the
+// victim's browser.
+func TestTokenEndpoint_NoWildcardCORS(t *testing.T) {
+	mux, _ := newChainTestServer(t)
+
+	form := url.Values{"grant_type": {"authorization_code"}, "code": {"nope"}}
+	req := httptest.NewRequest("POST", "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Origin", "https://attacker.example")
+	w := do(mux, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("POST /oauth/token: expected no Access-Control-Allow-Origin, got %q", got)
+	}
+
+	pre := httptest.NewRequest("OPTIONS", "/oauth/token", nil)
+	pre.Header.Set("Origin", "https://attacker.example")
+	wp := do(mux, pre)
+	if got := wp.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("OPTIONS /oauth/token: expected no Access-Control-Allow-Origin, got %q", got)
+	}
+}

--- a/apps/mcp-onboarding/oauth_security_test.go
+++ b/apps/mcp-onboarding/oauth_security_test.go
@@ -2,13 +2,16 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 	"time"
+	"unicode"
 )
 
 // newChainTestServer wires the real route table (RegisterRoutes) against a
@@ -259,10 +262,197 @@ func TestTokenEndpoint_NoStore(t *testing.T) {
 	}
 }
 
-// TestAuthorize_UnknownClientIDIsNotLoggedRaw: client_id is attacker
-// controlled and reaches a log line, so a newline in it would forge an entry.
-func TestAuthorize_UnknownClientIDIsNotLoggedRaw(t *testing.T) {
-	if got := logSafe("evil\nINFO forged entry"); strings.Contains(got, "\n") {
-		t.Fatalf("logSafe left a newline in %q", got)
+// captureHandler keeps every slog.Record so a test can assert on the attribute
+// values the handler passed, rather than on a formatted line: the JSON handler
+// used in production escapes a newline on the way out, which would hide an
+// unsanitised value.
+type captureHandler struct{ records *[]slog.Record }
+
+func (h captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h captureHandler) WithAttrs([]slog.Attr) slog.Handler       { return h }
+func (h captureHandler) WithGroup(string) slog.Handler            { return h }
+func (h captureHandler) Handle(_ context.Context, r slog.Record) error {
+	*h.records = append(*h.records, r)
+	return nil
+}
+
+// captureLogs installs a capturing default logger at debug level for the test.
+func captureLogs(t *testing.T) *[]slog.Record {
+	t.Helper()
+	records := &[]slog.Record{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(captureHandler{records: records}))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return records
+}
+
+// TestAuthorize_AttackerControlledFieldsAreNotLoggedRaw drives the real
+// handler with control characters in every field it logs. client_id,
+// redirect_uri and User-Agent are all attacker-chosen and all reach a log line
+// in /oauth/authorize, so none of them may arrive there raw: a newline forges a
+// second entry and an unbounded field pushes real entries out of a buffer.
+func TestAuthorize_AttackerControlledFieldsAreNotLoggedRaw(t *testing.T) {
+	mux, _ := newChainTestServer(t)
+	records := captureLogs(t)
+
+	evil := "evil\nlevel=ERROR msg=\"forged\"\x1b[2K"
+	req := httptest.NewRequest("GET", "/oauth/authorize?client_id="+url.QueryEscape(evil)+
+		"&redirect_uri="+url.QueryEscape("http://127.0.0.1:1/"+evil)+"&state=abc", nil)
+	req.Header.Set("User-Agent", evil)
+	do(mux, req)
+
+	if len(*records) == 0 {
+		t.Fatal("the handler logged nothing, so this test would pass vacuously")
+	}
+	sawClientID := false
+	for _, rec := range *records {
+		rec.Attrs(func(a slog.Attr) bool {
+			v, ok := a.Value.Any().(string)
+			if !ok {
+				return true
+			}
+			if a.Key == "client_id" {
+				sawClientID = true
+			}
+			for _, r := range v {
+				if unicode.IsControl(r) {
+					t.Errorf("log record %q attribute %q kept a control character %q: %q",
+						rec.Message, a.Key, r, v)
+					break
+				}
+			}
+			if len([]rune(v)) > 129 {
+				t.Errorf("log record %q attribute %q is unbounded (%d runes)", rec.Message, a.Key, len([]rune(v)))
+			}
+			return true
+		})
+	}
+	if !sawClientID {
+		t.Fatal("no log record carried a client_id, so this test would pass vacuously")
+	}
+}
+
+// TestAuthorize_UnknownClientID_BrowserGetsRecoverablePage: the extension sits
+// blocked on its loopback callback and never reads this response, so whatever a
+// browser is shown here is the only thing the person gets. It must tell them
+// how to recover; machine clients keep the JSON.
+func TestAuthorize_UnknownClientID_BrowserGetsRecoverablePage(t *testing.T) {
+	mux, _ := newChainTestServer(t)
+
+	req := httptest.NewRequest("GET", "/oauth/authorize?client_id=gone-on-deploy&redirect_uri=http://127.0.0.1:33418/callback&state=abc", nil)
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+	w := do(mux, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Fatalf("a browser must get HTML, got Content-Type %q and body %q", ct, w.Body.String())
+	}
+	body := strings.ToLower(w.Body.String())
+	for _, want := range []string{"<html", "sign in", "registration"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("the page does not mention %q, so it does not tell the person how to recover: %s", want, w.Body.String())
+		}
+	}
+
+	// A client that parses the body still gets the machine-readable error.
+	jsonReq := httptest.NewRequest("GET", "/oauth/authorize?client_id=gone-on-deploy&redirect_uri=http://127.0.0.1:33418/callback&state=abc", nil)
+	jsonReq.Header.Set("Accept", "application/json")
+	jw := do(mux, jsonReq)
+	var errResp map[string]string
+	if err := json.NewDecoder(jw.Body).Decode(&errResp); err != nil {
+		t.Fatalf("a JSON client must still get JSON, got %q (%v)", jw.Body.String(), err)
+	}
+	if errResp["error"] != "invalid_client" {
+		t.Fatalf("expected error=invalid_client, got %v", errResp)
+	}
+	if !strings.Contains(strings.ToLower(errResp["error_description"]), "register") {
+		t.Errorf("error_description should name the recovery, got %q", errResp["error_description"])
+	}
+}
+
+// TestIsRegisteredRedirectURI pins the matcher directly. Without this, a
+// version that returns true for any non-empty URI against any non-empty
+// registration list is only caught indirectly.
+func TestIsRegisteredRedirectURI(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		registered []string
+		uri        string
+		want       bool
+	}{
+		{"exact loopback match", []string{"http://127.0.0.1:33418/callback"}, "http://127.0.0.1:33418/callback", true},
+		{"loopback port is ignored (RFC 8252 7.3)", []string{"http://127.0.0.1:33418/callback"}, "http://127.0.0.1:51234/callback", true},
+		{"exact https match", []string{"https://vscode.dev/redirect"}, "https://vscode.dev/redirect", true},
+		{"attacker host", []string{"http://127.0.0.1:33418/callback"}, "https://attacker.example/cb", false},
+		{"loopback path must still match", []string{"http://127.0.0.1:33418/callback"}, "http://127.0.0.1:33418/steal", false},
+		{"https host must match exactly", []string{"https://vscode.dev/redirect"}, "https://vscode.dev.attacker.example/redirect", false},
+		{"empty uri is not registered", []string{"http://127.0.0.1:33418/callback"}, "", false},
+		{"no registrations at all", nil, "http://127.0.0.1:33418/callback", false},
+	} {
+		if got := isRegisteredRedirectURI(tc.registered, tc.uri); got != tc.want {
+			t.Errorf("%s: isRegisteredRedirectURI(%v, %q) = %v, want %v", tc.name, tc.registered, tc.uri, got, tc.want)
+		}
+	}
+}
+
+// TestTokenEndpoint_CrossClientRedemption_Rejected: a code minted for client A
+// must not be redeemable by client B. Only the omitted-client_id case was
+// pinned; a mismatched but present client_id is the other half.
+func TestTokenEndpoint_CrossClientRedemption_Rejected(t *testing.T) {
+	mux, _ := newChainTestServer(t)
+	redirectURI := "http://127.0.0.1:33418/callback"
+	clientA := registerClient(t, mux, redirectURI)
+	clientB := registerClient(t, mux, redirectURI)
+	if clientA == clientB {
+		t.Fatal("precondition: the two registrations got the same client_id")
+	}
+
+	// Mint a code for A, stopping just before the token request.
+	authorize := do(mux, httptest.NewRequest("GET", "/oauth/authorize?client_id="+url.QueryEscape(clientA)+
+		"&redirect_uri="+url.QueryEscape(redirectURI)+"&state=client-state", nil))
+	if authorize.Code != http.StatusFound {
+		t.Fatalf("precondition: authorize returned %d: %s", authorize.Code, authorize.Body.String())
+	}
+	ghURL, err := url.Parse(authorize.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("authorize: bad Location: %v", err)
+	}
+	callback := do(mux, httptest.NewRequest("GET", "/oauth/callback?code=gh-code&state="+
+		url.QueryEscape(ghURL.Query().Get("state")), nil))
+	if callback.Code != http.StatusFound {
+		t.Fatalf("precondition: callback returned %d: %s", callback.Code, callback.Body.String())
+	}
+	cbURL, err := url.Parse(callback.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("callback: bad Location: %v", err)
+	}
+	code := cbURL.Query().Get("code")
+	if code == "" {
+		t.Fatal("precondition: no authorization code was minted")
+	}
+
+	// Redeem it as B.
+	form := url.Values{
+		"grant_type":   {"authorization_code"},
+		"code":         {code},
+		"client_id":    {clientB},
+		"redirect_uri": {redirectURI},
+	}
+	req := httptest.NewRequest("POST", "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := do(mux, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("client B redeemed client A's code: got %d: %s", w.Code, w.Body.String())
+	}
+	var errResp map[string]string
+	_ = json.NewDecoder(w.Body).Decode(&errResp)
+	if errResp["error"] != "invalid_client" {
+		t.Fatalf("expected error=invalid_client, got %v", errResp)
+	}
+	if errResp["access_token"] != "" {
+		t.Fatalf("a token was issued to the wrong client: %v", errResp)
 	}
 }

--- a/apps/mcp-onboarding/oauth_security_test.go
+++ b/apps/mcp-onboarding/oauth_security_test.go
@@ -239,3 +239,30 @@ func TestTokenEndpoint_NoWildcardCORS(t *testing.T) {
 		t.Fatalf("OPTIONS /oauth/token: expected no Access-Control-Allow-Origin, got %q", got)
 	}
 }
+
+// TestTokenEndpoint_NoStore: RFC 6749 §5.1. A token response carries
+// credentials, so no intermediary and no browser cache may keep a copy.
+func TestTokenEndpoint_NoStore(t *testing.T) {
+	mux, _ := newChainTestServer(t)
+	redirectURI := "http://127.0.0.1:33418/callback"
+	clientID := registerClient(t, mux, redirectURI)
+
+	_, _, token := runChain(t, mux, clientID, redirectURI)
+	if token.Code != http.StatusOK {
+		t.Fatalf("precondition: token request failed: %d %s", token.Code, token.Body.String())
+	}
+	if got := token.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control = %q, want no-store: a token response must not be cached", got)
+	}
+	if got := token.Header().Get("Pragma"); got != "no-cache" {
+		t.Errorf("Pragma = %q, want no-cache", got)
+	}
+}
+
+// TestAuthorize_UnknownClientIDIsNotLoggedRaw: client_id is attacker
+// controlled and reaches a log line, so a newline in it would forge an entry.
+func TestAuthorize_UnknownClientIDIsNotLoggedRaw(t *testing.T) {
+	if got := logSafe("evil\nINFO forged entry"); strings.Contains(got, "\n") {
+		t.Fatalf("logSafe left a newline in %q", got)
+	}
+}


### PR DESCRIPTION
Retter sikkerhetsvarselet **GHSA-7hwf-488h-59x8** (Medium) i `apps/mcp-onboarding`.
Detaljene ligger i varselet; de gjentas ikke her mens det fortsatt er under triage.

## Hva som er rettet

**1. `/oauth/authorize` avviser ukjent `client_id` (hovedfiksen).**
`redirect_uri` ble bare validert når `client_id` allerede lå i klientlageret, så
kontrollen ble hoppet helt over for klient-ID-er lageret ikke kjente. Nå gir ukjent
`client_id` `400` med `{"error": "invalid_client"}`, og `redirect_uri` valideres for
hver forespørsel — også når den er tom.

**2. `/oauth/token` krever `client_id` — men bare for `authorization_code`-grantet.**
Den ble tidligere bare sammenlignet når begge sider var ikke-tomme, så å utelate den
helt passerte kontrollen. Merk at `refresh_token`-grantet (`oauth.go`,
`handleRefreshTokenGrant`) fortsatt ikke autentiserer klienten i det hele tatt: det tar
imot `refresh_token` og ingenting annet. Det er uendret og bevisst utenfor scope her, så
remedieringspunktet i varselet om klientautentisering på token-endepunktet er **ikke**
å regne som ferdig.

**3. `/oauth/token` sender ikke lenger `Access-Control-Allow-Origin: *`.** Alle klientene
vi støtter (VS Code og andre IDE-utvidelser) veksler koden fra en native prosess, ikke fra
en nettside, så ingen legitim flyt trenger CORS her. Endepunktet setter nå også
`Cache-Control: no-store` (RFC 6749 §5.1).

**4. Feilsvaret er mulig å komme seg ut av.** Se under.

**5. Alle loggfeltene i `handleAuthorize` er sanert.** `client_id`, `redirect_uri`,
`code_challenge_method` og `User-Agent` går gjennom `logSafe` på alle fire loggstedene i
handleren, ikke bare det ene. JSON-handleren i `main.go` escaper linjeskift, så forfalskede
loggoppføringer var uansett ikke nåbare — den reelle eksponeringen er ubegrenset feltlengde.

## Hva dette betyr for brukerne

Klientregistreringene ligger i minnet og appen kjører én replica, så **hver deploy tømmer
dem**. Før denne PR-en re-autoriserte klientene stille med sin cachede `client_id` og det
virket — nettopp på grunn av feilen. Etter denne PR-en får den samme re-autoriseringen
`400 invalid_client`.

Dette er *ikke* «samme situasjon som når registreringene utløper etter 30 dager». Den
utløpingen ga aldri en brukersynlig feil, fordi den sårbare kodestien svelget den. Dette er
en ny, synlig feil etter hver deploy, og den er den største risikoen for at denne PR-en blir
rullet tilbake.

Derfor forhandler `/oauth/authorize` nå på `Accept`. Feilsvaret rendres i nettleserfanen
klienten åpnet, mens utvidelsen står blokkert på loopback-callbacken og aldri leser kroppen —
så nettleseren er det eneste stedet et menneske får beskjed. En nettleser får en HTML-side som
sier hva som skjedde og hva man gjør (fjern cachet MCP-registrering og tokens for denne
serveren, logg inn på nytt). Maskinklienter som faktisk parser kroppen beholder JSON-en med
`error=invalid_client`.

Vi har ikke verifisert i praksis at VS Code forkaster den cachede `client_id`-en og kjører
DCR på nytt av seg selv. I verste fall må brukeren logge ut og inn igjen én gang etter en
deploy, og siden over sier hvordan. Persistering av registreringene (under) fjerner problemet.

## Tester

- `TestOAuthChain_UnregisteredClientID_Rejected` kjører hele kjeden authorize → callback →
  token gjennom det virkelige rutetreet, med GitHub stubbet.
- `TestOAuthChain_RegisteredClient_IssuesToken` er kontrollen: den beviser at riggen faktisk
  kan nå fram til et access token, slik at avvisningen over betyr noe.
- `TestHandleAuthorize_EmptyRedirectURI_Rejected`, `TestTokenEndpoint_MissingClientID_Rejected`,
  `TestTokenEndpoint_NoWildcardCORS` og `TestTokenEndpoint_NoStore` dekker hver sin endring.
- `TestAuthorize_UnknownClientID_BrowserGetsRecoverablePage` dekker innholdsforhandlingen
  begge veier.
- `TestAuthorize_AttackerControlledFieldsAreNotLoggedRaw` driver ruta med kontrolltegn i
  `client_id`, `redirect_uri` og `User-Agent` og inspiserer attributtene på hver `slog.Record`.
  Den erstatter en tidligere test i denne PR-en som kalte `logSafe` direkte og aldri drev
  handleren — den passerte uendret mot usanert kode.
- `TestIsRegisteredRedirectURI` fastholder matcheren direkte; en permissiv variant ble før
  bare fanget indirekte.
- `TestTokenEndpoint_CrossClientRedemption_Rejected`: en kode utstedt til klient A kan ikke
  innløses med klient B sin `client_id`.
- `TestHandleAuthorize_UnregisteredClientID_Allowed` er skrevet om til `..._Rejected`; den
  fastholdt den sårbare oppførselen.

Hver test er kjørt mot en bevisst svekket versjon av koden den dekker og feiler der.
`mise run check` er grønn.

## Oppfølging (bevisst holdt utenfor)

- **Ubetinget `redirect_uri`-policy.** Avtalt neste steg, får sin egen PR.
- **Klientautentisering på `refresh_token`-grantet.** Se punkt 2 over.
- Persistere klientregistreringer, så deploy ikke tømmer dem.
- Gjøre PKCE obligatorisk. Merk at dette **ikke** løser feilen over — angriperen er den
  initierende klienten og lager sin egen verifier — men det lukker et separat hull.
- `/register` er åpen, så en angriper kan registrere sin egen `redirect_uri` og få en gyldig
  `client_id`. Denne PR-en hever terskelen, men lukker ikke den varianten.
- Et registrerings-orakel: `/oauth/authorize` skiller ukjent fra kjent `client_id`. Lav
  alvorlighet — `client_id` er 128 bits fra `crypto/rand`.
- `Access-Control-Allow-Origin: *` står igjen på `/.well-known/*` og `/register`.
- Ubegrenset metrikk-label i `main.go`.
- Rette `README.md` (feil vertsnavn, og påstanden om levetid på tokens).
