### PR TITLE
fix(pricing): let the date guard survive a reflowed sentence

### DIFF
--- a/scripts/sync-model-pricing.mjs
+++ b/scripts/sync-model-pricing.mjs
@@ -24,7 +24,9 @@ const DOC_FILE = new URL("../docs/modellvalg.md", import.meta.url);
 
 // The one sentence in docs/modellvalg.md that timestamps the price table.
 // Anchored on its wording so the editorial dates elsewhere in the file stay put.
-const DOC_DATE_RE = /(GitHubs listepriser slik de sto \*\*)([^*]+)(\*\*)/;
+// The sentence wraps, so the gap before the date can be a newline. Matching
+// a literal space made the guard throw the moment prettier reflowed it.
+const DOC_DATE_RE = /(GitHubs listepriser slik de sto\s+\*\*)([^*]+)(\*\*)/;
 
 const NB_MONTHS = [
   "januar", "februar", "mars", "april", "mai", "juni",

--- a/scripts/sync-model-pricing.test.mjs
+++ b/scripts/sync-model-pricing.test.mjs
@@ -146,6 +146,21 @@ test("the doc's pricing date is rewritten, and the editorial dates are not", () 
   assert.equal(out.split("\n").slice(1).join("\n"), doc.split("\n").slice(1).join("\n"));
 });
 
+test("the pricing date is found when the sentence wraps before the date", () => {
+  // How docs/modellvalg.md actually reads: prettier put a newline between
+  // "sto" and the bolded date, and matching a literal space made the guard
+  // throw "the pricing-date sentence is gone" on a sentence that was there.
+  const doc = [
+    "GitHub priser. Prisene under er GitHubs listepriser slik de sto",
+    "**30. august 2026**, hentet fra `apps/my-copilot/src/lib/model-pricing.ts`.",
+  ].join("\n");
+
+  const out = setDocPricingDate(doc, "2026-09-03");
+
+  assert.match(out, /\*\*3\. september 2026\*\*/);
+  assert.equal(out.split("\n")[0], doc.split("\n")[0]);
+});
+
 test("a doc without the sentence is an error, not a silent no-op", () => {
   assert.throws(() => setDocPricingDate("ingen priser her", "2026-09-03"));
 });


### PR DESCRIPTION
`mise run check` fails on main with `Failed: the pricing-date sentence is gone from docs/modellvalg.md`.

The sentence is still there. `scripts/sync-model-pricing.mjs` matched a literal space between `slik de sto` and the bolded date, and the paragraph now wraps at exactly that point, so the guard threw. Beyond failing the check, it meant the pricing date could no longer be synced automatically.

Matching any whitespace fixes it and survives the next reflow.

`mise run pricing:check` and `pricing:test` (10 pass, 0 fail) both green.