### PR TITLE
fix(pricing): kampanjeprisen på GPT-5.6 Sol gikk ut i går

### DIFF
--- a/apps/my-copilot/src/app/priser/page.test.tsx
+++ b/apps/my-copilot/src/app/priser/page.test.tsx
@@ -11,15 +11,13 @@ describe("kampanjemerket på prissiden", () => {
 
     const badges = screen.getAllByText(/^Kampanjepris t\.o\.m\. /);
     expect(badges.map((b) => b.textContent)).toEqual([
-      "Kampanjepris t.o.m. 3. september 2026",
-      "Kampanjepris t.o.m. 3. september 2026",
       "Kampanjepris t.o.m. 31. desember 2026",
       "Kampanjepris t.o.m. 31. desember 2026",
       "Kampanjepris t.o.m. 31. desember 2026",
     ]);
 
     expect(badges[0].closest("td")).toHaveAccessibleName(
-      "GPT-5.6 Sol (Default, ≤ 272K) Kampanjepris t.o.m. 3. september 2026"
+      "Gemini 3.6 Flash (Default) Kampanjepris t.o.m. 31. desember 2026"
     );
   });
 
@@ -51,8 +49,8 @@ describe("cache write-kolonnen", () => {
 
     // Kolonnen var gated på `provider === "Anthropic"`, så disse tallene falt ut
     // av sida selv om de lå i generert data. Sol-fotnoten oppga dem på hover.
-    expect(within(radFor("GPT-5.6 Sol (Default, ≤ 272K)")).getByText("$2.50")).toBeInTheDocument();
-    expect(within(radFor("GPT-5.6 Sol (Long context, 272K)")).getByText("$5.00")).toBeInTheDocument();
+    expect(within(radFor("GPT-5.6 Sol (Default, ≤ 272K)")).getByText("$5.00")).toBeInTheDocument();
+    expect(within(radFor("GPT-5.6 Sol (Long context, 272K)")).getByText("$10.00")).toBeInTheDocument();
   });
 
   it("gir rader uten cache write en tankestrek, ikke en tom celle", () => {

--- a/apps/my-copilot/src/lib/model-pricing.test.ts
+++ b/apps/my-copilot/src/lib/model-pricing.test.ts
@@ -6,8 +6,6 @@ describe("promotionEndsOn", () => {
   it("merker nøyaktig radene med kampanjefotnote hos GitHub", () => {
     const promoted = MODEL_PRICING.filter((m) => m.promotionEndsOn).map((m) => m.model);
     expect(promoted).toEqual([
-      "GPT-5.6 Sol (Default, ≤ 272K)",
-      "GPT-5.6 Sol (Long context, 272K)",
       "Gemini 3.6 Flash (Default)",
       "Gemini 3.7 Flash (Default)",
       "Gemini 3.8 Flash (Default)",
@@ -15,7 +13,7 @@ describe("promotionEndsOn", () => {
   });
 
   it("gir sluttdatoen, som er hele poenget med merket", () => {
-    expect(MODEL_PRICING.find((m) => m.model === "GPT-5.6 Sol (Default, ≤ 272K)")?.promotionEndsOn).toBe("2026-09-03");
+    expect(MODEL_PRICING.find((m) => m.model === "Gemini 3.6 Flash (Default)")?.promotionEndsOn).toBe("2026-12-31");
   });
 
   it("lar modeller uten fotnote være", () => {

--- a/apps/my-copilot/src/lib/model-pricing.ts
+++ b/apps/my-copilot/src/lib/model-pricing.ts
@@ -1,7 +1,7 @@
 /**
  * GitHub Copilot model pricing data.
  * Source: https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
- * Last updated: 2026-09-03
+ * Last updated: 2026-09-04
  *
  * All prices are per 1 million tokens in USD.
  * 1 AI credit = $0.01 USD.
@@ -122,24 +122,20 @@ export const MODEL_PRICING: ModelPrice[] = [
     provider: "OpenAI",
     category: "Powerful",
     status: "GA",
-    input: 2,
-    cachedInput: 0.2,
-    cacheWrite: 2.5,
-    output: 10,
-    promotionEndsOn: "2026-09-03",
-    note: "GPT-5.6 Sol is available at promotional pricing, 50% off standard rates, through September 3, 2026. The default tier is $2.00 per 1M input tokens, $0.20 per 1M cached input tokens, $2.50 per 1M cache write tokens, and $10.00 per 1M output tokens. The long context tier is $4.00 per 1M input tokens, $0.40 per 1M cached input tokens, $5.00 per 1M cache write tokens, and $15.00 per 1M output tokens.",
+    input: 4,
+    cachedInput: 0.4,
+    cacheWrite: 5,
+    output: 20,
   },
   {
     model: "GPT-5.6 Sol (Long context, 272K)",
     provider: "OpenAI",
     category: "Powerful",
     status: "GA",
-    input: 4,
-    cachedInput: 0.4,
-    cacheWrite: 5,
-    output: 15,
-    promotionEndsOn: "2026-09-03",
-    note: "GPT-5.6 Sol is available at promotional pricing, 50% off standard rates, through September 3, 2026. The default tier is $2.00 per 1M input tokens, $0.20 per 1M cached input tokens, $2.50 per 1M cache write tokens, and $10.00 per 1M output tokens. The long context tier is $4.00 per 1M input tokens, $0.40 per 1M cached input tokens, $5.00 per 1M cache write tokens, and $15.00 per 1M output tokens.",
+    input: 8,
+    cachedInput: 0.8,
+    cacheWrite: 10,
+    output: 30,
   },
   {
     model: "GPT-5.6 Terra (Default, ≤ 272K)",
@@ -404,4 +400,4 @@ export const MODEL_PRICING: ModelPrice[] = [
 ];
 
 export const PRICING_SOURCE_URL = "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing";
-export const PRICING_LAST_UPDATED = "2026-09-03";
+export const PRICING_LAST_UPDATED = "2026-09-04";

--- a/docs/modellvalg.md
+++ b/docs/modellvalg.md
@@ -83,7 +83,7 @@ anslag, ikke noe vi har målt**, og forholdet varierer med oppgaven.
 ## Tilgjengelige modeller og bruksområder
 
 Hele modellflåten, ikke bare de som er pinnet i agenter. Prisene under er
-GitHubs listepriser slik de sto **3. september 2026**, og speiler
+GitHubs listepriser slik de sto **4. september 2026**, og speiler
 `apps/my-copilot/src/lib/model-pricing.ts`. De endrer seg uten varsel, så
 tallene her har et tidsstempel og ikke evig gyldighet.
 


### PR DESCRIPTION
`main` har vært rød siden midnatt.

`src/lib/model-pricing.test.ts` har en test som lover at fila ikke oppgir en kampanjepris som allerede er utløpt. Den fyrte da datoen rullet til 4. september, fordi `model-pricing.ts` fortsatt lovte en kampanje ut 3. september. Testen gjorde jobben sin.

Dette er ikke innført av noen PR. Det er #503, som sa at kampanjeprisen på GPT-5.6 Sol reverterer 3. september, og som skjedde på klokka.

## Hva synken hentet

GPT-5.6 Sol er tilbake på listepris, og den doblet seg:

| | Kampanje | Nå |
| --- | ---: | ---: |
| Default, inn | $2 | $4 |
| Default, ut | $10 | $20 |
| Default, cache write | $2,50 | $5 |
| Long context, inn | $4 | $8 |
| Long context, ut | $15 | $30 |
| Long context, cache write | $5 | $10 |

Fotnoten om kampanjen er borte fra begge radene.

## Testene

Fire tester skrev opp kampanjeradene i sin helhet og pekte på Sol som eksempel. De peker nå på Gemini 3.6 Flash, som har den kampanjen som fortsatt løper, ut året.

Listene står fortsatt skrevet ut med vilje. Det er dem som fanger at en kampanje dukker opp eller forsvinner uten at noen har sett det, og her er det nettopp det som skjedde.

## Dette låser ikke problemet

Neste kampanje som går ut gjør `main` rød igjen, på samme måte, uten at noen har rørt koden. #503 er stedet der det hører hjemme. En planlagt synk som åpner PR før datoen passerer ville tatt det, men den finnes ikke i dag.

`pricing:check`, `docs:check` og `mise run check` i `apps/my-copilot` er grønne.