### PR TITLE
fix(agentpakke): the four remaining user-facing bugs from the #504 review

### DIFF
--- a/cli/nav-pilot/internal/agentpakke/load.go
+++ b/cli/nav-pilot/internal/agentpakke/load.go
@@ -59,6 +59,22 @@ func Validate(data []byte) error {
 // parse is Parse with the running version injected, so version gating is
 // testable without mutating package state.
 func parse(data []byte, runningVersion string) (*Manifest, error) {
+	// The contract-version gate runs before the schema, or it never runs at
+	// all: the v1 schema pins contractVersion to ^1(\.\d+)?$, so a manifest on
+	// a future contract major would surface as a schema error telling the
+	// author to fix the manifest, when the party that has to act is the user,
+	// by upgrading nav-pilot. Only a numeric major is gated here; anything
+	// else is a malformed manifest and stays the schema's to reject.
+	var gate struct {
+		ContractVersion string `json:"contractVersion"`
+	}
+	if err := json.Unmarshal(data, &gate); err == nil {
+		if major, _, _ := strings.Cut(gate.ContractVersion, "."); isAllDigits(major) {
+			if err := checkContractVersion(gate.ContractVersion); err != nil {
+				return nil, err
+			}
+		}
+	}
 	if err := validateSchema(data); err != nil {
 		return nil, err
 	}
@@ -76,7 +92,8 @@ func parse(data []byte, runningVersion string) (*Manifest, error) {
 
 // checkSemantics runs the fail-closed rules that JSON Schema cannot express:
 // contract-version support, minimum binary version, Tier 1's dependence on
-// layout, and path containment for every repo-relative path in the manifest.
+// layout, the compatibility-range grammar, and path containment for every
+// repo-relative path in the manifest.
 func (m *Manifest) checkSemantics(runningVersion string) error {
 	if err := m.checkContractVersion(); err != nil {
 		return err
@@ -87,7 +104,32 @@ func (m *Manifest) checkSemantics(runningVersion string) error {
 	if err := m.checkTiers(); err != nil {
 		return err
 	}
+	if err := m.checkCompatibility(); err != nil {
+		return err
+	}
 	return m.checkPaths()
+}
+
+// checkCompatibility parses every declared clients.<id>.compatibility with the
+// grammar the launch gate enforces (#504 U2) — the same [ParseVersionRange],
+// so validation and launch can never disagree. Without this the schema types
+// the field as a bare string, `nav-pilot validate` passes ">=1.18.20 <2" or
+// "^1.18", and every Tier 2 launch then dies on the runtime gate. Checked for
+// every client entry, known or not, the way checkPaths is: the grammar belongs
+// to the contract version, not to the client id.
+func (m *Manifest) checkCompatibility() error {
+	for _, client := range m.ClientIDs() {
+		c := m.Clients[client].Compatibility
+		if c == "" {
+			continue
+		}
+		if _, err := ParseVersionRange(c); err != nil {
+			return fmt.Errorf(
+				"clients.%s.compatibility %q is not a valid version range (comma-separated comparators over semver, e.g. \">=1.18.20,<2\"): %w",
+				client, c, err)
+		}
+	}
+	return nil
 }
 
 // checkContractVersion rejects a contract major this binary does not implement,
@@ -117,6 +159,20 @@ func checkContractVersionFor(version, remedy string) error {
 		"contractVersion %q is not supported by this nav-pilot; supported contract versions: %s. "+
 			"Upgrade nav-pilot (nav-pilot update) or %s",
 		version, strings.Join(SupportedContractMajors, ", "), remedy)
+}
+
+// isAllDigits reports whether s is a non-empty run of ASCII digits — the shape
+// of a contract major the version gate can meaningfully compare.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // checkMinVersion enforces minNavPilotVersion against the running binary.

--- a/cli/nav-pilot/internal/agentpakke/load_test.go
+++ b/cli/nav-pilot/internal/agentpakke/load_test.go
@@ -182,7 +182,11 @@ func TestParseRejectsMalformedKnownConstructs(t *testing.T) {
 			patch: func(doc map[string]any) {
 				doc["contractVersion"] = "2"
 			},
-			wantErrs: []string{"contractVersion", "supported"},
+			// The remedy must point at the party that has to act: a future
+			// contract major means this binary is too old, not that the
+			// manifest is broken. The schema hint says neither, so this is
+			// what proves the version gate ran before the schema (#504 U1).
+			wantErrs: []string{"contractVersion", "supported", "Upgrade nav-pilot", "nav-pilot update"},
 		},
 		{
 			name: "contractVersion of the wrong type",
@@ -670,4 +674,42 @@ func joinErrs(errs []error) string {
 		msgs = append(msgs, err.Error())
 	}
 	return strings.Join(msgs, "\n")
+}
+
+// The compatibility grammar must be enforced at validation, not first at
+// launch (#504 U2): every value here used to pass `nav-pilot validate` and
+// then kill every Tier 2 launch on the runtime gate.
+func TestParseRejectsInvalidCompatibilityRange(t *testing.T) {
+	invalid := []string{
+		">=1.18.20 <2",   // space instead of comma
+		"^1.18",          // npm-style caret, not in the grammar
+		"1.18.20+",       // no operator
+		">=1.18.20-rc.1", // prerelease operand
+	}
+	for _, rng := range invalid {
+		data := patchManifest(t, grillmesterManifest, func(doc map[string]any) {
+			doc["clients"].(map[string]any)["opencode"].(map[string]any)["compatibility"] = rng
+		})
+		_, err := parse(data, devVersion)
+		if err == nil {
+			t.Errorf("parse accepted compatibility %q, want a validation error", rng)
+			continue
+		}
+		if !strings.Contains(err.Error(), "clients.opencode.compatibility") {
+			t.Errorf("parse(compatibility %q) error should name the field, got: %v", rng, err)
+		}
+	}
+
+	// An unknown client's entry rides the same contract grammar.
+	data := patchManifest(t, grillmesterManifest, func(doc map[string]any) {
+		doc["clients"].(map[string]any)["futurecli"] = map[string]any{
+			"primaryAgents": []any{"x"},
+			"compatibility": "^9",
+			"payloads":      map[string]any{"full": map[string]any{"path": "p", "primaryAgents": []any{"x"}}},
+		}
+	})
+	_, err := parse(data, devVersion)
+	if err == nil || !strings.Contains(err.Error(), "clients.futurecli.compatibility") {
+		t.Errorf("parse should reject the unknown client's invalid compatibility by name, got: %v", err)
+	}
 }

--- a/cli/nav-pilot/internal/agentpakke/versionrange.go
+++ b/cli/nav-pilot/internal/agentpakke/versionrange.go
@@ -1,0 +1,126 @@
+package agentpakke
+
+// The compatibility-range grammar, moved here from internal/provider's runtime
+// gate (#504 U2). This package owns the manifest contract, and validation
+// (checkSemantics) and the launch gate must accept and reject exactly the same
+// strings — internal/provider imports this package and not the other way
+// round, so one shared parser can only live here.
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Semver3 is a major.minor.patch triple. The contract's compatibility grammar
+// has no ordering over prereleases and the reference refuses them outright, so
+// three integers is the whole model.
+type Semver3 [3]int
+
+func (v Semver3) String() string { return fmt.Sprintf("%d.%d.%d", v[0], v[1], v[2]) }
+
+func (v Semver3) Compare(o Semver3) int {
+	for i := range v {
+		switch {
+		case v[i] < o[i]:
+			return -1
+		case v[i] > o[i]:
+			return 1
+		}
+	}
+	return 0
+}
+
+// Comparator is one clause of a compatibility range, e.g. ">=1.18.20".
+type Comparator struct {
+	Op string
+	V  Semver3
+}
+
+// VersionRange is the conjunction of every comparator in a compatibility
+// string: all must hold.
+type VersionRange []Comparator
+
+// comparatorOps are the operators the contract documents, longest first so
+// ">=" is not read as ">" followed by a bad operand.
+var comparatorOps = []string{">=", "<=", ">", "<", "="}
+
+// ParseVersionRange parses the range grammar README.agentpakke.md documents:
+// comma-separated comparators over semver, e.g. ">=1.18.20,<2". Operands may be
+// partial ("2" means 2.0.0) — that is what makes an upper major bound writable.
+func ParseVersionRange(s string) (VersionRange, error) {
+	var rng VersionRange
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil, fmt.Errorf("empty comparator in %q", s)
+		}
+		op := ""
+		for _, candidate := range comparatorOps {
+			if strings.HasPrefix(part, candidate) {
+				op = candidate
+				break
+			}
+		}
+		if op == "" {
+			return nil, fmt.Errorf("comparator %q has no operator (expected one of >= > <= < =)", part)
+		}
+		v, err := parseVersionOperand(strings.TrimSpace(part[len(op):]))
+		if err != nil {
+			return nil, fmt.Errorf("comparator %q: %w", part, err)
+		}
+		rng = append(rng, Comparator{Op: op, V: v})
+	}
+	return rng, nil
+}
+
+var versionPartPattern = regexp.MustCompile(`^(0|[1-9]\d*)$`)
+
+// parseVersionOperand parses one to three dot-separated numeric parts, filling
+// the missing ones with zero.
+func parseVersionOperand(s string) (Semver3, error) {
+	var v Semver3
+	if s == "" {
+		return v, errors.New("missing version")
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) > 3 {
+		return v, fmt.Errorf("version %q has more than three parts", s)
+	}
+	for i, part := range parts {
+		if !versionPartPattern.MatchString(part) {
+			return Semver3{}, fmt.Errorf("version %q has a non-numeric part %q", s, part)
+		}
+		n, err := strconv.Atoi(part)
+		if err != nil {
+			return Semver3{}, fmt.Errorf("version %q: %w", s, err)
+		}
+		v[i] = n
+	}
+	return v, nil
+}
+
+func (r VersionRange) Contains(v Semver3) bool {
+	for _, c := range r {
+		cmp := v.Compare(c.V)
+		ok := false
+		switch c.Op {
+		case ">=":
+			ok = cmp >= 0
+		case ">":
+			ok = cmp > 0
+		case "<=":
+			ok = cmp <= 0
+		case "<":
+			ok = cmp < 0
+		case "=":
+			ok = cmp == 0
+		}
+		if !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/cli/nav-pilot/internal/agentpakke/versionrange_test.go
+++ b/cli/nav-pilot/internal/agentpakke/versionrange_test.go
@@ -1,0 +1,92 @@
+package agentpakke
+
+// Moved with the grammar from internal/provider's runtime gate (#504 U2).
+
+import (
+	"testing"
+)
+
+func TestParseVersionRange(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    string
+		want  []Comparator
+		isErr bool
+	}{
+		{name: "contract example", in: ">=1.18.20,<2", want: []Comparator{
+			{Op: ">=", V: Semver3{1, 18, 20}},
+			{Op: "<", V: Semver3{2, 0, 0}},
+		}},
+		{name: "spaces are tolerated", in: " >= 1.0.79 , < 2 ", want: []Comparator{
+			{Op: ">=", V: Semver3{1, 0, 79}},
+			{Op: "<", V: Semver3{2, 0, 0}},
+		}},
+		{name: "exact", in: "=1.2.3", want: []Comparator{{Op: "=", V: Semver3{1, 2, 3}}}},
+		{name: "two-part operand zero-fills", in: "<=1.18", want: []Comparator{{Op: "<=", V: Semver3{1, 18, 0}}}},
+		{name: "greater than", in: ">1.0.0", want: []Comparator{{Op: ">", V: Semver3{1, 0, 0}}}},
+
+		{name: "empty", in: "", isErr: true},
+		{name: "no operator", in: "1.2.3", isErr: true},
+		{name: "operator without operand", in: ">=", isErr: true},
+		{name: "trailing comma", in: ">=1.0.0,", isErr: true},
+		{name: "leading comma", in: ",<2", isErr: true},
+		{name: "non-numeric part", in: ">=1.x.3", isErr: true},
+		{name: "four parts", in: ">=1.2.3.4", isErr: true},
+		{name: "prerelease operand", in: ">=1.2.3-beta", isErr: true},
+		{name: "leading zero", in: ">=01.2.3", isErr: true},
+		{name: "caret is not an operator", in: "^1.2.3", isErr: true},
+		{name: "double equals", in: "==1.2.3", isErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseVersionRange(tc.in)
+			if tc.isErr {
+				if err == nil {
+					t.Fatalf("ParseVersionRange(%q) = %v, want error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseVersionRange(%q) errored: %v", tc.in, err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("ParseVersionRange(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("ParseVersionRange(%q)[%d] = %v, want %v", tc.in, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestVersionRangeContains(t *testing.T) {
+	tests := []struct {
+		rng     string
+		version Semver3
+		want    bool
+	}{
+		{">=1.18.20,<2", Semver3{1, 18, 20}, true},  // lower bound is inclusive
+		{">=1.18.20,<2", Semver3{1, 18, 19}, false}, // one patch below
+		{">=1.18.20,<2", Semver3{1, 19, 0}, true},
+		{">=1.18.20,<2", Semver3{2, 0, 0}, false}, // upper bound is exclusive
+		{">=1.18.20,<2", Semver3{1, 99, 99}, true},
+		{">=1.18.20,<2", Semver3{0, 99, 99}, false},
+		{">1.0.0", Semver3{1, 0, 0}, false},
+		{">1.0.0", Semver3{1, 0, 1}, true},
+		{"<=1.0.0", Semver3{1, 0, 0}, true},
+		{"=1.2.3", Semver3{1, 2, 3}, true},
+		{"=1.2.3", Semver3{1, 2, 4}, false},
+		{"=1.2", Semver3{1, 2, 0}, true},
+	}
+	for _, tc := range tests {
+		rng, err := ParseVersionRange(tc.rng)
+		if err != nil {
+			t.Fatalf("ParseVersionRange(%q): %v", tc.rng, err)
+		}
+		if got := rng.Contains(tc.version); got != tc.want {
+			t.Errorf("%q contains %v = %v, want %v", tc.rng, tc.version, got, tc.want)
+		}
+	}
+}

--- a/cli/nav-pilot/internal/cli/pakke_install.go
+++ b/cli/nav-pilot/internal/cli/pakke_install.go
@@ -405,8 +405,13 @@ func removeStateFiles(scope *InstallScope, state *StateFile, dryRun, quiet bool)
 //
 // The order is load-bearing. State is written only after the rename has
 // published a complete revision, so a crash mid-install leaves the previous pin
-// intact; pruning runs only after the state names the new pin, so nothing is
-// removed while it is still the recorded one.
+// intact; every removal — the outgoing install's files, its revision trees,
+// the prune — runs only after the state names the new pin (#504 U7). A state
+// write that fails therefore loses nothing: the outgoing install is still on
+// disk and still recorded. The window that remains is a kill between the write
+// and the removals, which leaves the outgoing files behind unrecorded —
+// leftovers, not loss, where the old delete-first order made the same
+// interruption delete a working install and keep a state that still named it.
 //
 // [installPakkePin] and the launch path's auto-pin both go through here — there
 // is exactly one place payload bytes are written.
@@ -430,26 +435,8 @@ func pinRevision(scope *InstallScope, src *Source, jsonOutput bool) (string, err
 	}
 
 	previousPin := ""
+	outgoingRevisions := ""
 	if existing != nil {
-		// The state this pin replaces is a zero-item entry, so any files it
-		// tracks are about to lose their only record. That is true whatever
-		// source they came from: the same repo dropping its layout and going
-		// payload-only orphans them exactly as a switch to another repo does,
-		// and a shape change like that must be picked up without a migration.
-		// An explicit install (or `sync --apply`) is the consent gesture for
-		// removing them; the launch path refuses instead, see [autoPin].
-		if len(existing.Files) > 0 {
-			// jsonOutput is not cosmetic here: `install --json` and `sync
-			// --apply --json` write one JSON document to stdout, and these
-			// lines land in front of it.
-			if !jsonOutput {
-				fmt.Printf("\n%s Removing the files installed from %s:\n", dim("ℹ"), bold(sourceLabelForRepo(existing.SourceRepo)))
-			}
-			removeStateFiles(scope, existing, false, jsonOutput)
-			if !jsonOutput {
-				fmt.Println()
-			}
-		}
 		if sameSourceRepo(existing.SourceRepo, src.Repo) {
 			previousPin = existing.SourceSHA
 		} else if outgoing := pakkeSourceDir(existing.SourceRepo); existing.SourceRepo != "" && outgoing != pakkeSourceDir(src.Repo) {
@@ -467,7 +454,7 @@ func pinRevision(scope *InstallScope, src *Source, jsonOutput bool) (string, err
 			// (a/b-c and a-b/c) two different repos share one directory, and
 			// removing the outgoing one there would delete the revision this
 			// call just materialized.
-			_ = os.RemoveAll(outgoing)
+			outgoingRevisions = outgoing
 		}
 	}
 
@@ -489,6 +476,30 @@ func pinRevision(scope *InstallScope, src *Source, jsonOutput bool) (string, err
 	}
 	if err := writeScopedState(scope, state); err != nil {
 		return "", fmt.Errorf("writing state: %w", err)
+	}
+
+	// The state this pin replaced was the only record of the files below, so
+	// they are removed only now that the pin is safely on disk (#504 U7).
+	// That is true whatever source they came from: the same repo dropping its
+	// layout and going payload-only orphans them exactly as a switch to
+	// another repo does, and a shape change like that must be picked up
+	// without a migration. An explicit install (or `sync --apply`) is the
+	// consent gesture for removing them; the launch path refuses instead, see
+	// [autoPin].
+	if existing != nil && len(existing.Files) > 0 {
+		// jsonOutput is not cosmetic here: `install --json` and `sync
+		// --apply --json` write one JSON document to stdout, and these
+		// lines land in front of it.
+		if !jsonOutput {
+			fmt.Printf("\n%s Removing the files installed from %s:\n", dim("ℹ"), bold(sourceLabelForRepo(existing.SourceRepo)))
+		}
+		removeStateFiles(scope, existing, false, jsonOutput)
+		if !jsonOutput {
+			fmt.Println()
+		}
+	}
+	if outgoingRevisions != "" {
+		_ = os.RemoveAll(outgoingRevisions)
 	}
 
 	prunePakkeRevisions(src.Repo, src.SHA, previousPin)

--- a/cli/nav-pilot/internal/cli/pakke_install_test.go
+++ b/cli/nav-pilot/internal/cli/pakke_install_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -1425,5 +1426,75 @@ func TestRecasedRepoIdKeepsOneRevisionDirectory(t *testing.T) {
 	assertRevisionVerifies(t, pakkeRevisionDir(upper.Repo, "sha-two"))
 	if _, err := os.Stat(pakkeRevisionDir(lower.Repo, "sha-one")); err != nil {
 		t.Errorf("the re-cased install dropped the revision it replaced (%v); a session running it survives one update", err)
+	}
+}
+
+// The most likely Tier 2 launch failure — a pinned tree that drifted on disk —
+// must name the command that rebuilds it (#504 U6).
+func TestPayloadDriftRefusalNamesSyncApply(t *testing.T) {
+	scope := pinEnv(t)
+	src := tier2PinSource(t, "sha-one")
+	installPin(t, scope, src)
+
+	target := filepath.Join(pakkeRevisionDir(src.Repo, src.SHA), unlaunchableClient, "full", "agents", "grillmester.agent.md")
+	if err := os.WriteFile(target, []byte("---\nname: grillmester\n---\nflipped\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	failingResolveSource(t)
+	assertRefusedBeforeHandover(t, launchPinned(t, ""), "nav-pilot sync --apply")
+}
+
+// A client this binary cannot stage-launch must point at the binary upgrade,
+// not dead-end (#504 U6).
+func TestUnlaunchableClientRefusalNamesUpdate(t *testing.T) {
+	scope := pinEnv(t)
+	installPin(t, scope, tier2PinSource(t, "sha-one"))
+
+	err := launchPinned(t, "")
+	if err == nil || !strings.Contains(err.Error(), handoverErr) {
+		t.Fatalf("launch = %v, want the handover refusal", err)
+	}
+	if !strings.Contains(err.Error(), "nav-pilot update") {
+		t.Errorf("handover refusal %q names no command to run", err)
+	}
+}
+
+// TestFailedStateWriteLosesNothing pins the ordering of #504 U7. The old order
+// deleted the outgoing Tier 1 install's files before writing the replacement
+// state, so a state write that failed had already destroyed the install while
+// the state on disk still named every deleted file. Every removal now runs
+// after the new state is written: a failed write must abort the install with
+// the outgoing files still on disk and still recorded.
+func TestFailedStateWriteLosesNothing(t *testing.T) {
+	scope := pinEnv(t)
+	installed := tier1InstallFrom(t, scope, "navikt/grillmester")
+
+	before, err := readScopedState(scope)
+	if err != nil || before == nil || len(before.Files) == 0 {
+		t.Fatalf("setup: readScopedState = (%+v, %v), want a Tier 1 state tracking files", before, err)
+	}
+
+	origWrite := writeScopedState
+	writeScopedState = func(scope *InstallScope, state *StateFile) error {
+		return errors.New("injected: disk full")
+	}
+	t.Cleanup(func() { writeScopedState = origWrite })
+
+	err = installPakkePin(scope, tier2PinSource(t, "sha-one"), false, false)
+	if err == nil || !strings.Contains(err.Error(), "writing state") {
+		t.Fatalf("installPakkePin = %v, want the state-write failure", err)
+	}
+
+	if _, statErr := os.Stat(installed); statErr != nil {
+		t.Errorf("%s is gone after a failed state write (stat: %v); the install was deleted before its replacement was recorded", installed, statErr)
+	}
+	writeScopedState = origWrite
+	after, err := readScopedState(scope)
+	if err != nil || after == nil {
+		t.Fatalf("readScopedState after the failed install = (%+v, %v)", after, err)
+	}
+	if len(after.Files) != len(before.Files) {
+		t.Errorf("state tracks %d files after the failed install, want the outgoing install's %d intact", len(after.Files), len(before.Files))
 	}
 }

--- a/cli/nav-pilot/internal/cli/pakke_launch.go
+++ b/cli/nav-pilot/internal/cli/pakke_launch.go
@@ -79,8 +79,12 @@ func tryPakkeLaunch(resolved ResolvedConfig) (bool, error) {
 	// in it. Fail-closed — a Tier 2 launch never degrades to the legacy path.
 	dir := filepath.Join(rev.Dir, resolved.Client, context)
 	if err := agentpakke.VerifyPayloadExact(dir, filepath.Join(dir, agentpakke.PayloadManifestFile)); err != nil {
-		return true, fmt.Errorf("the pinned %q payload of agentpakke %q for %s does not match its manifest: %w",
-			context, pakke.Name, resolved.Client, err)
+		// The tree sits on disk for weeks, so drift — a restore, an antivirus
+		// quarantine, a half-synced home directory — is the expected failure
+		// here, not an exotic one. It names the way out like every other
+		// refusal in this file does (#504 U6).
+		return true, fmt.Errorf("the pinned %q payload of agentpakke %q for %s does not match its manifest: %w\n\n  Rebuild it:  %s",
+			context, pakke.Name, resolved.Client, err, bold("nav-pilot sync --apply"))
 	}
 
 	// The only SetActivePakke call site: past the tier gate the manifest is
@@ -92,8 +96,8 @@ func tryPakkeLaunch(resolved ResolvedConfig) (bool, error) {
 
 	launch, ok := stagedLaunchers[resolved.Client]
 	if !ok {
-		return true, fmt.Errorf("agentpakke %q declares payloads for %s, but this nav-pilot cannot launch staged payloads for that client",
-			pakke.Name, resolved.Client)
+		return true, fmt.Errorf("agentpakke %q declares payloads for %s, but this nav-pilot cannot launch staged payloads for that client\n\n  Upgrade it:  %s",
+			pakke.Name, resolved.Client, bold("nav-pilot update"))
 	}
 	// After the handover gate: the notice announces a session that is about to
 	// start, and this is the last point that can still refuse to start one.

--- a/cli/nav-pilot/internal/provider/runtime_gate.go
+++ b/cli/nav-pilot/internal/provider/runtime_gate.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
 	"github.com/navikt/copilot/cli/nav-pilot/internal/artifacts"
 	"github.com/navikt/copilot/cli/nav-pilot/internal/domain"
 	"github.com/navikt/copilot/cli/nav-pilot/internal/source"
@@ -285,7 +286,7 @@ func ParseCpltVersion(out string) string {
 // established, since an unenforceable declaration is not an enforced one.
 func checkClientCompatibility(client, compatibility string) error {
 	pakke := source.ActivePakke().Name
-	rng, err := parseVersionRange(compatibility)
+	rng, err := agentpakke.ParseVersionRange(compatibility)
 	if err != nil {
 		return fmt.Errorf("agentpakke %q declares an unusable compatibility range %q for %s: %w", pakke, compatibility, client, err)
 	}
@@ -297,122 +298,22 @@ func checkClientCompatibility(client, compatibility string) error {
 	if err != nil {
 		return fmt.Errorf("could not read the %s version, which agentpakke %q requires to be %s: %w", client, pakke, compatibility, err)
 	}
-	if !rng.contains(found) {
-		return fmt.Errorf("%s %s is outside %s, the range agentpakke %q declares it supports", client, found, compatibility, pakke)
+	if !rng.Contains(found) {
+		// Which way to move the version depends on which bound failed, and
+		// how depends on how the client was installed — doctor knows both
+		// halves, so it is the command named here (#504 U6), the way the cplt
+		// floor above names brew.
+		return fmt.Errorf("%s %s is outside %s, the range agentpakke %q declares it supports.\n\n  Diagnose the install:  %s",
+			client, found, compatibility, pakke, domain.Bold("nav-pilot doctor"))
 	}
 	return nil
 }
 
-// semver3 is a major.minor.patch triple. The contract's compatibility grammar
-// has no ordering over prereleases and the reference refuses them outright, so
-// three integers is the whole model.
-type semver3 [3]int
-
-func (v semver3) String() string { return fmt.Sprintf("%d.%d.%d", v[0], v[1], v[2]) }
-
-func (v semver3) compare(o semver3) int {
-	for i := range v {
-		switch {
-		case v[i] < o[i]:
-			return -1
-		case v[i] > o[i]:
-			return 1
-		}
-	}
-	return 0
-}
-
-// comparator is one clause of a compatibility range, e.g. ">=1.18.20".
-type comparator struct {
-	op string
-	v  semver3
-}
-
-// versionRange is the conjunction of every comparator in a compatibility
-// string: all must hold.
-type versionRange []comparator
-
-// comparatorOps are the operators the contract documents, longest first so
-// ">=" is not read as ">" followed by a bad operand.
-var comparatorOps = []string{">=", "<=", ">", "<", "="}
-
-// parseVersionRange parses the range grammar README.agentpakke.md documents:
-// comma-separated comparators over semver, e.g. ">=1.18.20,<2". Operands may be
-// partial ("2" means 2.0.0) — that is what makes an upper major bound writable.
-func parseVersionRange(s string) (versionRange, error) {
-	var rng versionRange
-	for _, part := range strings.Split(s, ",") {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			return nil, fmt.Errorf("empty comparator in %q", s)
-		}
-		op := ""
-		for _, candidate := range comparatorOps {
-			if strings.HasPrefix(part, candidate) {
-				op = candidate
-				break
-			}
-		}
-		if op == "" {
-			return nil, fmt.Errorf("comparator %q has no operator (expected one of >= > <= < =)", part)
-		}
-		v, err := parseVersionOperand(strings.TrimSpace(part[len(op):]))
-		if err != nil {
-			return nil, fmt.Errorf("comparator %q: %w", part, err)
-		}
-		rng = append(rng, comparator{op: op, v: v})
-	}
-	return rng, nil
-}
-
-var versionPartPattern = regexp.MustCompile(`^(0|[1-9]\d*)$`)
-
-// parseVersionOperand parses one to three dot-separated numeric parts, filling
-// the missing ones with zero.
-func parseVersionOperand(s string) (semver3, error) {
-	var v semver3
-	if s == "" {
-		return v, errors.New("missing version")
-	}
-	parts := strings.Split(s, ".")
-	if len(parts) > 3 {
-		return v, fmt.Errorf("version %q has more than three parts", s)
-	}
-	for i, part := range parts {
-		if !versionPartPattern.MatchString(part) {
-			return semver3{}, fmt.Errorf("version %q has a non-numeric part %q", s, part)
-		}
-		n, err := strconv.Atoi(part)
-		if err != nil {
-			return semver3{}, fmt.Errorf("version %q: %w", s, err)
-		}
-		v[i] = n
-	}
-	return v, nil
-}
-
-func (r versionRange) contains(v semver3) bool {
-	for _, c := range r {
-		cmp := v.compare(c.v)
-		ok := false
-		switch c.op {
-		case ">=":
-			ok = cmp >= 0
-		case ">":
-			ok = cmp > 0
-		case "<=":
-			ok = cmp <= 0
-		case "<":
-			ok = cmp < 0
-		case "=":
-			ok = cmp == 0
-		}
-		if !ok {
-			return false
-		}
-	}
-	return true
-}
+// semver3 and the compatibility-range grammar live in internal/agentpakke,
+// the package that owns the contract, so `nav-pilot validate` rejects with
+// exactly the grammar this gate enforces (#504 U2). Aliased here because this
+// gate and the client version parsing below are their main consumers.
+type semver3 = agentpakke.Semver3
 
 // Client version-line patterns, transcribed from the reference's
 // OPENCODE_VERSION_PATTERN and COPILOT_VERSION_PATTERN (grillmester.py lines

--- a/cli/nav-pilot/internal/provider/runtime_gate_test.go
+++ b/cli/nav-pilot/internal/provider/runtime_gate_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
 )
 
 // stubProbes replaces both staged version probes for the duration of a test, so
@@ -22,91 +24,6 @@ func stubProbes(t *testing.T, cplt string, cpltErr error, client string, clientE
 
 // okCplt is a cplt release comfortably past minStagedCpltStamp.
 const okCplt = "cplt 2026.08.24-153138-0d1d66d\n"
-
-func TestParseVersionRange(t *testing.T) {
-	tests := []struct {
-		name  string
-		in    string
-		want  []comparator
-		isErr bool
-	}{
-		{name: "contract example", in: ">=1.18.20,<2", want: []comparator{
-			{op: ">=", v: semver3{1, 18, 20}},
-			{op: "<", v: semver3{2, 0, 0}},
-		}},
-		{name: "spaces are tolerated", in: " >= 1.0.79 , < 2 ", want: []comparator{
-			{op: ">=", v: semver3{1, 0, 79}},
-			{op: "<", v: semver3{2, 0, 0}},
-		}},
-		{name: "exact", in: "=1.2.3", want: []comparator{{op: "=", v: semver3{1, 2, 3}}}},
-		{name: "two-part operand zero-fills", in: "<=1.18", want: []comparator{{op: "<=", v: semver3{1, 18, 0}}}},
-		{name: "greater than", in: ">1.0.0", want: []comparator{{op: ">", v: semver3{1, 0, 0}}}},
-
-		{name: "empty", in: "", isErr: true},
-		{name: "no operator", in: "1.2.3", isErr: true},
-		{name: "operator without operand", in: ">=", isErr: true},
-		{name: "trailing comma", in: ">=1.0.0,", isErr: true},
-		{name: "leading comma", in: ",<2", isErr: true},
-		{name: "non-numeric part", in: ">=1.x.3", isErr: true},
-		{name: "four parts", in: ">=1.2.3.4", isErr: true},
-		{name: "prerelease operand", in: ">=1.2.3-beta", isErr: true},
-		{name: "leading zero", in: ">=01.2.3", isErr: true},
-		{name: "caret is not an operator", in: "^1.2.3", isErr: true},
-		{name: "double equals", in: "==1.2.3", isErr: true},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got, err := parseVersionRange(tc.in)
-			if tc.isErr {
-				if err == nil {
-					t.Fatalf("parseVersionRange(%q) = %v, want error", tc.in, got)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("parseVersionRange(%q) errored: %v", tc.in, err)
-			}
-			if len(got) != len(tc.want) {
-				t.Fatalf("parseVersionRange(%q) = %v, want %v", tc.in, got, tc.want)
-			}
-			for i := range got {
-				if got[i] != tc.want[i] {
-					t.Errorf("parseVersionRange(%q)[%d] = %v, want %v", tc.in, i, got[i], tc.want[i])
-				}
-			}
-		})
-	}
-}
-
-func TestVersionRangeContains(t *testing.T) {
-	tests := []struct {
-		rng     string
-		version semver3
-		want    bool
-	}{
-		{">=1.18.20,<2", semver3{1, 18, 20}, true},  // lower bound is inclusive
-		{">=1.18.20,<2", semver3{1, 18, 19}, false}, // one patch below
-		{">=1.18.20,<2", semver3{1, 19, 0}, true},
-		{">=1.18.20,<2", semver3{2, 0, 0}, false}, // upper bound is exclusive
-		{">=1.18.20,<2", semver3{1, 99, 99}, true},
-		{">=1.18.20,<2", semver3{0, 99, 99}, false},
-		{">1.0.0", semver3{1, 0, 0}, false},
-		{">1.0.0", semver3{1, 0, 1}, true},
-		{"<=1.0.0", semver3{1, 0, 0}, true},
-		{"=1.2.3", semver3{1, 2, 3}, true},
-		{"=1.2.3", semver3{1, 2, 4}, false},
-		{"=1.2", semver3{1, 2, 0}, true},
-	}
-	for _, tc := range tests {
-		rng, err := parseVersionRange(tc.rng)
-		if err != nil {
-			t.Fatalf("parseVersionRange(%q): %v", tc.rng, err)
-		}
-		if got := rng.contains(tc.version); got != tc.want {
-			t.Errorf("%q contains %v = %v, want %v", tc.rng, tc.version, got, tc.want)
-		}
-	}
-}
 
 func TestParseClientVersion(t *testing.T) {
 	tests := []struct {
@@ -323,11 +240,11 @@ func TestParseClientVersionAcceptsTheRealCopilotOutput(t *testing.T) {
 	if want := (semver3{1, 0, 81}); got != want {
 		t.Fatalf("parseClientVersion = %v, want %v (the build suffix is dropped, not compared)", got, want)
 	}
-	rng, err := parseVersionRange(">=1.0.79,<2")
+	rng, err := agentpakke.ParseVersionRange(">=1.0.79,<2")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !rng.contains(got) {
+	if !rng.Contains(got) {
 		t.Errorf("%v is outside the contract's documented copilot range >=1.0.79,<2", got)
 	}
 }
@@ -545,4 +462,17 @@ func TestRealCpltFloor(t *testing.T) {
 		t.Fatalf("could not read a stamp from the real cplt output %q", out)
 	}
 	t.Logf("real cplt probe: %q", strings.TrimSpace(out))
+}
+
+// An out-of-range client version must name a way forward (#504 U6), the way
+// the cplt floor right above it names its upgrade command.
+func TestOutOfRangeClientVersionNamesACommand(t *testing.T) {
+	stubProbes(t, okCplt, nil, "1.18.19\n", nil)
+	err := checkStagedRuntime("opencode", ">=1.18.20,<2")
+	if err == nil {
+		t.Fatal("checkStagedRuntime accepted an out-of-range version")
+	}
+	if !strings.Contains(err.Error(), "nav-pilot doctor") {
+		t.Errorf("out-of-range refusal %q names no command to run", err)
+	}
 }

--- a/docs/README.agentpakke.md
+++ b/docs/README.agentpakke.md
@@ -82,7 +82,7 @@ Add a layout with agents and skills paths, or declare payloads to make them Tier
 Regelen har to halvdeler, og de gjelder samtidig:
 
 - **Ukjente konstruksjoner ignoreres.** Ukjente klientnøkler, ukjente kontekstnøkler i `payloads`, og ekstra felt på ethvert nivå gjør ikke manifestet ugyldig. En eldre binær tilbyr bare ikke det den ikke kjenner navnet på. Dermed kan økosystemet vokse uten å ugyldiggjøre manifester som allerede er ute.
-- **Feilformede *kjente* konstruksjoner feiler lukket.** En `primaryAgents` som er tom eller mangler der den kreves (Tier 1-oppføring eller Tier 2-payload), en `layout` som mangler for en Tier 1-klient, en `contractVersion` med en major nav-pilot ikke implementerer, en `minNavPilotVersion` nav-pilot ikke kan sammenligne: alt stopper. Et repo som *har* et manifest må ha et gyldig et. Install avbrytes før første filoperasjon, og ingenting skrives delvis.
+- **Feilformede *kjente* konstruksjoner feiler lukket.** En `primaryAgents` som er tom eller mangler der den kreves (Tier 1-oppføring eller Tier 2-payload), en `layout` som mangler for en Tier 1-klient, en `contractVersion` med en major nav-pilot ikke implementerer, en `minNavPilotVersion` nav-pilot ikke kan sammenligne, en `compatibility` som ikke er et gyldig versjonsområde: alt stopper. Et repo som *har* et manifest må ha et gyldig et. Install avbrytes før første filoperasjon, og ingenting skrives delvis.
 
 Et repo helt uten `.nav-pilot/agentpakke.json` er ikke en feil. Det behandles som en legacy-samlingskilde (`collections/<navn>/manifest.json`) akkurat som før.
 


### PR DESCRIPTION
The four untouched user-facing bugs from the #504 review, verified against current code before fixing. U9 was already fixed (move-aside in `materializeRevision`); U8 has its own follow-up in #544 and is deliberately not taken here.

**U1 — "upgrade nav-pilot" was unreachable.** `validateSchema` runs first and the v1 schema pins `contractVersion` to `^1(\.\d+)?$`, so `checkContractVersion` could never fire: a manifest on a future contract major surfaced as a schema error telling the author to fix the manifest. The version gate now runs before the schema for any numeric major, so the error names the party that has to act ("Upgrade nav-pilot (nav-pilot update) …"). Garbage values stay the schema's to reject.

**U2 — the compatibility grammar is now validated, not first enforced at launch.** `">=1.18.20 <2"`, `"^1.18"`, `"1.18.20+"` and `">=1.18.20-rc.1"` all passed `nav-pilot validate` and then killed every Tier 2 launch on the runtime gate. Of the two shapes #504/#470 sketched, this takes moving `parseVersionRange` into `internal/agentpakke` rather than adding a schema `pattern`: the package that owns the contract owns the grammar, `checkSemantics` and the runtime gate call the same parser and can never drift, and a regex approximation of the comparator grammar would have been a second, weaker copy. (`internal/agentpakke` cannot import `internal/provider` — the dependency runs the other way — so the move is the only direction that works.) Checked for every client entry, known or not, the way `checkPaths` is. `docs/README.agentpakke.md`'s fail-closed list now names `compatibility`.

**U6 — the dead-end refusals name a way out.** Payload drift (the expected Tier 2 failure: restores, antivirus quarantines, half-synced home directories) names `nav-pilot sync --apply`, which rebuilds the tree. The staged-launch handover gap names `nav-pilot update`. An out-of-range client version names `nav-pilot doctor` — which way to move the version depends on which bound failed and on how the client was installed, and doctor knows both halves, the way the cplt floor right above names `brew upgrade cplt`.

**U7 — write before deleting.** `pinRevision` deleted the outgoing install's files and revision trees before writing the replacement state, so a state write that failed had already destroyed a working install while the state on disk still named every deleted file. Every removal now runs after the new state is written: a failed write loses nothing. The remaining crash window (kill between write and removals) leaves the outgoing files behind unrecorded — leftovers, not loss. `TestFailedStateWriteLosesNothing` demonstrates the loss against the old ordering (files gone after an injected write failure) and fails under it; it is not a test that passes both ways.

Every fix was mutation-checked: defect reintroduced, named test red, fix restored, suite green. Gates run locally with isolated `HOME`: `gofmt -l`, `go vet ./...`, `go build ./...`, `go test -race -coverpkg=./... ./...` (73.8%, floor 65), `staticcheck ./...`.

Part of #504 — with this, five of its six findings are resolved and #544 tracks the remainder (U8).
