### PR TITLE
docs(nav-pilot): rett påstanden om agentenes innebygde vertsliste

### DIFF
--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -200,12 +200,12 @@ macOS har ingen slik grense. Der håndheves det samme med Seatbelt.
 ### Logging av blokkeringer
 
 `proxy.log_level` styrer hva cplt sin proxy skriver til stderr. Standardverdien er `none`,
-men cplt hever den selv til `blocked` så snart en vertsliste er aktiv, enten fordi agenten
-har en innebygd liste (copilot, opencode) eller fordi `proxy.allowed_domains` er satt
+men cplt hever den selv til `blocked` så snart en vertsliste er aktiv, enten fordi
+`proxy.default_allowlist` er på eller fordi `proxy.allowed_domains` er satt
 (`proxy_log_level` i cplt-repoet, `src/main.rs`). Sikkerhetsnivået nav-pilot anbefaler skriver alltid
 vertslistefila `proxy.allowed_domains` peker på, så på `strict` er `blocked` allerede i kraft
-uten at du setter noe. Merk at den innebygde lista er tom for `pi`, `goose` og `shell`, så
-der er det bare vertslistefila som slår til.
+uten at du setter noe. Alle agentene har en innebygd liste: `pi`, `goose` og `shell` mangler
+egne infrastrukturverter, men får pakkeregister-basen som alle andre.
 Nav-pilot anbefaler derfor ikke nøkkelen: den er allerede dekket der den betyr noe.
 
 Kjører du `standard` uten egen `proxy.allowed_domains`, er det ingen vertsliste å heve for,


### PR DESCRIPTION
#677 la inn denne setningen: «den innebygde lista er tom for `pi`, `goose` og `shell`, så der er det bare vertslistefila som slår til.» Den er feil, og jeg skrev den.

`default_allowed_domains()` i cplt (`src/agent.rs`) bygger lista i to lag: en agent-spesifikk infrastruktur-del, og deretter `PACKAGE_REGISTRY_DOMAINS` som legges til for **alle** agenter. Det som er tomt for `pi`, `goose` og `shell` er bare det første laget. Alle agentene har en ikke-tom innebygd liste, og `proxy.default_allowlist` slår derfor til for alle.

Setningen over hadde samme feil i motsatt retning: den ramset opp «(copilot, opencode)» som om bare de to har en innebygd liste. Betingelsen for auto-hevingen er `proxy.default_allowlist`, ikke hvilken agent som kjører.

Konsekvensen av feilen var ikke stor — begge setningene handler om når `proxy.log_level` heves av seg selv, ikke om hva som blokkeres — men en leser som kjører `goose` ville trodd at bare vertslistefila beskytter dem, og satt opp deretter.

Funnet under en gjennomgang av en fail-open i cplt sin allowlist, der noen sjekket den samme koden fra en annen vinkel og fikk et annet svar enn det jeg hadde skrevet ned.

Ingen kode endret.