### PR TITLE
docs(agents): Lukker #NNN closes nothing, use Closes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,12 @@ After editing an app, run `mise check` in that app's directory. Run `mise all` w
 
 ## Conventions
 
+- PR bodies may be in Norwegian, but issue-closing references must use GitHub's
+  English keywords: `Closes #NNN` / `Fixes #NNN`. `Lukker #NNN` does not link or
+  auto-close anything, and three months of shipped-but-open issues in this repo
+  trace back to exactly that. Verify with the PR's `closingIssuesReferences`
+  when it matters.
+
 - Start with the smallest safe change and keep diffs task-focused.
 - Reuse existing patterns before adding new abstractions.
 - In `my-copilot`, use Aksel spacing tokens, not Tailwind `p-*/m-*` utilities.


### PR DESCRIPTION
Funnet i dag: tre PR-er brukte «Lukker #NNN» i bodyen, og GitHub koblet ingen av dem — `closingIssuesReferences` var tom på alle tre, og sakene måtte lukkes for hånd. GitHub auto-lukker bare på de engelske nøkkelordene (`Closes`, `Fixes`, `Resolves`).

Dette forklarer sannsynligvis også mønsteret fra ryddesjauen: arbeid levert i juni (#175, #201, #332) sto som åpne saker i tre måneder fordi lukkereferansen aldri virket.

Én linje i AGENTS.md, så slutter det å skje.