### PR TITLE
fix(nav-pilot): name cplt when a hook write is denied in its sandbox

### DIFF
--- a/cli/nav-pilot/internal/cli/hooks.go
+++ b/cli/nav-pilot/internal/cli/hooks.go
@@ -1,11 +1,14 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 
 	"github.com/navikt/copilot/cli/nav-pilot/internal/source"
 )
@@ -47,10 +50,10 @@ func activateHook(scope *InstallScope, art Resolved, result *installResult) erro
 
 	hooksDir := scope.DstPath(KindHook.Dir)
 	if !scope.IsUser() {
-		return source.MergeRepoHooks(hooksDir, []source.HookEntry{entry})
+		return explainHookWrite(source.MergeRepoHooks(hooksDir, []source.HookEntry{entry}), hooksDir)
 	}
 
-	if err := source.WriteUserHook(hooksDir, entry); err != nil {
+	if err := explainHookWrite(source.WriteUserHook(hooksDir, entry), hooksDir); err != nil {
 		return err
 	}
 	configRel := scope.RelPath(KindHook.Dir, source.UserHookConfigName(art.Name))
@@ -134,4 +137,63 @@ func reportHooks(repoDir string, userScope *InstallScope) {
 	fmt.Printf("      %s In prompt mode (%s) an untrusted folder does not load repo hooks.\n", yellow("Note:"), bold("copilot -p"))
 	fmt.Printf("          Trust the folder, or set %s for that run.\n", bold("GITHUB_COPILOT_PROMPT_MODE_REPO_HOOKS=true"))
 	fmt.Printf("          The variable is in the CLI's changelog but not its public docs, so verify it still works before relying on it.\n")
+}
+
+// ─── hook writes inside a cplt sandbox ───────────────────────────────────────
+
+// cpltSandboxEnvVar is the marker cplt exports into every process it sandboxes.
+// It is cplt's own recursion guard — set once in `sandbox_exec.rs` on both the
+// macOS Seatbelt and the Linux Landlock path, so it is present whatever backend
+// is in use — and cplt documents it as the way a process tells it is inside:
+// its README says cplt "refuses to nest… via the `__CPLT_WRAPPED` environment
+// variable", its agent-facing brief tells the agent "you are running under cplt
+// if `$__CPLT_WRAPPED` is set", and its own Gradle init script keys on it.
+//
+// There is no better signal. cplt sets no positive "I am cplt" variable of its
+// own, and the alternatives are worse: the proxy variables it injects are also
+// set by any corporate proxy, and probing the filesystem for a denial is a
+// side effect, not a check.
+const cpltSandboxEnvVar = "__CPLT_WRAPPED"
+
+// insideCpltSandbox reports whether this process is running inside a cplt
+// sandbox.
+func insideCpltSandbox() bool {
+	_, ok := os.LookupEnv(cpltSandboxEnvVar)
+	return ok
+}
+
+// explainHookWrite turns the bare permission error a hook write gets inside a
+// cplt sandbox into one that names the tool doing the denying.
+//
+// cplt protects exactly the paths nav-pilot's hooks land in, and for a reason
+// that is not a bug: a hook file is code that runs later, unsandboxed, on the
+// host. `~/.copilot/hooks` and `~/.copilot/settings.json` are in cplt's
+// host-persistence deny list for the Copilot agent (cplt src/agent.rs, #331),
+// and `.github/hooks` is re-bound read-only in the project directory (cplt
+// src/sandbox_policy.rs `PROTECTED_IN_ROOT`, #347). Neither is going to change,
+// and nav-pilot should not try to route around a deliberate guard rail.
+//
+// What it can do is stop the failure reading as a broken install. Left alone
+// the user sees an EPERM naming a path and neither tool, on a command that
+// works perfectly well one shell out.
+//
+// The net is permission-denied and read-only-filesystem: macOS Seatbelt returns
+// EPERM for the deny, Linux returns EROFS for the read-only bind. A disk-full
+// or missing-directory error is a real error and is passed through untouched,
+// because claiming cplt denied something it did not is its own bug.
+func explainHookWrite(err error, path string) error {
+	if err == nil || !insideCpltSandbox() {
+		return err
+	}
+	if !errors.Is(err, fs.ErrPermission) && !errors.Is(err, syscall.EROFS) {
+		return err
+	}
+	return fmt.Errorf("%w\n\n"+
+		"    This looks like cplt: nav-pilot is running inside a cplt sandbox (%s is set),\n"+
+		"    and cplt denies writes to Copilot hook paths — %s here. A hook file is code\n"+
+		"    that runs later on the host, outside the sandbox, so cplt refuses to let a\n"+
+		"    sandboxed process plant one. That is deliberate, and nav-pilot will not work\n"+
+		"    around it.\n\n"+
+		"    Run the install from a shell outside cplt instead",
+		err, cpltSandboxEnvVar, path)
 }

--- a/cli/nav-pilot/internal/cli/hooks_test.go
+++ b/cli/nav-pilot/internal/cli/hooks_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/navikt/copilot/cli/nav-pilot/internal/artifacts"
@@ -223,5 +224,68 @@ func TestOpenCodeRefusesHooks(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(out, "hooks")); !os.IsNotExist(err) {
 		t.Errorf("a hooks directory reached the opencode scope: %v", err)
+	}
+}
+
+// End to end: a real install into a hooks directory the process cannot write,
+// with cplt's marker set. The error the user sees must name cplt, name the
+// path, and say what to do — not just "permission denied".
+//
+// The write is denied by mode bits rather than by cplt, because a test cannot
+// build a sandbox. What is being asserted is the annotation, and the errno it
+// keys on is the same one Seatbelt returns for the real deny.
+func TestInstallHookInsideCpltSandboxNamesCplt(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the mode bits this test denies with")
+	}
+	src := hookSource(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(cpltSandboxEnvVar, "1")
+
+	hooksDir := filepath.Join(home, ".copilot", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(hooksDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(hooksDir, 0o755) })
+
+	scope, err := ScopeUser()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = installArtifact(NewSourceResolver(src), scope, nil, KindHook, "klarsprak-gate", false, false, &installResult{})
+	if err == nil {
+		t.Fatal("install into an unwritable hooks dir succeeded; the test denied nothing")
+	}
+	msg := err.Error()
+	for _, want := range []string{"cplt", cpltSandboxEnvVar, hooksDir, "outside cplt"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error does not mention %q:\n%s", want, msg)
+		}
+	}
+}
+
+// The annotation is keyed on cplt actually being there. Outside a sandbox the
+// same permission error must stay the plain one — naming cplt when cplt is not
+// involved sends the user somewhere useless.
+func TestHookWriteFailureOutsideCpltIsNotBlamedOnIt(t *testing.T) {
+	if _, set := os.LookupEnv(cpltSandboxEnvVar); set {
+		t.Skip("this test suite is itself running inside cplt")
+	}
+	err := explainHookWrite(&os.PathError{Op: "mkdir", Path: "/x", Err: syscall.EACCES}, "/x")
+	if strings.Contains(err.Error(), "cplt") {
+		t.Errorf("blamed cplt outside a cplt sandbox: %v", err)
+	}
+}
+
+// A failure that is not a denial is not cplt's doing, even inside a sandbox.
+func TestHookWriteNonPermissionErrorPassesThrough(t *testing.T) {
+	t.Setenv(cpltSandboxEnvVar, "1")
+	err := explainHookWrite(&os.PathError{Op: "write", Path: "/x", Err: syscall.ENOSPC}, "/x")
+	if strings.Contains(err.Error(), "cplt") {
+		t.Errorf("blamed cplt for a full disk: %v", err)
 	}
 }

--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -216,6 +216,12 @@ func installArtifact(resolver *SourceResolver, scope *InstallScope, stateHashes 
 	}
 
 	if err := copyArtifact(art.AbsPath, dst, scope.RootDir, art.IsDir); err != nil {
+		if kind == KindHook {
+			// The hook script lands in the same denied directory its config
+			// entry does, and it lands there first, so this is the copy that
+			// actually fails inside a cplt sandbox.
+			err = explainHookWrite(err, filepath.Dir(dst))
+		}
 		return fmt.Errorf("copying %s %s: %w", kind.Name, name, err)
 	}
 	hash, err := rawArtifactHash(dst, art.IsDir)

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -100,6 +100,17 @@ Dette når den ikke:
   repoet du står i, ikke fra `~/.copilot/` (`repoScopeDir()` i
   `cli/nav-pilot/internal/provider/opencode_launch.go`).
 
+### Hooks kan ikke installeres inne i cplt
+
+`nav-pilot install` skriver hooks til `~/.copilot/hooks/` (personlig) eller
+`.github/hooks/` (repo). cplt nekter skriving til begge stedene, og det er med vilje: en
+hook er kode som kjører senere på maskinen din, utenfor sandboxen, så cplt lar ikke en
+prosess inne i sandboxen legge igjen en. Kjører du `nav-pilot install` fra en agentsesjon
+i cplt, stopper installasjonen med en feil som forteller deg akkurat det.
+
+Kjør installasjonen fra et vanlig skall i stedet. Alle andre artefakttyper — agenter,
+skills, prompts, instruksjoner — installeres helt fint inne i cplt.
+
 ### Hub-repo
 
 Mekanisk er et hub-repo en vanlig repo-installasjon i et repo som ikke er en applikasjon,


### PR DESCRIPTION
## Problem

`nav-pilot install` writes hooks to `~/.copilot/hooks/` (user scope) or `.github/hooks/` (repo scope). cplt protects all three paths:

- `~/.copilot/settings.json` and `~/.copilot/hooks` are in the Copilot agent's host-persistence deny list — `cplt src/agent.rs:687-688` (navikt/cplt#331).
- `.github/hooks` is re-bound read-only in the project directory — `cplt src/sandbox_policy.rs:2010` `PROTECTED_IN_ROOT`, enforced on macOS at `sandbox_profile.rs:2865` and on Linux at `sandbox_bubblewrap.rs:1395` (navikt/cplt#347).

So an `install` run from inside a cplt session fails with a bare `permission denied` naming a path and neither tool, on a command that works fine one shell out.

## What this does

Detects the sandbox and explains. It does **not** relocate the hook payload — cplt is right to deny this. A hook file is code that runs later, unsandboxed, on the host, in whichever repo the user opens next; that is exactly the class cplt#331 and cplt#347 exist to close. Moving the payload would be a cplt-side conversation, not a nav-pilot patch.

## Detection signal

`__CPLT_WRAPPED`, set at `cplt src/sandbox_exec.rs:203` — one call site, outside any `cfg(target_os)`, so it covers both the macOS Seatbelt and the Linux Landlock backend. cplt documents it as the thing it checks to refuse nesting (README.md:357), tells the agent about it in its own brief (`src/brief.rs:344`), and keys its Gradle init script on it (`src/gradle_init.rs:46`).

There is no better one. cplt exports no positive "I am cplt" variable; the proxy variables it injects (`HTTPS_PROXY` and friends) are indistinguishable from a corporate proxy, and probing the filesystem for a denial is a side effect rather than a check.

## Scoping

The annotation fires only when the marker is set **and** the error is a denial — `fs.ErrPermission` (what Seatbelt returns) or `EROFS` (what the Linux read-only bind returns). A full disk stays a full disk. Blaming cplt for something it did not do is its own bug, so it is tested in both directions.

Wired at two sites: the artifact copy in `install.go` (which fails first — the script lands in the denied directory before its config entry does) and `activateHook` in `hooks.go` (both the repo merge and the user-scope write).

## Tests

- `TestInstallHookInsideCpltSandboxNamesCplt` — a real `installArtifact` into a hooks directory the process cannot write, with the marker set; asserts the error names cplt, names the variable, names the path, and says to run outside. The write is denied by mode bits rather than by a sandbox (a test cannot build one), but the errno it keys on is the one Seatbelt returns.
- `TestHookWriteFailureOutsideCpltIsNotBlamedOnIt` — same errno, no marker, no mention of cplt.
- `TestHookWriteNonPermissionErrorPassesThrough` — `ENOSPC` inside a sandbox is not blamed on cplt.

**Mutation-checked.** Removing the `explainHookWrite` call at the `install.go` copy site makes `TestInstallHookInsideCpltSandboxNamesCplt` fail with three assertions (`cplt`, `__CPLT_WRAPPED`, `outside cplt`); restoring it turns them green.

## Gates

`go build`, `go vet`, `staticcheck v0.7.0`, `go test -race ./...` — all pass.

One caveat on `mise nav-pilot:check`: `TestRun_AliasSync` fails on any machine whose real `~/.nav-pilot/config.toml` points at a `source` that is not a GitHub slug, because that test calls `run(["s"])` without isolating `HOME`. It is unrelated to this change (it fails on a clean checkout of `main` too) and is the exact isolation gap `AGENTS.md` warns about. With `HOME` set to a temp dir the whole suite is green. Worth its own fix; not this PR.

Verified against cplt at `eac7641`.