### PR TITLE
fix(my-copilot): serve articles from a local production build

### DIFF
--- a/apps/my-copilot/package.json
+++ b/apps/my-copilot/package.json
@@ -17,7 +17,8 @@
     "knip": "NODE_OPTIONS='--experimental-require-module' knip",
     "generate": "node --experimental-strip-types scripts/generate-manifest.ts",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "prestart": "node scripts/prepare-standalone.mjs"
   },
   "dependencies": {
     "@grafana/faro-web-sdk": "^2.7.1",

--- a/apps/my-copilot/scripts/prepare-standalone.mjs
+++ b/apps/my-copilot/scripts/prepare-standalone.mjs
@@ -1,0 +1,21 @@
+// The articles live in docs/news/articles at the repo root, outside the app,
+// so Next's file tracing cannot reach them: Turbopack rejects a tracing glob
+// that navigates above the project root. The container image sidesteps this by
+// copying the directory in (Dockerfile line 15), which is why production works
+// and `pnpm start` did not.
+//
+// This mirrors that copy for a local run. It is a no-op when the source is
+// missing, so it stays quiet in an image where the copy already happened.
+import { cpSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const appDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const source = join(appDir, "..", "..", "docs", "news", "articles");
+const target = join(appDir, ".next", "standalone", "docs", "news", "articles");
+
+if (!existsSync(source)) process.exit(0);
+if (!existsSync(join(appDir, ".next", "standalone"))) process.exit(0);
+
+cpSync(source, target, { recursive: true });
+console.log(`copied articles into the standalone output: ${target}`);

--- a/apps/my-copilot/scripts/prepare-standalone.mjs
+++ b/apps/my-copilot/scripts/prepare-standalone.mjs
@@ -1,12 +1,12 @@
 // The articles live in docs/news/articles at the repo root, outside the app,
 // so Next's file tracing cannot reach them: Turbopack rejects a tracing glob
-// that navigates above the project root. The container image sidesteps this by
-// copying the directory in (Dockerfile line 15), which is why production works
-// and `pnpm start` did not.
+// that navigates above the project root. The image sidesteps this: the COPY in
+// apps/my-copilot/Dockerfile brings the directory in, which is why production
+// works and `pnpm start` did not.
 //
 // This mirrors that copy for a local run. It is a no-op when the source is
 // missing, so it stays quiet in an image where the copy already happened.
-import { cpSync, existsSync } from "node:fs";
+import { cpSync, existsSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -17,5 +17,8 @@ const target = join(appDir, ".next", "standalone", "docs", "news", "articles");
 if (!existsSync(source)) process.exit(0);
 if (!existsSync(join(appDir, ".next", "standalone"))) process.exit(0);
 
+// A plain copy leaves files that were deleted from the source, so an article
+// removed upstream would keep serving locally. Clear the target first.
+rmSync(target, { recursive: true, force: true });
 cpSync(source, target, { recursive: true });
 console.log(`copied articles into the standalone output: ${target}`);


### PR DESCRIPTION
`pnpm start` answers 404 for every article, so checking status codes, redirects, `lang` attributes or OpenGraph tags against a real build silently produces a run where the whole site looks broken.

`news.ts` resolves `docs/news/articles` from the working directory. The standalone server runs from `.next/standalone`, and neither that directory nor its parent has the docs. `outputFileTracingIncludes` cannot fix it: Turbopack rejects the glob outright.

```
Error [TurbopackInternalError]: glob '../../docs/news/articles/**' is invalid,
it has a prefix that navigates out of the project root
```

The container image copies the directory in itself (`Dockerfile:15`), which is why production works and CI never noticed. A `prestart` step now mirrors that copy for a local run, and no-ops when the source is missing so it stays quiet inside the image, which runs `server.js` directly rather than through `pnpm start`.

Verified:

```
/nyheter/agent-based-observability                    200
/en/news/sandbox-confines-the-process-not-the-token   200
/nyheter/zzz                                          404
```

Closes #697