### PR TITLE
docs(harness): test 6 fanger et navn, ikke en spawn

### DIFF
--- a/scripts/nav-pilot-golden.sh
+++ b/scripts/nav-pilot-golden.sh
@@ -1570,10 +1570,23 @@ run_pass_nav_pilot() {
     # was not an action the agent could take — only a sentence it could write.
     # `nav-pilot-opus` appears in 0 of the 28 kept t6 transcripts across eight
     # kept run directories, and every one of those was recorded under that
-    # frontmatter. #688 added `agent` to the tool list, so the clause is now live:
-    # a run that escalates spawns a real Opus subagent and this assertion is the
-    # thing that catches it. The 28 are therefore a baseline for the model gate's
-    # wording, not for its cost. Re-measure before reading them as either.
+    # frontmatter. #688 added `agent` to the tool list, so escalation is now an
+    # action and not only a sentence.
+    #
+    # What the assertion sees did NOT change with it. `absent "$T6" "$RE_OPUS"`
+    # greps the transcript for the handle, so it fails on a run that NAMES
+    # `nav-pilot-opus`, whether or not a subagent was spawned. A spawn that never
+    # writes the handle to the transcript is not caught, and a mention with no
+    # spawn still fails. That is the same ceiling cr4 has, and it is acceptable
+    # for the same reason: the model gate is about whether the agent reaches for
+    # Opus at all, and reaching for it without naming it is not a failure mode
+    # any kept transcript shows.
+    #
+    # The consequence of #688 is for the 28, not for the regex: they are a
+    # baseline for the model gate's wording, recorded when escalation cost
+    # nothing because it could not happen. Re-measure before reading them as a
+    # cost baseline. Catching a spawn as a spawn needs a different instrument
+    # than a grep over stdout.
     #
     # cr4 is soft because naming a handle is the whole of what it can measure.
     # Test 6 has somewhere better to go: the routine refactor still has to


### PR DESCRIPTION
Oppfølging av #688, på en review-kommentar som kom inn samtidig med merge.

Kommentaren jeg la inn i #688 sa at eskaleringsklausulen nå fanger en ekte Opus-subagent. Det stemmer ikke. Assertionen er `absent "$T6" "$RE_OPUS"` med `RE_OPUS='nav-pilot-opus'`, altså et grep over transkriptet. Den feiler på en kjøring som *nevner* handlet, uavhengig av om noe ble spawnet, og den fanger ikke en spawn som aldri skriver navnet.

Det som faktisk endret seg med #688 er de 28 lagrede transkriptene, ikke regexen: de er tatt opp da eskalering ikke kostet noe fordi den ikke kunne skje. Taket i regexen er det samme cr4 har, og det er akseptabelt av samme grunn. Modellporten handler om hvorvidt agenten strekker seg etter Opus i det hele tatt, og å strekke seg etter den uten å nevne den er ikke et feilmodus noen lagret kjøring viser.

Kommentaren sier nå dette, og sier eksplisitt at å fange en spawn *som* spawn krever et annet instrument enn et grep over stdout.

Bare kommentar. Ingen assertion, regex eller terskel er rørt, så harnessen oppfører seg identisk. `mise run check` grønn.