### PR TITLE
fix(agentpakke): manifestet leses med samme mistillit som payloaden det peker på

### DIFF
--- a/cli/nav-pilot/internal/agentpakke/load.go
+++ b/cli/nav-pilot/internal/agentpakke/load.go
@@ -28,7 +28,7 @@ var ErrNoManifest = errors.New("no agentpakke manifest")
 // does not conform, so nothing should be installed, synced, or launched from it.
 func Load(sourceRoot string) (*Manifest, error) {
 	file := filepath.Join(sourceRoot, ManifestDir, ManifestFile)
-	data, err := os.ReadFile(file)
+	data, err := readGuardedManifest(file, "agentpakke manifest")
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, fmt.Errorf("%s: %w", file, ErrNoManifest)
@@ -107,7 +107,48 @@ func (m *Manifest) checkSemantics(runningVersion string) error {
 	if err := m.checkCompatibility(); err != nil {
 		return err
 	}
+	if err := m.checkDefaultContext(); err != nil {
+		return err
+	}
 	return m.checkPaths()
+}
+
+// checkDefaultContext requires that every payload-bearing client's default
+// context names a payload the manifest actually declares (#704 T2). Without it
+// the schema asks only for an identifier, `nav-pilot validate` passes, and the
+// launch dies at [Manifest.DefaultContext]'s lookup instead — the same "green
+// validate, dead launch" shape #504 U2 had.
+//
+// The lookup is the launch's own, [Manifest.Payload] over
+// [Manifest.DefaultContext], so validation and launch cannot disagree. That
+// also covers the implicit case: a client that declares payloads but no
+// defaultContext falls back to "full", and a manifest that never declares a
+// "full" payload is just as dead as one pointing at a typo.
+//
+// Every declared client, not just AvailableClients: a manifest is wrong for a
+// client this binary cannot launch too, and the contract belongs to the
+// contract version rather than to the client id — the same reasoning
+// checkCompatibility is built on.
+func (m *Manifest) checkDefaultContext() error {
+	for _, client := range m.ClientIDs() {
+		entry, ok := m.Client(client)
+		if !ok || len(entry.Payloads) == 0 {
+			continue
+		}
+		context := m.DefaultContext(client)
+		if _, found := m.Payload(client, context); !found {
+			declared := make([]string, 0, len(entry.Payloads))
+			for name := range entry.Payloads {
+				declared = append(declared, name)
+			}
+			sort.Strings(declared)
+			return fmt.Errorf(
+				"clients.%s resolves its default context to %q, which is not among the payloads it declares (%s). "+
+					"Set clients.%s.defaultContext to one of those, or declare a %q payload",
+				client, context, strings.Join(declared, ", "), client, context)
+		}
+	}
+	return nil
 }
 
 // checkCompatibility parses every declared clients.<id>.compatibility with the
@@ -408,6 +449,12 @@ func requireDir(sourceRoot, field, rel string) error {
 	}
 	info, err := os.Stat(abs)
 	if err != nil {
+		// Anything but ErrNotExist is reported as itself. A permission error
+		// told as "does not exist" sends the author looking for a path that is
+		// right there, which is the one wrong turn this message can cause.
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("%s references %q, which cannot be read in the agentpakke repo: %w", field, rel, err)
+		}
 		return fmt.Errorf("%s references %q, which does not exist in the agentpakke repo", field, rel)
 	}
 	if !info.IsDir() {
@@ -425,6 +472,9 @@ func requireFile(sourceRoot, field, rel string) error {
 	}
 	info, err := os.Stat(abs)
 	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("%s expects the file %q, which cannot be read in the agentpakke repo: %w", field, rel, err)
+		}
 		return fmt.Errorf("%s expects the file %q, which does not exist in the agentpakke repo", field, rel)
 	}
 	if info.IsDir() {

--- a/cli/nav-pilot/internal/agentpakke/load_test.go
+++ b/cli/nav-pilot/internal/agentpakke/load_test.go
@@ -189,6 +189,32 @@ func TestParseRejectsMalformedKnownConstructs(t *testing.T) {
 			wantErrs: []string{"contractVersion", "supported", "Upgrade nav-pilot", "nav-pilot update"},
 		},
 		{
+			// The launch resolves the default context and looks the payload
+			// up; validation has to reach the same verdict, or the author
+			// ships a manifest that passes CI and dies on every launch
+			// (#704 T2).
+			name: "defaultContext names a payload that is not declared",
+			patch: func(doc map[string]any) {
+				clients := doc["clients"].(map[string]any)
+				copilot := clients["copilot"].(map[string]any)
+				copilot["defaultContext"] = "fokusert"
+			},
+			wantErrs: []string{"clients.copilot", "fokusert", "focused, full"},
+		},
+		{
+			// The implicit half of the same rule: no defaultContext falls back
+			// to "full", so a client declaring payloads without one is just as
+			// dead as a typo.
+			name: "no defaultContext and no full payload",
+			patch: func(doc map[string]any) {
+				clients := doc["clients"].(map[string]any)
+				opencode := clients["opencode"].(map[string]any)
+				payloads := opencode["payloads"].(map[string]any)
+				delete(payloads, "full")
+			},
+			wantErrs: []string{"clients.opencode", "full", "focused"},
+		},
+		{
 			name: "contractVersion of the wrong type",
 			patch: func(doc map[string]any) {
 				doc["contractVersion"] = 1
@@ -711,5 +737,103 @@ func TestParseRejectsInvalidCompatibilityRange(t *testing.T) {
 	_, err := parse(data, devVersion)
 	if err == nil || !strings.Contains(err.Error(), "clients.futurecli.compatibility") {
 		t.Errorf("parse should reject the unknown client's invalid compatibility by name, got: %v", err)
+	}
+}
+
+// TestLoadGuardsTheManifestFile covers the top-level manifest getting the same
+// distrust as the payload manifest it points at (#704 T1). Both cases are
+// silent failures without the guard: a symlink is followed, and an oversized
+// file is read into memory whole.
+func TestLoadGuardsTheManifestFile(t *testing.T) {
+	t.Run("symlinked manifest is refused", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(root, ManifestDir), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		real := filepath.Join(root, "elsewhere.json")
+		if err := os.WriteFile(real, []byte(grillmesterManifest), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(real, filepath.Join(root, ManifestDir, ManifestFile)); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+
+		_, err := Load(root)
+		if err == nil {
+			t.Fatal("Load = nil for a symlinked manifest, want a refusal")
+		}
+		if !strings.Contains(err.Error(), "symlink") {
+			t.Errorf("error %q does not say the manifest must not be a symlink", err)
+		}
+		// A symlinked manifest is not a missing one: mapping it to
+		// ErrNoManifest would send the caller down the no-manifest fallback
+		// instead of failing closed.
+		if errors.Is(err, ErrNoManifest) {
+			t.Error("a symlinked manifest matched ErrNoManifest, want a refusal that fails closed")
+		}
+	})
+
+	t.Run("oversized manifest is refused", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(root, ManifestDir), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		big := make([]byte, maxPayloadManifestBytes+1)
+		if err := os.WriteFile(filepath.Join(root, ManifestDir, ManifestFile), big, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := Load(root)
+		if err == nil {
+			t.Fatal("Load = nil for an oversized manifest, want a refusal")
+		}
+		if !strings.Contains(err.Error(), "limit") {
+			t.Errorf("error %q does not name the size limit", err)
+		}
+	})
+
+	// The mapping the guard must not break: a genuinely absent manifest is
+	// still ErrNoManifest, which is what every no-manifest fallback keys on.
+	t.Run("a missing manifest still matches ErrNoManifest", func(t *testing.T) {
+		if _, err := Load(t.TempDir()); !errors.Is(err, ErrNoManifest) {
+			t.Errorf("Load of an empty root = %v, want ErrNoManifest", err)
+		}
+	})
+}
+
+// TestRequireSeparatesUnreadableFromAbsent covers #704 T3: a permission error
+// reported as "does not exist" sends the author looking for a path that is
+// right there.
+func TestRequireSeparatesUnreadableFromAbsent(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root reads through any mode")
+	}
+	root := t.TempDir()
+	locked := filepath.Join(root, "locked")
+	if err := os.MkdirAll(filepath.Join(locked, "inner"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(locked, "inner", "file.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Skipf("cannot drop permissions: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o700) })
+
+	dirErr := requireDir(root, "layout.agents", "locked/inner")
+	if dirErr == nil {
+		t.Fatal("requireDir = nil for an unreadable directory, want an error")
+	}
+	if strings.Contains(dirErr.Error(), "does not exist") {
+		t.Errorf("requireDir reported a permission failure as absence: %v", dirErr)
+	}
+
+	fileErr := requireFile(root, "layout.instructions", "locked/inner/file.md")
+	if fileErr == nil {
+		t.Fatal("requireFile = nil for an unreadable file, want an error")
+	}
+	if strings.Contains(fileErr.Error(), "does not exist") {
+		t.Errorf("requireFile reported a permission failure as absence: %v", fileErr)
 	}
 }

--- a/cli/nav-pilot/internal/agentpakke/payload.go
+++ b/cli/nav-pilot/internal/agentpakke/payload.go
@@ -235,19 +235,32 @@ func verifyPayload(payloadDir, manifestPath string, exact bool) error {
 // distrust as the tree it describes: a symlinked or non-regular manifest could
 // point anywhere, and an oversized one is not a payload manifest.
 func readPayloadManifestFile(manifestPath string) ([]byte, error) {
+	return readGuardedManifest(manifestPath, "payload manifest")
+}
+
+// readGuardedManifest reads a manifest under the distrust both halves of the
+// trust boundary need: a symlinked or non-regular file could point anywhere,
+// and an oversized one is not a manifest. The top-level manifest is read
+// through here too (#704 T1) — it decides what gets staged and launched, so
+// reading it with fewer guards than the payload manifest it points at had the
+// asymmetry backwards.
+//
+// Errors wrap rather than flatten, so a caller can still tell os.ErrNotExist
+// from a permission failure. [Load] maps exactly that to ErrNoManifest.
+func readGuardedManifest(manifestPath, label string) ([]byte, error) {
 	info, err := os.Lstat(manifestPath)
 	if err != nil {
-		return nil, fmt.Errorf("payload manifest %s is unavailable: %v", manifestPath, err)
+		return nil, fmt.Errorf("%s %s is unavailable: %w", label, manifestPath, err)
 	}
 	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
-		return nil, fmt.Errorf("payload manifest %s must be a real, regular file, not a symlink or a directory", manifestPath)
+		return nil, fmt.Errorf("%s %s must be a real, regular file, not a symlink or a directory", label, manifestPath)
 	}
 	if info.Size() > maxPayloadManifestBytes {
-		return nil, fmt.Errorf("payload manifest %s is %d bytes, past the %d-byte limit", manifestPath, info.Size(), maxPayloadManifestBytes)
+		return nil, fmt.Errorf("%s %s is %d bytes, past the %d-byte limit", label, manifestPath, info.Size(), maxPayloadManifestBytes)
 	}
 	data, err := os.ReadFile(manifestPath)
 	if err != nil {
-		return nil, fmt.Errorf("reading payload manifest %s: %v", manifestPath, err)
+		return nil, fmt.Errorf("reading %s %s: %w", label, manifestPath, err)
 	}
 	return data, nil
 }


### PR DESCRIPTION
T1, T2 og T3 fra #704. Alle tre i `load.go`, alle små, alle av samme slag: manifestet blir behandlet med mindre mistillit enn det fortjener, eller sier noe usant om hvorfor det feilet.

## T1 — manifestet leses uten symlink-sjekk og uten størrelsesgrense

`load.go:31` var en naken `os.ReadFile`. Payload-manifestet, som er den andre halvparten av samme tillitsgrense, går allerede gjennom `Lstat`, avviser symlink og ikke-regulær fil, og har et tak på 2 MiB (`payload.go:237-252`).

Asymmetrien sto feil vei: toppnivåmanifestet er det som avgjør hva som stages og launches. `readPayloadManifestFile` er generalisert til `readGuardedManifest(path, label)` og brukes begge steder, så det er én guard og ikke to som kan gli fra hverandre.

Én ting å være obs på i review: hjelperen wrappet med `%v`. Den wrapper nå med `%w`, ellers slutter `errors.Is(err, os.ErrNotExist)`-mappingen til `ErrNoManifest` på `load.go:33` å virke, og hver no-manifest-fallback i CLI-en nøster på den. Det er dekket av en egen test.

Alvoret er lavt i praksis: et symlinket manifest feilet før på JSON-parsing, og `schema.go:76` skriver bare dekoderfeilen, så ingenting lakk. Størrelsestaket er den reelle gevinsten.

## T2 — `defaultContext` kunne navngi en payload som ikke finnes

Grønn `nav-pilot validate`, død launch. Samme form som #504 U2, som er rettet.

`checkDefaultContext` bruker launchens eget oppslag — `Payload` over `DefaultContext` — så validering og launch ikke kan komme til ulik konklusjon. Det dekker begge halvdelene av regelen:

- en eksplisitt `defaultContext` som peker på noe som ikke er erklært
- ingen `defaultContext` i det hele tatt, som faller tilbake til `"full"`, der en pakke som aldri erklærer en `"full"`-payload er like død som en skrivefeil

Sjekken går over alle erklærte klienter, ikke bare `AvailableClients`. Et manifest er galt for en klient denne binæren ikke kan starte også, og grammatikken hører til kontraktversjonen framfor til klient-id-en — samme begrunnelse som `checkCompatibility` er bygget på.

## T3 — rettighetsfeil ble rapportert som «finnes ikke»

`requireDir` og `requireFile` kastet `os.Stat`-feilen og sa «does not exist in the agentpakke repo». En `EACCES` ble dermed en usannhet som sender pakkeforfatteren til å lete etter en fil som ligger der hele tiden.

## Testene er kontrollert, ikke bare skrevet

Hver endring er fjernet igjen for å se testen bli rød:

| Fjernet | Rødt |
|---|---|
| `readGuardedManifest` i `Load` | begge `TestLoadGuardsTheManifestFile`-casene |
| `checkDefaultContext`-kallet | to rader i `TestParseRejectsMalformedKnownConstructs` |
| `errors.Is`-grenene i require* | `TestRequireSeparatesUnreadableFromAbsent` |

Ingen av dem fanger de andres feil, som er poenget med å kjøre kontrollen enkeltvis. `mise run check` er grønn.

Det som *ikke* er her: T4 (publisert skjema for payload-manifestet) og T5 (peker til beslutnings-id-ene) står igjen i #704, og resten av U9 spores i #703.
