### PR TITLE
fix(kom-i-gang): npm-installasjon av Copilot CLI feiler i WSL2

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ Kernel-level sandbox for AI-agenter. Sandboxer AI-kodingsagenter med OS-primitiv
 brew install navikt/tap/cplt
 ```
 
+**Windows (WSL2):** kjør alt inne i Ubuntu, ikke i PowerShell, og bruk installasjonsskriptene i stedet for brew:
+
+```bash
+curl -fsSL https://gh.io/copilot-install | bash                                   # Copilot CLI
+curl -fsSL https://raw.githubusercontent.com/navikt/cplt/main/install.sh | bash   # cplt
+export PATH="$HOME/.local/bin:$PATH"   # skriptene installerer hit
+which -a copilot cplt   # ingen treff skal starte med /mnt/c
+```
+
+WSL2 arver Windows-PATH. Mangler et verktøy i Ubuntu, plukker terminalen Windows-varianten i stedet, og den kjører via interop som en Windows-prosess — den installerer til Windows-siden og ser ikke Linux-filsystemet slik du forventer. Vanligste fella: `apt install nodejs` gir `node` i Ubuntu, men ikke `npm`, så `npm install -g` havner i Windows-prefixet og henter win32-pakken. Symptomet er `no platform package found` fra `copilot --version`. Jobb også fra Linux-filsystemet (`~/git/...`), ikke `/mnt/c/...` — 9p-I/O er tregt.
+
 ### My Copilot
 
 Selvbetjeningsportalen. Administrer Copilot-abonnement, se bruksstatistikk og utforsk tilpasninger fra verktøykatalogen. Har også offentlige sider for [cplt](https://min-copilot.ansatt.nav.no/cplt), [nav-pilot](https://min-copilot.ansatt.nav.no/nav-pilot) og [kom i gang](https://min-copilot.ansatt.nav.no/kom-i-gang).

--- a/apps/my-copilot/src/app/cplt/page.tsx
+++ b/apps/my-copilot/src/app/cplt/page.tsx
@@ -284,7 +284,11 @@ function HeroSection({ stars }: { stars: number | null }) {
               <CopyButton copyText={INSTALL_SCRIPT} size="xsmall" style={{ color: "white" }} />
             </div>
             <p style={{ color: "#a7f3d0", fontSize: "0.8125rem", margin: 0 }}>
-              macOS (Apple Seatbelt) · Linux (Landlock + seccomp-BPF)
+              macOS (Apple Seatbelt) · Linux (Landlock + seccomp-BPF) · Windows via WSL2
+            </p>
+            <p style={{ color: "rgba(255,255,255,0.45)", fontSize: "0.75rem", margin: 0, textAlign: "center" }}>
+              På WSL2: bruk skriptet, og kjør det inne i Ubuntu. Verktøy installert på Windows kjører som
+              Windows-prosesser via interop, utenfor sandkassen.
             </p>
           </div>
         </VStack>

--- a/apps/my-copilot/src/app/praksis/sections/tools-and-modes.tsx
+++ b/apps/my-copilot/src/app/praksis/sections/tools-and-modes.tsx
@@ -185,7 +185,7 @@ export default function ToolsAndModes() {
             <BodyShort className="text-gray-500 text-xs">
               Installer: <code className="bg-gray-100 px-1 rounded">brew install copilot-cli</code>{" "}
               <code className="bg-gray-100 px-1 rounded">winget install GitHub.Copilot</code>{" "}
-              <code className="bg-gray-100 px-1 rounded">npm install -g @github/copilot</code>
+              <code className="bg-gray-100 px-1 rounded">curl -fsSL https://gh.io/copilot-install | bash</code>
             </BodyShort>
           </div>
         </Box>

--- a/apps/my-copilot/src/components/nav-pilot/interactive-setup-wizard.test.tsx
+++ b/apps/my-copilot/src/components/nav-pilot/interactive-setup-wizard.test.tsx
@@ -16,8 +16,10 @@ describe("generateSetupScript", () => {
     it("generates correct CLI script", () => {
       const result = generateSetupScript(os, "cli", "kotlin-backend");
       expect(result.code).toContain("brew install navikt/tap/nav-pilot navikt/tap/cplt");
-      expect(result.code).toContain("npm install -g @github/copilot");
+      expect(result.code).toContain("curl -fsSL https://gh.io/copilot-install | bash");
+      expect(result.code).not.toContain("npm install");
       expect(result.code).toContain("nav-pilot install kotlin-backend");
+      expect(result.code).not.toContain("which -a");
       expect(result.code).not.toContain("opencode");
     });
 
@@ -38,11 +40,13 @@ describe("generateSetupScript", () => {
 
     it("generates correct CLI script with curl", () => {
       const result = generateSetupScript(os, "cli", "kotlin-backend");
-      expect(result.code).toContain("npm install -g @github/copilot");
+      expect(result.code).toContain("curl -fsSL https://gh.io/copilot-install | bash");
+      expect(result.code).not.toContain("npm install");
       expect(result.code).toContain(
         "curl -fsSL https://raw.githubusercontent.com/navikt/copilot/main/scripts/install.sh | bash"
       );
       expect(result.code).toContain("nav-pilot install kotlin-backend");
+      expect(result.code).not.toContain("which -a");
     });
 
     it("generates correct OpenCode script with curl", () => {
@@ -63,7 +67,9 @@ describe("generateSetupScript", () => {
     it("generates WSL instructions for CLI", () => {
       const result = generateSetupScript(os, "cli", "kotlin-backend");
       expect(result.code).toContain("WSL2-terminalen");
-      expect(result.code).toContain("npm install -g @github/copilot");
+      expect(result.code).toContain("curl -fsSL https://gh.io/copilot-install | bash");
+      expect(result.code).not.toContain("npm install");
+      expect(result.code).toContain("which -a copilot cplt nav-pilot");
       expect(result.code).toContain(
         "curl -fsSL https://raw.githubusercontent.com/navikt/copilot/main/scripts/install.sh | bash"
       );
@@ -76,6 +82,7 @@ describe("generateSetupScript", () => {
       expect(result.code).toContain("curl -fsSL https://opencode.ai/install | bash");
       expect(result.code).toContain("nav-pilot config set client opencode");
       expect(result.code).toContain("nav-pilot install kotlin-backend");
+      expect(result.code).toContain("which -a opencode cplt nav-pilot");
       expect(result.code).not.toContain("npm install");
     });
   });

--- a/apps/my-copilot/src/components/nav-pilot/interactive-setup-wizard.test.tsx
+++ b/apps/my-copilot/src/components/nav-pilot/interactive-setup-wizard.test.tsx
@@ -19,6 +19,7 @@ describe("generateSetupScript", () => {
       expect(result.code).toContain("curl -fsSL https://gh.io/copilot-install | bash");
       expect(result.code).not.toContain("npm install");
       expect(result.code).toContain("nav-pilot install kotlin-backend");
+      expect(result.code).toContain('export PATH="$HOME/.local/bin:$PATH"');
       expect(result.code).not.toContain("which -a");
       expect(result.code).not.toContain("opencode");
     });
@@ -30,6 +31,7 @@ describe("generateSetupScript", () => {
       expect(result.code).toContain("nav-pilot config set client opencode");
       expect(result.code).toContain("nav-pilot --client opencode");
       expect(result.code).toContain("nav-pilot install kotlin-backend");
+      expect(result.code).toContain('export PATH="$HOME/.local/bin:$PATH"');
       expect(result.code).not.toContain("@github/copilot");
       expect(result.code).not.toContain("npm install");
     });
@@ -46,6 +48,7 @@ describe("generateSetupScript", () => {
         "curl -fsSL https://raw.githubusercontent.com/navikt/copilot/main/scripts/install.sh | bash"
       );
       expect(result.code).toContain("nav-pilot install kotlin-backend");
+      expect(result.code).toContain('export PATH="$HOME/.local/bin:$PATH"');
       expect(result.code).not.toContain("which -a");
     });
 
@@ -58,6 +61,7 @@ describe("generateSetupScript", () => {
       );
       expect(result.code).toContain("nav-pilot config set client opencode");
       expect(result.code).toContain("nav-pilot install kotlin-backend");
+      expect(result.code).toContain('export PATH="$HOME/.local/bin:$PATH"');
     });
   });
 
@@ -74,6 +78,7 @@ describe("generateSetupScript", () => {
         "curl -fsSL https://raw.githubusercontent.com/navikt/copilot/main/scripts/install.sh | bash"
       );
       expect(result.code).toContain("nav-pilot install kotlin-backend");
+      expect(result.code).toContain('export PATH="$HOME/.local/bin:$PATH"');
     });
 
     it("generates WSL instructions for OpenCode", () => {
@@ -82,6 +87,7 @@ describe("generateSetupScript", () => {
       expect(result.code).toContain("curl -fsSL https://opencode.ai/install | bash");
       expect(result.code).toContain("nav-pilot config set client opencode");
       expect(result.code).toContain("nav-pilot install kotlin-backend");
+      expect(result.code).toContain('export PATH="$HOME/.local/bin:$PATH"');
       expect(result.code).toContain("which -a opencode cplt nav-pilot");
       expect(result.code).not.toContain("npm install");
     });

--- a/apps/my-copilot/src/components/nav-pilot/interactive-setup-wizard.tsx
+++ b/apps/my-copilot/src/components/nav-pilot/interactive-setup-wizard.tsx
@@ -52,10 +52,12 @@ export function generateSetupScript(os: OS, workflow: Workflow, stack: Collectio
 
   const blocks: SetupCommandBlock[] = [];
 
-  if (os === "windows") {
+  const isWindows = os === "windows";
+
+  if (isWindows) {
     blocks.push({
       title:
-        "# Nav-pilot (agent og context) fungerer best i WSL (Linux).\n# Åpne WSL2-terminalen din og kjør følgende:",
+        "# Nav-pilot (agent og context) fungerer best i WSL (Linux).\n# Åpne WSL2-terminalen din og kjør følgende.\n# Alt skal installeres inne i Linux — verktøy du har på Windows installerer og kjører på Windows-siden.",
       commands: [],
     });
   }
@@ -63,7 +65,13 @@ export function generateSetupScript(os: OS, workflow: Workflow, stack: Collectio
   const isMac = os === "mac";
 
   if (workflow === "cli") {
-    blocks.push({ title: "# 1. Installer Copilot CLI (NPM)", commands: ["npm install -g @github/copilot"] });
+    blocks.push({
+      title: "# 1. Installer Copilot CLI",
+      commands: [
+        "curl -fsSL https://gh.io/copilot-install | bash",
+        'export PATH="$HOME/.local/bin:$PATH"   # skriptet installerer hit',
+      ],
+    });
   } else if (workflow === "opencode") {
     blocks.push({ title: "# 1. Installer OpenCode", commands: ["curl -fsSL https://opencode.ai/install | bash"] });
   }
@@ -84,6 +92,14 @@ export function generateSetupScript(os: OS, workflow: Workflow, stack: Collectio
     title: "# 3. Sett opp for ditt prosjekt",
     commands: [`nav-pilot install ${stack} --repo`, ...WORKFLOW_COMMANDS[workflow]],
   });
+
+  if (isWindows) {
+    const agentBinary = workflow === "opencode" ? "opencode" : "copilot";
+    blocks.push({
+      title: "# 4. Sjekk at ingen verktøy kommer fra Windows-siden",
+      commands: [`which -a ${agentBinary} cplt nav-pilot   # ingen treff skal starte med /mnt/c`],
+    });
+  }
 
   const codeString = blocks.map((b) => [b.title, ...b.commands].filter(Boolean).join("\n")).join("\n\n");
 

--- a/apps/my-copilot/src/components/nav-pilot/interactive-setup-wizard.tsx
+++ b/apps/my-copilot/src/components/nav-pilot/interactive-setup-wizard.tsx
@@ -67,10 +67,7 @@ export function generateSetupScript(os: OS, workflow: Workflow, stack: Collectio
   if (workflow === "cli") {
     blocks.push({
       title: "# 1. Installer Copilot CLI",
-      commands: [
-        "curl -fsSL https://gh.io/copilot-install | bash",
-        'export PATH="$HOME/.local/bin:$PATH"   # skriptet installerer hit',
-      ],
+      commands: ["curl -fsSL https://gh.io/copilot-install | bash"],
     });
   } else if (workflow === "opencode") {
     blocks.push({ title: "# 1. Installer OpenCode", commands: ["curl -fsSL https://opencode.ai/install | bash"] });
@@ -87,6 +84,11 @@ export function generateSetupScript(os: OS, workflow: Workflow, stack: Collectio
       commands: ["curl -fsSL https://raw.githubusercontent.com/navikt/copilot/main/scripts/install.sh | bash"],
     });
   }
+
+  blocks.push({
+    title: "# 2b. Gjør de nyinstallerte verktøyene tilgjengelige i dette skallet",
+    commands: ['export PATH="$HOME/.local/bin:$PATH"   # installasjonsskriptene legger binærene hit'],
+  });
 
   blocks.push({
     title: "# 3. Sett opp for ditt prosjekt",


### PR DESCRIPTION
En Windows-bruker brukte over en time på å få Copilot CLI til å kjøre i WSL2, med kommandoen vår egen oppsettsveiviser ga ham.

## Rotårsak

WSL2 legger Windows-PATH bakerst i Linux-PATH. Det går bra så lenge Linux-varianten av et verktøy finnes — den vinner alltid. `apt install nodejs` gir `/usr/bin/node`, men Ubuntu-pakken bunter ikke `npm`. Da løses `npm` til Windows-installasjonen, `npm root -g` gir `C:\Users\...\AppData\Roaming\npm\node_modules`, og `npm install -g @github/copilot` henter win32-x64-plattformpakken:

```
$ copilot --version
GitHub Copilot CLI: no platform package found. Reinstall with `npm install -g @github/copilot` to fetch the package for your platform.
```

Feilmeldingen er teknisk korrekt og peker på en reinstallasjon som gir nøyaktig samme resultat. Delvis skygging er det farlige tilfellet: mangler Linux-varianten for ett enkelt verktøy, hentes akkurat det stille fra Windows.

## Endringer

- Oppsettsveiviseren bruker `curl -fsSL https://gh.io/copilot-install | bash` i stedet for `npm install -g @github/copilot`. Skriptet laster ned en standalone Linux-binær til `~/.local/bin` — ingen npm, ingen node-versjonskrav, ingen `sudo`, ingen global prefix å rote til. Recepten setter `PATH` eksplisitt, siden `~/.local/bin` først plukkes opp ved neste innlogging.
- Windows-grenen har fått et steg 4 som verifiserer at ingen verktøy løses til `/mnt/c`, og bruker riktig agent-binær avhengig av valgt arbeidsflyt.
- README har fått en kort WSL2-seksjon under cplt-installasjonen, og cplt-siden nevner WSL2 i plattformlinjen. Ingen av dem hadde Windows-innhold fra før.
- `praksis`-siden listet fortsatt npm som installasjonsvei, og er oppdatert til samme skript.

## Vurdert og forkastet

`interop.appendWindowsPath=false` fikser symptomet, men dreper `code .`, `explorer.exe` og VS Code sin WSL-integrasjon. `sudo npm install -g` virker, men gjenskaper prefix-fella ved neste verktøy.

## Videre arbeid

- #642 — robust WSL2-preflight som sjekker distro, arbeidskatalog, PATH-oppløsning og byggverktøy før brukeren står fast.
- navikt/cplt#271 — `cplt doctor` printet `✓ Copilot (copilot): /mnt/c/Users/.../npm/copilot` og avsluttet med `All critical checks passed ✓`. Den hadde beviset, men graderte det som grønt.

## Testing

`vitest` på `src/components/nav-pilot` (12 passed), `tsc --noEmit`, `eslint` og `prettier --check` på endrede filer. Testene pinner nå også at verifiseringssteget bare finnes i Windows-grenen.