### PR TITLE
fix(probe): vis gh-guardens melding i stedet for å kaste den

### DIFF
--- a/.github/workflows/nav-pilot-ci.yaml
+++ b/.github/workflows/nav-pilot-ci.yaml
@@ -97,7 +97,7 @@ jobs:
           experimental: true
 
       - name: Run BATS
-        run: mise exec -- bats scripts/install.bats scripts/sync-pr-body.bats
+        run: mise exec -- bats scripts/install.bats scripts/sync-pr-body.bats scripts/skill-selvutlosning-probe.bats
 
   e2e-install:
     name: E2E test install.sh

--- a/.mise.toml
+++ b/.mise.toml
@@ -130,7 +130,7 @@ echo "  vet..."     && go vet ./... && \
 echo "  staticcheck..." && go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 ./... && \
 cd ../.. && \
 echo "  shellcheck..." && shellcheck scripts/install.sh && \
-echo "  bats..." && bats scripts/install.bats scripts/sync-pr-body.bats && \
+echo "  bats..." && bats scripts/install.bats scripts/sync-pr-body.bats scripts/skill-selvutlosning-probe.bats && \
 echo "  ✅ nav-pilot checks passed"
 """
 

--- a/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
+++ b/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
@@ -1091,7 +1091,7 @@
       "displayName": "workstation-security",
       "description": "Sikkerhetssjekk for macOS-utviklermaskiner — brannmur, SSH, Git, hemmeligheter, nettverk og Nav-plattformverktøy",
       "filePath": "skills/workstation-security/SKILL.md",
-      "contentHash": "56f5848884ca5a29b5ed70f650266f8e9374a237c5a115e6fcccba155d3b447e",
+      "contentHash": "b302aa86a0e3010344a0f43a31ba49d6324e1d2d50f695ad20b74cef8f7cb324",
       "installUrl": "",
       "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/skills/workstation-security/SKILL.md"
     }

--- a/apps/my-copilot/src/lib/copilot-manifest.json
+++ b/apps/my-copilot/src/lib/copilot-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-09-05T10:11:29.148Z",
+  "generatedAt": "2026-09-05T13:32:54.188Z",
   "items": [
     {
       "id": "accessibility-agent",
@@ -1839,7 +1839,7 @@
       "domain": "auth",
       "filePath": "skills/workstation-security/SKILL.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/skills/workstation-security/SKILL.md",
-      "contentHash": "56f5848884ca5a29b5ed70f650266f8e9374a237c5a115e6fcccba155d3b447e",
+      "contentHash": "b302aa86a0e3010344a0f43a31ba49d6324e1d2d50f695ad20b74cef8f7cb324",
       "installUrl": null,
       "insidersInstallUrl": null,
       "tags": ["security", "macos", "developer-tools", "audit", "hardening"],

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -235,7 +235,8 @@ if command -v gh &>/dev/null; then
       echo "  Error from gh: $(echo "$ERR_MSG" | tr '\n' ' ')"
       echo "  To enable provenance verification:"
       echo "    - In GitHub Actions: pass env: GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}"
-      echo "    - Locally: run 'gh auth login' or set GH_TOKEN environment variable."
+      echo "    - Locally: set GH_TOKEN, or run 'gh auth login' outside a cplt sandbox"
+      echo "      ('gh auth login' is blocked by cplt's gh guard, on by default since cplt#335)."
       echo ""
     else
       echo "Error: Provenance verification failed!"

--- a/scripts/skill-selvutlosning-probe.bats
+++ b/scripts/skill-selvutlosning-probe.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+#
+# Mutasjonssjekk for tokenhentingen i skill-selvutlosning-probe.sh (#660).
+#
+# cplt sin gh-guard er på som standard og blokkerer `gh auth token`. Guarden
+# forklarer hvorfor på stderr. Skriptet kastet den forklaringen (`2>/dev/null`)
+# og rådet i stedet «gh auth login» — som guarden også blokkerer. Testen feiler
+# hvis forklaringen forsvinner igjen, eller hvis skriptet igjen gir det rådet
+# som eneste utvei.
+
+SCRIPT="${BATS_TEST_DIRNAME}/skill-selvutlosning-probe.sh"
+
+GUARD_MSG="⚠️ BLOCKED by sandbox: revealing the GitHub token is not allowed in this environment."
+
+setup() {
+  SHIM="$(mktemp -d)"
+  cat >"$SHIM/gh" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "auth" && "\$2" == "token" ]]; then
+  printf '%s\n' "$GUARD_MSG" >&2
+  printf 'Reason: token exfiltration prevention. Use the GH_TOKEN env var instead.\n' >&2
+  exit 1
+fi
+exit 0
+EOF
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$SHIM/copilot"
+  chmod +x "$SHIM/gh" "$SHIM/copilot"
+  OUTDIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$SHIM" "$OUTDIR"
+}
+
+run_probe() {
+  env -u COPILOT_GITHUB_TOKEN -u GH_TOKEN -u GITHUB_TOKEN \
+    HOME="$OUTDIR/home" PATH="$SHIM:/usr/bin:/bin" \
+    bash "$SCRIPT" --model dummy --out "$OUTDIR/out"
+}
+
+@test "guard-blokkering feiler høylytt med guardens egen melding" {
+  run run_probe
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"BLOCKED by sandbox"* ]]
+}
+
+@test "rådet peker på GH_TOKEN, ikke bare gh auth login" {
+  run run_probe
+  [[ "$output" == *"GH_TOKEN"* ]]
+}
+
+@test "eksplisitt token hopper over gh helt" {
+  run env -u GH_TOKEN COPILOT_GITHUB_TOKEN=ghp_dummy \
+    HOME="$OUTDIR/home" PATH="$SHIM:/usr/bin:/bin" \
+    bash "$SCRIPT" --model dummy --out "$OUTDIR/out"
+  [[ "$output" != *"ingen GitHub-token"* ]]
+}

--- a/scripts/skill-selvutlosning-probe.sh
+++ b/scripts/skill-selvutlosning-probe.sh
@@ -89,7 +89,7 @@ done
 # både `gh auth token` (block_auth_token, default true) og `gh auth login`. Guarden
 # skriver forklaringen på stderr, så den må vises i stedet for å kastes: uten den
 # ser en blokkering ut som «ikke innlogget», og rådet blir feil.
-TOKEN="${COPILOT_GITHUB_TOKEN:-${GH_TOKEN:-}}"
+TOKEN="${COPILOT_GITHUB_TOKEN:-${GH_TOKEN:-${GITHUB_TOKEN:-}}}"
 if [[ -z "$TOKEN" ]]; then
   # $OUT finnes allerede (mkdir over), så feilteksten trenger ingen mktemp som
   # kan feile og etterlate et tomt filnavn i redirecten.
@@ -101,7 +101,7 @@ if [[ -z "$TOKEN" ]]; then
       echo "gh svarte:" >&2
       sed 's/^/  /' "$GH_ERR" >&2
     fi
-    echo "Sett COPILOT_GITHUB_TOKEN eller GH_TOKEN." >&2
+    echo "Sett COPILOT_GITHUB_TOKEN, GH_TOKEN eller GITHUB_TOKEN." >&2
     echo "Inne i en cplt-sandkasse er både 'gh auth token' og 'gh auth login' blokkert av gh-guarden; logg inn utenfor sandkassen, eller sett gh_guard.inject_token = true slik at cplt injiserer GH_TOKEN." >&2
     exit 2
   fi

--- a/scripts/skill-selvutlosning-probe.sh
+++ b/scripts/skill-selvutlosning-probe.sh
@@ -85,8 +85,27 @@ HOMEDIR="$OUT/home"; mkdir -p "$HOMEDIR/.copilot"
 for f in config.json settings.json permissions-config.json copilot-instructions.md; do
   [[ -f "$HOME/.copilot/$f" ]] && cp "$HOME/.copilot/$f" "$HOMEDIR/.copilot/"
 done
-TOKEN="${COPILOT_GITHUB_TOKEN:-$(gh auth token 2>/dev/null)}"
-[[ -n "$TOKEN" ]] || { echo "ingen GitHub-token (gh auth login)" >&2; exit 2; }
+# gh-guarden i cplt er på som standard (standard-presetet, cplt#335) og blokkerer
+# både `gh auth token` (block_auth_token, default true) og `gh auth login`. Guarden
+# skriver forklaringen på stderr, så den må vises i stedet for å kastes: uten den
+# ser en blokkering ut som «ikke innlogget», og rådet blir feil.
+TOKEN="${COPILOT_GITHUB_TOKEN:-${GH_TOKEN:-}}"
+if [[ -z "$TOKEN" ]]; then
+  GH_ERR="$(mktemp)"
+  TOKEN="$(gh auth token 2>"$GH_ERR")" || true
+  if [[ -z "$TOKEN" ]]; then
+    echo "ingen GitHub-token." >&2
+    if [[ -s "$GH_ERR" ]]; then
+      echo "gh svarte:" >&2
+      sed 's/^/  /' "$GH_ERR" >&2
+    fi
+    echo "Sett COPILOT_GITHUB_TOKEN eller GH_TOKEN." >&2
+    echo "Inne i en cplt-sandkasse er både 'gh auth token' og 'gh auth login' blokkert av gh-guarden; logg inn utenfor sandkassen, eller sett gh_guard.inject_token = true slik at cplt injiserer GH_TOKEN." >&2
+    rm -f "$GH_ERR"
+    exit 2
+  fi
+  rm -f "$GH_ERR"
+fi
 
 WS="$OUT/ws"
 FIXTURE=""   # fila en feilutløsning kan komme til å skrive i

--- a/scripts/skill-selvutlosning-probe.sh
+++ b/scripts/skill-selvutlosning-probe.sh
@@ -91,7 +91,9 @@ done
 # ser en blokkering ut som «ikke innlogget», og rådet blir feil.
 TOKEN="${COPILOT_GITHUB_TOKEN:-${GH_TOKEN:-}}"
 if [[ -z "$TOKEN" ]]; then
-  GH_ERR="$(mktemp)"
+  # $OUT finnes allerede (mkdir over), så feilteksten trenger ingen mktemp som
+  # kan feile og etterlate et tomt filnavn i redirecten.
+  GH_ERR="$OUT/gh-auth-token.err"
   TOKEN="$(gh auth token 2>"$GH_ERR")" || true
   if [[ -z "$TOKEN" ]]; then
     echo "ingen GitHub-token." >&2
@@ -101,7 +103,6 @@ if [[ -z "$TOKEN" ]]; then
     fi
     echo "Sett COPILOT_GITHUB_TOKEN eller GH_TOKEN." >&2
     echo "Inne i en cplt-sandkasse er både 'gh auth token' og 'gh auth login' blokkert av gh-guarden; logg inn utenfor sandkassen, eller sett gh_guard.inject_token = true slik at cplt injiserer GH_TOKEN." >&2
-    rm -f "$GH_ERR"
     exit 2
   fi
   rm -f "$GH_ERR"

--- a/skills/workstation-security/SKILL.md
+++ b/skills/workstation-security/SKILL.md
@@ -83,7 +83,11 @@ These checks are specific to Nav developer machines connected to the NAIS platfo
    ```bash
    gh auth status 2>/dev/null
    ```
-   Not logged in or expired → **MEDIUM**. Fix: `gh auth login`.
+   Not logged in or expired → **MEDIUM**. Fix: run `gh auth login` **outside** the cplt
+   sandbox. Inside a sandbox the gh guard blocks `gh auth login` as credential
+   modification, and it is on by default (the `standard` preset, cplt#335), so the
+   command will fail there no matter how many times it is retried. `gh auth status`
+   itself is allowed; only the token-revealing form (`--show-token`/`-t`) is blocked.
 
 4. **Security scanning tools** — should be installed:
    ```bash


### PR DESCRIPTION
Lukker #660.

`scripts/skill-selvutlosning-probe.sh:88` kjørte `gh auth token 2>/dev/null`. cplt sin gh-guard blokkerer den kommandoen som standard (`gh_guard.block_auth_token` er `true`, `src/config/types.rs:720`, og `gh_guard` er på i `standard`-presetet siden cplt#335, `src/config/types.rs:294`). Redirecten spiste guardens forklaring, så skriptet falt gjennom til «ingen GitHub-token (gh auth login)» og exit 2. Rådet er feil to ganger: tokenet fantes, og `gh auth login` er selv blokkert som credential modification (`src/gh_proxy.rs:661`).

## Endringer

- Probe-skriptet leser gh sin stderr og skriver den ut når tokenet mangler, godtar `GH_TOKEN` ved siden av `COPILOT_GITHUB_TOKEN`, og peker på det som faktisk virker: token i miljøet, innlogging utenfor sandkassen, eller `gh_guard.inject_token = true`.
- Samme feilråd rettet i `skills/workstation-security/SKILL.md:86` og `scripts/install.sh:238`, jf. issuens egen liste over de tre stedene.
- `scripts/skill-selvutlosning-probe.bats` simulerer blokkeringen med en `gh`-shim og krever at meldingen kommer ut.

## Verifisert

Påstandene er lest på nytt i `navikt/cplt` på main, ikke tatt fra issuen: `types.rs:294` (standard-presetet slår på gh_guard), `types.rs:720` (`block_auth_token` default true), `gh_proxy.rs:1787` (pre-sjekken som overstyrer tabellens Allow), `gh_proxy.rs:661` (`auth login` = Block).

Mutasjonssjekk: med fiksen reversert feiler to av de tre bats-testene på nøyaktig den manglende forklaringen.

## Kjørt

`bats scripts/skill-selvutlosning-probe.bats` (3/3), `shellcheck` på begge skriptene, `scripts/lint-skills.sh` (33 skills, eneste advarsel er `klarsprak`-tokenstørrelse som er forhåndseksisterende). Ny bats-fil registrert i `.mise.toml` og i `nav-pilot-ci.yaml`.