### PR TITLE
fix(mcp-onboarding): refresh-tokenet må vise fram klienten det ble utstedt til

### DIFF
--- a/apps/mcp-onboarding/oauth.go
+++ b/apps/mcp-onboarding/oauth.go
@@ -411,6 +411,7 @@ func (s *OAuthServer) handleAuthorizationCodeGrant(w http.ResponseWriter, r *htt
 	})
 
 	s.Store.SaveRefreshToken(refreshToken, &RefreshTokenData{
+		ClientID:           authCode.ClientID,
 		GitHubRefreshToken: authCode.GitHubRefreshToken,
 		UserLogin:          authCode.UserLogin,
 		UserID:             authCode.UserID,
@@ -433,10 +434,32 @@ func (s *OAuthServer) handleAuthorizationCodeGrant(w http.ResponseWriter, r *htt
 // Body size is already limited by handleToken via http.MaxBytesReader.
 func (s *OAuthServer) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request) {
 	refreshToken := r.FormValue("refresh_token") //nolint:gosec // body limited in handleToken
+	clientID := r.FormValue("client_id")         //nolint:gosec // body limited in handleToken
 
 	rtData, err := s.Store.GetRefreshToken(refreshToken)
 	if err != nil {
 		s.writeTokenError(w, "invalid_grant", "Invalid refresh token")
+		return
+	}
+
+	// RFC 6749 §6 requires the authorization server to ensure a refresh token
+	// was issued to the client redeeming it. This is a public client
+	// (token_endpoint_auth_method "none"), so client_id is that check, the same
+	// one the authorization_code grant already makes. Without it a stolen
+	// refresh token mints access tokens for anyone holding it, for the full
+	// 30-day lifetime (GHSA-7hwf-488h-59x8).
+	//
+	// An empty rtData.ClientID means a token issued before the binding existed.
+	// It is rejected rather than grandfathered: the store is in-memory, so a
+	// restart drops every refresh token anyway, and trusting an unbound token
+	// is the hole itself.
+	if clientID == "" || clientID != rtData.ClientID {
+		slog.Warn("client_id missing or mismatched in refresh grant",
+			"user", rtData.UserLogin,
+			"bound", rtData.ClientID != "",
+		)
+		recordOAuthFlow("token_refresh", "invalid_client")
+		s.writeTokenError(w, "invalid_client", "client_id missing or does not match the refresh token")
 		return
 	}
 
@@ -462,6 +485,7 @@ func (s *OAuthServer) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Req
 
 	s.Store.DeleteRefreshToken(refreshToken)
 	s.Store.SaveRefreshToken(newRefreshToken, &RefreshTokenData{
+		ClientID:           rtData.ClientID,
 		GitHubRefreshToken: newGitHubToken.RefreshToken,
 		UserLogin:          rtData.UserLogin,
 		UserID:             rtData.UserID,

--- a/apps/mcp-onboarding/oauth_security_test.go
+++ b/apps/mcp-onboarding/oauth_security_test.go
@@ -467,3 +467,126 @@ func TestTokenEndpoint_CrossClientRedemption_Rejected(t *testing.T) {
 		t.Fatalf("a token was issued to the wrong client: %v", errResp)
 	}
 }
+
+// --- refresh_token grant is client-authenticated (GHSA-7hwf-488h-59x8) ---
+
+// issueRefreshToken runs the full chain and returns the refresh_token the
+// authorization_code grant handed out.
+func issueRefreshToken(t *testing.T, mux *http.ServeMux, clientID, redirectURI string) string {
+	t.Helper()
+	_, _, token := runChain(t, mux, clientID, redirectURI)
+	if token == nil || token.Code != http.StatusOK {
+		t.Fatalf("chain did not reach a token: %v", token)
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(token.Body).Decode(&resp); err != nil {
+		t.Fatalf("token: decode: %v", err)
+	}
+	rt, _ := resp["refresh_token"].(string)
+	if rt == "" {
+		t.Fatalf("token: expected a refresh_token, got %v", resp)
+	}
+	return rt
+}
+
+// refresh posts a refresh_token grant. An empty clientID omits the parameter.
+func refresh(mux *http.ServeMux, refreshToken, clientID string) *httptest.ResponseRecorder {
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refreshToken},
+	}
+	if clientID != "" {
+		form.Set("client_id", clientID)
+	}
+	req := httptest.NewRequest("POST", "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return do(mux, req)
+}
+
+// TestRefreshGrant_SameClient_Succeeds is the control for the three rejection
+// tests below: the refresh grant still works for the client it was issued to.
+func TestRefreshGrant_SameClient_Succeeds(t *testing.T) {
+	mux, _ := newChainTestServer(t)
+	redirectURI := "http://127.0.0.1:33418/callback"
+	clientID := registerClient(t, mux, redirectURI)
+
+	w := refresh(mux, issueRefreshToken(t, mux, clientID, redirectURI), clientID)
+	if w.Code != http.StatusOK {
+		t.Fatalf("refresh: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("refresh: decode: %v", err)
+	}
+	if resp["access_token"] == nil || resp["access_token"] == "" {
+		t.Fatalf("refresh: expected an access_token, got %v", resp)
+	}
+	if resp["refresh_token"] == nil || resp["refresh_token"] == "" {
+		t.Fatalf("refresh: expected a rotated refresh_token, got %v", resp)
+	}
+}
+
+// TestRefreshGrant_OtherClient_Rejected is the substantive one: a refresh token
+// stolen from client A must not be redeemable by client B. Without the binding
+// the refresh grant asks for no client at all, so anyone holding the token can
+// mint access tokens for 30 days (GHSA-7hwf-488h-59x8).
+func TestRefreshGrant_OtherClient_Rejected(t *testing.T) {
+	mux, _ := newChainTestServer(t)
+	victimRedirect := "http://127.0.0.1:33418/callback"
+	victimClient := registerClient(t, mux, victimRedirect)
+	attackerClient := registerClient(t, mux, "http://127.0.0.1:44444/callback")
+
+	rt := issueRefreshToken(t, mux, victimClient, victimRedirect)
+
+	w := refresh(mux, rt, attackerClient)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("refresh as other client: expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	var errResp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&errResp); err != nil {
+		t.Fatalf("refresh: decode: %v", err)
+	}
+	if errResp["error"] != "invalid_client" {
+		t.Fatalf("refresh: expected invalid_client, got %v", errResp)
+	}
+
+	// A rejected attempt must not burn the victim's token.
+	if w := refresh(mux, rt, victimClient); w.Code != http.StatusOK {
+		t.Fatalf("victim refresh after rejected attempt: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRefreshGrant_MissingClientID_Rejected(t *testing.T) {
+	mux, _ := newChainTestServer(t)
+	redirectURI := "http://127.0.0.1:33418/callback"
+	clientID := registerClient(t, mux, redirectURI)
+
+	w := refresh(mux, issueRefreshToken(t, mux, clientID, redirectURI), "")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("refresh without client_id: expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestRefreshGrant_UnboundToken_Rejected pins the transition decision: a
+// refresh token carrying no client_id is rejected rather than grandfathered.
+// Nothing is grandfathered in practice — the store is in-memory, so a restart
+// drops every refresh token along with every client registration — and an
+// unbound token accepted on trust is exactly the hole being closed.
+func TestRefreshGrant_UnboundToken_Rejected(t *testing.T) {
+	mux, oauth := newChainTestServer(t)
+	clientID := registerClient(t, mux, "http://127.0.0.1:33418/callback")
+
+	oauth.Store.SaveRefreshToken("legacy-unbound", &RefreshTokenData{
+		GitHubRefreshToken: "ghr_victim",
+		UserLogin:          "victim",
+		UserID:             42,
+		CreatedAt:          time.Now(),
+	})
+
+	for _, cid := range []string{"", clientID} {
+		w := refresh(mux, "legacy-unbound", cid)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("unbound refresh token with client_id=%q: expected 400, got %d: %s", cid, w.Code, w.Body.String())
+		}
+	}
+}

--- a/apps/mcp-onboarding/store.go
+++ b/apps/mcp-onboarding/store.go
@@ -43,6 +43,10 @@ type TokenData struct {
 }
 
 type RefreshTokenData struct {
+	// ClientID is the client the token was issued to. The refresh grant
+	// requires the caller to present it, so a stolen refresh token is not
+	// usable on its own (GHSA-7hwf-488h-59x8).
+	ClientID           string
 	GitHubRefreshToken string
 	UserLogin          string
 	UserID             int64


### PR DESCRIPTION
Følger opp GHSA-7hwf-488h-59x8. Punktet står i remediation-lista i rådgivningen og var ikke gjort.

## Problemet

`handleRefreshTokenGrant` krevde verken `client_id`, `redirect_uri` eller PKCE. Et refresh-token var dermed nok i seg selv: den som satt på det kunne veksle det inn i nye access-tokens i hele levetiden på 30 dager. Det er derfor persistensen i rådgivningen lever mye lenger enn access-tokenets ene time.

`authorization_code`-grantet krever allerede `client_id` og avviser en som ikke stemmer med koden (#632). Refresh-grantet gjorde ikke det.

## Endringen

- `RefreshTokenData` bærer `ClientID`, satt fra autorisasjonskoden når tokenet utstedes.
- Bindingen følger med når tokenet roteres.
- Grantet krever at kallet viser fram den samme `client_id`-en, ellers `invalid_client`.

Et avvist forsøk brenner ikke offerets token — det er dekket av en test.

### RFC

RFC 6749 §6 sier at serveren skal sikre at refresh-tokenet ble utstedt til klienten som veksler det inn. Dette er en public client (`token_endpoint_auth_method: "none"`), så `client_id` er den kontrollen. Rotasjon ved hver bruk var på plass fra før. Det er ikke noe mer å kreve for en public client.

### Tokens uten binding

Tokens utstedt før denne endringen har ingen `ClientID`. De avvises framfor å slippes gjennom i en overgangsperiode.

Det koster ingenting i praksis. Refresh-tokens ligger i minnet (`TokenStore.refreshTokens`) — også etter #634, som flyttet *klientregistreringene* ut i en signert `client_id`, men lot tokenlageret stå. En omstart tømmer dem, så etter deployet finnes det ikke noe token å skåne. Og å slippe gjennom et token uten binding ville vært akkurat hullet vi tetter. Valget er pinnet av `TestRefreshGrant_UnboundToken_Rejected`, som sjekker begge veier: uten `client_id` og med en gyldig `client_id`.

## Tester

Uten endringen, mot basen:

```
--- FAIL: TestRefreshGrant_OtherClient_Rejected
    refresh as other client: expected 400, got 200: {"access_token":"OWOrrUrM...","expires_in":3600,...}
--- FAIL: TestRefreshGrant_MissingClientID_Rejected
    refresh without client_id: expected 400, got 200: {"access_token":"SGSlGDVS...","expires_in":3600,...}
--- FAIL: TestRefreshGrant_UnboundToken_Rejected
    unbound refresh token with client_id="": expected 400, got 200: {"access_token":"mmGMbDla...","expires_in":3600,...}
```

`TestRefreshGrant_SameClient_Succeeds` er den positive kontrollen og passerer både før og etter, så suiten kan ikke bli grønn av å avvise alt.

`mise run check` er grønn i `apps/mcp-onboarding`.

## Basert på

`origin/main` etter at #634 ble merget (`fd010400`). Rebaset på den; #634 tok ikke i refresh-grantet, så rebasen gikk rent. #635 er fortsatt åpen.

De tre mindre opprydningene fra samme gjennomgang — vertsnavnet i README-ene, wildcard-CORS på `/.well-known/*` og `/register`, og den ubegrensede `path`-labelen — ligger i #637. Denne står alene fordi den endrer oppførselen til et grant og bør kunne rulles tilbake for seg.