### PR TITLE
test(my-copilot): fail the build when a public route needs a login

### DIFF
--- a/apps/my-copilot/package.json
+++ b/apps/my-copilot/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build --experimental-build-mode compile",
     "start": "node .next/standalone/server.js",
-    "check": "eslint . --fix && tsc --noEmit && prettier --check . && NODE_OPTIONS='--experimental-require-module' knip && vitest run",
+    "check": "eslint . --fix && node scripts/check-public-routes.mjs && tsc --noEmit && prettier --check . && NODE_OPTIONS='--experimental-require-module' knip && vitest run",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write . --list-different",

--- a/apps/my-copilot/scripts/check-public-routes.mjs
+++ b/apps/my-copilot/scripts/check-public-routes.mjs
@@ -1,0 +1,53 @@
+// Every public page route must be listed in autoLoginIgnorePaths, or Wonderwall
+// intercepts it and anonymous readers get a 401. Nothing else catches that: the
+// build passes, the deploy succeeds, and the page is live and unreachable. It
+// happened to /en/news in #682 and was only noticed by loading the site.
+//
+// The private routes below are deliberate. Add a route there when it should
+// require a login, not to silence this check.
+import { readFileSync } from "node:fs";
+import { globSync } from "node:fs";
+import { dirname, join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const appDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const PRIVATE_ROUTES = ["/abonnement", "/kostnad", "/overview", "/usage"];
+
+function routeFor(pageFile) {
+  const rel = relative(join(appDir, "src", "app"), dirname(pageFile));
+  const segments = rel.split(sep).filter((s) => s && !(s.startsWith("(") && s.endsWith(")")));
+  return "/" + segments.join("/");
+}
+
+function matches(route, pattern) {
+  if (pattern === route) return true;
+  if (pattern.endsWith("/**")) return route.startsWith(pattern.slice(0, -2));
+  return false;
+}
+
+const yaml = readFileSync(join(appDir, ".nais", "app.yaml"), "utf-8");
+const block = yaml.match(/autoLoginIgnorePaths:\n((?:\s*(?:#.*|- .*)\n)+)/);
+if (!block) {
+  console.error("could not find autoLoginIgnorePaths in .nais/app.yaml");
+  process.exit(1);
+}
+const allowed = [...block[1].matchAll(/^\s*- (\S+)/gm)].map((m) => m[1]);
+
+const pages = globSync("src/app/**/page.tsx", { cwd: appDir })
+  .map((p) => join(appDir, p))
+  .filter((p) => !p.includes("[")); // dynamic segments are covered by a /** entry
+
+const missing = pages
+  .map(routeFor)
+  .filter((route) => !PRIVATE_ROUTES.includes(route))
+  .filter((route) => !allowed.some((pattern) => matches(route, pattern)));
+
+if (missing.length > 0) {
+  console.error("These routes are public pages but are not in autoLoginIgnorePaths:");
+  for (const route of [...new Set(missing)].sort()) console.error(`  ${route}`);
+  console.error("\nAdd them to apps/my-copilot/.nais/app.yaml, or to PRIVATE_ROUTES in this");
+  console.error("script if they are meant to require a login.");
+  process.exit(1);
+}
+
+console.log(`✅ all ${pages.length} page routes are reachable without a login, or listed as private`);


### PR DESCRIPTION
`autoLoginIgnorePaths` in `.nais/app.yaml` enumerates every public route by hand. A route that is not listed is intercepted by Wonderwall and answers 401 to anyone not signed in, and nothing in CI notices.

That is not hypothetical. #682 added `/en/news`, built clean, deployed successfully, and the English article was live and unreadable from outside Nav until #693. The only thing that caught it was loading the page.

`pnpm check` now walks `src/app/**/page.tsx`, derives each route, and asserts it is either matched by an allowlist glob or listed in `PRIVATE_ROUTES` as deliberately behind a login (`/abonnement`, `/kostnad`, `/overview`, `/usage`).

Verified in both directions:

```
$ node scripts/check-public-routes.mjs
✅ all 21 page routes are reachable without a login, or listed as private

# with the /en entries removed from app.yaml:
These routes are public pages but are not in autoLoginIgnorePaths:
  /en/news
exit 1
```

A failing check names the file to edit, so the next person adding a public section is told rather than finding out from a reader.

Closes #696