### PR TITLE
feat(mcp-onboarding): client_id-en bærer sin egen signerte registrering

### DIFF
--- a/apps/mcp-onboarding/README.md
+++ b/apps/mcp-onboarding/README.md
@@ -258,7 +258,7 @@ Not tested with this server — likely same third-party OAuth issues as JetBrain
 - Uses OAuth 2.1 with PKCE (Proof Key for Code Exchange)
 - Dynamic Client Registration for seamless MCP client onboarding
 - Redirect URIs restricted to `http://127.0.0.1`, `http://localhost`, or `https://`
-- Client registrations are not stored: the issued `client_id` is the registration, HMAC-SHA256 signed with a key derived from `GITHUB_CLIENT_SECRET`, so it survives a restart without any registration ever touching disk. Rotating `GITHUB_CLIENT_SECRET` invalidates every outstanding `client_id`; clients get `invalid_client` and re-register.
+- Client registrations are not stored: the issued `client_id` is the registration, HMAC-SHA256 signed with a key derived from `GITHUB_CLIENT_SECRET`, so it survives a restart without any registration ever touching disk. Rotating `GITHUB_CLIENT_SECRET` invalidates every outstanding `client_id`; clients get `invalid_client` and re-register. Registrations expire 30 days after issue, enforced when the `client_id` is verified.
 - Validates GitHub organization membership before issuing tokens
 - Tokens expire after 1 hour (refresh tokens: 30 days)
 - Tokens are stored in memory only, and are lost on restart by design (they are live GitHub credentials and must not be persisted)

--- a/apps/mcp-onboarding/README.md
+++ b/apps/mcp-onboarding/README.md
@@ -165,7 +165,7 @@ Exposed via `GET /metrics` in Prometheus format.
 | `mcp_tool_calls_total`          | Counter   | `tool`, `status`                | MCP tool invocations                                                                     |
 | `oauth_flows_total`             | Counter   | `stage`, `result`               | OAuth flow outcomes (authorize, callback, token)                                         |
 | `authenticated_users_total`     | Counter   | —                               | Total successful authentications                                                         |
-| `token_store_size`              | Gauge     | `type`                          | Current size of token stores (`active_tokens`, `refresh_tokens`, `client_registrations`) |
+| `token_store_size`              | Gauge     | `type`                          | Current size of token stores (`active_tokens`, `refresh_tokens`) |
 
 A shared Grafana dashboard is available at [`dashboards/copilot-ecosystem.json`](../../dashboards/copilot-ecosystem.json).
 
@@ -258,10 +258,10 @@ Not tested with this server — likely same third-party OAuth issues as JetBrain
 - Uses OAuth 2.1 with PKCE (Proof Key for Code Exchange)
 - Dynamic Client Registration for seamless MCP client onboarding
 - Redirect URIs restricted to `http://127.0.0.1`, `http://localhost`, or `https://`
-- Client registrations rate limited (max 1000) and expire after 30 days
+- Client registrations are not stored: the issued `client_id` is the registration, HMAC-SHA256 signed with a key derived from `GITHUB_CLIENT_SECRET`, so it survives a restart without any registration ever touching disk. Rotating `GITHUB_CLIENT_SECRET` invalidates every outstanding `client_id`; clients get `invalid_client` and re-register.
 - Validates GitHub organization membership before issuing tokens
 - Tokens expire after 1 hour (refresh tokens: 30 days)
-- All tokens and client registrations stored in memory (lost on restart)
+- Tokens are stored in memory only, and are lost on restart by design (they are live GitHub credentials and must not be persisted)
 
 ## License
 

--- a/apps/mcp-onboarding/clientid.go
+++ b/apps/mcp-onboarding/clientid.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"crypto/hkdf"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+)
+
+// The client_id is the registration.
+//
+// Client registrations used to live in a map in this process, and this app runs
+// a single replica, so every deploy forgot every client. Accepting an unknown
+// client_id to paper over that is what became GHSA-7hwf-488h-59x8; rejecting it
+// (the fix) strands every client until it re-registers. Neither is acceptable,
+// and persisting the registrations to disk is worse still: the same store holds
+// live employee GitHub tokens.
+//
+// So nothing is stored. /register signs the parts of the registration that
+// /oauth/authorize has to trust — the redirect_uris — and hands them back as
+// the client_id. Verifying the tag proves the server issued it, which is
+// exactly what the map lookup used to prove, and it keeps proving it after a
+// restart.
+type clientIDInfo struct {
+	RedirectURIs []string `json:"u"`
+	IssuedAt     int64    `json:"t"`
+	// Nonce keeps two registrations of the same redirect_uris distinct. Without
+	// it the client_id would be a pure function of the registration, and two
+	// editors on the same loopback port would share one client identity — which
+	// is what binds an authorization code to the client that asked for it.
+	Nonce string `json:"n"`
+}
+
+var errInvalidClientID = errors.New("invalid client_id")
+
+// maxClientIDLen bounds what is worth base64-decoding. A real client_id with
+// one loopback redirect_uri is around 110 characters; the registration handler
+// caps redirect_uris so it cannot grow far past that.
+const maxClientIDLen = 4096
+
+// deriveClientIDKey derives the signing key from the GitHub OAuth client
+// secret, which the app already receives through mcp-onboarding-secrets. That
+// avoids a second secret to provision and rotate, and ties the two together:
+// rotating the GitHub secret invalidates every outstanding client_id, and the
+// clients then get the recoverable invalid_client answer and re-register.
+//
+// Without a secret (local development) the key is random per process, so
+// client_ids die with the process — the same behaviour the in-memory map had.
+func deriveClientIDKey(githubClientSecret string) []byte {
+	if githubClientSecret == "" {
+		key := make([]byte, 32)
+		_, _ = rand.Read(key)
+		slog.Warn("no GitHub client secret set: client_id signing key is random per process, clients must re-register after every restart")
+		return key
+	}
+	key, err := hkdf.Key(sha256.New, []byte(githubClientSecret), nil, "mcp-onboarding client_id v1", 32)
+	if err != nil {
+		// hkdf.Key only fails on an absurd key length, which is a constant here.
+		panic("deriving client_id signing key: " + err.Error())
+	}
+	return key
+}
+
+// mintClientID encodes the registration and appends its HMAC tag.
+func mintClientID(key []byte, info clientIDInfo) string {
+	payload, err := json.Marshal(info)
+	if err != nil {
+		panic("encoding client_id payload: " + err.Error()) // []string and int64 only
+	}
+	encoded := base64.RawURLEncoding.EncodeToString(payload)
+	return encoded + "." + base64.RawURLEncoding.EncodeToString(tagClientID(key, encoded))
+}
+
+func tagClientID(key []byte, encodedPayload string) []byte {
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(encodedPayload))
+	return mac.Sum(nil)
+}
+
+// verifyClientID returns the registration carried by a client_id, or
+// errInvalidClientID. The tag is checked in constant time and before anything
+// in the payload is decoded, so an attacker never reaches the JSON parser.
+func verifyClientID(key []byte, clientID string) (*clientIDInfo, error) {
+	if clientID == "" || len(clientID) > maxClientIDLen {
+		return nil, errInvalidClientID
+	}
+	encodedPayload, encodedTag, ok := strings.Cut(clientID, ".")
+	if !ok {
+		return nil, errInvalidClientID
+	}
+	tag, err := base64.RawURLEncoding.DecodeString(encodedTag)
+	if err != nil {
+		return nil, errInvalidClientID
+	}
+	if !hmac.Equal(tag, tagClientID(key, encodedPayload)) {
+		return nil, errInvalidClientID
+	}
+
+	// Past this point the payload is one this server signed.
+	payload, err := base64.RawURLEncoding.DecodeString(encodedPayload)
+	if err != nil {
+		return nil, errInvalidClientID
+	}
+	var info clientIDInfo
+	if err := json.Unmarshal(payload, &info); err != nil {
+		return nil, errInvalidClientID
+	}
+	if len(info.RedirectURIs) == 0 {
+		return nil, errInvalidClientID
+	}
+	return &info, nil
+}

--- a/apps/mcp-onboarding/clientid.go
+++ b/apps/mcp-onboarding/clientid.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"log/slog"
 	"strings"
+	"time"
 )
 
 // The client_id is the registration.
@@ -28,7 +29,10 @@ import (
 // restart.
 type clientIDInfo struct {
 	RedirectURIs []string `json:"u"`
-	IssuedAt     int64    `json:"t"`
+	// IssuedAt is what bounds the lifetime of a registration. Nothing is
+	// stored, so there is no cleanup loop to expire one; verifyClientID
+	// enforces the same 30-day window the deleted loop did.
+	IssuedAt int64 `json:"t"`
 	// Nonce keeps two registrations of the same redirect_uris distinct. Without
 	// it the client_id would be a pure function of the registration, and two
 	// editors on the same loopback port would share one client identity — which
@@ -39,9 +43,16 @@ type clientIDInfo struct {
 var errInvalidClientID = errors.New("invalid client_id")
 
 // maxClientIDLen bounds what is worth base64-decoding. A real client_id with
-// one loopback redirect_uri is around 110 characters; the registration handler
-// caps redirect_uris so it cannot grow far past that.
+// one loopback redirect_uri is around 110 characters. The registration handler
+// checks the minted client_id against this same limit, so /register never hands
+// out an id that verifyClientID would refuse to look at.
 const maxClientIDLen = 4096
+
+// clientIDTTL is how long a registration stays valid. /register is
+// unauthenticated and accepts any https redirect_uri, so without this an
+// attacker-minted client_id would be valid forever, revocable only by rotating
+// GITHUB_CLIENT_SECRET — which strands every legitimate client too.
+const clientIDTTL = 30 * 24 * time.Hour
 
 // deriveClientIDKey derives the signing key from the GitHub OAuth client
 // secret, which the app already receives through mcp-onboarding-secrets. That
@@ -83,8 +94,16 @@ func tagClientID(key []byte, encodedPayload string) []byte {
 }
 
 // verifyClientID returns the registration carried by a client_id, or
-// errInvalidClientID. The tag is checked in constant time and before anything
-// in the payload is decoded, so an attacker never reaches the JSON parser.
+// errInvalidClientID. The tag is compared in constant time and before anything
+// in the payload is decoded, so an attacker never reaches the JSON parser;
+// TestVerifyClientID_ChecksTagFirst pins both, since neither is observable from
+// the outside — every path fails closed.
+//
+// The comparison is against the re-encoded tag rather than the decoded bytes:
+// a 32-byte tag is 43 base64url characters with two slack bits, and Go's
+// decoder accepts non-canonical trailing bits, so decoding first would make
+// four spellings of one client_id verify. Comparing the encoding makes the
+// client_id a canonical identifier.
 func verifyClientID(key []byte, clientID string) (*clientIDInfo, error) {
 	if clientID == "" || len(clientID) > maxClientIDLen {
 		return nil, errInvalidClientID
@@ -93,11 +112,8 @@ func verifyClientID(key []byte, clientID string) (*clientIDInfo, error) {
 	if !ok {
 		return nil, errInvalidClientID
 	}
-	tag, err := base64.RawURLEncoding.DecodeString(encodedTag)
-	if err != nil {
-		return nil, errInvalidClientID
-	}
-	if !hmac.Equal(tag, tagClientID(key, encodedPayload)) {
+	want := base64.RawURLEncoding.EncodeToString(tagClientID(key, encodedPayload))
+	if !hmac.Equal([]byte(encodedTag), []byte(want)) {
 		return nil, errInvalidClientID
 	}
 
@@ -111,6 +127,11 @@ func verifyClientID(key []byte, clientID string) (*clientIDInfo, error) {
 		return nil, errInvalidClientID
 	}
 	if len(info.RedirectURIs) == 0 {
+		return nil, errInvalidClientID
+	}
+	// An absent, zero or future IssuedAt is as unusable as an expired one: it
+	// would mean a registration with no bounded lifetime.
+	if age := time.Since(time.Unix(info.IssuedAt, 0)); info.IssuedAt <= 0 || age < 0 || age > clientIDTTL {
 		return nil, errInvalidClientID
 	}
 	return &info, nil

--- a/apps/mcp-onboarding/clientid.go
+++ b/apps/mcp-onboarding/clientid.go
@@ -129,6 +129,13 @@ func verifyClientID(key []byte, clientID string) (*clientIDInfo, error) {
 	if len(info.RedirectURIs) == 0 {
 		return nil, errInvalidClientID
 	}
+	// The nonce is what keeps two registrations of the same redirect_uris
+	// distinct, so an id without one has an identity that is not its own.
+	// Enforced here rather than trusted from the mint side, because this is the
+	// boundary that decides whether a client_id is usable.
+	if info.Nonce == "" {
+		return nil, errInvalidClientID
+	}
 	// An absent, zero or future IssuedAt is as unusable as an expired one: it
 	// would mean a registration with no bounded lifetime.
 	if age := time.Since(time.Unix(info.IssuedAt, 0)); info.IssuedAt <= 0 || age < 0 || age > clientIDTTL {

--- a/apps/mcp-onboarding/clientid_test.go
+++ b/apps/mcp-onboarding/clientid_test.go
@@ -408,3 +408,33 @@ func TestVerifyClientID_ChecksTagFirst(t *testing.T) {
 		}
 	}
 }
+
+// TestSignedClientID_EmptyNonce: the nonce is what keeps two registrations of
+// the same redirect_uris distinct, so an id minted without one has an identity
+// that is not its own. Enforced at verification rather than trusted from the
+// mint side.
+func TestSignedClientID_EmptyNonce(t *testing.T) {
+	mux, server := newChainTestServer(t)
+	uri := "http://127.0.0.1:33418/callback"
+
+	// Control: the same mint with a nonce authorises on this server.
+	withNonce := mintClientID(server.clientIDKey, clientIDInfo{
+		RedirectURIs: []string{uri}, IssuedAt: time.Now().Unix(), Nonce: generateSecureToken(8),
+	})
+	req := httptest.NewRequest("GET", "/oauth/authorize?client_id="+url.QueryEscape(withNonce)+"&redirect_uri="+url.QueryEscape(uri)+"&state=abc", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusFound {
+		t.Fatalf("control: a nonced client_id should authorise, got %d: %s", w.Code, w.Body.String())
+	}
+
+	without := mintClientID(server.clientIDKey, clientIDInfo{
+		RedirectURIs: []string{uri}, IssuedAt: time.Now().Unix(),
+	})
+	req = httptest.NewRequest("GET", "/oauth/authorize?client_id="+url.QueryEscape(without)+"&redirect_uri="+url.QueryEscape(uri)+"&state=abc", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("a client_id with an empty nonce was accepted: got %d", w.Code)
+	}
+}

--- a/apps/mcp-onboarding/clientid_test.go
+++ b/apps/mcp-onboarding/clientid_test.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+const testRedirectURI = "http://127.0.0.1:33418/callback"
+
+// authorize runs one /oauth/authorize request through the mux.
+func authorize(mux *http.ServeMux, clientID, redirectURI string) *httptest.ResponseRecorder {
+	return do(mux, httptest.NewRequest("GET", "/oauth/authorize?client_id="+url.QueryEscape(clientID)+
+		"&redirect_uri="+url.QueryEscape(redirectURI)+"&state=client-state", nil))
+}
+
+// TestSignedClientID_SurvivesRestart is the point of the whole change: a
+// client_id issued by one process still authorises against a later process
+// with an empty store, because the registration travels inside the client_id
+// rather than in a map that a deploy wipes.
+func TestSignedClientID_SurvivesRestart(t *testing.T) {
+	before, _ := newChainTestServer(t)
+	clientID := registerClient(t, before, testRedirectURI)
+
+	// Same app, restarted: new mux, new store, same signing key.
+	after, _ := newChainTestServer(t)
+
+	auth, callback, token := runChain(t, after, clientID, testRedirectURI)
+	if auth.Code != http.StatusFound {
+		t.Fatalf("authorize after restart: expected 302, got %d: %s", auth.Code, auth.Body.String())
+	}
+	if callback.Code != http.StatusFound {
+		t.Fatalf("callback after restart: expected 302, got %d: %s", callback.Code, callback.Body.String())
+	}
+	if token.Code != http.StatusOK {
+		t.Fatalf("token after restart: expected 200, got %d: %s", token.Code, token.Body.String())
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(token.Body).Decode(&resp); err != nil {
+		t.Fatalf("token: decode: %v", err)
+	}
+	if resp["access_token"] == "" || resp["access_token"] == nil {
+		t.Fatalf("token: no access_token in %v", resp)
+	}
+}
+
+// TestSignedClientID_ForgedTag pairs the rejection with a control on the same
+// server, so the test cannot pass just because everything is rejected.
+func TestSignedClientID_ForgedTag(t *testing.T) {
+	issuer, _ := newChainTestServer(t)
+	clientID := registerClient(t, issuer, testRedirectURI)
+
+	verifier, _ := newChainTestServer(t)
+
+	if w := authorize(verifier, clientID, testRedirectURI); w.Code != http.StatusFound {
+		t.Fatalf("control: genuine client_id should authorise, got %d: %s", w.Code, w.Body.String())
+	}
+
+	payload, tag, _ := strings.Cut(clientID, ".")
+	forged := payload + "." + flipLastChar(tag)
+	w := authorize(verifier, forged, testRedirectURI)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("forged tag: expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	assertInvalidClient(t, w)
+}
+
+// TestSignedClientID_TamperedPayload swaps the signed redirect_uri for an
+// attacker's own and keeps the original tag. This is the GHSA-7hwf-488h-59x8
+// shape: if it went through, the authorization code would be delivered to the
+// attacker's URL.
+func TestSignedClientID_TamperedPayload(t *testing.T) {
+	mux, _ := newChainTestServer(t)
+	clientID := registerClient(t, mux, testRedirectURI)
+
+	if w := authorize(mux, clientID, testRedirectURI); w.Code != http.StatusFound {
+		t.Fatalf("control: genuine client_id should authorise, got %d: %s", w.Code, w.Body.String())
+	}
+
+	_, tag, _ := strings.Cut(clientID, ".")
+	evil := "https://evil.example.com/callback"
+	// Written out as the raw wire format an attacker would craft, rather than
+	// through the server's own type.
+	tampered, err := json.Marshal(map[string]any{"u": []string{evil}, "t": 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	swapped := base64.RawURLEncoding.EncodeToString(tampered) + "." + tag
+
+	w := authorize(mux, swapped, evil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("tampered payload: expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if loc := w.Header().Get("Location"); loc != "" {
+		t.Fatalf("tampered payload: server redirected to %q", loc)
+	}
+	assertInvalidClient(t, w)
+}
+
+// TestSignedClientID_DifferentKey covers key rotation: a client_id signed under
+// the old key stops verifying, and the client gets the recoverable
+// invalid_client answer rather than a hang.
+func TestSignedClientID_DifferentKey(t *testing.T) {
+	issuer, _ := newChainTestServerWithSecret(t, "secret-before-rotation")
+	clientID := registerClient(t, issuer, testRedirectURI)
+
+	same, _ := newChainTestServerWithSecret(t, "secret-before-rotation")
+	if w := authorize(same, clientID, testRedirectURI); w.Code != http.StatusFound {
+		t.Fatalf("control: same key should authorise, got %d: %s", w.Code, w.Body.String())
+	}
+
+	rotated, _ := newChainTestServerWithSecret(t, "secret-after-rotation")
+	w := authorize(rotated, clientID, testRedirectURI)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("rotated key: expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	assertInvalidClient(t, w)
+}
+
+// TestSignedClientID_Malformed feeds junk to the verifier. Nothing may panic:
+// the tag is checked before any of this reaches a decoder.
+func TestSignedClientID_Malformed(t *testing.T) {
+	mux, _ := newChainTestServer(t)
+	genuine := registerClient(t, mux, testRedirectURI)
+	payload, tag, _ := strings.Cut(genuine, ".")
+
+	cases := map[string]string{
+		"no separator":       strings.ReplaceAll(genuine, ".", ""),
+		"truncated":          genuine[:len(genuine)/2],
+		"payload only":       payload + ".",
+		"tag only":           "." + tag,
+		"empty parts":        ".",
+		"not base64":         "!!!.???",
+		"random opaque id":   generateSecureToken(16),
+		"two separators":     genuine + "." + genuine,
+		"huge":               strings.Repeat("a", 5000),
+		"tag over wrong pay": base64.RawURLEncoding.EncodeToString([]byte("not json")) + "." + tag,
+	}
+
+	for name, id := range cases {
+		t.Run(name, func(t *testing.T) {
+			w := authorize(mux, id, testRedirectURI)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+
+	// And the control still works after all of that.
+	if w := authorize(mux, genuine, testRedirectURI); w.Code != http.StatusFound {
+		t.Fatalf("control: genuine client_id should authorise, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleRegister_PublicClientResponse checks the RFC 7591 shape for a
+// public client: no client_secret, so no client_secret_expires_at either.
+func TestHandleRegister_PublicClientResponse(t *testing.T) {
+	mux, _ := newChainTestServer(t)
+	b, _ := json.Marshal(map[string]any{
+		"client_name":   "VS Code",
+		"redirect_uris": []string{testRedirectURI},
+	})
+	w := do(mux, httptest.NewRequest("POST", "/register", bytes.NewReader(b)))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := resp["client_secret"]; ok {
+		t.Fatal("a public client must not be issued a client_secret")
+	}
+	if _, ok := resp["client_secret_expires_at"]; ok {
+		t.Fatal("client_secret_expires_at is only defined when a client_secret is issued")
+	}
+	if resp["token_endpoint_auth_method"] != "none" {
+		t.Fatalf("expected token_endpoint_auth_method 'none', got %v", resp["token_endpoint_auth_method"])
+	}
+	if _, ok := resp["client_id_issued_at"].(float64); !ok {
+		t.Fatalf("expected a numeric client_id_issued_at, got %v", resp["client_id_issued_at"])
+	}
+
+	// The client_id grew from 22 characters to a signed blob; nothing may
+	// depend on it staying short, but it must stay a sane size.
+	clientID, _ := resp["client_id"].(string)
+	if len(clientID) < 60 || len(clientID) > 512 {
+		t.Fatalf("unexpected client_id length %d: %q", len(clientID), clientID)
+	}
+}
+
+func TestHandleRegister_TooManyRedirectURIs(t *testing.T) {
+	mux, _ := newChainTestServer(t)
+	uris := make([]string, 11)
+	for i := range uris {
+		uris[i] = testRedirectURI
+	}
+	b, _ := json.Marshal(map[string]any{"redirect_uris": uris})
+	w := do(mux, httptest.NewRequest("POST", "/register", bytes.NewReader(b)))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func assertInvalidClient(t *testing.T, w *httptest.ResponseRecorder) {
+	t.Helper()
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	// invalid_client is what tells the client to re-run registration instead of
+	// retrying the same client_id forever.
+	if resp["error"] != "invalid_client" {
+		t.Fatalf("expected error 'invalid_client', got %q", resp["error"])
+	}
+}
+
+func flipLastChar(s string) string {
+	if s == "" {
+		return "A"
+	}
+	last := s[len(s)-1]
+	if last == 'A' {
+		return s[:len(s)-1] + "B"
+	}
+	return s[:len(s)-1] + "A"
+}
+
+// TestSignedClientID_EmptyPayloadIsRejected pins that a correctly signed but
+// empty registration is still refused; without redirect_uris there is nothing
+// to match against.
+func TestSignedClientID_EmptyPayloadIsRejected(t *testing.T) {
+	key := deriveClientIDKey("a-secret")
+	id := mintClientID(key, clientIDInfo{})
+	if _, err := verifyClientID(key, id); err == nil {
+		t.Fatal("expected a client_id with no redirect_uris to be rejected")
+	}
+}
+
+// TestDeriveClientIDKey_Deterministic is what makes the restart property work:
+// the same secret must produce the same key, a different secret must not.
+func TestDeriveClientIDKey_Deterministic(t *testing.T) {
+	a := deriveClientIDKey("shared-secret")
+	b := deriveClientIDKey("shared-secret")
+	if !bytes.Equal(a, b) {
+		t.Fatal("same secret produced different signing keys")
+	}
+	if bytes.Equal(a, deriveClientIDKey("other-secret")) {
+		t.Fatal("different secrets produced the same signing key")
+	}
+	if bytes.Equal(deriveClientIDKey(""), deriveClientIDKey("")) {
+		t.Fatal("an unset secret must produce a random per-process key")
+	}
+}

--- a/apps/mcp-onboarding/clientid_test.go
+++ b/apps/mcp-onboarding/clientid_test.go
@@ -7,8 +7,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 const testRedirectURI = "http://127.0.0.1:33418/callback"
@@ -256,5 +258,153 @@ func TestDeriveClientIDKey_Deterministic(t *testing.T) {
 	}
 	if bytes.Equal(deriveClientIDKey(""), deriveClientIDKey("")) {
 		t.Fatal("an unset secret must produce a random per-process key")
+	}
+}
+
+// TestSignedClientID_Expired is the TTL the deleted cleanup loop used to
+// enforce. /register is unauthenticated and accepts any https redirect_uri, so
+// a client_id that never expires is an unrevocable registration bound to an
+// attacker's callback.
+func TestSignedClientID_Expired(t *testing.T) {
+	mux, server := newChainTestServer(t)
+
+	fresh := mintClientID(server.clientIDKey, clientIDInfo{
+		RedirectURIs: []string{testRedirectURI},
+		IssuedAt:     time.Now().Unix(),
+		Nonce:        generateSecureToken(8),
+	})
+	if w := authorize(mux, fresh, testRedirectURI); w.Code != http.StatusFound {
+		t.Fatalf("control: a fresh client_id should authorise, got %d: %s", w.Code, w.Body.String())
+	}
+
+	cases := map[string]int64{
+		"older than the window": time.Now().Add(-clientIDTTL - time.Hour).Unix(),
+		"absent":                0,
+		"negative":              -1,
+		"in the future":         time.Now().Add(48 * time.Hour).Unix(),
+	}
+	for name, issuedAt := range cases {
+		t.Run(name, func(t *testing.T) {
+			id := mintClientID(server.clientIDKey, clientIDInfo{
+				RedirectURIs: []string{testRedirectURI},
+				IssuedAt:     issuedAt,
+				Nonce:        generateSecureToken(8),
+			})
+			w := authorize(mux, id, testRedirectURI)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+			}
+			// invalid_client is the recoverable answer: the client re-registers
+			// rather than retrying a dead client_id forever.
+			assertInvalidClient(t, w)
+		})
+	}
+
+	// Just inside the window still authorises, so the check is a window and not
+	// a blanket rejection.
+	recent := mintClientID(server.clientIDKey, clientIDInfo{
+		RedirectURIs: []string{testRedirectURI},
+		IssuedAt:     time.Now().Add(-clientIDTTL + time.Hour).Unix(),
+		Nonce:        generateSecureToken(8),
+	})
+	if w := authorize(mux, recent, testRedirectURI); w.Code != http.StatusFound {
+		t.Fatalf("a client_id just inside the window should authorise, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleRegister_RedirectURITooLong: the 10-URI and 64 KB caps bound the
+// request, not one URI, so /register used to answer 201 with a client_id that
+// /oauth/authorize would then always reject.
+func TestHandleRegister_RedirectURITooLong(t *testing.T) {
+	mux, _ := newChainTestServer(t)
+
+	// Control: an ordinary registration on the same server still succeeds.
+	if id := registerClient(t, mux, testRedirectURI); id == "" {
+		t.Fatal("control: expected a client_id")
+	}
+
+	long := "https://example.com/" + strings.Repeat("a", 6000)
+	b, _ := json.Marshal(map[string]any{"redirect_uris": []string{long}})
+	w := do(mux, httptest.NewRequest("POST", "/register", bytes.NewReader(b)))
+	if w.Code != http.StatusBadRequest {
+		var resp map[string]any
+		_ = json.NewDecoder(w.Body).Decode(&resp)
+		id, _ := resp["client_id"].(string)
+		t.Fatalf("expected 400, got %d with a %d-character client_id", w.Code, len(id))
+	}
+}
+
+// TestSignedClientID_NonCanonicalTag: a 32-byte tag is 43 base64url characters
+// carrying 258 bits, and Go's decoder accepts the two slack bits set. Without
+// canonical encoding the same registration has four spellings, and client_id is
+// not an identifier anything can safely key on.
+func TestSignedClientID_NonCanonicalTag(t *testing.T) {
+	mux, _ := newChainTestServer(t)
+	genuine := registerClient(t, mux, testRedirectURI)
+	if w := authorize(mux, genuine, testRedirectURI); w.Code != http.StatusFound {
+		t.Fatalf("control: genuine client_id should authorise, got %d: %s", w.Code, w.Body.String())
+	}
+
+	payload, tag, _ := strings.Cut(genuine, ".")
+	want, err := base64.RawURLEncoding.DecodeString(tag)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+	variants := 0
+	for i := 0; i < len(alphabet); i++ {
+		alt := tag[:len(tag)-1] + string(alphabet[i])
+		if alt == tag {
+			continue
+		}
+		got, err := base64.RawURLEncoding.DecodeString(alt)
+		if err != nil || !bytes.Equal(got, want) {
+			continue
+		}
+		variants++
+		w := authorize(mux, payload+"."+alt, testRedirectURI)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("non-canonical tag %q: expected 400, got %d: %s", alt, w.Code, w.Body.String())
+		}
+	}
+	// If this ever hits zero the test has stopped testing anything.
+	if variants == 0 {
+		t.Fatal("found no non-canonical spellings of the tag; the test proves nothing")
+	}
+}
+
+// TestVerifyClientID_ChecksTagFirst pins two properties the comment on
+// verifyClientID claims and that no behavioural test can see, because every
+// path fails closed: the tag is compared before the payload is parsed, and the
+// comparison is constant time. Both are defence in depth, so pinning the source
+// is enough — the reviewer's point was only that they were asserted and
+// unguarded.
+func TestVerifyClientID_ChecksTagFirst(t *testing.T) {
+	src, err := os.ReadFile("clientid.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := strings.Index(string(src), "func verifyClientID(")
+	if start < 0 {
+		t.Fatal("verifyClientID not found in clientid.go")
+	}
+	body := string(src)[start:]
+	if end := strings.Index(body, "\nfunc "); end > 0 {
+		body = body[:end]
+	}
+
+	compare := strings.Index(body, "hmac.Equal")
+	if compare < 0 {
+		t.Fatal("verifyClientID does not compare the tag with hmac.Equal; a plain string comparison is not constant time")
+	}
+	for _, after := range []string{"json.Unmarshal", "DecodeString(encodedPayload)", "info.RedirectURIs", "info.IssuedAt"} {
+		at := strings.Index(body, after)
+		if at < 0 {
+			t.Fatalf("verifyClientID no longer contains %q", after)
+		}
+		if at < compare {
+			t.Fatalf("%s runs before the hmac.Equal tag check; an unauthenticated payload must not reach it", after)
+		}
 	}
 }

--- a/apps/mcp-onboarding/dcr_test.go
+++ b/apps/mcp-onboarding/dcr_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 )
 
 func newTestOAuthServer() *OAuthServer {
@@ -265,7 +266,7 @@ func TestHandleAuthorize_UnregisteredClientID_Rejected(t *testing.T) {
 func TestHandleAuthorize_RedirectURIMismatch(t *testing.T) {
 	server := newTestOAuthServer()
 
-	clientID := mintClientID(server.clientIDKey, clientIDInfo{RedirectURIs: []string{"http://127.0.0.1:33418"}})
+	clientID := mintClientID(server.clientIDKey, clientIDInfo{RedirectURIs: []string{"http://127.0.0.1:33418"}, IssuedAt: time.Now().Unix()})
 
 	req := httptest.NewRequest("GET", "/oauth/authorize?client_id="+url.QueryEscape(clientID)+"&redirect_uri=http://evil.com/callback&state=abc", nil)
 	w := httptest.NewRecorder()
@@ -280,7 +281,7 @@ func TestHandleAuthorize_RedirectURIMismatch(t *testing.T) {
 func TestHandleAuthorize_LoopbackDifferentPort(t *testing.T) {
 	server := newTestOAuthServer()
 
-	clientID := mintClientID(server.clientIDKey, clientIDInfo{RedirectURIs: []string{"http://127.0.0.1:33418/"}})
+	clientID := mintClientID(server.clientIDKey, clientIDInfo{RedirectURIs: []string{"http://127.0.0.1:33418/"}, IssuedAt: time.Now().Unix()})
 
 	req := httptest.NewRequest("GET", "/oauth/authorize?client_id="+url.QueryEscape(clientID)+"&redirect_uri=http://127.0.0.1:50049/&state=abc", nil)
 	w := httptest.NewRecorder()

--- a/apps/mcp-onboarding/dcr_test.go
+++ b/apps/mcp-onboarding/dcr_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 )
 
@@ -52,12 +53,13 @@ func TestHandleRegister_Success(t *testing.T) {
 		t.Fatalf("expected token_endpoint_auth_method 'none', got %q", resp.TokenEndpointAuthMethod)
 	}
 
-	reg, err := server.Store.GetClientRegistration(resp.ClientID)
+	// The registration is not stored anywhere; it travels inside the client_id.
+	info, err := verifyClientID(server.clientIDKey, resp.ClientID)
 	if err != nil {
-		t.Fatalf("client not stored: %v", err)
+		t.Fatalf("issued client_id does not verify: %v", err)
 	}
-	if reg.ClientName != "VS Code" {
-		t.Fatalf("stored client_name mismatch: %q", reg.ClientName)
+	if len(info.RedirectURIs) != 1 || info.RedirectURIs[0] != "http://127.0.0.1:33418" {
+		t.Fatalf("client_id carries the wrong redirect_uris: %v", info.RedirectURIs)
 	}
 }
 
@@ -263,12 +265,9 @@ func TestHandleAuthorize_UnregisteredClientID_Rejected(t *testing.T) {
 func TestHandleAuthorize_RedirectURIMismatch(t *testing.T) {
 	server := newTestOAuthServer()
 
-	server.Store.SaveClientRegistration(&ClientRegistration{
-		ClientID:     "test-client",
-		RedirectURIs: []string{"http://127.0.0.1:33418"},
-	})
+	clientID := mintClientID(server.clientIDKey, clientIDInfo{RedirectURIs: []string{"http://127.0.0.1:33418"}})
 
-	req := httptest.NewRequest("GET", "/oauth/authorize?client_id=test-client&redirect_uri=http://evil.com/callback&state=abc", nil)
+	req := httptest.NewRequest("GET", "/oauth/authorize?client_id="+url.QueryEscape(clientID)+"&redirect_uri=http://evil.com/callback&state=abc", nil)
 	w := httptest.NewRecorder()
 
 	server.handleAuthorize(w, req)
@@ -281,12 +280,9 @@ func TestHandleAuthorize_RedirectURIMismatch(t *testing.T) {
 func TestHandleAuthorize_LoopbackDifferentPort(t *testing.T) {
 	server := newTestOAuthServer()
 
-	server.Store.SaveClientRegistration(&ClientRegistration{
-		ClientID:     "cli-client",
-		RedirectURIs: []string{"http://127.0.0.1:33418/"},
-	})
+	clientID := mintClientID(server.clientIDKey, clientIDInfo{RedirectURIs: []string{"http://127.0.0.1:33418/"}})
 
-	req := httptest.NewRequest("GET", "/oauth/authorize?client_id=cli-client&redirect_uri=http://127.0.0.1:50049/&state=abc", nil)
+	req := httptest.NewRequest("GET", "/oauth/authorize?client_id="+url.QueryEscape(clientID)+"&redirect_uri=http://127.0.0.1:50049/&state=abc", nil)
 	w := httptest.NewRecorder()
 
 	server.handleAuthorize(w, req)

--- a/apps/mcp-onboarding/dcr_test.go
+++ b/apps/mcp-onboarding/dcr_test.go
@@ -281,7 +281,7 @@ func TestHandleAuthorize_RedirectURIMismatch(t *testing.T) {
 func TestHandleAuthorize_LoopbackDifferentPort(t *testing.T) {
 	server := newTestOAuthServer()
 
-	clientID := mintClientID(server.clientIDKey, clientIDInfo{RedirectURIs: []string{"http://127.0.0.1:33418/"}, IssuedAt: time.Now().Unix()})
+	clientID := mintClientID(server.clientIDKey, clientIDInfo{RedirectURIs: []string{"http://127.0.0.1:33418/"}, IssuedAt: time.Now().Unix(), Nonce: generateSecureToken(8)})
 
 	req := httptest.NewRequest("GET", "/oauth/authorize?client_id="+url.QueryEscape(clientID)+"&redirect_uri=http://127.0.0.1:50049/&state=abc", nil)
 	w := httptest.NewRecorder()

--- a/apps/mcp-onboarding/mcp.go
+++ b/apps/mcp-onboarding/mcp.go
@@ -527,6 +527,22 @@ func (h *MCPHandler) handleListTools(req *JSONRPCRequest) *JSONRPCResponse {
 //
 // Bounded as well as sanitised, because an unbounded field lets a caller push
 // real entries out of a fixed-size buffer.
+// logSafeAll is logSafe over a slice, for the registration fields a caller
+// supplies wholesale. Bounded in length as well as count, because an unbounded
+// slice pushes real entries out of a fixed-size buffer just as an unbounded
+// string does.
+func logSafeAll(vs []string) []string {
+	const maxLogged = 10
+	if len(vs) > maxLogged {
+		vs = vs[:maxLogged]
+	}
+	out := make([]string, len(vs))
+	for i, v := range vs {
+		out[i] = logSafe(v)
+	}
+	return out
+}
+
 func logSafe(v string) string {
 	const maxLogged = 128
 	// The newline and carriage return are replaced explicitly, before the general

--- a/apps/mcp-onboarding/metrics.go
+++ b/apps/mcp-onboarding/metrics.go
@@ -63,5 +63,4 @@ func updateTokenStoreGauges(store *TokenStore) {
 	defer store.mu.RUnlock()
 	tokenStoreSize.WithLabelValues("active_tokens").Set(float64(len(store.tokens)))
 	tokenStoreSize.WithLabelValues("refresh_tokens").Set(float64(len(store.refreshTokens)))
-	tokenStoreSize.WithLabelValues("client_registrations").Set(float64(len(store.clientRegistrations)))
 }

--- a/apps/mcp-onboarding/metrics_test.go
+++ b/apps/mcp-onboarding/metrics_test.go
@@ -16,11 +16,6 @@ func TestUpdateTokenStoreGauges(t *testing.T) {
 		refreshTokens: map[string]*RefreshTokenData{
 			"ref1": {UserLogin: "user1"},
 		},
-		clientRegistrations: map[string]*ClientRegistration{
-			"client1": {ClientID: "client1"},
-			"client2": {ClientID: "client2"},
-			"client3": {ClientID: "client3"},
-		},
 	}
 
 	tokenStoreSize.Reset()
@@ -34,11 +29,6 @@ func TestUpdateTokenStoreGauges(t *testing.T) {
 	refreshTokens := testutil.ToFloat64(tokenStoreSize.WithLabelValues("refresh_tokens"))
 	if refreshTokens != 1 {
 		t.Errorf("expected refresh_tokens=1, got %v", refreshTokens)
-	}
-
-	clientRegs := testutil.ToFloat64(tokenStoreSize.WithLabelValues("client_registrations"))
-	if clientRegs != 3 {
-		t.Errorf("expected client_registrations=3, got %v", clientRegs)
 	}
 }
 

--- a/apps/mcp-onboarding/oauth.go
+++ b/apps/mcp-onboarding/oauth.go
@@ -17,6 +17,21 @@ type OAuthServer struct {
 	GitHubClient        *GitHubClient
 	Store               *TokenStore
 	AllowedOrganization string
+	clientIDKey         []byte
+}
+
+// ClientRegistration is the RFC 7591 response to a Dynamic Client Registration
+// request. Nothing here is stored: ClientID carries the registration itself
+// (see clientid.go). No client_secret is issued, so client_secret and
+// client_secret_expires_at are both absent, per RFC 7591 section 3.2.1.
+type ClientRegistration struct {
+	ClientID                string   `json:"client_id"`
+	ClientIDIssuedAt        int64    `json:"client_id_issued_at,omitempty"`
+	ClientName              string   `json:"client_name,omitempty"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	GrantTypes              []string `json:"grant_types,omitempty"`
+	ResponseTypes           []string `json:"response_types,omitempty"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
 }
 
 type AuthorizationServerMetadata struct {
@@ -41,6 +56,7 @@ func NewOAuthServer(baseURL string, githubClient *GitHubClient, store *TokenStor
 		GitHubClient:        githubClient,
 		Store:               store,
 		AllowedOrganization: allowedOrganization,
+		clientIDKey:         deriveClientIDKey(githubClient.ClientSecret),
 	}
 }
 
@@ -106,11 +122,12 @@ func (s *OAuthServer) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	reg, err := s.Store.GetClientRegistration(clientID)
+	reg, err := verifyClientID(s.clientIDKey, clientID)
 	if err != nil {
-		// Unknown client_id — normally the in-memory store lost it on restart.
-		// Tell the client to re-register rather than trusting an unregistered
-		// client's redirect_uri (GHSA-7hwf-488h-59x8).
+		// The client_id is not one this server signed: forged, tampered with,
+		// or issued under a signing key that has since rotated. Either way its
+		// redirect_uri cannot be trusted (GHSA-7hwf-488h-59x8); tell the client
+		// to re-register.
 		slog.Warn("unknown client_id", "client_id", logSafe(clientID))
 		recordOAuthFlow("authorize", "invalid_client")
 		writeUnknownClient(w, r)
@@ -164,19 +181,19 @@ func (s *OAuthServer) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 // unknownClientPage is what a person sees when their browser lands on the
 // invalid_client error from /oauth/authorize.
 //
-// Client registrations live in memory and the app runs a single replica, so
-// every deploy drops every client_id. The editor extension then re-authorises
-// with the one it cached, gets rejected here, and sits blocked on its loopback
-// callback without ever reading the response body. The browser tab is the only
-// place a human is told what happened, so it has to say how to recover.
+// A signed client_id survives restarts, so this is now the rare case: a forged
+// or corrupted client_id, or one issued before the signing key rotated. The
+// editor extension sits blocked on its loopback callback without ever reading
+// the response body, so the browser tab is the only place a human is told what
+// happened and it has to say how to recover.
 const unknownClientPage = `<!DOCTYPE html>
 <html lang="en">
 <head><meta charset="utf-8"><title>Unknown client - sign in again</title></head>
 <body>
-<h1>This server no longer knows your editor's registration</h1>
-<p>Client registrations are kept in memory, so a deploy or a restart of this server clears
-them all. Your editor is still sending a <code>client_id</code> from before that, and the
-server cannot accept it (<code>invalid_client</code>).</p>
+<h1>This server does not recognise your editor's registration</h1>
+<p>Your editor is sending a <code>client_id</code> that this server did not issue, or issued
+before its signing key was rotated, so the server cannot accept it
+(<code>invalid_client</code>).</p>
 <h2>How to recover</h2>
 <p>Remove the cached MCP registration and tokens for this server in your editor, then sign in
 again. The editor registers itself anew and the sign-in goes through.</p>
@@ -485,16 +502,10 @@ func (s *OAuthServer) handleRegisterOptions(w http.ResponseWriter, _ *http.Reque
 func (s *OAuthServer) handleRegister(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w)
 
-	if s.Store.CountClientRegistrations() > 1000 {
-		slog.Warn("too many client registrations")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusTooManyRequests)
-		_ = json.NewEncoder(w).Encode(map[string]string{
-			"error":             "too_many_requests",
-			"error_description": "Too many client registrations",
-		})
-		return
-	}
+	// Registrations are not stored, so there is nothing to exhaust and no
+	// registration cap. The body is still bounded, and so is the number of
+	// redirect_uris below, because both end up inside the issued client_id.
+	r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
 
 	var req struct {
 		ClientName              string   `json:"client_name"`
@@ -520,6 +531,16 @@ func (s *OAuthServer) handleRegister(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]string{
 			"error":             "invalid_client_metadata",
 			"error_description": "redirect_uris is required and must not be empty",
+		})
+		return
+	}
+
+	if len(req.RedirectURIs) > 10 {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":             "invalid_client_metadata",
+			"error_description": "At most 10 redirect_uris are supported",
 		})
 		return
 	}
@@ -568,22 +589,26 @@ func (s *OAuthServer) handleRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	clientID := generateSecureToken(16)
+	issuedAt := time.Now().Unix()
+	clientID := mintClientID(s.clientIDKey, clientIDInfo{
+		RedirectURIs: req.RedirectURIs,
+		IssuedAt:     issuedAt,
+		Nonce:        generateSecureToken(8),
+	})
 
 	reg := &ClientRegistration{
 		ClientID:                clientID,
+		ClientIDIssuedAt:        issuedAt,
 		ClientName:              req.ClientName,
 		RedirectURIs:            req.RedirectURIs,
 		GrantTypes:              req.GrantTypes,
 		ResponseTypes:           req.ResponseTypes,
 		TokenEndpointAuthMethod: req.TokenEndpointAuthMethod,
-		CreatedAt:               time.Now(),
 	}
-	s.Store.SaveClientRegistration(reg)
 
 	slog.Info("client registered",
-		"client_id", clientID,
-		"client_name", req.ClientName,
+		"client_id", logSafe(clientID),
+		"client_name", logSafe(req.ClientName),
 		"redirect_uris", req.RedirectURIs,
 		"grant_types", req.GrantTypes,
 		"token_endpoint_auth_method", req.TokenEndpointAuthMethod,

--- a/apps/mcp-onboarding/oauth.go
+++ b/apps/mcp-onboarding/oauth.go
@@ -504,7 +504,9 @@ func (s *OAuthServer) handleRegister(w http.ResponseWriter, r *http.Request) {
 
 	// Registrations are not stored, so there is nothing to exhaust and no
 	// registration cap. The body is still bounded, and so is the number of
-	// redirect_uris below, because both end up inside the issued client_id.
+	// redirect_uris below — but neither bounds the length of a single
+	// redirect_uri, so the minted client_id is checked against maxClientIDLen
+	// before it is handed out.
 	r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
 
 	var req struct {
@@ -595,6 +597,20 @@ func (s *OAuthServer) handleRegister(w http.ResponseWriter, r *http.Request) {
 		IssuedAt:     issuedAt,
 		Nonce:        generateSecureToken(8),
 	})
+
+	// The caps above bound the request, not the length of one redirect_uri, so
+	// a single long URI can still produce a client_id that verifyClientID would
+	// refuse to decode. Reject the registration rather than issue one that can
+	// never authorise.
+	if len(clientID) > maxClientIDLen {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":             "invalid_client_metadata",
+			"error_description": "redirect_uris are too long to fit in a client_id",
+		})
+		return
+	}
 
 	reg := &ClientRegistration{
 		ClientID:                clientID,

--- a/apps/mcp-onboarding/oauth.go
+++ b/apps/mcp-onboarding/oauth.go
@@ -625,9 +625,12 @@ func (s *OAuthServer) handleRegister(w http.ResponseWriter, r *http.Request) {
 	slog.Info("client registered",
 		"client_id", logSafe(clientID),
 		"client_name", logSafe(req.ClientName),
-		"redirect_uris", req.RedirectURIs,
-		"grant_types", req.GrantTypes,
-		"token_endpoint_auth_method", req.TokenEndpointAuthMethod,
+		// Sanitised for consistency and for whoever loosens the validation
+		// above. Not reachable today: every one of these is validated before
+		// this line, so a control character cannot survive to be logged.
+		"redirect_uris", logSafeAll(req.RedirectURIs),
+		"grant_types", logSafeAll(req.GrantTypes),
+		"token_endpoint_auth_method", logSafe(req.TokenEndpointAuthMethod),
 	)
 	recordOAuthFlow("client_registration", "success")
 

--- a/apps/mcp-onboarding/oauth_security_test.go
+++ b/apps/mcp-onboarding/oauth_security_test.go
@@ -19,6 +19,15 @@ import (
 // token chain through the mux rather than calling handlers directly.
 func newChainTestServer(t *testing.T) (*http.ServeMux, *OAuthServer) {
 	t.Helper()
+	return newChainTestServerWithSecret(t, "test-secret")
+}
+
+// newChainTestServerWithSecret is newChainTestServer with control over the
+// GitHub client secret, which is what the client_id signing key is derived
+// from. Two servers built with the same secret behave like the same app
+// restarted; two built with different secrets like a key rotation.
+func newChainTestServerWithSecret(t *testing.T, githubClientSecret string) (*http.ServeMux, *OAuthServer) {
+	t.Helper()
 
 	github := newGitHubMock(t, map[string]http.HandlerFunc{
 		"POST /login/oauth/access_token": func(w http.ResponseWriter, _ *http.Request) {
@@ -38,7 +47,9 @@ func newChainTestServer(t *testing.T) (*http.ServeMux, *OAuthServer) {
 		},
 	})
 
-	oauth := NewOAuthServer("http://localhost:8080", newTestGitHubClient(github), NewTokenStore(), "navikt")
+	githubClient := newTestGitHubClient(github)
+	githubClient.ClientSecret = githubClientSecret
+	oauth := NewOAuthServer("http://localhost:8080", githubClient, NewTokenStore(), "navikt")
 	mux := http.NewServeMux()
 	oauth.RegisterRoutes(mux)
 	return mux, oauth

--- a/apps/mcp-onboarding/store.go
+++ b/apps/mcp-onboarding/store.go
@@ -9,7 +9,8 @@ import (
 var ErrNotFound = errors.New("not found")
 
 // TODO: If we need to scale beyond a single replica, replace in-memory maps with Redis
-// to share sessions, tokens, and client registrations across pods.
+// to share sessions and tokens across pods. Client registrations are not here:
+// the client_id carries its own signed registration (see clientid.go).
 
 type AuthSession struct {
 	ClientID            string
@@ -48,32 +49,20 @@ type RefreshTokenData struct {
 	CreatedAt          time.Time
 }
 
-type ClientRegistration struct {
-	ClientID                string    `json:"client_id"`
-	ClientName              string    `json:"client_name,omitempty"`
-	RedirectURIs            []string  `json:"redirect_uris"`
-	GrantTypes              []string  `json:"grant_types,omitempty"`
-	ResponseTypes           []string  `json:"response_types,omitempty"`
-	TokenEndpointAuthMethod string    `json:"token_endpoint_auth_method,omitempty"`
-	CreatedAt               time.Time `json:"-"`
-}
-
 type TokenStore struct {
-	authSessions        map[string]*AuthSession
-	authCodes           map[string]*AuthCode
-	tokens              map[string]*TokenData
-	refreshTokens       map[string]*RefreshTokenData
-	clientRegistrations map[string]*ClientRegistration
-	mu                  sync.RWMutex
+	authSessions  map[string]*AuthSession
+	authCodes     map[string]*AuthCode
+	tokens        map[string]*TokenData
+	refreshTokens map[string]*RefreshTokenData
+	mu            sync.RWMutex
 }
 
 func NewTokenStore() *TokenStore {
 	store := &TokenStore{
-		authSessions:        make(map[string]*AuthSession),
-		authCodes:           make(map[string]*AuthCode),
-		tokens:              make(map[string]*TokenData),
-		refreshTokens:       make(map[string]*RefreshTokenData),
-		clientRegistrations: make(map[string]*ClientRegistration),
+		authSessions:  make(map[string]*AuthSession),
+		authCodes:     make(map[string]*AuthCode),
+		tokens:        make(map[string]*TokenData),
+		refreshTokens: make(map[string]*RefreshTokenData),
 	}
 
 	go store.cleanupExpired()
@@ -172,28 +161,6 @@ func (s *TokenStore) DeleteRefreshToken(token string) {
 	delete(s.refreshTokens, token)
 }
 
-func (s *TokenStore) SaveClientRegistration(reg *ClientRegistration) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.clientRegistrations[reg.ClientID] = reg
-}
-
-func (s *TokenStore) GetClientRegistration(clientID string) (*ClientRegistration, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	reg, ok := s.clientRegistrations[clientID]
-	if !ok {
-		return nil, ErrNotFound
-	}
-	return reg, nil
-}
-
-func (s *TokenStore) CountClientRegistrations() int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return len(s.clientRegistrations)
-}
-
 func (s *TokenStore) cleanupExpired() {
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
@@ -224,12 +191,6 @@ func (s *TokenStore) cleanupExpired() {
 		for token, data := range s.refreshTokens {
 			if now.Sub(data.CreatedAt) > 30*24*time.Hour {
 				delete(s.refreshTokens, token)
-			}
-		}
-
-		for id, reg := range s.clientRegistrations {
-			if now.Sub(reg.CreatedAt) > 30*24*time.Hour {
-				delete(s.clientRegistrations, id)
 			}
 		}
 

--- a/apps/mcp-onboarding/store_test.go
+++ b/apps/mcp-onboarding/store_test.go
@@ -8,11 +8,10 @@ import (
 // newTestStore creates a store without starting the cleanup goroutine
 func newTestStore() *TokenStore {
 	return &TokenStore{
-		authSessions:        make(map[string]*AuthSession),
-		authCodes:           make(map[string]*AuthCode),
-		tokens:              make(map[string]*TokenData),
-		refreshTokens:       make(map[string]*RefreshTokenData),
-		clientRegistrations: make(map[string]*ClientRegistration),
+		authSessions:  make(map[string]*AuthSession),
+		authCodes:     make(map[string]*AuthCode),
+		tokens:        make(map[string]*TokenData),
+		refreshTokens: make(map[string]*RefreshTokenData),
 	}
 }
 
@@ -149,50 +148,5 @@ func TestTokenStore_RefreshToken(t *testing.T) {
 	_, err = store.GetRefreshToken("refresh123")
 	if err != ErrNotFound {
 		t.Errorf("expected ErrNotFound after delete, got %v", err)
-	}
-}
-
-func TestTokenStore_ClientRegistration(t *testing.T) {
-	store := newTestStore()
-
-	reg := &ClientRegistration{
-		ClientID:     "client-123",
-		ClientName:   "Test App",
-		RedirectURIs: []string{"http://localhost:33418"},
-		CreatedAt:    time.Now(),
-	}
-
-	store.SaveClientRegistration(reg)
-
-	got, err := store.GetClientRegistration("client-123")
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if got.ClientName != "Test App" {
-		t.Errorf("expected ClientName 'Test App', got %q", got.ClientName)
-	}
-}
-
-func TestTokenStore_ClientRegistration_NotFound(t *testing.T) {
-	store := newTestStore()
-
-	_, err := store.GetClientRegistration("nonexistent")
-	if err != ErrNotFound {
-		t.Errorf("expected ErrNotFound, got %v", err)
-	}
-}
-
-func TestTokenStore_CountClientRegistrations(t *testing.T) {
-	store := newTestStore()
-
-	if count := store.CountClientRegistrations(); count != 0 {
-		t.Errorf("expected 0 registrations, got %d", count)
-	}
-
-	store.SaveClientRegistration(&ClientRegistration{ClientID: "c1", CreatedAt: time.Now()})
-	store.SaveClientRegistration(&ClientRegistration{ClientID: "c2", CreatedAt: time.Now()})
-
-	if count := store.CountClientRegistrations(); count != 2 {
-		t.Errorf("expected 2 registrations, got %d", count)
 	}
 }


### PR DESCRIPTION
Bygger på #632 (merget som e613270c, som er basen for denne grenen).

## Problemet

Klientregistreringene lå i et map i prosessen (`store.go`), og appen kjører én replica. Hver deploy glemte hver klient. Det var den amnesien som fikk `9fbba2f5` til å godta ukjente `client_id`-er, og det ble [GHSA-7hwf-488h-59x8](https://github.com/navikt/copilot/security/advisories/GHSA-7hwf-488h-59x8): en angriper kunne sende sin egen `redirect_uri` med en uregistrert `client_id` og få autorisasjonskoden levert til seg.

#632 gjenoppretter streng avvisning, som er riktig. Men da strander hver deploy alle klienter til de registrerer seg på nytt.

## Hvorfor ikke persistering

Persistering ble vurdert og forkastet. Det samme lageret holder levende GitHub-tokens for ansatte; å legge det på disk gjør dem lesbare for alle med tilgang til namespacet og for plattformdrift. Det er strengt verre enn in-memory. Og det er bare registreringene som trenger å overleve — de inneholder ingen legitimasjon i det hele tatt.

Så: ingenting lagres. **`client_id`-en er registreringen.**

## Designet

`POST /register` serialiserer det `/oauth/authorize` faktisk må stole på — `redirect_uris`, et utstedelsestidspunkt og en nonce — som kompakt JSON, base64url-koder det og legger på en HMAC-SHA256-tagg:

```
eyJ1IjpbImh0dHA6Ly8xMjcuMC4wLjE6MzM0MTgiXSwidCI6MTc4ODQyNTMzMywibiI6IkRWRmFpYmFwR09BIn0.KuVZd9AHCnvBipfsnpdsa6370elC73Z1xxoWHTqWLBc
```

`handleAuthorize` verifiserer taggen og matcher forespurt `redirect_uri` mot nyttelasten. Å verifisere taggen beviser nøyaktig det samme som oppslaget i mapet beviste — at denne serveren utstedte registreringen — og fortsetter å bevise det etter en restart. En forfalsket eller endret `client_id` avvises som før.

**Nonce.** Uten den ville `client_id` vært en ren funksjon av registreringen, og to editorer som registrerer seg med samme loopback-port ville fått samme klientidentitet. `TestTokenEndpoint_CrossClientRedemption_Rejected` fra #632 fanget nettopp det under arbeidet, og en 8-byte nonce fikser det.

**Utløp.** `IssuedAt` i nyttelasten er ikke pynt: `verifyClientID` håndhever det samme 30-dagersvinduet som den slettede oppryddingssløyfen. Uten det var hver registrering udødelig — `/register` er uautentisert og godtar enhver `https`-`redirect_uri`, så hvem som helst kunne prege én `client_id` bundet til sin egen callback som var gyldig for alltid, uten annen tilbakekalling enn å rotere `GITHUB_CLIENT_SECRET`, som også strander alle ekte klienter. En manglende, null eller fremtidig `IssuedAt` avvises på samme måte. Svaret er `invalid_client`, altså den gjenopprettbare veien fra #632. `TestSignedClientID_Expired` pinner både avvisningen og at en `client_id` rett innenfor vinduet fortsatt autoriserer.

**Kanonisk `client_id`.** Taggen sammenlignes mot den re-kodede base64-strengen, ikke mot de dekodede bytene. En 32-byte tagg er 43 base64url-tegn med to slakke bits, og Go-dekoderen godtar dem, så tre alternative sluttegn verifiserte også. Ingenting utnyttbart i dag — `handleToken` sammenligner `client_id` som streng, så en malleert variant leses som en annen klient og feiler lukket — men `client_id` bør være en kanonisk identifikator før noe (metrikker, dedup, rate limiting) begynner å nøkle på den. `TestSignedClientID_NonCanonicalTag` pinner det.

**Rekkefølge.** Taggen sjekkes med `hmac.Equal` (konstant tid) *før* nyttelasten base64-dekodes eller JSON-parses. Ingen angriperkontrollert byte når en parser. Begge deler var påstander i en kommentar som ingen test holdt — en omskriving som parser først, eller som bytter `hmac.Equal` mot `==`, passerte hele suiten. Ingen av dem er observerbare utenfra, siden alle veier feiler lukket, så `TestVerifyClientID_ChecksTagFirst` pinner kilden i stedet.

### Nøkkelmateriale og rotasjon

`mcp-onboarding-secrets` (`.nais/app.yaml:46-47`) er montert som `envFrom`, og appen leser bare `GITHUB_CLIENT_ID` og `GITHUB_CLIENT_SECRET` fra miljøet — det er innholdet. Signeringsnøkkelen utledes fra `GITHUB_CLIENT_SECRET` med `crypto/hkdf` (stdlib i Go 1.24+) og en fast `info`-streng. Ingen ny hemmelighet å opprette, rullere eller glemme, og ingen endring i `.nais`.

Rotasjon av `GITHUB_CLIENT_SECRET` ugyldiggjør alle utestående `client_id`-er. Klientene får da `invalid_client` — det gjenopprettbare svaret #632 la inn, med JSON for maskiner og en side for nettlesere som sier hvordan man kommer videre — i stedet for å henge på loopback-callbacken. Det er den aksepterte kostnaden, og feilen er den riktige typen. `TestSignedClientID_DifferentKey` pinner det.

Uten hemmelighet satt (lokal utvikling) genereres en tilfeldig nøkkel per prosess, med en `slog.Warn`. Da dør `client_id`-ene med prosessen, akkurat som mapet gjorde.

### Størrelse

`client_id` går fra 22 til ~148 tegn med én loopback-`redirect_uri`. Sjekket:

- **Lageret**: `client_id` er ikke lenger en nøkkel noe sted. Den ligger i `AuthSession.ClientID` og `AuthCode.ClientID` som vanlige strenger, sammenlignet med `==`.
- **Metrikker**: `client_id` har aldri vært en label, og `client_registrations`-måleren er slettet.
- **Logging**: `logSafe` kutter ved 128 tegn, så en `client_id` vises avkortet med `…` i loggen. Det er kosmetisk — ingen leser den fra loggen for å slå den opp noe sted — og alternativet er å heve grensen for alle felt. Latt være.
- **Registreringstaket på 1000**: meningsløst når ingenting lagres. Slettet. I stedet bindes `/register`-bodyen med `http.MaxBytesReader` (64 KB) og `redirect_uris` til maks 10. De to binder forespørselen, ikke lengden på én `redirect_uri` — en 6000-tegns URI ga 201 med en 8128-tegns `client_id` som `/oauth/authorize` deretter alltid avviste. Derfor sjekkes den pregede `client_id`-en mot `maxClientIDLen` før den utstedes, så `/register` aldri leverer en registrering som ikke kan brukes.

### DCR-svaret (RFC 7591)

Fortsatt riktig form for en public client: ingen `client_secret`, og dermed heller ingen `client_secret_expires_at` (den er bare definert når en `client_secret` utstedes, §3.2.1). `client_id_issued_at` er lagt til siden vi har tidspunktet uansett, og `token_endpoint_auth_method: "none"` er uendret. `TestHandleRegister_PublicClientResponse` pinner alle fire.

## Hva som er slettet

- `clientRegistrations`-mapet, `SaveClientRegistration`, `GetClientRegistration`, `CountClientRegistrations`
- registreringsdelen av `cleanupExpired`; 30-dagers utløpet er ikke borte, det håndheves nå i `verifyClientID` (se under)
- taket på 1000 registreringer i `handleRegister`
- `client_registrations`-labelen på `token_store_size`
- `ClientRegistration.CreatedAt`; structen er flyttet til `oauth.go`, der den nå bare er DCR-svarformen
- de tre `store_test`-testene for registreringslageret

Netto −157/+93 linjer utenom den nye fila. Tokens ligger fortsatt bare i minnet, uendret.

## Testene feiler mot uendret kode

Kjørt mot `e613270c` (uendret kode + kun de nye testfilene):

```
--- FAIL: TestSignedClientID_SurvivesRestart (0.00s)
    clientid_test.go:35: authorize after restart: expected 302, got 400: {"error":"invalid_client",...}
--- FAIL: TestSignedClientID_ForgedTag (0.00s)
    clientid_test.go:61: control: genuine client_id should authorise, got 400: {"error":"invalid_client",...}
--- FAIL: TestSignedClientID_DifferentKey (0.00s)
    clientid_test.go:114: control: same key should authorise, got 400: {"error":"invalid_client",...}
--- FAIL: TestSignedClientID_Malformed (0.00s)
    --- FAIL: TestSignedClientID_Malformed/no_separator (0.00s)
        clientid_test.go:149: expected 400, got 302: <a href="https://github.com/login/oauth/authorize?...">Found</a>.
--- FAIL: TestHandleRegister_PublicClientResponse (0.00s)
    clientid_test.go:187: expected a numeric client_id_issued_at, got <nil>
--- FAIL: TestHandleRegister_TooManyRedirectURIs (0.00s)
    clientid_test.go:207: expected 400, got 201: {"client_id":"arwz1RG_UOdLz_rl_Hu6-g","redirect_uris":[... 11 stk ...]}
FAIL	github.com/navikt/copilot/mcp-onboarding	0.230s
```

Hver avvisningstest er paret med en positiv kontroll på samme server, slik at den ikke kan bestå bare fordi alt avvises — det er kontrollen som feiler over. `TestSignedClientID_TamperedPayload` (bytter signert `redirect_uri` mot `https://evil.example.com/callback` og beholder taggen) er den ene som består trivielt mot uendret kode, siden #632 allerede avviser alt ukjent; den er tatt med fordi den pinner selve GHSA-formen mot fremtidige endringer, og kontrollen i den feiler også mot uendret kode.

Dekket: gyldig `client_id` gjennom authorize, forfalsket tagg, endret nyttelast, annen nøkkel, avkortet/ugyldig `client_id` uten panikk (10 varianter), og hele kjeden authorize → callback → token for en ekte registrert klient etter restart.

De fire testene som kom til etter gjennomgangen, kjørt mot grenen med hver enkelt fiks fjernet:

```
=== utløp fjernet fra verifyClientID ===
--- FAIL: TestSignedClientID_Expired/older_than_the_window
    clientid_test.go:295: expected 400, got 302: <a href="https://github.com/login/oauth/authorize?...">Found</a>.
--- FAIL: TestSignedClientID_Expired/absent
--- FAIL: TestSignedClientID_Expired/negative
--- FAIL: TestSignedClientID_Expired/in_the_future

=== lengdesjekken fjernet fra /register ===
--- FAIL: TestHandleRegister_RedirectURITooLong
    clientid_test.go:333: expected 400, got 201 with a 8128-character client_id

=== tagg dekodet før sammenligning ===
--- FAIL: TestSignedClientID_NonCanonicalTag
    clientid_test.go:368: non-canonical tag "LUMn_bDbjBVciIyKSzruj5f6mzQ02BVL0AW2PzhxbIt": expected 400, got 302

=== JSON parset før taggsjekken ===
--- FAIL: TestVerifyClientID_ChecksTagFirst
    clientid_test.go:407: json.Unmarshal runs before the hmac.Equal tag check; an unauthenticated payload must not reach it

=== hmac.Equal byttet mot == ===
--- FAIL: TestVerifyClientID_ChecksTagFirst
    clientid_test.go:399: verifyClientID does not compare the tag with hmac.Equal; a plain string comparison is not constant time
```

Også disse er paret med en positiv kontroll på samme server: en fersk `client_id` og en rett innenfor 30-dagersvinduet autoriserer, en vanlig registrering svarer 201, og den ekte `client_id`-en autoriserer før de ikke-kanoniske variantene prøves.

`mise run check` grønn i `apps/mcp-onboarding` (fmt, vet, staticcheck, lint 0 issues, test, generate:check).

## Utenfor scope

Loopback-only-policyen for `redirect_uri` (#633) er neste PR. Refresh-token-grantet er ikke rørt. Ingen persistering er lagt til.

