### PR TITLE
fix(news): send link-only slugs to the source instead of 404

### DIFF
--- a/apps/my-copilot/src/app/(en)/en/news/[slug]/page.tsx
+++ b/apps/my-copilot/src/app/(en)/en/news/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
-import { notFound } from "next/navigation";
-import { getArticle, getArticleSlugs } from "@/lib/news";
+import { notFound, redirect } from "next/navigation";
+import { getArticle, getArticleSlugs, getLinkTarget } from "@/lib/news";
 import { ArticleView } from "@/components/article-view";
 
 interface Props {
@@ -43,7 +43,11 @@ export default async function EnglishArticlePage({ params }: Props) {
   const { slug } = await params;
   const article = getArticle(slug, "en");
 
-  if (!article) notFound();
+  if (!article) {
+    const linkTarget = getLinkTarget(slug, "en");
+    if (linkTarget) redirect(linkTarget);
+    notFound();
+  }
 
   return (
     <ArticleView

--- a/apps/my-copilot/src/app/(nb)/nyheter/[slug]/page.tsx
+++ b/apps/my-copilot/src/app/(nb)/nyheter/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
-import { notFound } from "next/navigation";
-import { getArticle, getArticleSlugs } from "@/lib/news";
+import { notFound, redirect } from "next/navigation";
+import { getArticle, getArticleSlugs, getLinkTarget } from "@/lib/news";
 import { ArticleView } from "@/components/article-view";
 
 interface Props {
@@ -44,7 +44,11 @@ export default async function ArticlePage({ params }: Props) {
   const { slug } = await params;
   const article = getArticle(slug);
 
-  if (!article) notFound();
+  if (!article) {
+    const linkTarget = getLinkTarget(slug);
+    if (linkTarget) redirect(linkTarget);
+    notFound();
+  }
 
   return (
     <ArticleView

--- a/apps/my-copilot/src/lib/news.ts
+++ b/apps/my-copilot/src/lib/news.ts
@@ -197,8 +197,18 @@ export function getArticle(slug: string, lang: NewsLang = "nb"): (NewsItem & { c
 export function getLinkTarget(slug: string, lang: NewsLang = "nb"): string | null {
   if (!isValidSlug(slug)) return null;
 
-  const item = getNewsItems({ lang }).find((candidate) => candidate.slug === slug);
-  return item?.type === "link" && item.url ? item.url : null;
+  // Read the one file rather than the whole directory: this runs on every miss,
+  // including slugs that do not exist, so parsing 150 files per request would
+  // make a 404 the most expensive response the site serves.
+  const filePath = path.join(articlesDir, `${slug}.md`);
+  if (!fs.existsSync(filePath)) return null;
+
+  const { data, content } = matter(fs.readFileSync(filePath, "utf-8"));
+  if (data.draft === true) return null;
+  if (parseLang(data.lang) !== lang) return null;
+  if (content.trim().length > 0) return null;
+
+  return typeof data.url === "string" && data.url ? data.url : null;
 }
 
 export function getArticleSlugs(lang: NewsLang = "nb"): string[] {

--- a/apps/my-copilot/src/lib/news.ts
+++ b/apps/my-copilot/src/lib/news.ts
@@ -191,6 +191,16 @@ export function getArticle(slug: string, lang: NewsLang = "nb"): (NewsItem & { c
   };
 }
 
+// A news item that is only a link has no page of its own. The URL still gets
+// shared, so the route sends the reader to the source rather than answering
+// 404 for a slug we can resolve.
+export function getLinkTarget(slug: string, lang: NewsLang = "nb"): string | null {
+  if (!isValidSlug(slug)) return null;
+
+  const item = getNewsItems({ lang }).find((candidate) => candidate.slug === slug);
+  return item?.type === "link" && item.url ? item.url : null;
+}
+
 export function getArticleSlugs(lang: NewsLang = "nb"): string[] {
   return getNewsItems({ lang })
     .filter((item) => item.type === "article")


### PR DESCRIPTION
99 of 152 news items are links rather than articles: frontmatter carries `url:` and there is no body. `/nyheter/<slug>` answered 404 for all of them.

The item exists and we know where it points, so the route now redirects there. `news-card.tsx:33` already links readers straight to `item.url`; this makes the URL agree with the card.

`getLinkTarget` lives in the loader next to `getArticle`, so both language routes use it and neither has to know how a link item is shaped.

Verified against a production build:

```
/nyheter/agent-hq                    307 -> https://github.blog/news-insights/company-news/pick-your-agent-use-claude-and-codex-on-agent-hq/
/nyheter/agent-based-observability   200
/nyheter/zzz                         404
```

515 tests pass.

Closes #695