### PR TITLE
fix(mcp): clarify Playwright capabilities and sandbox setup

### DIFF
--- a/apps/mcp-registry/README.md
+++ b/apps/mcp-registry/README.md
@@ -135,7 +135,9 @@ Names follow reverse-DNS with exactly one `/`:
 
 **Required fields**: `name`, `description`, `version`
 
-**Optional fields**: `status` (default: `active`), `publishedAt`, `remotes`, `packages`
+**Optional fields**: `status` (default: `active`), `publishedAt`, `remotes`, `packages`, `setupInstructions`
+
+`setupInstructions` is an array of `{ "title", "description", "commands" }` steps, shown with copyable commands in Min Copilot.
 
 ### Remote Servers (HTTP)
 

--- a/apps/mcp-registry/allowlist.json
+++ b/apps/mcp-registry/allowlist.json
@@ -219,12 +219,57 @@
         "url": "https://github.com/microsoft/playwright-mcp",
         "source": "github"
       },
-      "tools": ["browser_navigate", "browser_click", "browser_type", "browser_snapshot", "browser_take_screenshot", "browser_wait"],
+      "tools": [
+        "browser_click",
+        "browser_close",
+        "browser_console_messages",
+        "browser_drag",
+        "browser_drop",
+        "browser_evaluate",
+        "browser_file_upload",
+        "browser_fill_form",
+        "browser_find",
+        "browser_handle_dialog",
+        "browser_hover",
+        "browser_navigate",
+        "browser_navigate_back",
+        "browser_network_request",
+        "browser_network_requests",
+        "browser_press_key",
+        "browser_resize",
+        "browser_run_code_unsafe",
+        "browser_select_option",
+        "browser_snapshot",
+        "browser_take_screenshot",
+        "browser_type",
+        "browser_wait_for",
+        "browser_tabs"
+      ],
       "tags": ["testing", "browser-automation", "frontend"],
       "examples": [
         {
           "scenario": "Test brukerflyt",
           "prompt": "Naviger til søknadssiden og test at skjemavalidering fungerer"
+        }
+      ],
+      "setupInstructions": [
+        {
+          "title": "Installer Chrome for Testing før første bruk",
+          "description": "Kjør kommandoen utenfor cplt. Den kjører den pinnede tredjepartspakken @playwright/mcp@0.0.80 utenfor cplt for å installere den Playwright-administrerte Chromium-nettleseren som oppskriften bruker.",
+          "commands": ["pnpm dlx @playwright/mcp@0.0.80 install-browser chromium"]
+        },
+        {
+          "title": "Tillat nødvendig cache-kjøring i cplt",
+          "description": "allow_cache_exec pnpm/dlx autoriserer kjørbar kode hvor som helst under hele brukerens pnpm/dlx-cachetre, ikke bare denne Playwright-pakken eller dens deklarerte avhengigheter. allow_cache_exec ms-playwright autoriserer kjørbare nettleserartefakter under det valgte cachetreet. Aktiver dem bare når du aksepterer disse grensene for cache-kjøring.",
+          "commands": [
+            "cplt config set sandbox.allow_cache_exec ms-playwright",
+            "cplt config set sandbox.allow_cache_exec pnpm/dlx"
+          ]
+        },
+        {
+          "title": "Oppdater cplt før første browserkjøring",
+          "description": "En oppdatert cplt gir runtime-støtten fra navikt/cplt#263. Under det eksplisitte ms-playwright-unntaket setter cplt PLAYWRIGHT_MCP_SANDBOX=false i tråd med navikt/cplt#268, fordi Chromiums nestede sandkasse ikke kan kjøre inni cplt. Når den nestede sandkassen er slått av, er cplt den håndhevende sandkassegrensen; en kompromittert renderer får derfor Playwright-profilen til cplt i stedet for Chromiums smalere child-profil.",
+          "commands": ["cplt update"]
         }
       ],
       "packages": [
@@ -244,21 +289,15 @@
             },
             {
               "type": "named",
-              "name": "--caps",
-              "value": "core",
-              "description": "Restrict to core capabilities only (no file upload or install)"
-            },
-            {
-              "type": "named",
               "name": "--browser",
               "value": "chromium",
-              "description": "Use Chromium"
+              "description": "Use Playwright-managed Chrome for Testing (--browser chromium)"
             },
             {
               "type": "named",
               "name": "--blocked-origins",
               "value": "*.intern.nav.no;*.intern.dev.nav.no;*.ansatt.nav.no;*.ansatt.dev.nav.no;*.ekstern.dev.nav.no;*.nav.no;*.nais.io;*.adeo.no",
-              "description": "Block access to all Nav NAIS ingress domains"
+              "description": "Defense-in-depth convenience filter for Nav domains, not a security boundary. Redirects are not covered; a security guarantee requires verified external network enforcement."
             },
             {
               "type": "named",

--- a/apps/mcp-registry/handlers.go
+++ b/apps/mcp-registry/handlers.go
@@ -78,6 +78,18 @@ func makeServersListHandler(config *Config) http.HandlerFunc {
 	}
 }
 
+func navRegistryMeta(server StaticServerData) *NavRegistryMeta {
+	if len(server.Tools) == 0 && len(server.Tags) == 0 && len(server.Examples) == 0 && len(server.SetupInstructions) == 0 {
+		return nil
+	}
+	return &NavRegistryMeta{
+		Tools:             server.Tools,
+		Tags:              server.Tags,
+		Examples:          server.Examples,
+		SetupInstructions: server.SetupInstructions,
+	}
+}
+
 func serversListHandler(w http.ResponseWriter, r *http.Request, config *Config) {
 	if r.Method == http.MethodOptions {
 		optionsHandler(w, r)
@@ -125,10 +137,6 @@ func serversListHandler(w http.ResponseWriter, r *http.Request, config *Config) 
 		if status == "" {
 			status = StatusActive
 		}
-		var navMeta *NavRegistryMeta
-		if len(s.Tools) > 0 || len(s.Tags) > 0 || len(s.Examples) > 0 {
-			navMeta = &NavRegistryMeta{Tools: s.Tools, Tags: s.Tags, Examples: s.Examples}
-		}
 		servers = append(servers, ServerResponse{
 			Server: ServerJSON{
 				Schema:      CurrentSchemaURL,
@@ -147,7 +155,7 @@ func serversListHandler(w http.ResponseWriter, r *http.Request, config *Config) 
 					UpdatedAt:   updatedAt,
 					IsLatest:    true,
 				},
-				NavRegistry: navMeta,
+				NavRegistry: navRegistryMeta(s),
 			},
 		})
 	}
@@ -245,10 +253,6 @@ func serverVersionHandler(w http.ResponseWriter, r *http.Request, config *Config
 			if status == "" {
 				status = StatusActive
 			}
-			var navMeta *NavRegistryMeta
-			if len(s.Tools) > 0 || len(s.Tags) > 0 {
-				navMeta = &NavRegistryMeta{Tools: s.Tools, Tags: s.Tags}
-			}
 			response := ServerResponse{
 				Server: ServerJSON{
 					Schema:      CurrentSchemaURL,
@@ -267,7 +271,7 @@ func serverVersionHandler(w http.ResponseWriter, r *http.Request, config *Config
 						UpdatedAt:   updatedAt,
 						IsLatest:    true,
 					},
-					NavRegistry: navMeta,
+					NavRegistry: navRegistryMeta(s),
 				},
 			}
 			slog.Debug("Returning server", "name", serverName, "version", version)

--- a/apps/mcp-registry/handlers_test.go
+++ b/apps/mcp-registry/handlers_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -725,76 +726,169 @@ func TestServerVersionHandler_PackageArguments(t *testing.T) {
 	}
 }
 
-func TestServersListHandler_PlaywrightArguments(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/v0.1/servers", nil)
-	w := httptest.NewRecorder()
-
-	serversListHandler(w, req, testConfig())
-
-	resp := w.Result()
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("failed to read response body: %v", err)
+func TestPlaywrightRecipeReturnedByListAndVersion(t *testing.T) {
+	expectedTools := []string{
+		"browser_click",
+		"browser_close",
+		"browser_console_messages",
+		"browser_drag",
+		"browser_drop",
+		"browser_evaluate",
+		"browser_file_upload",
+		"browser_fill_form",
+		"browser_find",
+		"browser_handle_dialog",
+		"browser_hover",
+		"browser_navigate",
+		"browser_navigate_back",
+		"browser_network_request",
+		"browser_network_requests",
+		"browser_press_key",
+		"browser_resize",
+		"browser_run_code_unsafe",
+		"browser_select_option",
+		"browser_snapshot",
+		"browser_take_screenshot",
+		"browser_type",
+		"browser_wait_for",
+		"browser_tabs",
+	}
+	expectedArguments := []Argument{
+		{Type: "named", Name: "--isolated"},
+		{Type: "named", Name: "--browser", Value: "chromium"},
+		{
+			Type:  "named",
+			Name:  "--blocked-origins",
+			Value: "*.intern.nav.no;*.intern.dev.nav.no;*.ansatt.nav.no;*.ansatt.dev.nav.no;*.ekstern.dev.nav.no;*.nav.no;*.nais.io;*.adeo.no",
+		},
+		{Type: "named", Name: "--block-service-workers"},
+	}
+	expectedCommands := [][]string{
+		{"pnpm dlx @playwright/mcp@0.0.80 install-browser chromium"},
+		{
+			"cplt config set sandbox.allow_cache_exec ms-playwright",
+			"cplt config set sandbox.allow_cache_exec pnpm/dlx",
+		},
+		{"cplt update"},
 	}
 
-	var response ServerListResponse
-	if err := json.Unmarshal(body, &response); err != nil {
-		t.Fatalf("failed to parse response: %v", err)
+	assertRecipe := func(t *testing.T, response ServerResponse) {
+		t.Helper()
+		if response.Server.Name != "com.microsoft/playwright-mcp" {
+			t.Fatalf("expected full registry ID, got %q", response.Server.Name)
+		}
+		if response.Server.Version != "0.0.80" {
+			t.Errorf("expected server version 0.0.80, got %q", response.Server.Version)
+		}
+		if len(response.Server.Packages) != 1 {
+			t.Fatalf("expected one package, got %d", len(response.Server.Packages))
+		}
+
+		pkg := response.Server.Packages[0]
+		if pkg.Identifier != "@playwright/mcp" || pkg.Version != "0.0.80" {
+			t.Errorf("expected @playwright/mcp@0.0.80, got %s@%s", pkg.Identifier, pkg.Version)
+		}
+		if len(pkg.PackageArguments) != len(expectedArguments) {
+			t.Fatalf("expected %d package arguments, got %d", len(expectedArguments), len(pkg.PackageArguments))
+		}
+		for i, expected := range expectedArguments {
+			actual := pkg.PackageArguments[i]
+			if actual.Type != expected.Type || actual.Name != expected.Name || actual.Value != expected.Value {
+				t.Errorf("package argument %d: expected %#v, got %#v", i, expected, actual)
+			}
+			if actual.Name == "--caps" || actual.Name == "--no-sandbox" {
+				t.Errorf("disallowed Playwright argument present: %s", actual.Name)
+			}
+		}
+		blockedOriginsDescription := pkg.PackageArguments[2].Description
+		for _, required := range []string{"Defense-in-depth", "not a security boundary", "Redirects", "verified external network enforcement"} {
+			if !strings.Contains(blockedOriginsDescription, required) {
+				t.Errorf("--blocked-origins description must contain %q", required)
+			}
+		}
+
+		if response.Meta.NavRegistry == nil {
+			t.Fatal("expected Nav registry metadata")
+		}
+		if !reflect.DeepEqual(response.Meta.NavRegistry.Tools, expectedTools) {
+			t.Errorf("unexpected Playwright tools: %#v", response.Meta.NavRegistry.Tools)
+		}
+		instructions := response.Meta.NavRegistry.SetupInstructions
+		if len(instructions) != len(expectedCommands) {
+			t.Fatalf("expected %d setup instructions, got %d", len(expectedCommands), len(instructions))
+		}
+		for i, commands := range expectedCommands {
+			if !reflect.DeepEqual(instructions[i].Commands, commands) {
+				t.Errorf("setup instruction %d: expected commands %#v, got %#v", i, commands, instructions[i].Commands)
+			}
+			for _, command := range instructions[i].Commands {
+				if strings.Contains(command, "--no-sandbox") {
+					t.Errorf("setup instruction %d must not add --no-sandbox", i)
+				}
+			}
+			if strings.TrimSpace(instructions[i].Title) == "" || strings.TrimSpace(instructions[i].Description) == "" {
+				t.Errorf("setup instruction %d must have title and description", i)
+			}
+		}
+		for _, required := range []string{"pinnede tredjepartspakken @playwright/mcp@0.0.80", "utenfor cplt", "installere"} {
+			if !strings.Contains(instructions[0].Description, required) {
+				t.Errorf("browser install explanation must contain %q", required)
+			}
+		}
+		for _, required := range []string{
+			"allow_cache_exec pnpm/dlx",
+			"hvor som helst under hele brukerens pnpm/dlx-cachetre",
+			"ikke bare denne Playwright-pakken eller dens deklarerte avhengigheter",
+			"allow_cache_exec ms-playwright",
+			"kjørbare nettleserartefakter under det valgte cachetreet",
+			"bare når du aksepterer disse grensene for cache-kjøring",
+		} {
+			if !strings.Contains(instructions[1].Description, required) {
+				t.Errorf("cache opt-in explanation must contain %q", required)
+			}
+		}
+		for _, required := range []string{"navikt/cplt#263", "PLAYWRIGHT_MCP_SANDBOX=false", "navikt/cplt#268", "cplt den håndhevende"} {
+			if !strings.Contains(instructions[2].Description, required) {
+				t.Errorf("cplt boundary explanation must contain %q", required)
+			}
+		}
 	}
 
-	var playwright *ServerResponse
-	for i, sr := range response.Servers {
-		if sr.Server.Name == "com.microsoft/playwright-mcp" {
-			playwright = &response.Servers[i]
+	listRequest := httptest.NewRequest(http.MethodGet, "/v0.1/servers", nil)
+	listRecorder := httptest.NewRecorder()
+	serversListHandler(listRecorder, listRequest, testConfig())
+	if listRecorder.Code != http.StatusOK {
+		t.Fatalf("expected list response 200, got %d: %s", listRecorder.Code, listRecorder.Body.String())
+	}
+	var listResponse ServerListResponse
+	if err := json.Unmarshal(listRecorder.Body.Bytes(), &listResponse); err != nil {
+		t.Fatalf("failed to parse list response: %v", err)
+	}
+	var playwrightResponse *ServerResponse
+	for i := range listResponse.Servers {
+		if listResponse.Servers[i].Server.Name == "com.microsoft/playwright-mcp" {
+			playwrightResponse = &listResponse.Servers[i]
 			break
 		}
 	}
+	if playwrightResponse == nil {
+		t.Fatal("Playwright server missing from list response")
+	}
+	assertRecipe(t, *playwrightResponse)
 
-	if playwright == nil {
-		t.Fatal("playwright-mcp not found in registry")
+	versionRequest := httptest.NewRequest(
+		http.MethodGet,
+		"/v0.1/servers/"+url.PathEscape("com.microsoft/playwright-mcp")+"/versions/0.0.80",
+		nil,
+	)
+	versionRecorder := httptest.NewRecorder()
+	serverVersionHandler(versionRecorder, versionRequest, testConfig())
+	if versionRecorder.Code != http.StatusOK {
+		t.Fatalf("expected version response 200, got %d: %s", versionRecorder.Code, versionRecorder.Body.String())
 	}
-
-	if len(playwright.Server.Packages) != 1 {
-		t.Fatalf("expected 1 package, got %d", len(playwright.Server.Packages))
+	var versionResponse ServerResponse
+	if err := json.Unmarshal(versionRecorder.Body.Bytes(), &versionResponse); err != nil {
+		t.Fatalf("failed to parse version response: %v", err)
 	}
-
-	pkg := playwright.Server.Packages[0]
-
-	if playwright.Server.Version != "0.0.80" {
-		t.Errorf("expected server version 0.0.80, got %q", playwright.Server.Version)
-	}
-	if pkg.Version != "0.0.80" {
-		t.Errorf("expected package version 0.0.80, got %q", pkg.Version)
-	}
-
-	expectedArguments := []struct {
-		name  string
-		value string
-	}{
-		{"--isolated", ""},
-		{"--caps", "core"},
-		{"--browser", "chromium"},
-		{"--blocked-origins", "*.intern.nav.no;*.intern.dev.nav.no;*.ansatt.nav.no;*.ansatt.dev.nav.no;*.ekstern.dev.nav.no;*.nav.no;*.nais.io;*.adeo.no"},
-		{"--block-service-workers", ""},
-	}
-
-	if len(pkg.PackageArguments) != len(expectedArguments) {
-		t.Fatalf("expected %d Playwright arguments, got %d", len(expectedArguments), len(pkg.PackageArguments))
-	}
-	for i, expected := range expectedArguments {
-		arg := pkg.PackageArguments[i]
-		if arg.Type != "named" || arg.Name != expected.name || arg.Value != expected.value {
-			t.Errorf(
-				"packageArguments[%d]: expected named argument %q=%q, got %q %q=%q",
-				i,
-				expected.name,
-				expected.value,
-				arg.Type,
-				arg.Name,
-				arg.Value,
-			)
-		}
-	}
+	assertRecipe(t, versionResponse)
 }

--- a/apps/mcp-registry/types.go
+++ b/apps/mcp-registry/types.go
@@ -86,10 +86,17 @@ type UsageExample struct {
 	Scenario string `json:"scenario"`
 }
 
+type SetupInstruction struct {
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Commands    []string `json:"commands"`
+}
+
 type NavRegistryMeta struct {
-	Tools    []string       `json:"tools,omitempty"`
-	Tags     []string       `json:"tags,omitempty"`
-	Examples []UsageExample `json:"examples,omitempty"`
+	Tools             []string           `json:"tools,omitempty"`
+	Tags              []string           `json:"tags,omitempty"`
+	Examples          []UsageExample     `json:"examples,omitempty"`
+	SetupInstructions []SetupInstruction `json:"setupInstructions,omitempty"`
 }
 
 type ResponseMeta struct {
@@ -113,19 +120,20 @@ type ServerListResponse struct {
 }
 
 type StaticServerData struct {
-	Schema      string         `json:"$schema,omitempty"`
-	Name        string         `json:"name"`
-	Description string         `json:"description"`
-	Version     string         `json:"version"`
-	Status      string         `json:"status,omitempty"`
-	PublishedAt string         `json:"publishedAt,omitempty"`
-	WebsiteURL  string         `json:"websiteUrl,omitempty"`
-	Repository  *Repository    `json:"repository,omitempty"`
-	Tools       []string       `json:"tools,omitempty"`
-	Tags        []string       `json:"tags,omitempty"`
-	Examples    []UsageExample `json:"examples,omitempty"`
-	Remotes     []Transport    `json:"remotes,omitempty"`
-	Packages    []Package      `json:"packages,omitempty"`
+	Schema            string             `json:"$schema,omitempty"`
+	Name              string             `json:"name"`
+	Description       string             `json:"description"`
+	Version           string             `json:"version"`
+	Status            string             `json:"status,omitempty"`
+	PublishedAt       string             `json:"publishedAt,omitempty"`
+	WebsiteURL        string             `json:"websiteUrl,omitempty"`
+	Repository        *Repository        `json:"repository,omitempty"`
+	Tools             []string           `json:"tools,omitempty"`
+	Tags              []string           `json:"tags,omitempty"`
+	Examples          []UsageExample     `json:"examples,omitempty"`
+	SetupInstructions []SetupInstruction `json:"setupInstructions,omitempty"`
+	Remotes           []Transport        `json:"remotes,omitempty"`
+	Packages          []Package          `json:"packages,omitempty"`
 }
 
 type StaticRegistryData struct {

--- a/apps/mcp-registry/validation.go
+++ b/apps/mcp-registry/validation.go
@@ -109,6 +109,31 @@ func validateServerEntry(server *StaticServerData, index int, existingNames map[
 		}
 	}
 
+	for j := range server.SetupInstructions {
+		if err := validateSetupInstruction(&server.SetupInstructions[j], index, j); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateSetupInstruction(instruction *SetupInstruction, serverIndex, instructionIndex int) error {
+	prefix := fmt.Sprintf("server[%d].setupInstructions[%d]", serverIndex, instructionIndex)
+	if strings.TrimSpace(instruction.Title) == "" {
+		return fmt.Errorf("%s: 'title' is required and cannot be empty", prefix)
+	}
+	if strings.TrimSpace(instruction.Description) == "" {
+		return fmt.Errorf("%s: 'description' is required and cannot be empty", prefix)
+	}
+	if len(instruction.Commands) == 0 {
+		return fmt.Errorf("%s: 'commands' must contain at least one command", prefix)
+	}
+	for commandIndex, command := range instruction.Commands {
+		if strings.TrimSpace(command) == "" {
+			return fmt.Errorf("%s.commands[%d]: command cannot be empty", prefix, commandIndex)
+		}
+	}
 	return nil
 }
 

--- a/apps/mcp-registry/validation_test.go
+++ b/apps/mcp-registry/validation_test.go
@@ -849,6 +849,71 @@ func TestValidateRegistry_RequiredFields(t *testing.T) {
 		},
 	}
 
+	t.Run("setup instructions", func(t *testing.T) {
+		registryWithInstruction := func(instruction SetupInstruction) *StaticRegistryData {
+			return &StaticRegistryData{Servers: []StaticServerData{{
+				Name:              "io.github.test/server",
+				Description:       "Test Description",
+				Version:           "1.0.0",
+				SetupInstructions: []SetupInstruction{instruction},
+			}}}
+		}
+
+		tests := []struct {
+			name        string
+			instruction SetupInstruction
+			errorMsg    string
+		}{
+			{
+				name: "valid",
+				instruction: SetupInstruction{
+					Title:       "Install dependency",
+					Description: "Run before first use.",
+					Commands:    []string{"tool install dependency"},
+				},
+			},
+			{
+				name:        "missing title",
+				instruction: SetupInstruction{Description: "Run before first use.", Commands: []string{"tool install dependency"}},
+				errorMsg:    "'title' is required",
+			},
+			{
+				name:        "missing description",
+				instruction: SetupInstruction{Title: "Install dependency", Commands: []string{"tool install dependency"}},
+				errorMsg:    "'description' is required",
+			},
+			{
+				name:        "missing commands",
+				instruction: SetupInstruction{Title: "Install dependency", Description: "Run before first use."},
+				errorMsg:    "'commands' must contain at least one command",
+			},
+			{
+				name: "empty command",
+				instruction: SetupInstruction{
+					Title:       "Install dependency",
+					Description: "Run before first use.",
+					Commands:    []string{" "},
+				},
+				errorMsg: "command cannot be empty",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				err := validateRegistry(registryWithInstruction(tt.instruction))
+				if tt.errorMsg == "" {
+					if err != nil {
+						t.Fatalf("expected valid setup instruction, got %v", err)
+					}
+					return
+				}
+				if err == nil || !strings.Contains(err.Error(), tt.errorMsg) {
+					t.Fatalf("expected error containing %q, got %v", tt.errorMsg, err)
+				}
+			})
+		}
+	})
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validateRegistry(tt.data)

--- a/apps/my-copilot/src/components/detail-drawer/mcp-details.test.tsx
+++ b/apps/my-copilot/src/components/detail-drawer/mcp-details.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import type { EnrichedCustomization } from "@/lib/enrich-customizations";
+import { McpDetails } from "./mcp-details";
+
+describe("McpDetails", () => {
+  it("renders setup instructions with duplicate titles and commands using safe keys", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const command = "cplt config set sandbox.allow_cache_exec ms-playwright";
+    const item: EnrichedCustomization = {
+      id: "mcp-com.microsoft/playwright-mcp",
+      name: "playwright-mcp",
+      description: "Browser automation.",
+      type: "mcp",
+      serverId: "com.microsoft/playwright-mcp",
+      domain: "testing",
+      filePath: "",
+      rawGitHubUrl: "",
+      installUrl: null,
+      insidersInstallUrl: null,
+      version: "0.0.80",
+      remotes: [],
+      setupInstructions: [
+        {
+          title: "Gjenta oppsett",
+          description: "Første instruksjon.",
+          commands: [command, command],
+        },
+        {
+          title: "Gjenta oppsett",
+          description: "Andre instruksjon.",
+          commands: [command],
+        },
+      ],
+      packages: [
+        {
+          registryType: "npm",
+          identifier: "@playwright/mcp",
+          version: "0.0.80",
+          transport: { type: "stdio" },
+          packageArguments: [{ type: "named", name: "--isolated", description: "Isolated browser state" }],
+        },
+      ],
+      usageCount: 0,
+      usedBy: [],
+    };
+
+    try {
+      render(<McpDetails item={item} />);
+
+      expect(screen.getByRole("heading", { name: "Oppsett" })).toBeInTheDocument();
+      expect(screen.getAllByText("Gjenta oppsett")).toHaveLength(2);
+      expect(screen.getAllByText(command)).toHaveLength(3);
+      expect(screen.getByText("Sikkerhetsargumenter:")).toBeInTheDocument();
+      expect(consoleError.mock.calls.flat().join(" ")).not.toContain("same key");
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});

--- a/apps/my-copilot/src/components/detail-drawer/mcp-details.test.tsx
+++ b/apps/my-copilot/src/components/detail-drawer/mcp-details.test.tsx
@@ -50,7 +50,7 @@ describe("McpDetails", () => {
       expect(screen.getByRole("heading", { name: "Oppsett" })).toBeInTheDocument();
       expect(screen.getAllByText("Gjenta oppsett")).toHaveLength(2);
       expect(screen.getAllByText(command)).toHaveLength(3);
-      expect(screen.getByText("Sikkerhetsargumenter:")).toBeInTheDocument();
+      expect(screen.getByText("Argumenter:")).toBeInTheDocument();
       expect(consoleError.mock.calls.flat().join(" ")).not.toContain("same key");
     } finally {
       consoleError.mockRestore();

--- a/apps/my-copilot/src/components/detail-drawer/mcp-details.tsx
+++ b/apps/my-copilot/src/components/detail-drawer/mcp-details.tsx
@@ -106,6 +106,41 @@ export function McpDetails({ item }: { item: EnrichedCustomization }) {
         </VStack>
       )}
 
+      {item.setupInstructions && item.setupInstructions.length > 0 && (
+        <VStack gap="space-8">
+          <Heading size="xsmall" level="4">
+            Oppsett
+          </Heading>
+          {item.setupInstructions.map((instruction, instructionIndex) => (
+            <Box
+              key={`${instruction.title}-${instructionIndex}`}
+              background="neutral-soft"
+              borderRadius="8"
+              padding="space-12"
+            >
+              <VStack gap="space-8">
+                <VStack gap="space-4">
+                  <BodyShort size="small" weight="semibold">
+                    {instruction.title}
+                  </BodyShort>
+                  <BodyShort size="small">{instruction.description}</BodyShort>
+                </VStack>
+                {instruction.commands.map((command, commandIndex) => (
+                  <Box key={`${command}-${commandIndex}`} background="default" borderRadius="4" padding="space-8">
+                    <VStack gap="space-4">
+                      <BodyShort size="small">
+                        <code className="text-xs break-all">{command}</code>
+                      </BodyShort>
+                      <CopyButton size="xsmall" copyText={command} />
+                    </VStack>
+                  </Box>
+                ))}
+              </VStack>
+            </Box>
+          ))}
+        </VStack>
+      )}
+
       {item.packages && item.packages.length > 0 && (
         <VStack gap="space-8">
           <Heading size="xsmall" level="4">

--- a/apps/my-copilot/src/lib/customization-types.ts
+++ b/apps/my-copilot/src/lib/customization-types.ts
@@ -56,6 +56,12 @@ export interface Skill extends BaseCustomization {
   references?: SkillReference[];
 }
 
+export interface SetupInstruction {
+  title: string;
+  description: string;
+  commands: string[];
+}
+
 export interface McpServerCustomization extends BaseCustomization {
   type: "mcp";
   serverId: string;
@@ -65,6 +71,7 @@ export interface McpServerCustomization extends BaseCustomization {
   repository?: { url: string; source: string; subfolder?: string };
   tools?: string[];
   tags?: string[];
+  setupInstructions?: SetupInstruction[];
   packages?: {
     registryType: string;
     identifier: string;

--- a/apps/my-copilot/src/lib/mcp-registry.test.ts
+++ b/apps/my-copilot/src/lib/mcp-registry.test.ts
@@ -10,7 +10,14 @@ describe("getMcpServers", () => {
     vi.unstubAllGlobals();
   });
 
-  it("preserves full registry IDs globally while retaining short display names", async () => {
+  it("preserves full registry IDs while mapping package versions and setup instructions", async () => {
+    const setupInstructions = [
+      {
+        title: "Installer Chromium før første bruk",
+        description: "Kjør kommandoen utenfor cplt.",
+        commands: ["pnpm dlx @playwright/mcp@0.0.80 install-browser chromium"],
+      },
+    ];
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -37,7 +44,10 @@ describe("getMcpServers", () => {
                   publishedAt: "2026-03-10T00:00:00Z",
                   isLatest: true,
                 },
-                "io.github.navikt/registry": { tags: ["testing"] },
+                "io.github.navikt/registry": {
+                  tags: ["testing"],
+                  setupInstructions,
+                },
               },
             },
             {
@@ -70,6 +80,7 @@ describe("getMcpServers", () => {
       serverId: "com.microsoft/playwright-mcp",
       version: "0.0.80",
       packages: [{ identifier: "@playwright/mcp", version: "0.0.80" }],
+      setupInstructions,
     });
     expect(servers[1]).toMatchObject({
       name: "github-mcp",

--- a/apps/my-copilot/src/lib/mcp-registry.ts
+++ b/apps/my-copilot/src/lib/mcp-registry.ts
@@ -1,5 +1,5 @@
 import { cacheLife, cacheTag } from "next/cache";
-import type { Domain, McpServerCustomization } from "./customization-types";
+import type { Domain, McpServerCustomization, SetupInstruction } from "./customization-types";
 import type { UsageExample } from "./manifest-types";
 
 const MCP_REGISTRY_URL = process.env.MCP_REGISTRY_URL || "https://mcp-registry.nav.no";
@@ -33,6 +33,7 @@ interface ServerResponse {
       tools?: string[];
       tags?: string[];
       examples?: UsageExample[];
+      setupInstructions?: SetupInstruction[];
     };
   };
 }
@@ -118,6 +119,7 @@ export async function getMcpServers(): Promise<McpServerCustomization[]> {
           repository: s.server.repository,
           tools: navMeta?.tools,
           tags,
+          setupInstructions: navMeta?.setupInstructions,
           packages: s.server.packages,
           ...(examples && examples.length > 0 && { examples }),
         };


### PR DESCRIPTION
## Hva

Dette skiller kapabilitets- og sandboxdelen av #601 fra runtimeoppskriften i #625 og den globale registry-ID-migreringen i #655.

- annonserer de 24 verktøyene som `@playwright/mcp@0.0.80` faktisk eksponerer
- fjerner den misvisende `--caps core`-begrensningen
- beskriver `--blocked-origins` som et defense-in-depth-filter, ikke en sikkerhetsgrense
- legger til strukturerte oppsettsinstruksjoner for Chrome for Testing og cplt
- viser oppsettsinstruksjonene med kopierbare kommandoer i Min Copilot

Refs #601.

## Sikkerhetsgrenser

Den delte oppskriften legger ikke til `--no-sandbox`.

Oppsettsinstruksjonene sier eksplisitt at:

- den pinnede tredjepartspakken kjøres utenfor cplt når nettleseren installeres
- `allow_cache_exec pnpm/dlx` autoriserer kjørbar kode i hele brukerens valgte `pnpm/dlx`-cachetre, ikke bare Playwright-pakken
- `allow_cache_exec ms-playwright` autoriserer nettleserartefakter i det valgte cachetreet
- `--blocked-origins` ikke dekker redirects og ikke erstatter ekstern nettverkshåndheving
- cplt er den håndhevende sandkassegrensen når Chromiums nestede sandbox er deaktivert

Merge-gaten er innfridd: eieraksept av `PLAYWRIGHT_MCP_SANDBOX=false` ble merget i navikt/cplt#268 (2026-09-04).

## PR-kjede

Dette er topplaget i en lineær kjede:

```text
#625 runtime/protokoll
  └─ #655 full registry-ID
       └─ #656 kapabiliteter og sandbox-oppsett
```

PR-en har #655 sin branch som base, slik at diffen bare viser kapabilitets- og sandboxendringene. PR-ene er registrert som GitHub stack 657, slik at GitHub håndterer bottom-up merge og retargeting mot `main`.

## Verifisering

- `apps/mcp-registry: mise check` — grønn
- `apps/my-copilot: mise check` — grønn, 39 testfiler og 517 tester
- `git diff --check` — grønn
- ekte `pnpm dlx @playwright/mcp@0.0.80`-smoke: 24 annonserte verktøy samsvarte med `tools/list`, `browser_navigate("about:blank")` lyktes, alle åtte blokkerte vertsformene ga `ERR_BLOCKED_BY_CLIENT`, og en kontrollvert ga `ERR_NAME_NOT_RESOLVED`

`mise all` ble også forsøkt. De endrede appene var grønne, mens den samlede kjøringen ble stoppet av miljøbegrensninger utenfor diffen: lokale sockettester fikk ikke binde loopback, `go` var ikke tilgjengelig for nav-pilot-deloppgavene, og Turbopack fikk ikke opprette hjelpeprosessen sin.

## Reviewfokus

- at kapabilitetslisten samsvarer med faktisk MCP-overflate
- at cache-exec- og nested-sandbox-konsekvensene er presist formulert
- at ingen formulering fremstiller origin-filteret som en nettverkssikkerhetsgrense

