### PR TITLE
fix(nav-pilot): erklæringa godtar hook som artefakttype (#649)

### DIFF
--- a/cli/nav-pilot/internal/agentpakke/declaration.go
+++ b/cli/nav-pilot/internal/agentpakke/declaration.go
@@ -42,7 +42,7 @@ var ErrNoDeclaration = errors.New("no agentpakke declaration")
 // DeclaredItemTypes are the artifact types an entry in [Declaration.Items] may
 // name. It mirrors the CLI's artifact kinds; the list lives here because the
 // declaration is parsed before any resolver exists.
-var DeclaredItemTypes = []string{"agent", "skill", "instruction", "prompt"}
+var DeclaredItemTypes = []string{"agent", "skill", "instruction", "prompt", "hook"}
 
 // Declaration is a repo's committed statement of which agentpakke it uses and
 // at which revision.

--- a/cli/nav-pilot/internal/agentpakke/declaration_kinds_test.go
+++ b/cli/nav-pilot/internal/agentpakke/declaration_kinds_test.go
@@ -1,0 +1,44 @@
+package agentpakke_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
+	"github.com/navikt/copilot/cli/nav-pilot/internal/source"
+)
+
+// DeclaredItemTypes speiler CLI-ens artefakttyper, men lista står for seg selv
+// fordi erklæringa leses før noen resolver finnes. #647 la til en femte type
+// uten å røre den, og et repo som installerte en pakke med hooks kom ikke forbi
+// sin egen erklæring (#649).
+//
+// Testen henter typene fra source.AllKinds i stedet for å skrive dem opp på
+// nytt. En liste skrevet to steder er nettopp det som glir fra hverandre, og en
+// test som gjentar den arver feilen den skal fange. Den ligger i
+// agentpakke_test fordi source importerer agentpakke.
+func TestEveryArtifactKindIsDeclarable(t *testing.T) {
+	for _, kind := range source.AllKinds {
+		root := t.TempDir()
+		dir := filepath.Join(root, ".nav-pilot")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body, err := json.Marshal(map[string]any{
+			"contractVersion": "1",
+			"source":          "navikt/grillmester",
+			"items":           map[string]string{"noe": kind.Name},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "agentpakke.lock.json"), body, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := agentpakke.LoadDeclaration(root); err != nil {
+			t.Errorf("artefakttypen %q kan ikke stå i en erklæring: %v", kind.Name, err)
+		}
+	}
+}

--- a/cli/nav-pilot/internal/agentpakke/declaration_test.go
+++ b/cli/nav-pilot/internal/agentpakke/declaration_test.go
@@ -119,20 +119,3 @@ func TestWriteDeclarationIsDeterministicAndTimestampFree(t *testing.T) {
 		t.Errorf("round-trip = %+v, want %+v", back, d)
 	}
 }
-
-// #647 ga CLI-en en femte artefakttype og lot install skrive hook-oppføringer
-// inn i erklæringa, men denne lista ble ikke oppdatert. Da skrev install en fil
-// lasteren avviste, og repoet kom ikke forbi den. Kommentaren over lista sier at
-// den speiler CLI-ens typer; testen holder den til det.
-func TestDeclaredItemTypesAcceptsEveryKind(t *testing.T) {
-	for _, typ := range []string{"agent", "skill", "instruction", "prompt", "hook"} {
-		d := &Declaration{
-			ContractVersion: "1",
-			Source:          "navikt/grillmester",
-			Items:           map[string]string{"noe": typ},
-		}
-		if err := d.validate(); err != nil {
-			t.Errorf("type %q avvises: %v", typ, err)
-		}
-	}
-}

--- a/cli/nav-pilot/internal/agentpakke/declaration_test.go
+++ b/cli/nav-pilot/internal/agentpakke/declaration_test.go
@@ -119,3 +119,20 @@ func TestWriteDeclarationIsDeterministicAndTimestampFree(t *testing.T) {
 		t.Errorf("round-trip = %+v, want %+v", back, d)
 	}
 }
+
+// #647 ga CLI-en en femte artefakttype og lot install skrive hook-oppføringer
+// inn i erklæringa, men denne lista ble ikke oppdatert. Da skrev install en fil
+// lasteren avviste, og repoet kom ikke forbi den. Kommentaren over lista sier at
+// den speiler CLI-ens typer; testen holder den til det.
+func TestDeclaredItemTypesAcceptsEveryKind(t *testing.T) {
+	for _, typ := range []string{"agent", "skill", "instruction", "prompt", "hook"} {
+		d := &Declaration{
+			ContractVersion: "1",
+			Source:          "navikt/grillmester",
+			Items:           map[string]string{"noe": typ},
+		}
+		if err := d.validate(); err != nil {
+			t.Errorf("type %q avvises: %v", typ, err)
+		}
+	}
+}


### PR DESCRIPTION
Lukker #649. Regresjon fra #647, som landet i dag.

`cli/nav-pilot/internal/cli/declaration.go:129` skriver hook-oppføringer inn i erklæringa. `DeclaredItemTypes` i `internal/agentpakke/declaration.go:45` kjente bare de fire gamle typene, så fila ble skrevet uten innsigelse og avvist ved neste lesing:

```
item "ask-first-aria" has type "hook"; valid types are agent, skill, instruction, prompt
```

Skrivesida validerer ikke, så feilen kom først når noen leste fila. Et repo som installerte en pakke med hooks kom dermed ikke forbi sin egen erklæring. Det er nøyaktig klassen #614 beskriver, og denne gangen laget verktøyet den selv.

Reprodusert mot `main` (`3d0fe5ce`) før rettelsen.

## Hvorfor det slapp gjennom

Testene i `internal/agentpakke` bygger erklæringer for hånd med de fire gamle typene, så ingen test lagde en erklæring fra et manifest med hooks. De to listene kunne gli fra hverandre i stillhet.

Den nye testen går gjennom alle fem typene. Kontrollert: fjernes `hook` fra lista igjen, feiler den med akkurat meldingen over.

`mise run nav-pilot:check` er grønn.