### PR TITLE
feat(web): link the English articles from the front page

### DIFF
--- a/apps/my-copilot/src/app/(nb)/(home)/page.tsx
+++ b/apps/my-copilot/src/app/(nb)/(home)/page.tsx
@@ -15,6 +15,7 @@ import { NavPill } from "@/components/navigation/nav-pill";
 export default async function Home() {
   const [user, videos] = await Promise.all([getUser(false), getPublicVideoFeed(5)]);
   const news = getNewsItems({ frontPage: true });
+  const englishNews = getNewsItems({ lang: "en" });
 
   return (
     <main>
@@ -65,6 +66,7 @@ export default async function Home() {
                 <div className="flex-1 min-w-0">
                   <NewsFeed
                     items={news}
+                    englishCount={englishNews.length}
                     compact
                     afterFeatured={
                       videos.length > 0 ? (

--- a/apps/my-copilot/src/app/(nb)/(home)/page.tsx
+++ b/apps/my-copilot/src/app/(nb)/(home)/page.tsx
@@ -15,7 +15,9 @@ import { NavPill } from "@/components/navigation/nav-pill";
 export default async function Home() {
   const [user, videos] = await Promise.all([getUser(false), getPublicVideoFeed(5)]);
   const news = getNewsItems({ frontPage: true });
-  const englishNews = getNewsItems({ lang: "en" });
+  // Count what /en/news actually lists: that page shows articles only, so a
+  // link item would make the count promise more than the page delivers.
+  const englishNews = getNewsItems({ lang: "en" }).filter((item) => item.type === "article");
 
   return (
     <main>

--- a/apps/my-copilot/src/components/news-feed.test.tsx
+++ b/apps/my-copilot/src/components/news-feed.test.tsx
@@ -1,4 +1,40 @@
-import { computeGridSpans } from "./news-feed";
+import { render, screen } from "@testing-library/react";
+import { computeGridSpans, NewsFeed } from "./news-feed";
+import type { NewsItem } from "@/lib/news";
+
+function makeItem(over: Partial<NewsItem> = {}): NewsItem {
+  return {
+    slug: "en-sak",
+    lang: "nb",
+    title: "En sak",
+    date: "2026-09-01",
+    draft: false,
+    category: "copilot",
+    excerpt: "",
+    tags: [],
+    type: "article",
+    ...over,
+  };
+}
+
+describe("NewsFeed English link", () => {
+  it("links to the English articles when there are some", () => {
+    render(<NewsFeed items={[makeItem()]} englishCount={2} />);
+    const link = screen.getByRole("link", { name: /In English/ });
+    expect(link).toHaveAttribute("href", "/en/news");
+    expect(link).toHaveTextContent("In English (2)");
+  });
+
+  it("says nothing when there are none", () => {
+    render(<NewsFeed items={[makeItem()]} englishCount={0} />);
+    expect(screen.queryByRole("link", { name: /In English/ })).toBeNull();
+  });
+
+  it("says nothing when the count is not given", () => {
+    render(<NewsFeed items={[makeItem()]} />);
+    expect(screen.queryByRole("link", { name: /In English/ })).toBeNull();
+  });
+});
 
 describe("computeGridSpans (bento layout)", () => {
   it("packs each 3-col row to full width without gaps", () => {

--- a/apps/my-copilot/src/components/news-feed.tsx
+++ b/apps/my-copilot/src/components/news-feed.tsx
@@ -4,12 +4,16 @@ import { useState, useMemo, type ReactNode } from "react";
 import { Chips, HStack, VStack, BodyShort, Heading } from "@navikt/ds-react";
 import type { NewsItem, NewsCategory } from "@/lib/news-types";
 import { CATEGORY_CONFIG } from "@/lib/news-types";
+import NextLink from "next/link";
 import { NewsCard, FeaturedNewsCard } from "./news-card";
 
 interface NewsFeedProps {
   items: NewsItem[];
   compact?: boolean;
   afterFeatured?: ReactNode;
+  // Articles published in English. They are not in `items`, which is Norwegian
+  // only, so without this link nothing on the site leads to /en/news.
+  englishCount?: number;
 }
 
 const COLS = 3;
@@ -70,7 +74,7 @@ export function computeGridSpans(count: number, cols: number = COLS): number[] {
   return spans;
 }
 
-export function NewsFeed({ items, compact = false, afterFeatured }: NewsFeedProps) {
+export function NewsFeed({ items, compact = false, afterFeatured, englishCount = 0 }: NewsFeedProps) {
   const [selected, setSelected] = useState<NewsCategory | null>(null);
 
   const availableCategories = useMemo(() => {
@@ -106,6 +110,11 @@ export function NewsFeed({ items, compact = false, afterFeatured }: NewsFeedProp
             </Chips.Toggle>
           ))}
         </Chips>
+        {englishCount > 0 && (
+          <NextLink href="/en/news" hrefLang="en" lang="en" className="text-sm text-text-action">
+            In English ({englishCount})
+          </NextLink>
+        )}
       </HStack>
 
       {filtered.length === 0 && <BodyShort className="text-text-subtle">Ingen nyheter i denne kategorien.</BodyShort>}


### PR DESCRIPTION
Nothing on the site linked to `/en/news`. The article shipped in #682, went public in #693, and was reachable only by typing the URL.

The "Siste nytt" heading now carries an "In English (n)" link, with `hrefLang` and `lang` set since the target is another language. The count comes from `getNewsItems({ lang: "en" })`, so the link is absent when there is nothing to link to rather than pointing at an empty page.

Verified on a production build: front page renders `In English (1)` linking to `/en/news`, tests still 515 pass.