### PR TITLE
test(pakke): mål vaktens listing på treet som faktisk er publisert

### DIFF
--- a/cli/nav-pilot/internal/cli/pakke_install_test.go
+++ b/cli/nav-pilot/internal/cli/pakke_install_test.go
@@ -477,12 +477,17 @@ func TestLocalRematerializeNeverPublishesAHalfDeletedRevision(t *testing.T) {
 			// was emptied in place, at the path, so the descriptor and the path
 			// stayed the same directory and the check below still catches it.
 			if d, err := os.Open(revDir); err == nil {
-				names, _ := d.Readdirnames(-1)
+				names, readErr := d.Readdirnames(-1)
 				opened, openedErr := d.Stat()
 				d.Close()
 				current, currentErr := os.Stat(revDir)
 				stillPublished := openedErr == nil && currentErr == nil && os.SameFile(opened, current)
-				if stillPublished && len(names) != wantEntries {
+				// A readdir error on the tree that is still at revDir counts as
+				// a partial listing rather than as no observation. Some
+				// platforms return a short listing together with a non-nil
+				// error under a concurrent rename or remove, and swallowing
+				// that would let the test miss exactly what it is looking for.
+				if stillPublished && (readErr != nil || len(names) != wantEntries) {
 					partial.Store(true)
 				}
 			}

--- a/cli/nav-pilot/internal/cli/pakke_install_test.go
+++ b/cli/nav-pilot/internal/cli/pakke_install_test.go
@@ -455,10 +455,34 @@ func TestLocalRematerializeNeverPublishesAHalfDeletedRevision(t *testing.T) {
 			// describes whatever directory was at revDir at that instant, even
 			// if it is renamed a moment later. Two stats would race the rename
 			// and report a partial tree that was never published.
+			//
+			// Resolving once is necessary but not sufficient, and that gap is
+			// what flaked this test on macOS (#668). The open can land on the
+			// outgoing tree microseconds before the republish renames it to
+			// aside; os.RemoveAll(aside) then empties it under this descriptor,
+			// and on APFS readdir reports the shrinking directory rather than
+			// the tree as it stood when it was opened. (Measured: a dirfd held
+			// across a concurrent RemoveAll returns a partial listing in
+			// roughly one run in two hundred on APFS. An open *file* descriptor
+			// is unaffected, which is why the live handle below reads through
+			// cleanly on both platforms.)
+			//
+			// That short listing is the retired revision going away on
+			// schedule, not a half-deleted one being published, and the two are
+			// told apart by identity rather than by timing: revDir is only ever
+			// created by renaming a fully staged tree onto it and only ever
+			// leaves by being renamed aside, so a listing counts against the
+			// invariant only when the directory it was taken on is still the
+			// one at revDir. Under the removal this fix replaced the old tree
+			// was emptied in place, at the path, so the descriptor and the path
+			// stayed the same directory and the check below still catches it.
 			if d, err := os.Open(revDir); err == nil {
 				names, _ := d.Readdirnames(-1)
+				opened, openedErr := d.Stat()
 				d.Close()
-				if len(names) != wantEntries {
+				current, currentErr := os.Stat(revDir)
+				stillPublished := openedErr == nil && currentErr == nil && os.SameFile(opened, current)
+				if stillPublished && len(names) != wantEntries {
 					partial.Store(true)
 				}
 			}


### PR DESCRIPTION
Lukker #668.

## Spørsmålet issuen ba om å få avgjort

Issuen spurte om produksjonskoden har det samme vinduet for en reell macOS-klient, eller om det bare er testens konstruksjon. Svaret er at **den publiserte stien aldri har vinduet**, og at det testen faktisk måler er noe annet enn det den mener å måle.

`revDir` opprettes utelukkende av `os.Rename(tmp, revDir)` med et ferdig staget tre, og forlates utelukkende av `os.Rename(revDir, aside)`. Ingenting kjører `os.RemoveAll(revDir)` (verifisert over hele `pakke_install.go` og `pakke_launch.go`). Hver tilstand stien observeres i er altså et komplett tre. Invarianten fra #666/#667 holder, og **rekkefølgen er ikke rørt i denne PR-en**.

## Hva som faktisk flaket

Vakten gjør `os.Open(revDir)` og så `Readdirnames`. Åpningen kan lande på det *utgående* treet mikrosekunder før republiseringen renamer det til `aside`. `os.RemoveAll(aside)` tømmer så den katalogen under deskriptoren, og på APFS rapporterer `readdir` den krympende katalogen i stedet for treet slik det sto ved åpning.

Målt med en frittstående probe på denne maskinen (APFS): en katalogdeskriptor holdt over en samtidig `RemoveAll` gir en delvis listing i ca. 1 av 200 runder. En åpen *fil*deskriptor er upåvirket, som er grunnen til at `live`-håndtaket i testen leser rent på begge plattformer, og til at feilen ser ut som ren flaks.

Det vakten så var altså den pensjonerte revisjonen som forsvant etter planen, ikke en halvslettet revisjon som ble publisert.

## Fiksen

Testen skiller nå de to på identitet i stedet for på timing: en listing teller mot invarianten bare når katalogen den ble tatt på fortsatt er den som ligger på `revDir` (`os.SameFile` mellom `d.Stat()` og `os.Stat(revDir)`).

## At den fortsatt biter

Med den gamle in-place-slettingen (`os.RemoveAll(revDir)` før renamen, altså oppførselen #504/U9 gjaldt) gjeninnført, feiler testen umiddelbart i runde 0, tre av tre kjøringer. Der er deskriptoren og stien samme katalog, så identitetssjekken slipper den gjennom akkurat som før.

## Kjørt

`gofmt -l` rent, `go build`, `go vet`, `go test -race ./...` grønn, `staticcheck` rent, dekning 74,2 % mot gulvet på 65. Testen kjørt 75 ganger med og uten `-race` uten flak.