### PR TITLE
fix: use neutral MCP argument label

### DIFF
--- a/apps/my-copilot/src/components/detail-drawer/mcp-details.tsx
+++ b/apps/my-copilot/src/components/detail-drawer/mcp-details.tsx
@@ -133,7 +133,7 @@ export function McpDetails({ item }: { item: EnrichedCustomization }) {
                 {pkg.packageArguments && pkg.packageArguments.length > 0 && (
                   <VStack gap="space-4">
                     <BodyShort size="small" weight="semibold">
-                      Sikkerhetsargumenter:
+                      Argumenter:
                     </BodyShort>
                     {pkg.packageArguments.map((arg) => (
                       <BodyShort key={arg.name ?? arg.value} size="small" className="text-gray-600">


### PR DESCRIPTION
## Hva

Endrer UI-etiketten fra `Sikkerhetsargumenter` til `Argumenter`. MCP-argumenter kan være nyttige, men utgjør ikke nødvendigvis en sikkerhetsgrense.

## Verifisering

- Prettier og ESLint for den endrede komponenten passerer.

Flyttet ut fra #625 for å holde Playwright-oppskriftens funksjons- og sikkerhetsavklaringer adskilt fra denne UI-ordlyden.