### PR TITLE
fix(nais): let anonymous readers reach the English articles

### DIFF
--- a/apps/my-copilot/.nais/app.yaml
+++ b/apps/my-copilot/.nais/app.yaml
@@ -43,6 +43,10 @@ spec:
       - /
       - /nyheter
       - /nyheter/**
+      # English articles. The list enumerates every public route, so a new one
+      # is invisible to anonymous readers until it is added here.
+      - /en
+      - /en/**
       - /praksis
       - /praksis/**
       - /verktoy


### PR DESCRIPTION
The English pages are live but unreadable: production returns **401** for `/en/news` and `/en/news/sandbox-confines-the-process-not-the-token`, while `/` returns 200.

`autoLoginIgnorePaths` in `apps/my-copilot/.nais/app.yaml` enumerates every public route, one entry per section, and #682 added routes without adding `/en`. Wonderwall auto-login therefore intercepts them.

My miss in #682. The English article exists so that someone outside Nav can read it, and right now nobody outside Nav can.

```
GET /                                                 200
GET /en/news                                          401
GET /en/news/sandbox-confines-the-process-not-the-token  401
```

Worth considering separately: the list is enumerated per route, so every new public section is invisible until someone remembers this file. A default-public-with-explicit-private list would fail the other way, which is the safer direction for a site whose content is public.