### PR TITLE
fix(nav-pilot): seed the Nav hosts before recommending strict

### DIFF
--- a/cli/nav-pilot/internal/cli/config_cmd.go
+++ b/cli/nav-pilot/internal/cli/config_cmd.go
@@ -337,8 +337,9 @@ version = 1
 # rtk_prompted_at = ""
 
 # ── cplt auth ──────────────────────────────────────────────────────────────────
-# nav-pilot never extracts a Copilot token itself. With cplt's gh guard on
-# (sandbox.preset = strict), cplt uses an inherited
+# nav-pilot never extracts a Copilot token itself. With cplt's gh guard on — the
+# default since cplt#335, not only under sandbox.preset = strict — cplt uses an
+# inherited
 # GH_TOKEN/GITHUB_TOKEN/COPILOT_GITHUB_TOKEN if one is set and otherwise runs
 # "gh auth token" outside the sandbox; with it off, Copilot authenticates on its
 # own. copilot_auth_mode decides which sources reach cplt.

--- a/cli/nav-pilot/internal/cli/config_sandbox.go
+++ b/cli/nav-pilot/internal/cli/config_sandbox.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -77,10 +79,27 @@ func cmdConfigSandbox() error {
 
 // ─── security posture (sandbox.preset) ───────────────────────────────────────
 
-// cpltRecommendedPreset is the sandbox preset nav-pilot recommends: it turns on
-// gh_guard, git_guard and proxy.forced in one key. Individually set keys still
-// override it, so it is safe to recommend to users who have tuned cplt already.
+// cpltRecommendedPreset is the sandbox preset nav-pilot recommends.
+//
+// What it buys over `standard` is narrower than it used to be. cplt#335 turned
+// gh_guard and git_guard on in `standard` too, so naming those as the reason is
+// now stale advice. What strict still adds is the network: forced-proxy egress,
+// the git guard escalated from warn to block, and `proxy.default_allowlist` —
+// which restricts egress to cplt's built-in host list plus whatever
+// `proxy.allowed_domains` names, and blocks everything else
+// (cplt src/config/types.rs, `Preset::Strict.baseline()`).
+//
+// That last one is why the recommendation is never made on its own: see
+// navAllowedDomains below. Individually set keys still override the preset, so
+// it stays safe to recommend to users who have tuned cplt already.
 const cpltRecommendedPreset = "strict"
+
+// cpltStrictConsequence is the one-paragraph version of what strict does, used
+// wherever nav-pilot recommends it. It leads with the consequence rather than
+// the feature list, because the feature list is what went stale.
+const cpltStrictConsequence = "Locks egress down: only cplt's built-in host list plus proxy.allowed_domains " +
+	"stay reachable, and the git guard blocks rather than warns. nav-pilot seeds the allowlist " +
+	"with the Nav hosts it and your agents need, or they go dark. Keys you set yourself still win."
 
 // cpltPresets are the values cplt accepts for sandbox.preset. Anything else is
 // treated as unknown rather than guessed at.
@@ -123,8 +142,16 @@ func cpltRecommendStrict(preset string) bool {
 	return preset != "" && preset != cpltRecommendedPreset
 }
 
-// cmdConfigStrictPreset asks for confirmation and sets sandbox.preset = strict.
-// cplt config is personal: nav-pilot never sets it silently.
+// cmdConfigStrictPreset asks for confirmation, seeds the allowlist, and sets
+// sandbox.preset = strict. cplt config is personal: nav-pilot never sets it
+// silently.
+//
+// The allowlist is seeded *before* the preset, not after. Strict is a network
+// lockdown that takes effect on the next launch, so a machine that gets the
+// preset without the hosts is one where nav-pilot's telemetry and every
+// Nav-internal endpoint have gone dark — and the user has no reason to connect
+// the two. Doing the harmless write first means the only way to end up in that
+// state is for the preset to be set by hand.
 func cmdConfigStrictPreset() error {
 	cliPath, err := findCplt()
 	if err != nil {
@@ -134,7 +161,7 @@ func cmdConfigStrictPreset() error {
 	var ok bool
 	if err := huh.NewConfirm().
 		Title("Set cplt sandbox.preset = strict?").
-		Description("Turns on gh_guard, git_guard and forced proxy in one key. Keys you set yourself still win.").
+		Description(cpltStrictConsequence).
 		Value(&ok).
 		WithTheme(navTheme()).
 		Run(); err != nil {
@@ -142,6 +169,26 @@ func cmdConfigStrictPreset() error {
 	}
 	if !ok {
 		return nil
+	}
+
+	return applyStrictPreset(cliPath)
+}
+
+// applyStrictPreset is everything cmdConfigStrictPreset does once the user has
+// said yes. Split out so the seed-then-set order — the part that matters — is
+// testable against a real cplt on PATH, without a terminal.
+func applyStrictPreset(cliPath string) error {
+	path, adopted, err := seedCpltAllowlist(cliPath)
+	if err != nil {
+		return err
+	}
+	if adopted {
+		fmt.Printf("%s cplt proxy.allowed_domains = %s (%d Nav hosts)\n",
+			domain.Green("✓"), path, len(navAllowedDomains))
+	} else {
+		fmt.Printf("%s You already have proxy.allowed_domains set, so nav-pilot left it alone.\n",
+			domain.Yellow("⚠"))
+		fmt.Printf("  Add the hosts in %s to your own file, or strict will block them.\n", path)
 	}
 
 	if err := cpltConfigSet(cliPath, "sandbox.preset", cpltRecommendedPreset); err != nil {
@@ -217,4 +264,134 @@ var cpltEnforcement = func() *cpltCheckReport {
 	defer cancel()
 	out, _ := exec.CommandContext(ctx, cliPath, "check", "--json").Output()
 	return parseCpltCheckReport(out)
+}
+
+// ─── the allowlist strict implies ────────────────────────────────────────────
+
+// The strict preset is a full network lockdown, not just a set of guards.
+// Beyond forced-proxy egress it turns on `proxy.default_allowlist`, which makes
+// cplt's built-in per-agent host list the *only* reachable set of hosts
+// (cplt src/config/types.rs, `Preset::Strict.baseline()`). That list covers
+// GitHub Copilot's own infrastructure and the public package registries. It
+// covers nothing of Nav's — so recommending strict on its own would silently
+// cut nav-pilot's telemetry export and every Nav-internal host the agents and
+// skills nav-pilot installs are built around.
+//
+// The recommendation therefore comes with the hosts. cplt merges
+// `proxy.allowed_domains` into the built-in list rather than replacing it, so
+// this file only has to carry the delta.
+
+// navAllowedDomains are the hosts nav-pilot and the artifacts it installs
+// actually reach, minus everything cplt's built-in Copilot allowlist already
+// covers (github.com, api.github.com, githubcopilot.com, the package
+// registries — see COPILOT_INFRA_DOMAINS and PACKAGE_REGISTRY_DOMAINS in
+// cplt src/agent.rs).
+//
+// Every entry is here because something nav-pilot ships fetches it, with the
+// call site named. The list is deliberately short: an allowlist padded with
+// hosts nobody verified is a lockdown that only looks like one. Hosts that
+// appear in the artifacts as citation links, human-facing UI links, or sample
+// config for the developer's own application are NOT here — nothing fetches
+// them, and adding them would widen the hole for nothing.
+//
+// cplt matches each entry exact-or-subdomain and does not read glob syntax, so
+// these are bare hostnames with no leading `*.` — and they are specific hosts
+// rather than `nav.cloud.nais.io`, which would open every Nais tenant at once.
+var navAllowedDomains = []string{
+	// nav-pilot's own OTel metrics export, on every command.
+	// internal/telemetry/telemetry.go, defaultTelemetryEndpoint — also injected
+	// into copilot and opencode sessions as OTEL_EXPORTER_OTLP_ENDPOINT.
+	"collector-internet.nav.cloud.nais.io",
+
+	// The Aksel design-system MCP server the aksel agent is built around.
+	// agents/aksel.agent.md declares it as a streamable-http MCP endpoint, and
+	// skills/aksel-builder/SKILL.md says in as many words that the URL has to
+	// be allowlisted for the agent to work.
+	"aksel-mcp.nav.no",
+
+	// The documented fallback when that MCP is unavailable: the agent fetches
+	// the llm.md index and follows the .md links off it.
+	// skills/aksel-builder/SKILL.md, skills/aksel-spacing/SKILL.md.
+	"aksel.nav.no",
+
+	// The observability skill hands the agent literal curl commands against
+	// these four APIs — Prometheus, Loki, and Tempo in each of the two
+	// environments Nav runs. skills/observability-debugging/SKILL.md.
+	// grafana.nav.cloud.nais.io is deliberately absent: the skill presents it
+	// as a browser link for the human, never as something the agent fetches.
+	"mimir.nav.cloud.nais.io",
+	"loki.nav.cloud.nais.io",
+	"tempo.dev-gcp.nav.cloud.nais.io",
+	"tempo.prod-gcp.nav.cloud.nais.io",
+
+	// The Entra ID OIDC discovery document for the nav.no tenant, curl'd
+	// directly by skills/nav-auth/SKILL.md.
+	"login.microsoftonline.com",
+}
+
+// navAllowedDomainsPath is where nav-pilot keeps the file cplt reads.
+//
+// `proxy.allowed_domains` takes a *path*, not a list, and cplt re-reads that
+// file every few seconds — so this is a live document, and putting it beside
+// the nav-pilot config rather than inside cplt's own is what lets nav-pilot
+// update it on a later run without touching anything the user owns.
+func navAllowedDomainsPath() string {
+	return filepath.Join(filepath.Dir(configPath()), "cplt-allowed-domains.txt")
+}
+
+// writeNavAllowedDomains renders navAllowedDomains to disk and returns the path.
+// The file is nav-pilot's to rewrite; the comment header says so, because a
+// stray hostname in it is a hole in the user's allowlist.
+func writeNavAllowedDomains() (string, error) {
+	path := navAllowedDomainsPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", fmt.Errorf("creating %s: %w", filepath.Dir(path), err)
+	}
+	var b strings.Builder
+	b.WriteString("# Written by nav-pilot. Edits are overwritten on the next run.\n")
+	b.WriteString("# Hosts nav-pilot and the agents and skills it installs need, on top of\n")
+	b.WriteString("# cplt's built-in allowlist. Read by cplt via proxy.allowed_domains.\n")
+	for _, d := range navAllowedDomains {
+		b.WriteString(d + "\n")
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		return "", fmt.Errorf("writing %s: %w", path, err)
+	}
+	return path, nil
+}
+
+// cpltConfigGet reads one cplt config key. Empty on any failure — callers treat
+// that as "not set", which is the safe reading: it makes them seed rather than
+// assume a user allowlist exists.
+func cpltConfigGet(cliPath, key string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, cliPath, "config", "get", key).Output()
+	if err != nil {
+		return ""
+	}
+	first, _, _ := strings.Cut(string(out), "\n")
+	return strings.TrimSpace(first)
+}
+
+// seedCpltAllowlist writes the domains file and points cplt at it, so that
+// turning on strict does not take nav-pilot's own network with it.
+//
+// It will not take over an allowlist the user already has. `allowed_domains`
+// holds exactly one path, so repointing it at nav-pilot's file would silently
+// revoke every host in theirs — under a preset whose whole point is that
+// unlisted hosts are unreachable. In that case the file is still written and
+// the path returned, and the caller tells the user to include it.
+func seedCpltAllowlist(cliPath string) (path string, adopted bool, err error) {
+	path, err = writeNavAllowedDomains()
+	if err != nil {
+		return "", false, err
+	}
+	if existing := cpltConfigGet(cliPath, "proxy.allowed_domains"); existing != "" && existing != path {
+		return path, false, nil
+	}
+	if err := cpltConfigSet(cliPath, "proxy.allowed_domains", path); err != nil {
+		return path, false, err
+	}
+	return path, true, nil
 }

--- a/cli/nav-pilot/internal/cli/config_sandbox.go
+++ b/cli/nav-pilot/internal/cli/config_sandbox.go
@@ -137,9 +137,18 @@ var cpltSandboxPreset = func() string {
 }
 
 // cpltRecommendStrict reports whether nav-pilot should nudge the user towards
-// the strict preset. An unknown preset is left alone.
+// the strict preset. An unknown preset is left alone, and so is a machine where
+// strict would not work — see strictPresetSupported.
+//
+// The platform gate lives here rather than at the call sites because both the
+// doctor report and the settings page route through this one predicate. A gate
+// added to only one of them is a recommendation nav-pilot still makes.
 func cpltRecommendStrict(preset string) bool {
-	return preset != "" && preset != cpltRecommendedPreset
+	if preset == "" || preset == cpltRecommendedPreset {
+		return false
+	}
+	ok, _ := strictPresetSupported()
+	return ok
 }
 
 // cmdConfigStrictPreset asks for confirmation, seeds the allowlist, and sets
@@ -156,6 +165,11 @@ func cmdConfigStrictPreset() error {
 	cliPath, err := findCplt()
 	if err != nil {
 		return err
+	}
+	// The row is selectable even where the recommendation is withheld, so the
+	// refusal is repeated here rather than assumed from the row being hidden.
+	if ok, reason := strictPresetSupported(); !ok {
+		return fmt.Errorf("nav-pilot will not set sandbox.preset = strict here: %s", reason)
 	}
 
 	var ok bool

--- a/cli/nav-pilot/internal/cli/config_sandbox.go
+++ b/cli/nav-pilot/internal/cli/config_sandbox.go
@@ -281,23 +281,79 @@ var cpltEnforcement = func() *cpltCheckReport {
 // `proxy.allowed_domains` into the built-in list rather than replacing it, so
 // this file only has to carry the delta.
 
-// navAllowedDomains are the hosts nav-pilot and the artifacts it installs
-// actually reach, minus everything cplt's built-in Copilot allowlist already
-// covers (github.com, api.github.com, githubcopilot.com, the package
-// registries — see COPILOT_INFRA_DOMAINS and PACKAGE_REGISTRY_DOMAINS in
-// cplt src/agent.rs).
+// navAllowedDomains is the COMPLETE set of hosts nav-pilot writes to the file
+// cplt reads. Complete, not a delta — that distinction is the whole design.
 //
-// Every entry is here because something nav-pilot ships fetches it, with the
-// call site named. The list is deliberately short: an allowlist padded with
-// hosts nobody verified is a lockdown that only looks like one. Hosts that
-// appear in the artifacts as citation links, human-facing UI links, or sample
-// config for the developer's own application are NOT here — nothing fetches
-// them, and adding them would widen the hole for nothing.
+// `proxy.allowed_domains` is fail-closed on its own account, independently of
+// `proxy.default_allowlist`: cplt blocks any host outside a non-empty allowlist
+// (cplt src/proxy.rs, the `BlockedAllowlist` arm), and the built-in per-agent
+// list is only unioned in while `default_allowlist` is on (cplt
+// src/proxy_domains.rs, `DomainList::current` — "no sticky half, the file is
+// the sole source"). So a delta file is a trap with three doors into it: the
+// window between nav-pilot's two config writes, a failed preset write, and a
+// user who later lowers the preset by hand or with `--preset`. Behind any of
+// them the file IS the allowlist, and a delta file would leave github.com and
+// every package registry unreachable, with nothing on screen naming nav-pilot.
+//
+// Writing the built-ins back out costs nothing — cplt unions and dedupes — and
+// makes the file correct standing alone. Which it also has to be for a second
+// reason: the built-in list is per agent (cplt src/agent.rs,
+// `Agent::default_allowed_domains`). nav-pilot launches copilot, opencode and
+// pi through cplt, and only the copilot list carries GitHub and Copilot
+// infrastructure. opencode gets `opencode.ai` and `models.dev`; pi gets the
+// package registries and nothing else. An opencode session on nav-pilot's
+// default `github-copilot/auto` model could not reach a model host at all.
+//
+// Every Nav entry below is something nav-pilot or an artifact it installs
+// actually fetches, with the call site named. Hosts that appear in the
+// artifacts as citation links, human-facing UI links, or sample config for the
+// developer's own application are NOT here — nothing fetches them, and each one
+// would widen the lockdown for nothing.
 //
 // cplt matches each entry exact-or-subdomain and does not read glob syntax, so
 // these are bare hostnames with no leading `*.` — and they are specific hosts
 // rather than `nav.cloud.nais.io`, which would open every Nais tenant at once.
-var navAllowedDomains = []string{
+var navAllowedDomains = append(append([]string{}, cpltBuiltinDomains...), navOwnDomains...)
+
+// cpltBuiltinDomains mirrors cplt's own built-in allowlists for the three
+// agents nav-pilot launches: COPILOT_INFRA_DOMAINS, OPENCODE_DOMAINS and
+// PACKAGE_REGISTRY_DOMAINS in cplt src/agent.rs.
+//
+// Copied rather than referenced because there is nothing to reference — cplt
+// exposes the list to `cplt --observe-domains` and to its own proxy, not to a
+// config command. A copy can go stale, so the cost of it being wrong is worth
+// stating: a host cplt adds later and nav-pilot does not is one an agent cannot
+// reach under strict, which is a visible failure with a one-line fix here. The
+// reverse — a host cplt drops — leaves an entry that was already reachable.
+// Neither silently weakens anything, because everything here is already in
+// cplt's own default-on list.
+var cpltBuiltinDomains = []string{
+	// Copilot: auth, model access and telemetry.
+	"githubcopilot.com",
+	"api.github.com",
+	"github.com",
+	"copilot-proxy.githubusercontent.com",
+	"actions.githubusercontent.com",
+	"default.exp2.cds.s9ch.io",
+
+	// opencode's own infrastructure.
+	"opencode.ai",
+	"models.dev",
+
+	// Package registries, shared by every agent.
+	"registry.npmjs.org",
+	"registry.yarnpkg.com",
+	"repo.maven.apache.org",
+	"plugins.gradle.org",
+	"crates.io",
+	"static.crates.io",
+	"pypi.org",
+	"files.pythonhosted.org",
+}
+
+// navOwnDomains are the hosts nav-pilot adds on top: nothing in cplt's
+// built-in lists reaches any of them.
+var navOwnDomains = []string{
 	// nav-pilot's own OTel metrics export, on every command.
 	// internal/telemetry/telemetry.go, defaultTelemetryEndpoint — also injected
 	// into copilot and opencode sessions as OTEL_EXPORTER_OTLP_ENDPOINT.
@@ -315,8 +371,12 @@ var navAllowedDomains = []string{
 	"aksel.nav.no",
 
 	// The observability skill hands the agent literal curl commands against
-	// these four APIs — Prometheus, Loki, and Tempo in each of the two
-	// environments Nav runs. skills/observability-debugging/SKILL.md.
+	// Prometheus, Loki and Tempo. Mimir and Loki are single global endpoints;
+	// Tempo is per cluster, and every concrete example in the skill uses one of
+	// these two. The skill's `dev-fss`/`prod-fss` clusters appear only as a
+	// Loki label value, never as a Tempo hostname, so they are left out until
+	// something shows Tempo is reachable there.
+	// skills/observability-debugging/SKILL.md.
 	// grafana.nav.cloud.nais.io is deliberately absent: the skill presents it
 	// as a browser link for the human, never as something the agent fetches.
 	"mimir.nav.cloud.nais.io",
@@ -327,14 +387,35 @@ var navAllowedDomains = []string{
 	// The Entra ID OIDC discovery document for the nav.no tenant, curl'd
 	// directly by skills/nav-auth/SKILL.md.
 	"login.microsoftonline.com",
+
+	// Nav's Maven mirror. skills/spring-boot-scaffold/SKILL.md writes it into
+	// the generated build.gradle.kts repositories block, so an agent that
+	// scaffolds a service and then builds it resolves against this host.
+	// repo.maven.apache.org being built in does not help.
+	"github-package-registry-mirror.gc.nav.no",
+
+	// scripts/install.sh — the documented install path for both nav-pilot and
+	// cplt — is `curl https://raw.githubusercontent.com/...  | bash`, and the
+	// release assets it then fetches redirect to the object hosts. None of
+	// these is covered by cplt's `github.com`: the matcher is
+	// exact-or-subdomain and githubusercontent.com is a different apex, of
+	// which cplt lists only the copilot-proxy and actions subdomains.
+	"raw.githubusercontent.com",
+	"objects.githubusercontent.com",
+	"release-assets.githubusercontent.com",
 }
 
 // navAllowedDomainsPath is where nav-pilot keeps the file cplt reads.
 //
 // `proxy.allowed_domains` takes a *path*, not a list, and cplt re-reads that
-// file every few seconds — so this is a live document, and putting it beside
-// the nav-pilot config rather than inside cplt's own is what lets nav-pilot
-// update it on a later run without touching anything the user owns.
+// file every few seconds. It lives beside the nav-pilot config rather than
+// inside cplt's own so nav-pilot can rewrite it without touching a file the
+// user owns.
+//
+// It is written on exactly one path today — the posture action — so a user who
+// adopts strict keeps whatever list shipped that day. Refreshing it when it is
+// already the configured allowlist is the obvious next step and is not in this
+// change.
 func navAllowedDomainsPath() string {
 	return filepath.Join(filepath.Dir(configPath()), "cplt-allowed-domains.txt")
 }
@@ -349,8 +430,11 @@ func writeNavAllowedDomains() (string, error) {
 	}
 	var b strings.Builder
 	b.WriteString("# Written by nav-pilot. Edits are overwritten on the next run.\n")
-	b.WriteString("# Hosts nav-pilot and the agents and skills it installs need, on top of\n")
-	b.WriteString("# cplt's built-in allowlist. Read by cplt via proxy.allowed_domains.\n")
+	b.WriteString("# The complete set of hosts nav-pilot and the agents and skills it installs\n")
+	b.WriteString("# need. Read by cplt via proxy.allowed_domains.\n")
+	b.WriteString("#\n")
+	b.WriteString("# Deleting this file does not fail loudly: cplt keeps serving its built-in\n")
+	b.WriteString("# list and the Nav hosts below simply stop being reachable.\n")
 	for _, d := range navAllowedDomains {
 		b.WriteString(d + "\n")
 	}

--- a/cli/nav-pilot/internal/cli/config_sandbox.go
+++ b/cli/nav-pilot/internal/cli/config_sandbox.go
@@ -197,8 +197,8 @@ func applyStrictPreset(cliPath string) error {
 		return err
 	}
 	if adopted {
-		fmt.Printf("%s cplt proxy.allowed_domains = %s (%d Nav hosts)\n",
-			domain.Green("✓"), path, len(navAllowedDomains))
+		fmt.Printf("%s cplt proxy.allowed_domains = %s (%d hosts, %d of them Nav's)\n",
+			domain.Green("✓"), path, len(navAllowedDomains), len(navOwnDomains))
 	} else {
 		fmt.Printf("%s You already have proxy.allowed_domains set, so nav-pilot left it alone.\n",
 			domain.Yellow("⚠"))
@@ -437,10 +437,22 @@ func navAllowedDomainsPath() string {
 // writeNavAllowedDomains renders navAllowedDomains to disk and returns the path.
 // The file is nav-pilot's to rewrite; the comment header says so, because a
 // stray hostname in it is a hole in the user's allowlist.
+//
+// Written by temp-file-and-rename rather than in place. cplt re-reads this file
+// every few seconds while a session runs, and a reader that catches an in-place
+// write half-done sees a truncated host list — which under strict is not a
+// cosmetic glitch but a set of hosts that briefly stop resolving. rename(2) is
+// atomic within a directory, so a reader sees either the old file or the new
+// one. The temp file is created in the same directory for that reason: a
+// rename across filesystems is not atomic and may not be a rename at all.
+//
+// Same directory permissions as the rest of nav-pilot's config (config_setup.go):
+// 0700, because ~/.nav-pilot is personal state.
 func writeNavAllowedDomains() (string, error) {
 	path := navAllowedDomainsPath()
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return "", fmt.Errorf("creating %s: %w", filepath.Dir(path), err)
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("creating %s: %w", dir, err)
 	}
 	var b strings.Builder
 	b.WriteString("# Written by nav-pilot. Edits are overwritten on the next run.\n")
@@ -452,7 +464,21 @@ func writeNavAllowedDomains() (string, error) {
 	for _, d := range navAllowedDomains {
 		b.WriteString(d + "\n")
 	}
-	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+	tmp, err := os.CreateTemp(dir, ".cplt-allowed-domains-*")
+	if err != nil {
+		return "", fmt.Errorf("writing %s: %w", path, err)
+	}
+	defer os.Remove(tmp.Name()) // no-op once the rename succeeds
+	if _, err := tmp.WriteString(b.String()); err != nil {
+		tmp.Close()
+		return "", fmt.Errorf("writing %s: %w", path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return "", fmt.Errorf("writing %s: %w", path, err)
+	}
+	// CreateTemp makes the file 0600. cplt reads it as the same user, so that
+	// is all it needs.
+	if err := os.Rename(tmp.Name(), path); err != nil {
 		return "", fmt.Errorf("writing %s: %w", path, err)
 	}
 	return path, nil

--- a/cli/nav-pilot/internal/cli/config_sandbox.go
+++ b/cli/nav-pilot/internal/cli/config_sandbox.go
@@ -291,9 +291,10 @@ var cpltEnforcement = func() *cpltCheckReport {
 // cut nav-pilot's telemetry export and every Nav-internal host the agents and
 // skills nav-pilot installs are built around.
 //
-// The recommendation therefore comes with the hosts. cplt merges
-// `proxy.allowed_domains` into the built-in list rather than replacing it, so
-// this file only has to carry the delta.
+// The recommendation therefore comes with the hosts, written to a file
+// `proxy.allowed_domains` points at. What goes in that file is the complete
+// list rather than the Nav delta, for reasons set out at navAllowedDomains
+// below.
 
 // navAllowedDomains is the COMPLETE set of hosts nav-pilot writes to the file
 // cplt reads. Complete, not a delta — that distinction is the whole design.

--- a/cli/nav-pilot/internal/cli/config_sandbox_test.go
+++ b/cli/nav-pilot/internal/cli/config_sandbox_test.go
@@ -373,6 +373,21 @@ func TestStrictActionRefusesOnAnUnsupportedKernel(t *testing.T) {
 	}
 }
 
+// The worst case: strict is already set on a kernel where cplt refuses to
+// launch under it. Nothing on that machine starts, and a bare "strict" in the
+// settings row — or a green check in doctor — says everything is fine. The
+// unsupported state has to surface whatever the current preset is.
+func TestPostureRowFlagsStrictAlreadySetOnAnUnsupportedKernel(t *testing.T) {
+	stubStrictSupport(t, false, "this kernel cannot enforce forced-proxy egress")
+	got := cpltPostureValue(cpltRecommendedPreset)
+	if got == cpltRecommendedPreset {
+		t.Fatalf("row shows a bare %q on a kernel where cplt will not launch", got)
+	}
+	if !strings.Contains(got, "will not launch") {
+		t.Errorf("row does not say the machine is stuck: %q", got)
+	}
+}
+
 // The settings page says the option is closed rather than showing a bare
 // preset name, which would read as a choice the user declined to make.
 func TestPostureRowNamesTheUnsupportedKernel(t *testing.T) {

--- a/cli/nav-pilot/internal/cli/config_sandbox_test.go
+++ b/cli/nav-pilot/internal/cli/config_sandbox_test.go
@@ -288,3 +288,33 @@ func TestNavAllowedDomainsAreBareAndSpecific(t *testing.T) {
 		}
 	}
 }
+
+// The file nav-pilot writes has to be a complete allowlist, never a delta.
+//
+// cplt blocks everything outside a non-empty `proxy.allowed_domains`
+// regardless of `proxy.default_allowlist`, and only unions in its built-in
+// per-agent list while that second key is on. Between nav-pilot's two config
+// writes, after a failed preset write, or once a user lowers the preset by
+// hand, this file IS the allowlist — and a delta would leave github.com and
+// every package registry unreachable.
+//
+// It also has to be complete because the built-in list is per agent, and
+// nav-pilot launches three. Only the copilot list carries GitHub and Copilot
+// infrastructure: opencode's is opencode.ai and models.dev, pi's is the package
+// registries alone.
+func TestSeededAllowlistStandsAloneForEveryAgent(t *testing.T) {
+	// Model access and auth, without which no agent reaches a model at all.
+	// cplt COPILOT_INFRA_DOMAINS — absent from the opencode and pi lists.
+	// opencode's own infrastructure. cplt OPENCODE_DOMAINS — absent from the
+	// copilot list.
+	// Package registries, so a sandboxed build still resolves.
+	for _, host := range []string{
+		"githubcopilot.com", "github.com", "api.github.com",
+		"opencode.ai", "models.dev",
+		"registry.npmjs.org", "repo.maven.apache.org", "pypi.org",
+	} {
+		if !containsStr(navAllowedDomains, host) {
+			t.Errorf("%q missing — the file is a delta, and on its own it locks the agent out", host)
+		}
+	}
+}

--- a/cli/nav-pilot/internal/cli/config_sandbox_test.go
+++ b/cli/nav-pilot/internal/cli/config_sandbox_test.go
@@ -318,3 +318,70 @@ func TestSeededAllowlistStandsAloneForEveryAgent(t *testing.T) {
 		}
 	}
 }
+
+// ─── the platform gate ───────────────────────────────────────────────────────
+
+// stubStrictSupport replaces the platform gate for one test.
+func stubStrictSupport(t *testing.T, ok bool, reason string) {
+	t.Helper()
+	prev := strictPresetSupported
+	strictPresetSupported = func() (bool, string) { return ok, reason }
+	t.Cleanup(func() { strictPresetSupported = prev })
+}
+
+// On a kernel that cannot enforce forced-proxy egress, cplt refuses to launch
+// under strict. Recommending it there would stop every session on the machine —
+// worse than the problem the recommendation solves — so the nudge is withheld.
+func TestStrictNotRecommendedWhereCpltWouldRefuseToLaunch(t *testing.T) {
+	stubStrictSupport(t, false, "this kernel cannot enforce forced-proxy egress")
+	for _, preset := range []string{"standard", "permissive", "full-trust"} {
+		if cpltRecommendStrict(preset) {
+			t.Errorf("recommended strict from %q on a kernel where cplt refuses to launch", preset)
+		}
+	}
+}
+
+// The gate must not swallow the recommendation everywhere else.
+func TestStrictStillRecommendedWhereItWorks(t *testing.T) {
+	stubStrictSupport(t, true, "")
+	for _, preset := range []string{"standard", "permissive", "full-trust"} {
+		if !cpltRecommendStrict(preset) {
+			t.Errorf("did not recommend strict from %q on a supported kernel", preset)
+		}
+	}
+	if cpltRecommendStrict(cpltRecommendedPreset) {
+		t.Error("recommended strict to someone already on strict")
+	}
+}
+
+// The settings row stays selectable, so the action refuses on its own account
+// rather than trusting that the row was hidden.
+func TestStrictActionRefusesOnAnUnsupportedKernel(t *testing.T) {
+	isolatedConfig(t)
+	log := fakeCplt(t, nil)
+	stubStrictSupport(t, false, "Landlock ABI v2, needs v4")
+
+	err := cmdConfigStrictPreset()
+	if err == nil {
+		t.Fatal("the action set strict on a kernel where cplt refuses to launch")
+	}
+	if !strings.Contains(err.Error(), "Landlock ABI v2") {
+		t.Errorf("refusal does not say why: %v", err)
+	}
+	if len(configSets(t, log)) != 0 {
+		t.Errorf("cplt config was written anyway: %v", configSets(t, log))
+	}
+}
+
+// The settings page says the option is closed rather than showing a bare
+// preset name, which would read as a choice the user declined to make.
+func TestPostureRowNamesTheUnsupportedKernel(t *testing.T) {
+	stubStrictSupport(t, false, "whatever")
+	if got := cpltPostureValue("standard"); !strings.Contains(got, "unavailable") {
+		t.Errorf("posture row hides the gate: %q", got)
+	}
+	stubStrictSupport(t, true, "")
+	if got := cpltPostureValue("standard"); !strings.Contains(got, cpltRecommendedPreset) {
+		t.Errorf("posture row dropped the recommendation where it works: %q", got)
+	}
+}

--- a/cli/nav-pilot/internal/cli/config_sandbox_test.go
+++ b/cli/nav-pilot/internal/cli/config_sandbox_test.go
@@ -385,3 +385,43 @@ func TestPostureRowNamesTheUnsupportedKernel(t *testing.T) {
 		t.Errorf("posture row dropped the recommendation where it works: %q", got)
 	}
 }
+
+// cplt re-reads this file every few seconds while a session runs, so an
+// in-place write is a window in which a reader sees a truncated host list —
+// under strict, hosts that briefly stop resolving. The write must be
+// temp-file-and-rename, and it must leave no temp file behind.
+func TestAllowlistIsWrittenAtomically(t *testing.T) {
+	isolatedConfig(t)
+	path, err := writeNavAllowedDomains()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Rewriting must be safe and must not accumulate temp files.
+	if _, err := writeNavAllowedDomains(); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+		if strings.HasPrefix(e.Name(), ".cplt-allowed-domains-") {
+			t.Errorf("a temp file was left behind: %s", e.Name())
+		}
+	}
+	if !containsStr(names, filepath.Base(path)) {
+		t.Errorf("the allowlist is not there after two writes: %v", names)
+	}
+
+	// The file itself is not world-readable. It is not secret, but it is
+	// personal config state and there is no reason for it to be looser.
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := fi.Mode().Perm(); perm&0o077 != 0 {
+		t.Errorf("allowlist is %o, want no group or other bits", perm)
+	}
+}

--- a/cli/nav-pilot/internal/cli/config_sandbox_test.go
+++ b/cli/nav-pilot/internal/cli/config_sandbox_test.go
@@ -1,6 +1,12 @@
 package cli
 
-import "testing"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestCpltPresetFromConfigGet(t *testing.T) {
 	tests := []struct {
@@ -118,5 +124,167 @@ func TestParseCpltCheckReport(t *testing.T) {
 				t.Errorf("Verified = %d, want %d", got.Verified, tc.wantVerified)
 			}
 		})
+	}
+}
+
+// ─── the allowlist strict implies ────────────────────────────────────────────
+
+// fakeCplt puts a stand-in `cplt` on PATH that records every `config set` into
+// a file and answers `config get` from an optional preset map. It is a real
+// binary at a real path, so findCplt, cpltConfigGet and cpltConfigSet all run
+// their actual exec paths — the point being to check the wiring, not a helper's
+// return value.
+//
+// Returns the path of the recording log.
+func fakeCplt(t *testing.T, get map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	log := filepath.Join(dir, "config-set.log")
+
+	var cases strings.Builder
+	for k, v := range get {
+		fmt.Fprintf(&cases, "    %s) printf '%%s\\n' %q ;;\n", k, v)
+	}
+
+	script := fmt.Sprintf(`#!/bin/sh
+case "$1 $2" in
+  "config set") printf '%%s %%s\n' "$3" "$4" >> %q ;;
+  "config get")
+    case "$3" in
+%s      *) exit 1 ;;
+    esac ;;
+  *) exit 1 ;;
+esac
+`, log, cases.String())
+
+	bin := filepath.Join(dir, "cplt")
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return log
+}
+
+func configSets(t *testing.T, log string) map[string]string {
+	t.Helper()
+	data, err := os.ReadFile(log)
+	if err != nil {
+		return map[string]string{}
+	}
+	out := map[string]string{}
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if k, v, ok := strings.Cut(line, " "); ok {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// The one that matters. Turning on strict must leave cplt configured with a
+// real allowlist file that really contains the telemetry collector — not merely
+// leave a helper returning a list of hosts.
+//
+// So this asserts the whole chain: cplt was told a path, that path exists, and
+// the collector is a line in it.
+func TestStrictPresetSeedsAllowlistIntoCpltConfig(t *testing.T) {
+	isolatedConfig(t)
+	log := fakeCplt(t, nil)
+
+	cliPath, err := findCplt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := applyStrictPreset(cliPath); err != nil {
+		t.Fatalf("applyStrictPreset: %v", err)
+	}
+
+	sets := configSets(t, log)
+	if sets["sandbox.preset"] != cpltRecommendedPreset {
+		t.Errorf("sandbox.preset = %q, want %q", sets["sandbox.preset"], cpltRecommendedPreset)
+	}
+
+	listPath := sets["proxy.allowed_domains"]
+	if listPath == "" {
+		t.Fatal("strict was set without pointing proxy.allowed_domains anywhere — the lockdown has no Nav hosts")
+	}
+	data, err := os.ReadFile(listPath)
+	if err != nil {
+		t.Fatalf("cplt was pointed at %s, which does not exist: %v", listPath, err)
+	}
+	var got []string
+	for _, line := range strings.Split(string(data), "\n") {
+		if line = strings.TrimSpace(line); line != "" && !strings.HasPrefix(line, "#") {
+			got = append(got, line)
+		}
+	}
+	if !containsStr(got, "collector-internet.nav.cloud.nais.io") {
+		t.Errorf("the telemetry collector is not in the file cplt reads: %v", got)
+	}
+	for _, want := range navAllowedDomains {
+		if !containsStr(got, want) {
+			t.Errorf("%q missing from the file cplt reads", want)
+		}
+	}
+}
+
+// The lockdown must be armed after the hosts are in place, never before.
+func TestStrictPresetSeedsBeforeSettingThePreset(t *testing.T) {
+	isolatedConfig(t)
+	log := fakeCplt(t, nil)
+
+	cliPath, err := findCplt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := applyStrictPreset(cliPath); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want two config writes, got %d: %v", len(lines), lines)
+	}
+	if !strings.HasPrefix(lines[0], "proxy.allowed_domains ") {
+		t.Errorf("the preset was set before the allowlist: %v", lines)
+	}
+}
+
+// An allowlist the user already owns is not nav-pilot's to repoint. The key
+// holds exactly one path, so taking it over would revoke every host in theirs —
+// under the one preset where an unlisted host is unreachable.
+func TestStrictPresetLeavesAUserAllowlistAlone(t *testing.T) {
+	isolatedConfig(t)
+	log := fakeCplt(t, map[string]string{"proxy.allowed_domains": "/home/me/my-domains.txt"})
+
+	cliPath, err := findCplt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := applyStrictPreset(cliPath); err != nil {
+		t.Fatal(err)
+	}
+	if got := configSets(t, log)["proxy.allowed_domains"]; got != "" {
+		t.Errorf("nav-pilot repointed the user's allowlist to %q", got)
+	}
+	// The file is still written, so the user has something to copy from.
+	if _, err := os.Stat(navAllowedDomainsPath()); err != nil {
+		t.Errorf("no host list written for the user to merge: %v", err)
+	}
+}
+
+// The list is a security boundary: a host in it is a hole in the lockdown.
+// Every entry has to be a bare hostname cplt's exact-or-subdomain matcher can
+// read, and the apex Nais domain would open every tenant at once.
+func TestNavAllowedDomainsAreBareAndSpecific(t *testing.T) {
+	for _, d := range navAllowedDomains {
+		if strings.ContainsAny(d, "*/: ") || strings.HasPrefix(d, ".") {
+			t.Errorf("%q is not a bare hostname; cplt does not read glob or URL syntax", d)
+		}
+		if d == "nav.no" || d == "nav.cloud.nais.io" || d == "nais.io" {
+			t.Errorf("%q is an apex domain — cplt matches subdomains, so this opens far more than intended", d)
+		}
 	}
 }

--- a/cli/nav-pilot/internal/cli/config_tui.go
+++ b/cli/nav-pilot/internal/cli/config_tui.go
@@ -95,7 +95,7 @@ func buildPageRows(entries []configPageEntry, preset string) []pageRow {
 			key:         configPagePosture,
 			entry:       configPageEntry{Key: "cplt security posture"},
 			value:       cpltPostureValue(preset),
-			description: "Sets cplt sandbox.preset = strict, which turns on gh_guard, git_guard and forced proxy in one key (requires cplt on your PATH).",
+			description: "Seeds cplt proxy.allowed_domains with the Nav hosts, then sets sandbox.preset = strict (requires cplt on your PATH). " + cpltStrictConsequence,
 		},
 		pageRow{
 			kind:        rowAction,

--- a/cli/nav-pilot/internal/cli/config_tui.go
+++ b/cli/nav-pilot/internal/cli/config_tui.go
@@ -130,6 +130,12 @@ func cpltPostureValue(preset string) string {
 	case cpltRecommendStrict(preset):
 		return preset + " (recommended: " + cpltRecommendedPreset + ")"
 	default:
+		// Where strict cannot work, the row still shows the current preset but
+		// says the option is closed, rather than looking like a choice the user
+		// declined to make.
+		if ok, _ := strictPresetSupported(); !ok && preset != cpltRecommendedPreset {
+			return preset + " (strict unavailable on this kernel)"
+		}
 		return preset
 	}
 }

--- a/cli/nav-pilot/internal/cli/config_tui.go
+++ b/cli/nav-pilot/internal/cli/config_tui.go
@@ -130,10 +130,15 @@ func cpltPostureValue(preset string) string {
 	case cpltRecommendStrict(preset):
 		return preset + " (recommended: " + cpltRecommendedPreset + ")"
 	default:
-		// Where strict cannot work, the row still shows the current preset but
-		// says the option is closed, rather than looking like a choice the user
-		// declined to make.
-		if ok, _ := strictPresetSupported(); !ok && preset != cpltRecommendedPreset {
+		// Where strict cannot work, say so whatever the current preset is. On a
+		// preset below strict that means the option is closed rather than
+		// declined; on strict itself it means the machine is already in the
+		// state where cplt refuses to launch, which is the one the user most
+		// needs told.
+		if ok, _ := strictPresetSupported(); !ok {
+			if preset == cpltRecommendedPreset {
+				return preset + " (cplt will not launch: unsupported kernel)"
+			}
 			return preset + " (strict unavailable on this kernel)"
 		}
 		return preset

--- a/cli/nav-pilot/internal/cli/doctor.go
+++ b/cli/nav-pilot/internal/cli/doctor.go
@@ -146,9 +146,21 @@ func cmdDoctor() error {
 		case preset == "":
 			// cplt could not tell us; nothing to recommend.
 		case cpltRecommendStrict(preset):
-			fmt.Printf("      %s Sandbox preset is %q (recommended: %q — turns on gh_guard, git_guard and forced proxy)\n",
+			// Not `cplt config set sandbox.preset strict` on its own. That
+			// command alone turns on proxy.default_allowlist, and from the
+			// next launch nav-pilot's telemetry and every Nav-internal host
+			// its agents and skills reach are unreachable, with nothing on
+			// screen connecting the two. The nav-pilot path seeds
+			// proxy.allowed_domains first and then sets the preset.
+			fmt.Printf("      %s Sandbox preset is %q (recommended: %q)\n",
 				yellow("⚠"), preset, cpltRecommendedPreset)
-			fmt.Printf("          %s Run %s\n", yellow("Solution:"), bold("cplt config set sandbox.preset strict"))
+			fmt.Printf("          %s locks egress down — only cplt's built-in host list plus\n", dim("What that does:"))
+			fmt.Printf("          %s stay reachable, and the git guard blocks rather than warns.\n", dim("proxy.allowed_domains"))
+			fmt.Printf("          Both guards are already on in %s since cplt#335; the network is what strict adds.\n", bold("standard"))
+			fmt.Printf("          %s Run %s and pick %s. It seeds the allowlist with the\n",
+				yellow("Solution:"), bold("nav-pilot config"), bold("cplt security posture"))
+			fmt.Printf("          %d Nav hosts nav-pilot and your agents need, then sets the preset.\n", len(navAllowedDomains))
+			fmt.Printf("          Setting the preset by hand skips that, and your Nav hosts go dark.\n")
 		default:
 			fmt.Printf("      %s Sandbox preset is %s\n", green("✓"), preset)
 		}

--- a/cli/nav-pilot/internal/cli/doctor.go
+++ b/cli/nav-pilot/internal/cli/doctor.go
@@ -142,9 +142,15 @@ func cmdDoctor() error {
 		// Security posture. A recommendation, not a failure — and an unknown
 		// preset is skipped rather than guessed at.
 		preset := cpltSandboxPreset()
+		supported, unsupportedReason := strictPresetSupported()
 		switch {
 		case preset == "":
 			// cplt could not tell us; nothing to recommend.
+		case !supported && preset != cpltRecommendedPreset:
+			// Silence here would read as approval of the current preset. Say
+			// that the recommendation is being withheld, and why.
+			fmt.Printf("      %s Sandbox preset is %s\n", green("✓"), preset)
+			fmt.Printf("          %s %s.\n", dim("Note:"), unsupportedReason)
 		case cpltRecommendStrict(preset):
 			// Not `cplt config set sandbox.preset strict` on its own. That
 			// command alone turns on proxy.default_allowlist, and from the

--- a/cli/nav-pilot/internal/cli/doctor.go
+++ b/cli/nav-pilot/internal/cli/doctor.go
@@ -146,11 +146,21 @@ func cmdDoctor() error {
 		switch {
 		case preset == "":
 			// cplt could not tell us; nothing to recommend.
-		case !supported && preset != cpltRecommendedPreset:
+		case !supported && preset == cpltRecommendedPreset:
+			// The worst case, and the one a green check would hide: strict is
+			// already set on a machine where cplt refuses to launch under it.
+			// Nothing here is going to start until the preset comes back down.
+			hasErrors = true
+			fmt.Printf("      %s Sandbox preset is %q, which cplt cannot honour here\n", red("[✗]"), preset)
+			fmt.Printf("          %s.\n", unsupportedReason)
+			fmt.Printf("          %s Run %s, or upgrade the kernel.\n",
+				red("Solution:"), bold("cplt config set sandbox.preset standard"))
+		case !supported:
 			// Silence here would read as approval of the current preset. Say
 			// that the recommendation is being withheld, and why.
 			fmt.Printf("      %s Sandbox preset is %s\n", green("✓"), preset)
-			fmt.Printf("          %s %s.\n", dim("Note:"), unsupportedReason)
+			fmt.Printf("          %s %s, so nav-pilot does not recommend it here.\n",
+				dim("Note:"), unsupportedReason)
 		case cpltRecommendStrict(preset):
 			// Not `cplt config set sandbox.preset strict` on its own. That
 			// command alone turns on proxy.default_allowlist, and from the

--- a/cli/nav-pilot/internal/cli/doctor.go
+++ b/cli/nav-pilot/internal/cli/doctor.go
@@ -165,7 +165,8 @@ func cmdDoctor() error {
 			fmt.Printf("          Both guards are already on in %s since cplt#335; the network is what strict adds.\n", bold("standard"))
 			fmt.Printf("          %s Run %s and pick %s. It seeds the allowlist with the\n",
 				yellow("Solution:"), bold("nav-pilot config"), bold("cplt security posture"))
-			fmt.Printf("          %d Nav hosts nav-pilot and your agents need, then sets the preset.\n", len(navAllowedDomains))
+			fmt.Printf("          %d hosts nav-pilot and your agents need (%d of them Nav's), then sets the preset.\n",
+				len(navAllowedDomains), len(navOwnDomains))
 			fmt.Printf("          Setting the preset by hand skips that, and your Nav hosts go dark.\n")
 		default:
 			fmt.Printf("      %s Sandbox preset is %s\n", green("✓"), preset)

--- a/cli/nav-pilot/internal/cli/strict_gate_linux.go
+++ b/cli/nav-pilot/internal/cli/strict_gate_linux.go
@@ -1,0 +1,61 @@
+//go:build linux
+
+package cli
+
+import (
+	"strconv"
+
+	"golang.org/x/sys/unix"
+)
+
+// Whether cplt's strict preset can work on this machine.
+//
+// `strict` turns on `proxy.forced`, and on Linux cplt enforces forced egress
+// with Landlock's kernel-level TCP-connect restriction. That needs Landlock ABI
+// v4 or newer (kernel 6.7+). Below it cplt does not degrade — it refuses to
+// launch, by design, because the alternative is open networking under a preset
+// whose whole point is that egress is closed (cplt src/sandbox_landlock.rs,
+// `check_proxy_forced_enforceable`).
+//
+// So on an older kernel, recommending strict does not weaken a session. It
+// stops every session on the machine. That is worse than the problem the
+// recommendation solves, so nav-pilot does not make it there.
+
+// landlockABIVersion asks the kernel for the highest Landlock ABI it supports,
+// returning 0 when Landlock is unavailable.
+//
+// This is the same probe cplt makes, deliberately: one
+// `landlock_create_ruleset(NULL, 0, LANDLOCK_CREATE_RULESET_VERSION)`, which
+// returns the version instead of creating a ruleset. It allocates no file
+// descriptor and has no side effects.
+//
+// Asking the kernel beats reading `uname`. A kernel version is a proxy for the
+// ABI, and a wrong one in the optimistic direction is exactly the failure being
+// avoided: Landlock can be compiled out or disabled at boot with `lsm=`, and a
+// 6.7+ host with Landlock off would pass a version check and then refuse to
+// launch. It also beats reading /sys/kernel/security/landlock/abi_version,
+// which is root-only on some hosts and would under-report.
+func landlockABIVersion() int {
+	// LANDLOCK_CREATE_RULESET_VERSION == 1.
+	r, _, errno := unix.Syscall(unix.SYS_LANDLOCK_CREATE_RULESET, 0, 0, 1)
+	if errno != 0 {
+		return 0
+	}
+	return int(r)
+}
+
+// minLandlockABIForForcedProxy is the ABI cplt requires to enforce forced
+// egress: v4, first in kernel 6.7.
+const minLandlockABIForForcedProxy = 4
+
+// strictPresetSupported reports whether cplt's strict preset can work here.
+// A var for the same reason cpltSandboxPreset is one: tests cannot arrange a
+// kernel, and the gate has to be exercised from both sides.
+var strictPresetSupported = func() (bool, string) {
+	if abi := landlockABIVersion(); abi < minLandlockABIForForcedProxy {
+		return false, "this kernel cannot enforce cplt's forced-proxy egress " +
+			"(Landlock ABI v" + strconv.Itoa(abi) + ", needs v4 — kernel 6.7+ with Landlock enabled). " +
+			"cplt refuses to launch under strict here, so nav-pilot does not recommend it"
+	}
+	return true, ""
+}

--- a/cli/nav-pilot/internal/cli/strict_gate_linux.go
+++ b/cli/nav-pilot/internal/cli/strict_gate_linux.go
@@ -53,9 +53,12 @@ const minLandlockABIForForcedProxy = 4
 // kernel, and the gate has to be exercised from both sides.
 var strictPresetSupported = func() (bool, string) {
 	if abi := landlockABIVersion(); abi < minLandlockABIForForcedProxy {
-		return false, "this kernel cannot enforce cplt's forced-proxy egress " +
-			"(Landlock ABI v" + strconv.Itoa(abi) + ", needs v4 — kernel 6.7+ with Landlock enabled). " +
-			"cplt refuses to launch under strict here, so nav-pilot does not recommend it"
+		// The reason states the fact only. Each caller adds its own
+		// consequence, because "so it is not recommended" is wrong to print to
+		// someone who already has strict set.
+		return false, "this kernel cannot enforce cplt's forced-proxy egress, " +
+			"so cplt refuses to launch under strict (Landlock ABI v" + strconv.Itoa(abi) +
+			", needs v4: kernel 6.7+ with Landlock enabled)"
 	}
 	return true, ""
 }

--- a/cli/nav-pilot/internal/cli/strict_gate_other.go
+++ b/cli/nav-pilot/internal/cli/strict_gate_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package cli
+
+// strictPresetSupported reports whether cplt's strict preset can work here.
+//
+// Only Linux has a gate: cplt enforces `proxy.forced` there with Landlock,
+// which needs ABI v4, and refuses to launch below it. macOS enforces the same
+// thing with Seatbelt, which has no equivalent floor. See strict_gate_linux.go.
+var strictPresetSupported = func() (bool, string) { return true, "" }

--- a/cli/nav-pilot/internal/local/guard.go
+++ b/cli/nav-pilot/internal/local/guard.go
@@ -170,6 +170,17 @@ func (g *Guard) URL() string {
 	return fmt.Sprintf("http://127.0.0.1:%d", g.ln.Addr().(*net.TCPAddr).Port)
 }
 
+// Port is the ephemeral port this guard listens on, or 0 when it is not
+// listening. The launch paths need the number rather than the URL: cplt's
+// sandbox blocks localhost by default, so the port has to be named to it with
+// `--allow-localhost`.
+func (g *Guard) Port() int {
+	if g == nil || g.ln == nil {
+		return 0
+	}
+	return g.ln.Addr().(*net.TCPAddr).Port
+}
+
 // StartGuard puts the guard in front of a local server and returns once it is
 // listening. Close it when the session ends: the guard's goroutines outlive the
 // call that started them, and only [Guard.Close] waits for them.

--- a/cli/nav-pilot/internal/provider/allow_localhost_test.go
+++ b/cli/nav-pilot/internal/provider/allow_localhost_test.go
@@ -16,10 +16,13 @@ func TestLocalLaunchNamesTheGuardPortToCplt(t *testing.T) {
 	if !strings.Contains(joined, "--allow-localhost 51234") {
 		t.Fatalf("the guard port never reaches cplt: %v", args)
 	}
-	// It is a cplt-level flag, so it must precede the agent selection the way
-	// --yes does, never land in the agent's own argument list.
+	// It is a cplt flag, not one of the agent's, so it has to sit before the
+	// `--` separator. TestGuardPortReachesTheLaunchVector pins the position in
+	// the vector cpltArgv builds; here the input has no separator, so what
+	// matters is only that it went to the front rather than being appended
+	// where the agent's own arguments go.
 	if args[0] != "--allow-localhost" {
-		t.Errorf("flag is not in cplt's own argument position: %v", args)
+		t.Errorf("flag was appended rather than passed to cplt: %v", args)
 	}
 }
 

--- a/cli/nav-pilot/internal/provider/allow_localhost_test.go
+++ b/cli/nav-pilot/internal/provider/allow_localhost_test.go
@@ -1,0 +1,56 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+// A local session's prompt path is a 127.0.0.1 hop to the loop guard, which
+// cplt blocks by default. The port has to reach cplt as `--allow-localhost`, or
+// local mode works only for users who turned on the machine-wide
+// allow_localhost_any toggle — which cplt's strict preset then supersedes,
+// making strict and `nav-pilot local` mutually exclusive.
+func TestLocalLaunchNamesTheGuardPortToCplt(t *testing.T) {
+	args := withCpltAllowLocalhost([]string{"--agent", "opencode"}, 51234)
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--allow-localhost 51234") {
+		t.Fatalf("the guard port never reaches cplt: %v", args)
+	}
+	// It is a cplt-level flag, so it must precede the agent selection the way
+	// --yes does, never land in the agent's own argument list.
+	if args[0] != "--allow-localhost" {
+		t.Errorf("flag is not in cplt's own argument position: %v", args)
+	}
+}
+
+// One named port, never the machine-wide relaxation: allow_localhost_any is
+// what disables cplt's kernel net-connect restriction and what forced-proxy
+// egress supersedes. Reaching for it would undo the preset being recommended.
+func TestLocalLaunchDoesNotRelaxAllLocalhost(t *testing.T) {
+	args := withCpltAllowLocalhost([]string{"--agent", "copilot"}, 51234)
+	if strings.Contains(strings.Join(args, " "), "allow-localhost-any") {
+		t.Errorf("used the machine-wide toggle instead of one port: %v", args)
+	}
+}
+
+// No guard, no flag: a cloud session must launch byte-identically to before.
+func TestNonLocalLaunchIsUnchanged(t *testing.T) {
+	base := []string{"--agent", "copilot", "--", "--model", "x"}
+	if got := withCpltAllowLocalhost(base, 0); len(got) != len(base) {
+		t.Errorf("a cloud launch grew an argument: %v", got)
+	}
+}
+
+// The flag has to survive into the vector cplt is actually handed, in the
+// cplt-flag slot between the agent selection and the `--` separator.
+func TestGuardPortReachesTheLaunchVector(t *testing.T) {
+	argv := cpltArgv(cpltLaunch{
+		agent:     "opencode",
+		cpltArgs:  withCpltAllowLocalhost(nil, 51234),
+		agentArgs: []string{"run"},
+	})
+	joined := strings.Join(argv, " ")
+	if !strings.Contains(joined, "--agent opencode --allow-localhost 51234 --") {
+		t.Errorf("flag is not in the cplt-flag slot: %v", argv)
+	}
+}

--- a/cli/nav-pilot/internal/provider/copilot_launch.go
+++ b/cli/nav-pilot/internal/provider/copilot_launch.go
@@ -340,9 +340,11 @@ var ghTokenVars = []string{"GH_TOKEN", "GITHUB_TOKEN", "COPILOT_GITHUB_TOKEN"}
 // applyCopilotAuthMode enforces copilot_auth_mode on the environment handed to
 // cplt.
 //
-// nav-pilot does not extract or inject a token. With cplt's gh guard on
-// (sandbox.preset = strict, which `nav-pilot doctor` recommends), cplt uses an
-// inherited GH_TOKEN/GITHUB_TOKEN/COPILOT_GITHUB_TOKEN when one is present and
+// nav-pilot does not extract or inject a token. With cplt's gh guard on — which
+// since cplt#335 is every preset except permissive and full-trust, `standard`
+// included, so it is the case by default rather than only under the `strict`
+// nav-pilot recommends — cplt uses an inherited
+// GH_TOKEN/GITHUB_TOKEN/COPILOT_GITHUB_TOKEN when one is present and
 // otherwise runs `gh auth token --hostname github.com` in the unsandboxed
 // parent, handing the result to the agent over a one-time 0600 file rather than
 // the environment. With the gh guard off, cplt does none of that and Copilot

--- a/cli/nav-pilot/internal/provider/copilot_launch.go
+++ b/cli/nav-pilot/internal/provider/copilot_launch.go
@@ -185,6 +185,12 @@ func LaunchCopilotResolved(resolved domain.ResolvedConfig) error {
 			domain.Dim("ℹ"), local.LoopGuardRepeat())
 	}
 	args := copilotLaunchArgs(cliName, resolved, IsTerminal(os.Stdin))
+	if cliName == "cplt" && guard != nil {
+		// The prompt path for a local session is a 127.0.0.1 hop to the guard,
+		// which cplt blocks by default. Name the port so it survives — and so
+		// it survives the strict preset, which supersedes allow_localhost_any.
+		args = withCpltAllowLocalhost(args, guard.Port())
+	}
 	displayName := CLIDisplayName(cliName)
 	fmt.Printf("Launching %s with agent %s...\n\n", domain.Bold(displayName), domain.Bold(PrimaryAgent("copilot")))
 

--- a/cli/nav-pilot/internal/provider/cplt.go
+++ b/cli/nav-pilot/internal/provider/cplt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"syscall"
 
 	"github.com/navikt/copilot/cli/nav-pilot/internal/domain"
@@ -82,6 +83,33 @@ func withCpltConfirmation(args []string, tty bool) []string {
 		return args
 	}
 	return append([]string{"--yes"}, args...)
+}
+
+// withCpltAllowLocalhost names the local loop guard's port to cplt.
+//
+// cplt blocks localhost outbound by default — SSRF to whatever else the
+// developer is running — so a local session, whose whole prompt path is a
+// 127.0.0.1 hop to the guard, only worked because the user had turned on
+// `sandbox.allow_localhost_any`. That is a machine-wide relaxation, and cplt's
+// strict preset supersedes it outright (forced egress cannot coexist with an
+// unrestricted localhost), which would have left `nav-pilot local` and strict
+// mutually exclusive.
+//
+// One named port is both narrower than the toggle and compatible with strict:
+// cplt emits the carve-out for explicit `--allow-localhost` ports outside its
+// `if !proxy_forced` block on macOS (src/sandbox_profile.rs) and adds a
+// port-scoped Landlock rule without disabling net-connect restriction on Linux
+// (src/sandbox_landlock.rs). Only `allow_localhost_any` turns that restriction
+// off, and this is not that.
+//
+// Passed on every local launch, not only under strict: the flag is what makes
+// the hop legal in the first place, so a user who never touched the toggle gets
+// a working local session too.
+func withCpltAllowLocalhost(args []string, port int) []string {
+	if port <= 0 {
+		return args
+	}
+	return append([]string{"--allow-localhost", strconv.Itoa(port)}, args...)
 }
 
 // launchViaCplt runs the given client agent inside the cplt sandbox, wiring

--- a/cli/nav-pilot/internal/provider/opencode_launch.go
+++ b/cli/nav-pilot/internal/provider/opencode_launch.go
@@ -770,9 +770,17 @@ func LaunchOpenCode(resolved domain.ResolvedConfig) error {
 		suffix = fmt.Sprintf(" with Nav context (%s)", navSummary)
 	}
 
+	// Same reason as the copilot local path: opencode's provider block points at
+	// the guard on 127.0.0.1, which cplt blocks unless the port is named.
+	var cpltFlags []string
+	if guard != nil {
+		cpltFlags = withCpltAllowLocalhost(nil, guard.Port())
+	}
+
 	return launchViaCplt(cpltLaunch{
 		agent:         "opencode",
 		agentArgs:     openCodeAgentArgs(resolved),
+		cpltArgs:      cpltFlags,
 		env:           launchEnv,
 		displayName:   "opencode",
 		messageSuffix: suffix,

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -158,16 +158,30 @@ med andre som trenger den.
 ### Sikkerhetsnivå og versjon i cplt
 
 `nav-pilot doctor` sjekker sikkerhetsnivået til cplt og anbefaler `sandbox.preset = strict`.
-Det presetet slår på `gh_guard`, `git_guard` og tvungen proxy i én nøkkel, og nøkler du har
-satt selv gjelder fortsatt foran presetet. cplt-config er personlig, så nav-pilot setter den
-aldri stilltiende. Du velger selv, enten med
+
+Det presetet er en nettverkslås. `gh_guard` og `git_guard` er allerede på i `standard`
+(cplt#335), så det strict legger til er nettverket: tvungen proxy, `git_guard` som blokkerer
+i stedet for å advare, og `proxy.default_allowlist`. Den siste er den viktige — den gjør at
+bare cplt sin innebygde vertsliste pluss det `proxy.allowed_domains` peker på er nåbart.
+Alt annet blokkeres.
+
+cplt sin innebygde liste dekker GitHub Copilot og de offentlige pakkeregistrene. Den dekker
+ingenting av Navs. Setter du presetet uten å gjøre noe mer, slutter nav-pilot sin telemetri å
+komme fram, og skills som `aksel-builder`, `observability-debugging` og `nav-auth` mister
+vertene de er bygget rundt — uten at noe på skjermen forteller deg hvorfor.
+
+Derfor skal du sette presetet via nav-pilot, ikke for hånd:
 
 ```bash
-cplt config set sandbox.preset strict
+nav-pilot config     # velg raden «cplt security posture»
 ```
 
-eller ved å velge raden `cplt security posture` på innstillingssiden (`nav-pilot config`),
-som spør før den setter nøkkelen.
+Den skriver Nav-vertene til `~/.nav-pilot/cplt-allowed-domains.txt`, peker
+`proxy.allowed_domains` dit, og setter så presetet — i den rekkefølgen, slik at låsen aldri
+rekker å tre i kraft uten vertene. Har du allerede en egen `proxy.allowed_domains`, lar
+nav-pilot den være i fred og sier fra at du må ta med vertene selv. cplt-config er personlig,
+så nav-pilot setter den aldri stilltiende, og nøkler du har satt selv gjelder fortsatt foran
+presetet.
 
 `nav-pilot doctor` sier også fra når cplt selv er utdatert, og foreslår
 `brew upgrade navikt/tap/cplt`. nav-pilot laster aldri ned eller oppgraderer cplt for deg.

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -161,14 +161,14 @@ med andre som trenger den.
 
 Det presetet er en nettverkslås. `gh_guard` og `git_guard` er allerede på i `standard`
 (cplt#335), så det strict legger til er nettverket: tvungen proxy, `git_guard` som blokkerer
-i stedet for å advare, og `proxy.default_allowlist`. Den siste er den viktige — den gjør at
+i stedet for å advare, og `proxy.default_allowlist`. Den siste er den viktige: den gjør at
 bare cplt sin innebygde vertsliste pluss det `proxy.allowed_domains` peker på er nåbart.
 Alt annet blokkeres.
 
 cplt sin innebygde liste dekker GitHub Copilot og de offentlige pakkeregistrene. Den dekker
 ingenting av Navs. Setter du presetet uten å gjøre noe mer, slutter nav-pilot sin telemetri å
 komme fram, og skills som `aksel-builder`, `observability-debugging` og `nav-auth` mister
-vertene de er bygget rundt — uten at noe på skjermen forteller deg hvorfor.
+vertene de er bygget rundt, uten at noe på skjermen forteller deg hvorfor.
 
 Derfor skal du sette presetet via nav-pilot, ikke for hånd:
 
@@ -177,7 +177,7 @@ nav-pilot config     # velg raden «cplt security posture»
 ```
 
 Den skriver vertslista til `~/.nav-pilot/cplt-allowed-domains.txt`, peker
-`proxy.allowed_domains` dit, og setter så presetet — i den rekkefølgen, slik at låsen aldri
+`proxy.allowed_domains` dit, og setter så presetet, i den rekkefølgen, slik at låsen aldri
 rekker å tre i kraft uten vertene. Har du allerede en egen `proxy.allowed_domains`, lar
 nav-pilot den være i fred og sier fra at du må ta med vertene selv. cplt-config er personlig,
 så nav-pilot setter den aldri stilltiende, og nøkler du har satt selv gjelder fortsatt foran
@@ -185,7 +185,7 @@ presetet.
 
 ### Når strict ikke anbefales
 
-På Linux krever `proxy.forced` at kjernen kan håndheve nettverksrestriksjon i Landlock — ABI
+På Linux krever `proxy.forced` at kjernen kan håndheve nettverksrestriksjon i Landlock: ABI
 v4, altså kjerne 6.7 eller nyere med Landlock påslått. Under det degraderer ikke cplt, den
 nekter å starte i det hele tatt. En anbefaling som stopper hver eneste økt på maskinen er
 verre enn problemet den løser, så `nav-pilot doctor` og innstillingssiden anbefaler ikke
@@ -195,19 +195,19 @@ nav-pilot spør kjernen direkte, med samme systemkall som cplt bruker, i stedet 
 `uname`. En kjerneversjon er bare en indikasjon: Landlock kan være kompilert bort eller slått
 av ved oppstart, og da ville en versjonssjekk sagt «går fint» rett før cplt nekter å starte.
 
-macOS har ingen slik grense — der håndheves det samme med Seatbelt.
+macOS har ingen slik grense. Der håndheves det samme med Seatbelt.
 
 ### Lokal modell og strict
 
 `nav-pilot local` sender prompten via en loop-guard på `127.0.0.1`. cplt blokkerer localhost
 som standard, så nav-pilot sender porten med som `--allow-localhost <port>` ved hver lokale
-oppstart. Det er én navngitt port, ikke `allow_localhost_any` — den maskinvide bryteren er
+oppstart. Det er én navngitt port, ikke `allow_localhost_any`. Den maskinvide bryteren er
 den `proxy.forced` overstyrer, så hadde vi brukt den, ville strict og lokal modell utelukket
 hverandre. Én port overlever tvungen proxy på både macOS og Linux.
 
 Fila er en fullstendig liste, ikke bare Nav-vertene. `proxy.allowed_domains` blokkerer alt
 utenfor seg selv uansett hva `proxy.default_allowlist` står på, og cplt sin innebygde liste
-er per agent — bare copilot-lista har GitHub og Copilot i seg, opencode har `opencode.ai` og
+er per agent. Bare copilot-lista har GitHub og Copilot i seg; opencode har `opencode.ai` og
 `models.dev`. Derfor står de innebygde vertene i fila også, slik at den er riktig alene.
 
 `nav-pilot doctor` sier også fra når cplt selv er utdatert, og foreslår

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -176,12 +176,17 @@ Derfor skal du sette presetet via nav-pilot, ikke for hånd:
 nav-pilot config     # velg raden «cplt security posture»
 ```
 
-Den skriver Nav-vertene til `~/.nav-pilot/cplt-allowed-domains.txt`, peker
+Den skriver vertslista til `~/.nav-pilot/cplt-allowed-domains.txt`, peker
 `proxy.allowed_domains` dit, og setter så presetet — i den rekkefølgen, slik at låsen aldri
 rekker å tre i kraft uten vertene. Har du allerede en egen `proxy.allowed_domains`, lar
 nav-pilot den være i fred og sier fra at du må ta med vertene selv. cplt-config er personlig,
 så nav-pilot setter den aldri stilltiende, og nøkler du har satt selv gjelder fortsatt foran
 presetet.
+
+Fila er en fullstendig liste, ikke bare Nav-vertene. `proxy.allowed_domains` blokkerer alt
+utenfor seg selv uansett hva `proxy.default_allowlist` står på, og cplt sin innebygde liste
+er per agent — bare copilot-lista har GitHub og Copilot i seg, opencode har `opencode.ai` og
+`models.dev`. Derfor står de innebygde vertene i fila også, slik at den er riktig alene.
 
 `nav-pilot doctor` sier også fra når cplt selv er utdatert, og foreslår
 `brew upgrade navikt/tap/cplt`. nav-pilot laster aldri ned eller oppgraderer cplt for deg.

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -183,6 +183,28 @@ nav-pilot den være i fred og sier fra at du må ta med vertene selv. cplt-confi
 så nav-pilot setter den aldri stilltiende, og nøkler du har satt selv gjelder fortsatt foran
 presetet.
 
+### Når strict ikke anbefales
+
+På Linux krever `proxy.forced` at kjernen kan håndheve nettverksrestriksjon i Landlock — ABI
+v4, altså kjerne 6.7 eller nyere med Landlock påslått. Under det degraderer ikke cplt, den
+nekter å starte i det hele tatt. En anbefaling som stopper hver eneste økt på maskinen er
+verre enn problemet den løser, så `nav-pilot doctor` og innstillingssiden anbefaler ikke
+strict der, og sier hvorfor i stedet.
+
+nav-pilot spør kjernen direkte, med samme systemkall som cplt bruker, i stedet for å lese
+`uname`. En kjerneversjon er bare en indikasjon: Landlock kan være kompilert bort eller slått
+av ved oppstart, og da ville en versjonssjekk sagt «går fint» rett før cplt nekter å starte.
+
+macOS har ingen slik grense — der håndheves det samme med Seatbelt.
+
+### Lokal modell og strict
+
+`nav-pilot local` sender prompten via en loop-guard på `127.0.0.1`. cplt blokkerer localhost
+som standard, så nav-pilot sender porten med som `--allow-localhost <port>` ved hver lokale
+oppstart. Det er én navngitt port, ikke `allow_localhost_any` — den maskinvide bryteren er
+den `proxy.forced` overstyrer, så hadde vi brukt den, ville strict og lokal modell utelukket
+hverandre. Én port overlever tvungen proxy på både macOS og Linux.
+
 Fila er en fullstendig liste, ikke bare Nav-vertene. `proxy.allowed_domains` blokkerer alt
 utenfor seg selv uansett hva `proxy.default_allowlist` står på, og cplt sin innebygde liste
 er per agent — bare copilot-lista har GitHub og Copilot i seg, opencode har `opencode.ai` og


### PR DESCRIPTION
## Problem

`nav-pilot doctor` recommends `cplt config set sandbox.preset strict`. Strict sets `proxy.default_allowlist = true` (`cplt src/config/types.rs`, `Preset::Strict.baseline()`), which makes cplt's built-in per-agent host list the **only** reachable set of hosts.

That built-in list is `COPILOT_INFRA_DOMAINS` + `PACKAGE_REGISTRY_DOMAINS` (`cplt src/agent.rs:38-66`): githubcopilot.com, github.com, api.github.com, npm, maven, crates, PyPI. It covers nothing of Nav's.

So a user who followed nav-pilot's own advice silently lost:

- nav-pilot's OTel metrics export (`internal/telemetry/telemetry.go`, `defaultTelemetryEndpoint`), and the same endpoint injected into every copilot/opencode session;
- every Nav-internal host the agents and skills nav-pilot installs are built around.

Nothing on screen connects the preset to the outage.

## Decision

Keep recommending strict. Ship the hosts with it.

`nav-pilot config` → `cplt security posture` now:

1. writes the hosts to `~/.nav-pilot/cplt-allowed-domains.txt`,
2. points `proxy.allowed_domains` at that file,
3. **then** sets `sandbox.preset = strict`.

That order matters and is tested. `proxy.allowed_domains` takes a path, not a list, and cplt merges its contents into the built-in list rather than replacing it, so the file only carries the delta.

If the user already has `proxy.allowed_domains` set, nav-pilot **leaves it alone** and tells them to merge. The key holds exactly one path, so repointing it would silently revoke every host in their file — under the one preset where an unlisted host is unreachable.

## The host list, and why each one

Eight entries. Each is something nav-pilot or a shipped artifact actually fetches, with the call site named in a comment at the entry:

| host | why |
| --- | --- |
| `collector-internet.nav.cloud.nais.io` | nav-pilot's OTel export, every command |
| `aksel-mcp.nav.no` | MCP endpoint declared in `agents/aksel.agent.md`; `skills/aksel-builder/SKILL.md:47` says in as many words that it needs allowlisting |
| `aksel.nav.no` | the documented fallback when that MCP is down — the agent fetches `llm.md` and follows the `.md` links |
| `mimir.nav.cloud.nais.io`, `loki.nav.cloud.nais.io`, `tempo.dev-gcp.nav.cloud.nais.io`, `tempo.prod-gcp.nav.cloud.nais.io` | literal `curl` commands in `skills/observability-debugging/SKILL.md` |
| `login.microsoftonline.com` | literal `curl` of the nav.no OIDC discovery doc, `skills/nav-auth/SKILL.md:30` |

**The list is complete, not a delta** (see the follow-up commits): it also carries cplt's own built-in domains for the agents nav-pilot launches, so the file is correct standing alone.

**What is deliberately not in it**, because an over-broad seed defeats the preset:

- `grafana.nav.cloud.nais.io`, `console.nav.cloud.nais.io` - presented as browser links for the human, never fetched by the agent.
- `sikkerhet.nav.no`, `doc.nais.io`, and every other documentation host - citation links in "Sources" tables.
- `www.nav.no`, the dekoratøren endpoints, `*.intern.nav.no` - sample config for the *developer's own application*.
- `npm.pkg.github.com` - a dependency of the developer's project build, resolved against GitHub's registry rather than anything nav-pilot ships.
- `github.blog`, `news.ycombinator.com` - real `web_fetch` targets in `skills/ai-news-research`, but that skill is unbounded open-web research. Two hosts neither make it work nor bound it; it is out of scope for a fail-closed proxy.
- `collector.nav.no` - appears only as a test fixture in `copilot_otel_test.go`. If it is a real internal collector, that has to come from Nais config, not from this repo.

Two hosts named as excluded in the first draft of this description **are now included**, on review: `github-package-registry-mirror.gc.nav.no`, because `skills/spring-boot-scaffold/SKILL.md` writes it into the `build.gradle.kts` it generates and an agent that then builds resolves against it; and `raw.githubusercontent.com` plus the release-asset object hosts, because `scripts/install.sh` curls them and cplt's `github.com` entry does not cover them (exact-or-subdomain matching, different apex).

Entries are bare hostnames — cplt matches exact-or-subdomain and does not read glob syntax — and are specific hosts rather than `nav.cloud.nais.io`, which would open every Nais tenant at once. A test enforces both.

## Stale descriptions

cplt#335 turned `gh_guard` and `git_guard` on in `standard` too. Describing strict as "gh_guard, git_guard and forced proxy" now names two things you already have and buries the one that bites. Refreshed at all four sites named in the review — `doctor.go`, `config_sandbox.go`, `config_tui.go`, `config_cmd.go` — plus the same stale claim in `provider/copilot_launch.go`. They now lead with the network lockdown, and note that the git guard escalates from warn to block.

`docs/README.nav-pilot.md` rewritten to match, and it now points at `nav-pilot config` rather than the bare `cplt config set`, because the bare command is exactly the thing that breaks you.

## Tests

- `TestStrictPresetSeedsAllowlistIntoCpltConfig` — the wiring test. Runs `applyStrictPreset` against a **real stand-in `cplt` binary on PATH**, so `findCplt`, `cpltConfigGet` and `cpltConfigSet` all take their actual exec paths. Asserts cplt was told a path, that path exists on disk, and the collector is a line in it. Not a helper's return value.
- `TestStrictPresetSeedsBeforeSettingThePreset` — exactly two config writes, allowlist first.
- `TestStrictPresetLeavesAUserAllowlistAlone` — an existing `proxy.allowed_domains` is not repointed, and the file is still written for them to merge.
- `TestNavAllowedDomainsAreBareAndSpecific` — no glob/URL syntax, no apex domains.

**Mutation-checked**, three ways:

| defect reintroduced | test that failed |
| --- | --- |
| drop the `cpltConfigSet(…, "proxy.allowed_domains", …)` call | `TestStrictPresetSeedsAllowlistIntoCpltConfig`, `…SeedsBeforeSettingThePreset` |
| set the preset before seeding | `TestStrictPresetSeedsBeforeSettingThePreset` — "want two config writes, got 3" |
| remove the collector from the list | `TestStrictPresetSeedsAllowlistIntoCpltConfig` — "the telemetry collector is not in the file cplt reads" |

Each restored to green afterwards.

## What this PR does not do

The review also asked to bump `minStagedCpltStamp` in `runtime_gate.go` from `2026.08.17-062831`. **I did not, and I think it would be wrong to.**

That constant is not nav-pilot's to move. Its own doc comment says so: it is adopted from the reference launcher's `SUPPORTED_CPLT_RELEASE` and "names a baseline both projects have reviewed, so nav-pilot does not raise it alone" — the joint-decision rule from `README.agentpakke.md`. I checked `navikt/grillmester` at `c15b4c0` (2026-09-04): `SUPPORTED_CPLT_RELEASE` is still `"2026.08.17-062831-1008a92"`, unchanged.

So nav-pilot is in exact parity with the reference, not eighteen days behind it. Raising it unilaterally would make nav-pilot refuse a staged launch on a cplt the reference launcher still supports, breaking Tier 2 for grillmester users on the pinned release. If the floor should move, that is a joint change with Team eSyfo and its own PR carrying the evidence.

## Gates

`go build`, `go vet`, `staticcheck v0.7.0`, `go test -race ./...`, `shellcheck scripts/install.sh`, `bats scripts/install.bats scripts/sync-pr-body.bats` — all pass.

Same caveat as #661: `TestRun_AliasSync` fails on any machine whose real `~/.nav-pilot/config.toml` has a non-slug `source`, because it calls `run(["s"])` without isolating `HOME`. Pre-existing, fails on a clean `main`, green with `HOME` set to a temp dir.

Verified against cplt at `eac7641`.
