### PR TITLE
docs(nav-pilot): document cplt logging keys instead of recommending them

### DIFF
--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -200,23 +200,23 @@ macOS har ingen slik grense. Der håndheves det samme med Seatbelt.
 ### Logging av blokkeringer
 
 `proxy.log_level` styrer hva cplt sin proxy skriver til stderr. Standardverdien er `none`,
-men cplt hever den selv til `blocked` så snart en vertsliste er aktiv — enten fordi
-`proxy.default_allowlist` er på, eller fordi `proxy.allowed_domains` peker på en fil
+men cplt hever den selv til `blocked` så snart en vertsliste er aktiv, enten fordi
+`proxy.default_allowlist` er på eller fordi `proxy.allowed_domains` peker på en fil
 (`src/main.rs`, `proxy_log_level`). Posturen nav-pilot anbefaler gjør begge deler, så på
 strict er `blocked` allerede i kraft uten at du setter noe. Nav-pilot anbefaler derfor ikke
 nøkkelen: den er allerede dekket der den betyr noe.
 
 Kjører du `standard` uten egen `proxy.allowed_domains`, er det ingen vertsliste å heve for,
-og proxyen tier også om de blokkeringene som ikke kommer fra vertslista — verter som slår
-opp til private eller link-local IP-er, altså DNS-rebinding- og metadatavernet. Vil du se
-dem, setter du nivået selv:
+og proxyen tier også om de blokkeringene som ikke kommer fra vertslista. Det er verter som
+slår opp til private eller link-local IP-er, altså DNS-rebinding- og metadatavernet. Vil du
+se dem, setter du nivået selv:
 
 ```bash
 cplt config set proxy.log_level blocked
 ```
 
 `audit.enabled` ser ut som svaret på det samme, men er det ikke i dagens cplt. `[audit]`-
-seksjonen leses og vises av `cplt config show`, men ingenting bruker den — cplt sier det
+seksjonen leses og vises av `cplt config show`, men ingenting bruker den. cplt sier det
 selv i registeret sitt (`src/config/registry.rs`, `BOOL_KEYS_EXEMPT`: «the `[audit]` section
 is parsed and displayed but has no consumer yet»). Å slå den på gir ingen logg. Vil du ha
 en fil å lese etterpå, er det `proxy.log_file` som faktisk skriver en.

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -197,6 +197,30 @@ av ved oppstart, og da ville en versjonssjekk sagt «går fint» rett før cplt 
 
 macOS har ingen slik grense. Der håndheves det samme med Seatbelt.
 
+### Logging av blokkeringer
+
+`proxy.log_level` styrer hva cplt sin proxy skriver til stderr. Standardverdien er `none`,
+men cplt hever den selv til `blocked` så snart en vertsliste er aktiv — enten fordi
+`proxy.default_allowlist` er på, eller fordi `proxy.allowed_domains` peker på en fil
+(`src/main.rs`, `proxy_log_level`). Posturen nav-pilot anbefaler gjør begge deler, så på
+strict er `blocked` allerede i kraft uten at du setter noe. Nav-pilot anbefaler derfor ikke
+nøkkelen: den er allerede dekket der den betyr noe.
+
+Kjører du `standard` uten egen `proxy.allowed_domains`, er det ingen vertsliste å heve for,
+og proxyen tier også om de blokkeringene som ikke kommer fra vertslista — verter som slår
+opp til private eller link-local IP-er, altså DNS-rebinding- og metadatavernet. Vil du se
+dem, setter du nivået selv:
+
+```bash
+cplt config set proxy.log_level blocked
+```
+
+`audit.enabled` ser ut som svaret på det samme, men er det ikke i dagens cplt. `[audit]`-
+seksjonen leses og vises av `cplt config show`, men ingenting bruker den — cplt sier det
+selv i registeret sitt (`src/config/registry.rs`, `BOOL_KEYS_EXEMPT`: «the `[audit]` section
+is parsed and displayed but has no consumer yet»). Å slå den på gir ingen logg. Vil du ha
+en fil å lese etterpå, er det `proxy.log_file` som faktisk skriver en.
+
 ### Lokal modell og strict
 
 `nav-pilot local` sender prompten via en loop-guard på `127.0.0.1`. cplt blokkerer localhost

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -203,8 +203,9 @@ macOS har ingen slik grense. Der håndheves det samme med Seatbelt.
 men cplt hever den selv til `blocked` så snart en vertsliste er aktiv, enten fordi agenten
 har en innebygd liste (copilot, opencode) eller fordi `proxy.allowed_domains` er satt
 (`proxy_log_level` i cplt-repoet, `src/main.rs`). Sikkerhetsnivået nav-pilot anbefaler skriver alltid
-fila, så på strict er `blocked` allerede i kraft uten at du setter noe. Merk at den
-innebygde lista er tom for `pi`, `goose` og `shell`, så der er det bare fila som slår til.
+vertslistefila `proxy.allowed_domains` peker på, så på strict er `blocked` allerede i kraft
+uten at du setter noe. Merk at den innebygde lista er tom for `pi`, `goose` og `shell`, så
+der er det bare vertslistefila som slår til.
 Nav-pilot anbefaler derfor ikke nøkkelen: den er allerede dekket der den betyr noe.
 
 Kjører du `standard` uten egen `proxy.allowed_domains`, er det ingen vertsliste å heve for,

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -200,29 +200,32 @@ macOS har ingen slik grense. Der håndheves det samme med Seatbelt.
 ### Logging av blokkeringer
 
 `proxy.log_level` styrer hva cplt sin proxy skriver til stderr. Standardverdien er `none`,
-men cplt hever den selv til `blocked` så snart en vertsliste er aktiv, enten fordi
-`proxy.default_allowlist` er på eller fordi `proxy.allowed_domains` peker på en fil
-(`src/main.rs`, `proxy_log_level`). Posturen nav-pilot anbefaler gjør begge deler, så på
-strict er `blocked` allerede i kraft uten at du setter noe. Nav-pilot anbefaler derfor ikke
-nøkkelen: den er allerede dekket der den betyr noe.
+men cplt hever den selv til `blocked` så snart en vertsliste er aktiv, enten fordi agenten
+har en innebygd liste (copilot, opencode) eller fordi `proxy.allowed_domains` er satt
+(`src/main.rs`, `proxy_log_level`). Sikkerhetsnivået nav-pilot anbefaler skriver alltid
+fila, så på strict er `blocked` allerede i kraft uten at du setter noe. Merk at den
+innebygde lista er tom for `pi`, `goose` og `shell`, så der er det bare fila som slår til.
+Nav-pilot anbefaler derfor ikke nøkkelen: den er allerede dekket der den betyr noe.
 
 Kjører du `standard` uten egen `proxy.allowed_domains`, er det ingen vertsliste å heve for,
-og proxyen tier også om de blokkeringene som ikke kommer fra vertslista. Det er verter som
-slår opp til private eller link-local IP-er, altså DNS-rebinding- og metadatavernet. Vil du
-se dem, setter du nivået selv:
+og proxyen tier da om alle andre blokkeringer og feil også: treff i cplt sin egen
+blokkliste, stengte porter, verter som slår opp til private eller link-local IP-er
+(DNS-rebinding- og metadatavernet), og oppslag som feiler. Vil du se dem, setter du nivået
+selv:
 
 ```bash
 cplt config set proxy.log_level blocked
 ```
 
-`audit.enabled` ser ut som svaret på det samme, men er det ikke i dagens cplt. `[audit]`-
-seksjonen leses og vises av `cplt config show`, men ingenting bruker den. cplt sier det
-selv i registeret sitt (`src/config/registry.rs`, `BOOL_KEYS_EXEMPT`: «the `[audit]` section
+`audit.enabled` ser ut som svaret på det samme, men er det ikke i dagens cplt.
+`[audit]`-seksjonen leses og vises av `cplt config show`, men ingenting bruker den. cplt
+sier det selv i registeret sitt (`src/config/registry.rs`, `BOOL_KEYS_EXEMPT`: «the `[audit]` section
 is parsed and displayed but has no consumer yet»). Å slå den på gir ingen logg. Vil du ha
-en fil å lese etterpå, er det `proxy.log_file` som faktisk skriver en.
+en fil å lese etterpå, er det `proxy.log_file` som faktisk skriver en. Den dekker
+proxy-verdiktene, ikke avgjørelsene til gh- og git-vakta.
 
-Ikke forveksle den med `sandbox.audit`, som er noe annet og allerede på: den skriver
-rapporten over filendringer cplt viser etter at agenten har avsluttet.
+Ikke forveksle den med `sandbox.audit`, som er noe annet og allerede på: den viser
+rapporten over filendringer på skjermen (stderr) etter at agenten har avsluttet.
 
 ### Lokal modell og strict
 

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -203,7 +203,7 @@ macOS har ingen slik grense. Der håndheves det samme med Seatbelt.
 men cplt hever den selv til `blocked` så snart en vertsliste er aktiv, enten fordi agenten
 har en innebygd liste (copilot, opencode) eller fordi `proxy.allowed_domains` er satt
 (`proxy_log_level` i cplt-repoet, `src/main.rs`). Sikkerhetsnivået nav-pilot anbefaler skriver alltid
-vertslistefila `proxy.allowed_domains` peker på, så på strict er `blocked` allerede i kraft
+vertslistefila `proxy.allowed_domains` peker på, så på `strict` er `blocked` allerede i kraft
 uten at du setter noe. Merk at den innebygde lista er tom for `pi`, `goose` og `shell`, så
 der er det bare vertslistefila som slår til.
 Nav-pilot anbefaler derfor ikke nøkkelen: den er allerede dekket der den betyr noe.

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -202,7 +202,7 @@ macOS har ingen slik grense. Der håndheves det samme med Seatbelt.
 `proxy.log_level` styrer hva cplt sin proxy skriver til stderr. Standardverdien er `none`,
 men cplt hever den selv til `blocked` så snart en vertsliste er aktiv, enten fordi agenten
 har en innebygd liste (copilot, opencode) eller fordi `proxy.allowed_domains` er satt
-(`src/main.rs`, `proxy_log_level`). Sikkerhetsnivået nav-pilot anbefaler skriver alltid
+(`proxy_log_level` i cplt-repoet, `src/main.rs`). Sikkerhetsnivået nav-pilot anbefaler skriver alltid
 fila, så på strict er `blocked` allerede i kraft uten at du setter noe. Merk at den
 innebygde lista er tom for `pi`, `goose` og `shell`, så der er det bare fila som slår til.
 Nav-pilot anbefaler derfor ikke nøkkelen: den er allerede dekket der den betyr noe.
@@ -219,7 +219,7 @@ cplt config set proxy.log_level blocked
 
 `audit.enabled` ser ut som svaret på det samme, men er det ikke i dagens cplt.
 `[audit]`-seksjonen leses og vises av `cplt config show`, men ingenting bruker den. cplt
-sier det selv i registeret sitt (`src/config/registry.rs`, `BOOL_KEYS_EXEMPT`: «the `[audit]` section
+sier det selv i registeret sitt (cplt-repoet, `src/config/registry.rs`, `BOOL_KEYS_EXEMPT`: «the `[audit]` section
 is parsed and displayed but has no consumer yet»). Å slå den på gir ingen logg. Vil du ha
 en fil å lese etterpå, er det `proxy.log_file` som faktisk skriver en. Den dekker
 proxy-verdiktene, ikke avgjørelsene til gh- og git-vakta.

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -221,6 +221,9 @@ selv i registeret sitt (`src/config/registry.rs`, `BOOL_KEYS_EXEMPT`: «the `[au
 is parsed and displayed but has no consumer yet»). Å slå den på gir ingen logg. Vil du ha
 en fil å lese etterpå, er det `proxy.log_file` som faktisk skriver en.
 
+Ikke forveksle den med `sandbox.audit`, som er noe annet og allerede på: den skriver
+rapporten over filendringer cplt viser etter at agenten har avsluttet.
+
 ### Lokal modell og strict
 
 `nav-pilot local` sender prompten via en loop-guard på `127.0.0.1`. cplt blokkerer localhost

--- a/docs/nav-pilot-changelog.md
+++ b/docs/nav-pilot-changelog.md
@@ -6,8 +6,8 @@ Endringslogg for nav-pilot agent harness — agenter, skills, instruksjoner, pro
 
 ### cplt-logging: hva som er verdt å anbefale, og hva som ikke er det
 
-- **`proxy.log_level` dokumentert i stedet for anbefalt**: cplt hever selv nivået til `blocked` så snart en vertsliste er aktiv (`src/main.rs`, `proxy_log_level`), og posturen nav-pilot anbefaler gjør nettopp det. En egen anbefaling ville vært en config-skriving som ikke endrer noe. README beskriver nå hvor auto-hevingen gjelder og hva du selv må sette på `standard` uten vertsliste, der proxyen ellers tier om alle blokkeringer og feil som ikke kommer fra vertslista (#422).
-- **`audit.enabled` anbefales ikke**: Nøkkelen finnes i cplt sitt register, men `[audit]`-seksjonen er kun lest og vist. Ingenting bruker den (`src/config/registry.rs`, `BOOL_KEYS_EXEMPT`). Å anbefale den ville sendt utviklere til en bryter som ikke gir noen logg. `proxy.log_file` er den som faktisk skriver en (#422).
+- **`proxy.log_level` dokumentert i stedet for anbefalt**: cplt hever selv nivået til `blocked` så snart en vertsliste er aktiv (`proxy_log_level` i cplt-repoet, `src/main.rs`), og posturen nav-pilot anbefaler gjør nettopp det. En egen anbefaling ville vært en config-skriving som ikke endrer noe. README beskriver nå hvor auto-hevingen gjelder og hva du selv må sette på `standard` uten vertsliste, der proxyen ellers tier om alle blokkeringer og feil som ikke kommer fra vertslista (#422).
+- **`audit.enabled` anbefales ikke**: Nøkkelen finnes i cplt sitt register, men `[audit]`-seksjonen er kun lest og vist. Ingenting bruker den (cplt-repoet, `src/config/registry.rs`, `BOOL_KEYS_EXEMPT`). Å anbefale den ville sendt utviklere til en bryter som ikke gir noen logg. `proxy.log_file` er den som faktisk skriver en (#422).
 
 ## 2026-09-03
 

--- a/docs/nav-pilot-changelog.md
+++ b/docs/nav-pilot-changelog.md
@@ -2,6 +2,13 @@
 
 Endringslogg for nav-pilot agent harness — agenter, skills, instruksjoner, prompts og samlinger.
 
+## 2026-09-05
+
+### cplt-logging: hva som er verdt å anbefale, og hva som ikke er det
+
+- **`proxy.log_level` dokumentert i stedet for anbefalt**: cplt hever selv nivået til `blocked` så snart en vertsliste er aktiv (`src/main.rs`, `proxy_log_level`), og posturen nav-pilot anbefaler gjør nettopp det. En egen anbefaling ville vært en config-skriving som ikke endrer noe. README beskriver nå hvor auto-hevingen gjelder og hva du selv må sette på `standard` uten vertsliste, der proxyen ellers tier om DNS-rebinding- og metadatablokkeringer (#422).
+- **`audit.enabled` anbefales ikke**: Nøkkelen finnes i cplt sitt register, men `[audit]`-seksjonen er kun lest og vist — ingenting bruker den (`src/config/registry.rs`, `BOOL_KEYS_EXEMPT`). Å anbefale den ville sendt utviklere til en bryter som ikke gir noen logg. `proxy.log_file` er den som faktisk skriver en (#422).
+
 ## 2026-09-03
 
 ### cplt-oppdateringer etter oppstrømsgjennomgang

--- a/docs/nav-pilot-changelog.md
+++ b/docs/nav-pilot-changelog.md
@@ -7,7 +7,7 @@ Endringslogg for nav-pilot agent harness — agenter, skills, instruksjoner, pro
 ### cplt-logging: hva som er verdt å anbefale, og hva som ikke er det
 
 - **`proxy.log_level` dokumentert i stedet for anbefalt**: cplt hever selv nivået til `blocked` så snart en vertsliste er aktiv (`src/main.rs`, `proxy_log_level`), og posturen nav-pilot anbefaler gjør nettopp det. En egen anbefaling ville vært en config-skriving som ikke endrer noe. README beskriver nå hvor auto-hevingen gjelder og hva du selv må sette på `standard` uten vertsliste, der proxyen ellers tier om DNS-rebinding- og metadatablokkeringer (#422).
-- **`audit.enabled` anbefales ikke**: Nøkkelen finnes i cplt sitt register, men `[audit]`-seksjonen er kun lest og vist — ingenting bruker den (`src/config/registry.rs`, `BOOL_KEYS_EXEMPT`). Å anbefale den ville sendt utviklere til en bryter som ikke gir noen logg. `proxy.log_file` er den som faktisk skriver en (#422).
+- **`audit.enabled` anbefales ikke**: Nøkkelen finnes i cplt sitt register, men `[audit]`-seksjonen er kun lest og vist. Ingenting bruker den (`src/config/registry.rs`, `BOOL_KEYS_EXEMPT`). Å anbefale den ville sendt utviklere til en bryter som ikke gir noen logg. `proxy.log_file` er den som faktisk skriver en (#422).
 
 ## 2026-09-03
 

--- a/docs/nav-pilot-changelog.md
+++ b/docs/nav-pilot-changelog.md
@@ -6,7 +6,7 @@ Endringslogg for nav-pilot agent harness — agenter, skills, instruksjoner, pro
 
 ### cplt-logging: hva som er verdt å anbefale, og hva som ikke er det
 
-- **`proxy.log_level` dokumentert i stedet for anbefalt**: cplt hever selv nivået til `blocked` så snart en vertsliste er aktiv (`src/main.rs`, `proxy_log_level`), og posturen nav-pilot anbefaler gjør nettopp det. En egen anbefaling ville vært en config-skriving som ikke endrer noe. README beskriver nå hvor auto-hevingen gjelder og hva du selv må sette på `standard` uten vertsliste, der proxyen ellers tier om DNS-rebinding- og metadatablokkeringer (#422).
+- **`proxy.log_level` dokumentert i stedet for anbefalt**: cplt hever selv nivået til `blocked` så snart en vertsliste er aktiv (`src/main.rs`, `proxy_log_level`), og posturen nav-pilot anbefaler gjør nettopp det. En egen anbefaling ville vært en config-skriving som ikke endrer noe. README beskriver nå hvor auto-hevingen gjelder og hva du selv må sette på `standard` uten vertsliste, der proxyen ellers tier om alle blokkeringer og feil som ikke kommer fra vertslista (#422).
 - **`audit.enabled` anbefales ikke**: Nøkkelen finnes i cplt sitt register, men `[audit]`-seksjonen er kun lest og vist. Ingenting bruker den (`src/config/registry.rs`, `BOOL_KEYS_EXEMPT`). Å anbefale den ville sendt utviklere til en bryter som ikke gir noen logg. `proxy.log_file` er den som faktisk skriver en (#422).
 
 ## 2026-09-03


### PR DESCRIPTION
#422 asked nav-pilot to recommend cplt's `audit.enabled` and `proxy.log_level`. Neither premise survives contact with cplt's current code, so this documents the situation rather than building a recommendation.

**`audit.enabled` has no consumer.** The `[audit]` section is parsed and shown by `cplt config show`, and nothing else reads it — cplt says so itself in `src/config/registry.rs` (`BOOL_KEYS_EXEMPT`). Recommending it would send developers to a switch that produces no log and then reports itself as enabled. The key that writes a file is `proxy.log_file`; the separate, live `sandbox.audit` (the post-session file-change report, on by default) is named too so nobody concludes cplt has no audit at all.

**`proxy.log_level` is real but already covered where it matters.** `proxy_log_level` in `src/main.rs` floors it at `blocked` whenever a host allowlist is active, and `applyStrictPreset`/`seedCpltAllowlist` make one active for anyone following nav-pilot's advice. A doctor check or a config write would change nothing for them.

The genuine gap is narrower: on `standard` with no allowlist there is nothing to raise, and the proxy also stays silent about the refusals that do not come from the allowlist — the DNS-rebinding and metadata-IP guards. That is a sentence and a command, so it went in the README.

Also confirmed stale in the issue: `gh_guard.enabled` and `git_guard.enabled` are already `true` in the `standard` baseline (`Preset::baseline()`), and Part 2 (version skew, combined `brew upgrade` line) shipped in `doctor.go`.

No Go code changed. `gofmt`, `go vet`, `go test ./...` and `scripts/generate-docs --check` all pass.

Closes #422