### PR TITLE
fix(pricing): synken oppdaterer datoen i modellvalg.md også

### DIFF
--- a/apps/my-copilot/src/app/priser/page.test.tsx
+++ b/apps/my-copilot/src/app/priser/page.test.tsx
@@ -15,6 +15,7 @@ describe("kampanjemerket på prissiden", () => {
       "Kampanjepris t.o.m. 3. september 2026",
       "Kampanjepris t.o.m. 31. desember 2026",
       "Kampanjepris t.o.m. 31. desember 2026",
+      "Kampanjepris t.o.m. 31. desember 2026",
     ]);
 
     expect(badges[0].closest("td")).toHaveAccessibleName(

--- a/apps/my-copilot/src/lib/model-pricing.test.ts
+++ b/apps/my-copilot/src/lib/model-pricing.test.ts
@@ -10,6 +10,7 @@ describe("promotionEndsOn", () => {
       "GPT-5.6 Sol (Long context, 272K)",
       "Gemini 3.6 Flash (Default)",
       "Gemini 3.7 Flash (Default)",
+      "Gemini 3.8 Flash (Default)",
     ]);
   });
 

--- a/apps/my-copilot/src/lib/model-pricing.ts
+++ b/apps/my-copilot/src/lib/model-pricing.ts
@@ -1,7 +1,7 @@
 /**
  * GitHub Copilot model pricing data.
  * Source: https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
- * Last updated: 2026-08-31
+ * Last updated: 2026-09-03
  *
  * All prices are per 1 million tokens in USD.
  * 1 AI credit = $0.01 USD.
@@ -282,6 +282,16 @@ export const MODEL_PRICING: ModelPrice[] = [
     cacheWrite: 12.5,
     output: 50,
   },
+  {
+    model: "Claude Fable 5.1",
+    provider: "Anthropic",
+    category: "Powerful",
+    status: "GA",
+    input: 10,
+    cachedInput: 0.25,
+    cacheWrite: 12.5,
+    output: 50,
+  },
   // Google
   {
     model: "Gemini 3.1 Pro (Default, ≤ 200K)",
@@ -319,7 +329,7 @@ export const MODEL_PRICING: ModelPrice[] = [
     cachedInput: 0.075,
     output: 3.75,
     promotionEndsOn: "2026-12-31",
-    note: "Gemini 3.6 Flash and Gemini 3.7 Flash are available at the promotional pricing of $0.75 per 1M input tokens, $0.075 per 1M cached input tokens, and $3.75 per 1M output tokens through December 31, 2026.",
+    note: "Gemini 3.6 Flash, Gemini 3.7 Flash, and Gemini 3.8 Flash are available at the promotional pricing of $0.75 per 1M input tokens, $0.075 per 1M cached input tokens, and $3.75 per 1M output tokens through December 31, 2026.",
   },
   {
     model: "Gemini 3.7 Flash (Default)",
@@ -330,7 +340,18 @@ export const MODEL_PRICING: ModelPrice[] = [
     cachedInput: 0.075,
     output: 3.75,
     promotionEndsOn: "2026-12-31",
-    note: "Gemini 3.6 Flash and Gemini 3.7 Flash are available at the promotional pricing of $0.75 per 1M input tokens, $0.075 per 1M cached input tokens, and $3.75 per 1M output tokens through December 31, 2026.",
+    note: "Gemini 3.6 Flash, Gemini 3.7 Flash, and Gemini 3.8 Flash are available at the promotional pricing of $0.75 per 1M input tokens, $0.075 per 1M cached input tokens, and $3.75 per 1M output tokens through December 31, 2026.",
+  },
+  {
+    model: "Gemini 3.8 Flash (Default)",
+    provider: "Google",
+    category: "Versatile",
+    status: "GA",
+    input: 0.75,
+    cachedInput: 0.075,
+    output: 3.75,
+    promotionEndsOn: "2026-12-31",
+    note: "Gemini 3.6 Flash, Gemini 3.7 Flash, and Gemini 3.8 Flash are available at the promotional pricing of $0.75 per 1M input tokens, $0.075 per 1M cached input tokens, and $3.75 per 1M output tokens through December 31, 2026.",
   },
   // GitHub
   {
@@ -383,4 +404,4 @@ export const MODEL_PRICING: ModelPrice[] = [
 ];
 
 export const PRICING_SOURCE_URL = "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing";
-export const PRICING_LAST_UPDATED = "2026-08-31";
+export const PRICING_LAST_UPDATED = "2026-09-03";

--- a/docs/modellvalg.md
+++ b/docs/modellvalg.md
@@ -83,7 +83,7 @@ anslag, ikke noe vi har målt**, og forholdet varierer med oppgaven.
 ## Tilgjengelige modeller og bruksområder
 
 Hele modellflåten, ikke bare de som er pinnet i agenter. Prisene under er
-GitHubs listepriser slik de sto **30. august 2026**, og speiler
+GitHubs listepriser slik de sto **3. september 2026**, og speiler
 `apps/my-copilot/src/lib/model-pricing.ts`. De endrer seg uten varsel, så
 tallene her har et tidsstempel og ikke evig gyldighet.
 

--- a/scripts/sync-model-pricing.mjs
+++ b/scripts/sync-model-pricing.mjs
@@ -20,6 +20,30 @@ const TARGET_FILE = new URL(
   "../apps/my-copilot/src/lib/model-pricing.ts",
   import.meta.url,
 );
+const DOC_FILE = new URL("../docs/modellvalg.md", import.meta.url);
+
+// The one sentence in docs/modellvalg.md that timestamps the price table.
+// Anchored on its wording so the editorial dates elsewhere in the file stay put.
+const DOC_DATE_RE = /(GitHubs listepriser slik de sto \*\*)([^*]+)(\*\*)/;
+
+const NB_MONTHS = [
+  "januar", "februar", "mars", "april", "mai", "juni",
+  "juli", "august", "september", "oktober", "november", "desember",
+];
+
+/** 2026-09-03 -> "3. september 2026". */
+function toNorwegianDate(iso) {
+  const [y, m, d] = iso.split("-").map(Number);
+  return `${d}. ${NB_MONTHS[m - 1]} ${y}`;
+}
+
+/** Rewrite the pricing date in that sentence. Throws if the sentence moved. */
+function setDocPricingDate(text, iso) {
+  if (!DOC_DATE_RE.test(text)) {
+    throw new Error(`the pricing-date sentence is gone from ${DOC_FILE.pathname}`);
+  }
+  return text.replace(DOC_DATE_RE, `$1${toNorwegianDate(iso)}$3`);
+}
 
 import { readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -400,7 +424,27 @@ async function main() {
 
   const newContent = generateTypeScript(models);
 
+  const docPath = fileURLToPath(DOC_FILE);
+  const doc = readFileSync(docPath, "utf-8");
+
   if (checkOnly) {
+    // The doc restates PRICING_LAST_UPDATED in Norwegian prose; nothing else
+    // keeps the two in step, so a drift here is the same kind of staleness.
+    const pricingDate = current.match(/PRICING_LAST_UPDATED = "([^"]+)"/)?.[1];
+    if (!pricingDate) {
+      console.error("\nERROR: no PRICING_LAST_UPDATED in the generated file.");
+      process.exit(1);
+    }
+    if (setDocPricingDate(doc, pricingDate) !== doc) {
+      console.error(`\nERROR: ${docPath} is out of date!`);
+      console.error(
+        `  says "${doc.match(DOC_DATE_RE)[2]}", PRICING_LAST_UPDATED is ${pricingDate} ` +
+          `("${toNorwegianDate(pricingDate)}")`,
+      );
+      console.error("Run: node scripts/sync-model-pricing.mjs");
+      process.exit(2);
+    }
+
     // Compare ignoring the date line (last-updated changes daily)
     const normalize = (s) =>
       s
@@ -420,10 +464,21 @@ async function main() {
   } else {
     writeFileSync(targetPath, newContent, "utf-8");
     console.log(`\n✓ Updated ${targetPath}`);
+    const today = new Date().toISOString().split("T")[0];
+    writeFileSync(docPath, setDocPricingDate(doc, today), "utf-8");
+    console.log(`✓ Updated ${docPath}`);
   }
 }
 
-export { parsePricingTables, parseFootnotes, parsePromotionEndDate, findFootnoteId, findUnresolvedPromotions };
+export {
+  parsePricingTables,
+  parseFootnotes,
+  parsePromotionEndDate,
+  findFootnoteId,
+  findUnresolvedPromotions,
+  setDocPricingDate,
+  toNorwegianDate,
+};
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch((err) => {

--- a/scripts/sync-model-pricing.test.mjs
+++ b/scripts/sync-model-pricing.test.mjs
@@ -16,6 +16,7 @@ import {
   parseFootnotes,
   parsePromotionEndDate,
   findUnresolvedPromotions,
+  setDocPricingDate,
 } from "./sync-model-pricing.mjs";
 
 // The fixtures carry two provider tables, not all six, and the parser warns
@@ -128,4 +129,23 @@ test("date parsing handles the shapes the page uses", () => {
   assert.equal(parsePromotionEndDate("... through December 31, 2026."), "2026-12-31");
   assert.equal(parsePromotionEndDate("... through Smarch 3, 2026."), undefined);
   assert.equal(parsePromotionEndDate("no end date at all"), undefined);
+});
+
+test("the doc's pricing date is rewritten, and the editorial dates are not", () => {
+  const doc = [
+    "GitHubs listepriser slik de sto **30. august 2026**, og speiler",
+    "`apps/my-copilot/src/lib/model-pricing.ts`.",
+    "Per 31. august 2026 gjelder det:",
+    "- **GPT-5.6 Sol:** 50 % av standardpris t.o.m. 3. september 2026.",
+    "## Målinger (august 2026)",
+  ].join("\n");
+
+  const out = setDocPricingDate(doc, "2026-09-03");
+
+  assert.match(out, /slik de sto \*\*3\. september 2026\*\*/);
+  assert.equal(out.split("\n").slice(1).join("\n"), doc.split("\n").slice(1).join("\n"));
+});
+
+test("a doc without the sentence is an error, not a silent no-op", () => {
+  assert.throws(() => setDocPricingDate("ingen priser her", "2026-09-03"));
 });


### PR DESCRIPTION
Erstatter #595.

`scripts/sync-model-pricing.mjs` skriver om to datoer i `model-pricing.ts`, men `docs/modellvalg.md` bærer sin egen dato i prosa: «GitHubs listepriser slik de sto **30. august 2026**». Ingenting oppdaterte den. Hver prissynk lot altså dokumentet påstå en dato som motsa `PRICING_LAST_UPDATED`, og Copilot-gjennomgangen blokkerte bot-PR-en på nettopp det.

## Hva som er gjort

Synken skriver nå om setningen i dokumentet også, med norsk datoform. Regexen er forankret på selve setningen, ikke på datoer generelt.

`pricing:check` sammenligner de to og feiler når de spriker. Kontroll: dokumentdatoen ble satt til «12. januar 2020», og porten feilet med

```
ERROR: docs/modellvalg.md is out of date!
  says "12. januar 2020", PRICING_LAST_UPDATED is 2026-09-03 ("3. september 2026")
```

Den navngir fila og begge datoene. Porten kan altså feile, og ble satt tilbake etterpå.

To testtilfeller i `scripts/sync-model-pricing.test.mjs`: setningen skrives om mens de redaksjonelle datoene står urørt, og et dokument uten setningen gir feil i stedet for en stille no-op.

## Redaksjonelle datoer er ikke rørt

Kampanjedatoene lenger nede i dokumentet er innhold, ikke synkartefakter. `git diff -U0 docs/modellvalg.md` viser nøyaktig to linjer, én `-` og én `+`. «Per 31. august 2026», «t.o.m. 3. september 2026», «mot kilden 4. september» og overskriftene «(august 2026)» er byte-identiske.

## Prisdataene følger med

`mise run pricing:sync` er kjørt, så denne PR-en bærer også dataene #595 hadde: dato `2026-08-31` til `2026-09-03`, nye modeller Claude Fable 5.1 og Gemini 3.8 Flash, og fotnoten om Gemini Flash-kampanjen navngir nå 3.8. #595 kan lukkes.

## Ikke gjort

Konklusjonene i `docs/modellvalg.md` er ikke utledet på nytt mot de nye prisene. Gjennomgangen av #595 ba også om det, og det er bevisst holdt utenfor: denne PR-en retter propageringsfeilen, ikke innholdet. Verdt en egen vurdering, særlig siden #503 sier at kampanjeprisen på GPT-5.6 Sol reverterer i dag.

Prisdataene selv er hentet fra GitHubs dokumentasjonsside av synken, og er ikke kontrollert mot en annen kilde.