### PR TITLE
fix(web): redirect the bare news path to the front page

### DIFF
--- a/apps/my-copilot/next.config.ts
+++ b/apps/my-copilot/next.config.ts
@@ -49,6 +49,9 @@ const nextConfig: NextConfig = {
   async redirects() {
     return [
       { source: "/en", destination: "/en/news", permanent: false },
+      // /nyheter has no index page; the news list is the front page. It used to
+      // answer 200 with the not-found body, so old links to it exist.
+      { source: "/nyheter", destination: "/", permanent: false },
       { source: "/best-practices", destination: "/praksis", permanent: true },
       { source: "/practice", destination: "/praksis", permanent: true },
       { source: "/customizations", destination: "/verktoy", permanent: true },


### PR DESCRIPTION
`/nyheter` has no index page; the news list is the front page. Until #685 fixed the 404 status it answered 200 with the not-found body, so links to it exist in the wild and now hit a hard 404.

A redirect is kinder than a 404 for a path that used to render. Nothing in the app links to it (checked), so this only helps people arriving from outside.

Verified on a production build:

```
/nyheter      307 -> /
/en           307 -> /en/news
/en/news      200
/nyheter/zzz  404
```

Split out of #693 because that PR was already in the merge queue and its branch was locked.