### PR TITLE
fix(mcp-onboarding): kjør client_id gjennom logSafe også i token-handleren

### DIFF
--- a/apps/mcp-onboarding/oauth.go
+++ b/apps/mcp-onboarding/oauth.go
@@ -389,7 +389,7 @@ func (s *OAuthServer) handleAuthorizationCodeGrant(w http.ResponseWriter, r *htt
 	if clientID == "" || clientID != authCode.ClientID {
 		slog.Warn("client_id missing or mismatched in token exchange",
 			"expected", authCode.ClientID,
-			"got", clientID,
+			"got", logSafe(clientID),
 		)
 		s.writeTokenError(w, "invalid_client", "client_id missing or does not match the authorization code")
 		return


### PR DESCRIPTION
#632 pakket de fire `client_id`-loggpunktene i `handleAuthorize` inn i `logSafe`, men lot dette staa igjen i token-utvekslingen (`oauth.go:392`). Verdien kommer fra forespoerselen og er den eneste ulogsikrede av dem. Det er CodeQL-varselet `go/log-injection` #94, som staar aapent i dag.

JSON-handleren escaper linjeskift, saa dette er en inkonsekvens i #632 mer enn en sarbarhet. Den boer likevel ikke staa aapen naar de fire andre er lukket, og et aapent varsel som «egentlig er greit» er dyrt aa lese om igjen hver gang noen ser paa lista.

`gofmt`, `go vet`, `go build` og `go test ./...` i `apps/mcp-onboarding` er groenne.

Funnet under sikkerhetsgjennomgangen som ogsaa rettet patched-versjonen i GHSA-7hwf-488h-59x8.