### PR TITLE
fix(mcp-onboarding): riktig vertsnavn, ingen wildcard-CORS, avgrenset path-label

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,14 +143,14 @@ Registry-servere dukker automatisk opp i MCP-panelet i VS Code og JetBrains, ute
 curl -s https://mcp-registry.nav.no/v0.1/servers | jq
 
 # Legg til en server
-gh copilot mcp add --url https://mcp-onboarding.nav.no/mcp
+gh copilot mcp add --url https://mcp-onboarding.intern.nav.no/mcp
 ```
 
 ### MCP Onboarding
 
 MCP-server for å utforske Nav Copilot-tilpasninger, vurdere agent-readiness og generere AGENTS.md rett fra Copilot Chat.
 
-**URL:** [mcp-onboarding.nav.no](https://mcp-onboarding.nav.no)
+**URL:** [mcp-onboarding.intern.nav.no](https://mcp-onboarding.intern.nav.no)
 
 #### Installer
 

--- a/apps/mcp-onboarding/README.md
+++ b/apps/mcp-onboarding/README.md
@@ -149,8 +149,12 @@ Always run `mise run generate` after adding or modifying agent, instruction, pro
 
 Automatic deployment via GitHub Actions on merge to main and pull requests.
 
-- **Production**: `https://mcp-onboarding.nav.no`
+- **Production**: `https://mcp-onboarding.intern.nav.no`
 - **Development**: `https://mcp-onboarding.intern.dev.nav.no`
+
+Both ingresses are `intern` only — the server is reachable from the Nav network, not
+from the public internet. There is no public ingress; a `nav.no` hostname without
+`intern` does not resolve to this server.
 
 Deployed to Nais using the reusable `mise-build-deploy-nais` workflow.
 
@@ -166,6 +170,9 @@ Exposed via `GET /metrics` in Prometheus format.
 | `oauth_flows_total`             | Counter   | `stage`, `result`               | OAuth flow outcomes (authorize, callback, token)                                         |
 | `authenticated_users_total`     | Counter   | —                               | Total successful authentications                                                         |
 | `token_store_size`              | Gauge     | `type`                          | Current size of token stores (`active_tokens`, `refresh_tokens`) |
+
+`path` is bounded to the registered routes; any other path is recorded as `other`, so an
+unknown path cannot grow the number of series.
 
 A shared Grafana dashboard is available at [`dashboards/copilot-ecosystem.json`](../../dashboards/copilot-ecosystem.json).
 
@@ -234,7 +241,7 @@ When you start the CLI, it opens a browser for GitHub authentication — this is
     "mcpServers": {
       "mcp-onboarding": {
         "type": "http",
-        "url": "https://mcp-onboarding.nav.no/mcp"
+        "url": "https://mcp-onboarding.intern.nav.no/mcp"
       }
     }
   }
@@ -258,9 +265,16 @@ Not tested with this server — likely same third-party OAuth issues as JetBrain
 - Uses OAuth 2.1 with PKCE (Proof Key for Code Exchange)
 - Dynamic Client Registration for seamless MCP client onboarding
 - Redirect URIs must be loopback: `http://127.0.0.1`, `http://[::1]` or `http://localhost` (RFC 8252 section 7.3). Non-loopback redirect URIs are dropped from a registration rather than failing it (a client that sends a hosted `https` redirect alongside its loopback one keeps the one it actually redeems at); a registration with no loopback URI left is refused, and `/oauth/authorize` enforces the same policy again. `/register` is unauthenticated by design (RFC 7591, which is how MCP clients onboard), so being registered proves only that this server minted the `client_id` — an attacker gets one for a single POST. Requiring loopback takes the destination out of their reach instead: the authorization code lands on the developer's own machine. Every supported client (see Client Compatibility above) redeems the code from a native process, so nothing legitimate needs a hosted redirect
+- `/oauth/authorize` rejects an unverifiable `client_id` and any `redirect_uri` the client
+  did not register
 - Client registrations are not stored: the issued `client_id` is the registration, HMAC-SHA256 signed with a key derived from `GITHUB_CLIENT_SECRET`, so it survives a restart without any registration ever touching disk. Rotating `GITHUB_CLIENT_SECRET` invalidates every outstanding `client_id`; clients get `invalid_client` and re-register. Registrations expire 30 days after issue, enforced when the `client_id` is verified.
 - Validates GitHub organization membership before issuing tokens
-- Tokens expire after 1 hour (refresh tokens: 30 days)
+- Access tokens expire after 1 hour. Refresh tokens are rotated on every use and expire
+  after 30 days
+- The authorization code is bound to the client it was issued to, and `/oauth/token`
+  requires that `client_id`
+- No endpoint sends `Access-Control-Allow-Origin` — discovery, registration and token
+  exchange are done by the editor's own process, not by a web page
 - Tokens are stored in memory only, and are lost on restart by design (they are live GitHub credentials and must not be persisted)
 
 ## License

--- a/apps/mcp-onboarding/README.md
+++ b/apps/mcp-onboarding/README.md
@@ -273,8 +273,10 @@ Not tested with this server — likely same third-party OAuth issues as JetBrain
   after 30 days
 - The authorization code is bound to the client it was issued to, and `/oauth/token`
   requires that `client_id`
-- No endpoint sends `Access-Control-Allow-Origin` — discovery, registration and token
-  exchange are done by the editor's own process, not by a web page
+- The OAuth endpoints send no `Access-Control-Allow-Origin` — discovery, registration
+  and token exchange are done by the editor's own process, not by a web page. `GET /mcp`
+  still sends it for the SSE stream; that stream requires an `Authorization: Bearer`
+  header, which a browser `EventSource` cannot set, so no page can use it either way
 - Tokens are stored in memory only, and are lost on restart by design (they are live GitHub credentials and must not be persisted)
 
 ## License

--- a/apps/mcp-onboarding/dcr_test.go
+++ b/apps/mcp-onboarding/dcr_test.go
@@ -363,3 +363,64 @@ func TestIsRegisteredRedirectURI_LoopbackPortIgnored(t *testing.T) {
 		})
 	}
 }
+
+// --- CORS on discovery and registration (GHSA-7hwf-488h-59x8) ---
+
+// TestDiscoveryAndRegister_NoWildcardCORS covers the endpoints that still sent
+// Access-Control-Allow-Origin: * after /oauth/token stopped. Metadata discovery
+// and DCR are done by a native process in every supported client, so no origin
+// needs to be granted.
+func TestDiscoveryAndRegister_NoWildcardCORS(t *testing.T) {
+	mux, _ := newChainTestServer(t)
+
+	body, _ := json.Marshal(map[string]any{
+		"client_name":   "test client",
+		"redirect_uris": []string{"http://127.0.0.1:33418/callback"},
+	})
+
+	cases := []struct {
+		method, path string
+		body         []byte
+	}{
+		{"GET", "/.well-known/oauth-authorization-server", nil},
+		{"GET", "/.well-known/oauth-protected-resource", nil},
+		{"GET", "/.well-known/oauth-protected-resource/mcp", nil},
+		{"POST", "/register", body},
+		{"OPTIONS", "/register", nil},
+	}
+
+	for _, tc := range cases {
+		var r *http.Request
+		if tc.body != nil {
+			r = httptest.NewRequest(tc.method, tc.path, bytes.NewReader(tc.body))
+		} else {
+			r = httptest.NewRequest(tc.method, tc.path, nil)
+		}
+		r.Header.Set("Origin", "https://evil.example")
+		w := do(mux, r)
+		if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+			t.Errorf("%s %s: expected no Access-Control-Allow-Origin, got %q", tc.method, tc.path, got)
+		}
+	}
+}
+
+// TestDiscoveryAndRegister_StillWork is the control: dropping CORS must not
+// break the endpoints themselves.
+func TestDiscoveryAndRegister_StillWork(t *testing.T) {
+	mux, _ := newChainTestServer(t)
+
+	w := do(mux, httptest.NewRequest("GET", "/.well-known/oauth-authorization-server", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("metadata: expected 200, got %d", w.Code)
+	}
+	var meta AuthorizationServerMetadata
+	if err := json.NewDecoder(w.Body).Decode(&meta); err != nil {
+		t.Fatalf("metadata: decode: %v", err)
+	}
+	if meta.RegistrationEndpoint == "" {
+		t.Fatalf("metadata: expected a registration_endpoint, got %+v", meta)
+	}
+	if id := registerClient(t, mux, "http://127.0.0.1:33418/callback"); id == "" {
+		t.Fatal("register: expected a client_id")
+	}
+}

--- a/apps/mcp-onboarding/metrics.go
+++ b/apps/mcp-onboarding/metrics.go
@@ -41,7 +41,36 @@ var (
 	}, []string{"type"})
 )
 
+// knownPaths is the route table as registered on the mux (see RegisterRoutes
+// and main). Anything else is bucketed, because "/" is a catch-all: without
+// this, a caller requesting made-up paths adds a new series per path to
+// http_requests_total and http_request_duration_seconds for as long as the
+// process lives. The known routes keep their own label so the shared Grafana
+// dashboard, which groups by path, is unaffected.
+var knownPaths = map[string]bool{
+	"/":                true,
+	"/mcp":             true,
+	"/register":        true,
+	"/oauth/authorize": true,
+	"/oauth/callback":  true,
+	"/oauth/token":     true,
+	"/health":          true,
+	"/ready":           true,
+	"/metrics":         true,
+	"/.well-known/oauth-authorization-server":   true,
+	"/.well-known/oauth-protected-resource":     true,
+	"/.well-known/oauth-protected-resource/mcp": true,
+}
+
+func normalizePath(path string) string {
+	if knownPaths[path] {
+		return path
+	}
+	return "other"
+}
+
 func recordHTTPMetrics(method, path string, statusCode int, duration time.Duration) {
+	path = normalizePath(path)
 	httpRequestsTotal.WithLabelValues(method, path, strconv.Itoa(statusCode)).Inc()
 	httpRequestDuration.WithLabelValues(method, path).Observe(duration.Seconds())
 }

--- a/apps/mcp-onboarding/metrics_test.go
+++ b/apps/mcp-onboarding/metrics_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -70,5 +71,42 @@ func TestRecordOAuthFlow(t *testing.T) {
 	callbackDenied := testutil.ToFloat64(oauthFlowsTotal.WithLabelValues("callback", "org_denied"))
 	if callbackDenied != 1 {
 		t.Errorf("expected 1 callback/org_denied, got %v", callbackDenied)
+	}
+}
+
+// TestRecordHTTPMetrics_PathLabelIsBounded covers the unbounded label: the
+// request path went straight into http_requests_total{path=...}, so anyone
+// hitting the catch-all "/" route with made-up paths could grow the series
+// count without limit. Known routes must survive (the shared dashboard groups
+// by path); everything else collapses to one bucket.
+func TestRecordHTTPMetrics_PathLabelIsBounded(t *testing.T) {
+	httpRequestsTotal.Reset()
+
+	known := []string{
+		"/",
+		"/mcp",
+		"/register",
+		"/oauth/authorize",
+		"/oauth/callback",
+		"/oauth/token",
+		"/.well-known/oauth-authorization-server",
+		"/.well-known/oauth-protected-resource",
+		"/.well-known/oauth-protected-resource/mcp",
+	}
+	for _, p := range known {
+		recordHTTPMetrics("GET", p, 200, time.Millisecond)
+		if got := testutil.ToFloat64(httpRequestsTotal.WithLabelValues("GET", p, "200")); got != 1 {
+			t.Errorf("known route %q: expected it to keep its own label, got %v", p, got)
+		}
+	}
+
+	for _, p := range []string{"/wp-admin", "/../etc/passwd", "/random/" + strings.Repeat("x", 64), "/MCP"} {
+		recordHTTPMetrics("GET", p, 404, time.Millisecond)
+		if got := testutil.ToFloat64(httpRequestsTotal.WithLabelValues("GET", p, "404")); got != 0 {
+			t.Errorf("unknown path %q: expected no series of its own, got %v", p, got)
+		}
+	}
+	if got := testutil.ToFloat64(httpRequestsTotal.WithLabelValues("GET", "other", "404")); got != 4 {
+		t.Errorf("expected 4 unknown paths bucketed as \"other\", got %v", got)
 	}
 }

--- a/apps/mcp-onboarding/oauth.go
+++ b/apps/mcp-onboarding/oauth.go
@@ -86,7 +86,6 @@ func (s *OAuthServer) handleAuthServerMetadata(w http.ResponseWriter, _ *http.Re
 		TokenEndpointAuthMethodsSupported: []string{"none"},
 	}
 
-	s.setCORSHeaders(w)
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(metadata)
 }
@@ -97,7 +96,6 @@ func (s *OAuthServer) handleProtectedResourceMetadata(w http.ResponseWriter, _ *
 		AuthorizationServers: []string{s.BaseURL},
 	}
 
-	s.setCORSHeaders(w)
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(metadata)
 }
@@ -529,20 +527,17 @@ func (s *OAuthServer) writeTokenError(w http.ResponseWriter, code, description s
 	})
 }
 
-func (s *OAuthServer) setCORSHeaders(w http.ResponseWriter) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, Accept")
-}
-
+// handleRegisterOptions answers the CORS preflight without granting any origin,
+// for the same reason /oauth/token does: metadata discovery and Dynamic Client
+// Registration happen in the editor's own process, never in a web page, in
+// every client this server supports. A wildcard grant here let any page in the
+// victim's browser register a client and read the metadata it needs to drive a
+// flow (GHSA-7hwf-488h-59x8).
 func (s *OAuthServer) handleRegisterOptions(w http.ResponseWriter, _ *http.Request) {
-	s.setCORSHeaders(w)
 	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *OAuthServer) handleRegister(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w)
-
 	// Registrations are not stored, so there is nothing to exhaust and no
 	// registration cap. The body is still bounded, and so is the number of
 	// redirect_uris below — but neither bounds the length of a single

--- a/apps/mcp-onboarding/readme_test.go
+++ b/apps/mcp-onboarding/readme_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestDocs_NoUnreachableProductionHostname pins the deployed hostname. The
+// service has only ever had an intern.nav.no ingress (see .nais/prod-gcp.yaml);
+// the public mcp-onboarding.nav.no 404s. Documenting the public host is what
+// led GHSA-7hwf-488h-59x8 to overstate how reachable this server is, so the
+// wrong name should not come back.
+func TestDocs_NoUnreachableProductionHostname(t *testing.T) {
+	for _, path := range []string{"README.md", "../../README.md"} {
+		b, err := os.ReadFile(path) //nolint:gosec // both paths are literals above
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		body := string(b)
+		// The bad host is the public one; the good hosts contain it as a
+		// substring only after ".intern" / ".intern.dev", so strip those first.
+		for _, deployed := range []string{"mcp-onboarding.intern.nav.no", "mcp-onboarding.intern.dev.nav.no"} {
+			body = strings.ReplaceAll(body, deployed, "")
+		}
+		if strings.Contains(body, "mcp-onboarding.nav.no") {
+			t.Errorf("%s: refers to mcp-onboarding.nav.no, which is not deployed; use mcp-onboarding.intern.nav.no", path)
+		}
+		if !strings.Contains(string(b), "mcp-onboarding.intern.nav.no") {
+			t.Errorf("%s: expected the deployed hostname mcp-onboarding.intern.nav.no to appear", path)
+		}
+	}
+}


### PR DESCRIPTION
Tre små opprydninger som kom fram i gjennomgangen etter GHSA-7hwf-488h-59x8. Den substansielle oppfølgingen — klientbinding av refresh-tokenet — ligger i #636.

## 1. Vertsnavnet

README-ene reklamerte for `https://mcp-onboarding.nav.no`. Tjenesten har bare intern-ingresser (`.nais/prod-gcp.yaml`), så det vertsnavnet svarer 404. Det var den feilen som fikk rådgivningen til å overdrive hvor eksponert serveren er, så den er verdt å ta ordentlig.

Alle fire forekomstene er rettet — to i rot-README-en (`gh copilot mcp add`-eksempelet og URL-lenken), to i app-README-en (deploy-avsnittet og `mcp.json`-eksempelet). `mcp-registry.nav.no` er sjekket og er *riktig*: den tjenesten har faktisk en offentlig ingress, noe som er en del av forklaringen på forvekslingen.

Sikkerhetsavsnittet er samtidig sjekket mot koden. Levetidene stemmer (access-token 1 time, refresh-token 30 dager med rotasjon ved hver bruk, registrering 30 dager). Punktet om klientregistrering er beholdt slik #634 skrev det, og punktene om klientbinding, CORS og tokenlagring er skrevet om til det koden faktisk gjør i dag.

## 2. Wildcard-CORS på `/.well-known/*` og `/register`

`/oauth/token` sluttet å sende `Access-Control-Allow-Origin: *`. Disse to gjorde det fortsatt.

Ingen legitim klient trenger det. Metadata-oppslag og Dynamic Client Registration gjøres av editorens egen prosess i alle klientene serveren støtter — VS Code, JetBrains, Eclipse, Xcode, Copilot CLI — ikke fra en nettside. Wildcard-en er fjernet, og `setCORSHeaders` med den. Preflighten på `/register` svarer fortsatt 204, uten å gi noen origin, akkurat som `/oauth/token` gjør.

## 3. Ubegrenset metrikk-label

`main.go:188` matet rå `r.URL.Path` inn i `http_requests_total{path=...}`. Siden `"/"` er en catch-all route kunne hvem som helst legge til en tidsserie per oppdiktet sti, per metrikk, så lenge prosessen levde.

Path-en avgrenses nå til rutetabellen; alt annet havner i `other`.

Sjekket før endring: `dashboards/copilot-ecosystem.json:1675` gjør `sum by (path) (rate(http_requests_total{app="mcp-onboarding"}))`. De kjente rutene beholder sin egen label, så panelet er upåvirket — det eneste som endrer seg er at søppelstier samles i én serie i stedet for å bli mange. Ingen alerts i repoet bruker metrikken.

## Tester

Uten endringene, mot basen:

```
--- FAIL: TestDiscoveryAndRegister_NoWildcardCORS
    GET /.well-known/oauth-authorization-server: expected no Access-Control-Allow-Origin, got "*"
    GET /.well-known/oauth-protected-resource: expected no Access-Control-Allow-Origin, got "*"
    GET /.well-known/oauth-protected-resource/mcp: expected no Access-Control-Allow-Origin, got "*"
    POST /register: expected no Access-Control-Allow-Origin, got "*"
    OPTIONS /register: expected no Access-Control-Allow-Origin, got "*"

--- FAIL: TestRecordHTTPMetrics_PathLabelIsBounded
    unknown path "/wp-admin": expected no series of its own, got 1
    unknown path "/../etc/passwd": expected no series of its own, got 1
    unknown path "/random/xxxxxxxx...": expected no series of its own, got 1
    unknown path "/MCP": expected no series of its own, got 1
    expected 4 unknown paths bucketed as "other", got 0

--- FAIL: TestDocs_NoUnreachableProductionHostname
    README.md: refers to mcp-onboarding.nav.no, which is not deployed
    ../../README.md: refers to mcp-onboarding.nav.no, which is not deployed
```

Positive kontroller ved siden av avvisningene:

- `TestDiscoveryAndRegister_StillWork` — metadata svarer fortsatt 200 med `registration_endpoint`, og DCR utsteder fortsatt en `client_id`. Passerer før og etter.
- Samme test som feiler på path-labelen sjekker først at alle ni kjente rutene beholder sin egen label. Den kan ikke bli grønn av å putte alt i `other`.
- `TestDocs_...` krever også at det *riktige* vertsnavnet finnes i begge filene, ikke bare at det gale mangler.

`mise run check` er grønn i `apps/mcp-onboarding`.

## Basert på

`origin/main` etter at #634 ble merget (`fd010400`). Rebaset på den; konflikten i `handleRegister` og i sikkerhetsavsnittet er løst til fordel for #634 sin tekst, med CORS-kallet fjernet.