### PR TITLE
docs(modellvalg): pinnen gjelder på toppnivå, ikke når nav-pilot delegerer

### DIFF
--- a/docs/modellvalg.md
+++ b/docs/modellvalg.md
@@ -95,7 +95,7 @@ Klientens egen konfigurasjon setter modell per subagent, uavhengig av hva modell
 
 Seks av agentene våre har et `name:` som ikke er filnavnet: `accessibility`, `aksel`, `kafka`, `research`, `rust` og `security-champion` heter alle `<navn>-agent` i frontmatteren. Den som setter opp dette fra agentens eget navn får ingen feilmelding, bare ingen effekt.
 
-Nav-pilot skriver ikke klientkonfigurasjon i dag ([beslutning 4.8](nav-pilot-design.md)). Om den skal gjøre det, er spørsmålet i [#500](https://github.com/navikt/copilot/issues/500).
+Nav-pilot skriver ikke klientkonfigurasjon i dag ([beslutning 4.8](nav-pilot-benchmark-og-beslutninger-2026-08.md#48---model-driver-klientmodellen-ikke-skriving-i-klientens-config)). Om den skal gjøre det, er spørsmålet i [#500](https://github.com/navikt/copilot/issues/500).
 
 ### AI-kreditter skiller ikke modeller
 

--- a/docs/modellvalg.md
+++ b/docs/modellvalg.md
@@ -6,6 +6,8 @@ Levende referansedokument for hvilke modeller vi bruker, hvorfor, og hvordan vi 
 
 De fleste agenter og prompts har et eksplisitt `model:`-felt i YAML-frontmatter. `nav-pilot` har det ikke: orkestratoren kjører på klientens egen standardmodell. Valget følger oppgavetype, kostnad og ytelse, ikke leverandørpreferanse. Priser og kategori står i modelltabellen under.
 
+**Pinnene under gjelder når agenten startes direkte.** Blir den startet som subagent av `@nav-pilot`, arver den modellen forelderen kjører på. Se [Pinner og delegering](#pinner-og-delegering).
+
 ### Agenter
 
 | Agent | Modell | Begrunnelse |
@@ -15,7 +17,7 @@ De fleste agenter og prompts har et eksplisitt `model:`-felt i YAML-frontmatter.
 | `@security-champion` | GPT-5.6 Sol | Sikkerhetskritiske vurderinger. Agenten er ikke målt mot Opus 4.6 eller mot noen annen modell. Byttet hviler på pris |
 | `@code-review` | GPT-5.3-Codex | Sterkest på kodeforståelse og terminal-oppgaver |
 | `@kafka` | GPT-5.3-Codex | Teknisk presis på hendelsesdrevne mønstre |
-| `@research` | GPT-5.6 Luna | Leser og søker uten å skrive kode, og Luna koster omtrent en tiendedel av Codex |
+| `@research` | GPT-5.6 Luna | Leser og søker uten å skrive kode. Luna er omtrent en tiendedel av Codex i listepris. Gjelder bare når agenten startes direkte, ikke når `@nav-pilot` delegerer til den |
 | `@rust` | GPT-5.3-Codex | Terminal-Bench-leder for kompilert kode |
 | `@aksel` | Claude Sonnet 4.6 | Sterk på komponentstruktur og designsystem-konvensjoner |
 | `@accessibility` | Claude Sonnet 4.6 | God på WCAG-tolkning og semantisk HTML |
@@ -32,6 +34,82 @@ De fleste agenter og prompts har et eksplisitt `model:`-felt i YAML-frontmatter.
 | `nextjs-api-route` | GPT-5.6 Luna | Enkel strukturert mal |
 | `spring-boot-endpoint` | GPT-5.6 Luna | Enkel strukturert mal |
 | `golang-service` | GPT-5.6 Luna | Enkel strukturert mal |
+
+## Pinner og delegering
+
+Målt mot Copilot CLI 1.0.83-4, 7. september 2026.
+
+### Pinnen gjelder bare på toppnivå
+
+`model:`-feltet i en agents frontmatter blir brukt når agenten startes direkte:
+
+```
+copilot --agent research      # kjører på gpt-5.6-luna, som pinnen sier
+```
+
+Blir den samme agenten startet som subagent, arver den forelderens modell, og pinnen leses ikke:
+
+```
+copilot --agent nav-pilot --model gpt-5.6-terra -p "start subagenten research"
+  -> ● Research (model: gpt-5.6-terra)
+
+copilot --agent nav-pilot --model gpt-5.6-sol -p "start subagenten research"
+  -> ● Research (model: gpt-5.6-sol)
+```
+
+Det betyr at `@nav-pilot` sin modell i praksis er modellen for hele delegeringstreet. Modellporten i `agents/nav-pilot.agent.md` bytter persona ved eskalering til `@nav-pilot-opus`, ikke modell, med mindre noen sier noe annet eksplisitt.
+
+Verktøyet tar imot en modell hvis den som kaller ber om det. Da gjelder den:
+
+```
+copilot --agent nav-pilot --model gpt-5.6-sol \
+  -p "start subagenten research, be eksplisitt om gpt-5.6-luna"
+  -> ● Research (model: gpt-5.6-luna)
+```
+
+Det hviler på at modellen velger å oppgi den. En instruks i personaen om å gjøre det er samme slag som soft-sjekk 2b i golden-harnessen, som aldri er innfridd over tre persona-revisjoner og fire modeller. Regn ikke med den.
+
+### Den deterministiske overstyringen
+
+Klientens egen konfigurasjon setter modell per subagent, uavhengig av hva modellen finner på. `~/.copilot/settings.json`:
+
+```json
+{
+  "subagents": {
+    "agents": {
+      "research": { "model": "gpt-5.6-luna" }
+    }
+  }
+}
+```
+
+`copilot help config` dokumenterer `subagents.agents.<agent-name>` med `model`, `effortLevel` og `contextTier`, der hvert felt også tar `"inherit"`. `/subagents` setter det interaktivt.
+
+**Nøkkelen er filnavnet, ikke `name:` i frontmatteren.** Målt med kontroll:
+
+| Nøkkel | Modell subagenten kjørte på |
+|--------|-----------------------------|
+| `research` (filnavnet, `research.agent.md`) | gpt-5.6-luna |
+| `research-agent` (frontmatterens `name:`) | gpt-5.6-sol |
+| `tullball` (kontroll) | gpt-5.6-sol |
+
+Seks av agentene våre har et `name:` som ikke er filnavnet: `accessibility`, `aksel`, `kafka`, `research`, `rust` og `security-champion` heter alle `<navn>-agent` i frontmatteren. Den som setter opp dette fra agentens eget navn får ingen feilmelding, bare ingen effekt.
+
+Nav-pilot skriver ikke klientkonfigurasjon i dag ([beslutning 4.8](nav-pilot-design.md)). Om den skal gjøre det, er spørsmålet i [#500](https://github.com/navikt/copilot/issues/500).
+
+### AI-kreditter skiller ikke modeller
+
+Samme agent, samme oppgave, 10,0k input-tokens:
+
+| Modell | AI Credits |
+|--------|-----------|
+| GPT-5.6 Luna | 0,26 |
+| GPT-5.6 Sol | 0,26 |
+| Claude Opus 5 | 0,26 |
+
+Kredittene følger tokenforbruk, ikke modellklasse: en nav-pilot-tur på 52k tokens kostet omtrent 18. Tallet CLI-en viser kan altså ikke brukes til å vise gevinsten av et modellbytte.
+
+Pristabellen lenger nede er GitHubs listepriser. Vi har ikke koblet dem mot det Nav faktisk faktureres, og vet ikke hvilken enhet den faktureringen er i. Kostnadsargumentene i dette dokumentet er derfor listepris ganget med et anslått forhold mellom input og output, ikke målt forbruk. Det står også i [Grunnlaget for Luna-byttene](#grunnlaget-for-luna-byttene-august-2026), og gjelder like fullt her.
 
 ## Grunnlaget for Luna-byttene (august 2026)
 

--- a/docs/nav-pilot-changelog.md
+++ b/docs/nav-pilot-changelog.md
@@ -4,6 +4,14 @@ Endringslogg for nav-pilot agent harness — agenter, skills, instruksjoner, pro
 
 ## 2026-09-07
 
+### Subagenter arver modellen, og pinnen leses ikke
+
+- **`model:` i frontmatteren gjelder bare når agenten startes direkte**: Startet som subagent arver den forelderens modell. Målt begge veier med samme agent: `--model gpt-5.6-terra` ga `● Research (model: gpt-5.6-terra)`, `--model gpt-5.6-sol` ga `● Research (model: gpt-5.6-sol)`. Pinnen sier `gpt-5.6-luna`. Konsekvensen er at modellen `@nav-pilot` kjører på i praksis er modellen for hele delegeringstreet, og at modellporten bytter persona ved eskalering, ikke modell (#688).
+- **Den deterministiske overstyringen er klientkonfigurasjon, ikke agentfila**: `subagents.agents.<navn>.model` i `~/.copilot/settings.json` setter modellen per subagent uansett hva modellen finner på. Nøkkelen er filnavnet og ikke `name:` i frontmatteren, verifisert med kontroll: `research` ga Luna, `research-agent` ga Sol, og en oppdiktet nøkkel ga Sol. Seks av agentene våre har et `name:` som ikke er filnavnet, så den som setter dette opp fra agentens eget navn får ingen effekt og ingen feilmelding.
+- **AI-kreditter skiller ikke modeller**: Samme agent og oppgave på 10,0k input-tokens kostet 0,26 på både Luna, Sol og Opus 5. Kredittene følger tokenforbruk, ikke modellklasse. Tallet CLI-en viser kan derfor ikke brukes til å vise gevinsten av et modellbytte, og kostnadsargumentene i modellvalg.md er listepris ganget med et anslag, ikke målt forbruk.
+- **Ingen pinner er endret.** `@nav-pilot` står fortsatt upinnet: benchmarken fra august skiller ingen modeller på noen påstand uten gjennom artefakter, så det finnes ikke grunnlag for en pinne, og under arv er orkestratorens modell brukerens valg for hele treet.
+
+
 ### Orkestratoren manglet verktøyet den orkestrerer med
 
 - **`agent` lagt til i verktøylista til `nav-pilot`**: Personaen ber modellen delegere fire steder: modellporten mot `@nav-pilot-opus`, leaf-only-regelen for spesialister, språkvasken til `@forfatter` og delegasjonstabellen. Frontmatteren ga den likevel aldri et subagent-verktøy. Copilot CLI begrenser en agent til sin egen liste, så delegeringen var umulig i praksis: `Error: Task tool is not available.` Standardagenten delegerte fint på samme modell (`gpt-5.6-sol`), så feilsøkingen pekte lenge på modellen framfor på verktøylista. Navnet er `agent` og ikke `task`. Begge virker i CLI-en, men VS Code kjenner bare `agent` og ignorerer ukjente verktøy uten å si fra, og `installUrl` i manifestet peker på VS Code (#688).


### PR DESCRIPTION
`docs/modellvalg.md` dokumenterer modellpinner per agent med kostnadsbegrunnelser. Pinnene virker, men ikke på den stien personaen faktisk bruker.

## Målt, 7. september 2026, Copilot CLI 1.0.83-4

En subagent arver forelderens modell. Agentens eget `model:` leses ikke:

```
copilot --agent nav-pilot --model gpt-5.6-terra -p "start subagenten research"
  -> ● Research (model: gpt-5.6-terra)

copilot --agent nav-pilot --model gpt-5.6-sol -p "start subagenten research"
  -> ● Research (model: gpt-5.6-sol)
```

`research.agent.md` er pinnet til `gpt-5.6-luna`. Startet direkte gjelder pinnen (debug-loggen viser `gpt-5.6-luna`); startet som subagent gjør den det ikke.

To konsekvenser som ikke sto noe sted:

- Modellen `@nav-pilot` kjører på er i praksis modellen for hele delegeringstreet.
- Modellporten i personaen bytter **persona** ved eskalering til `@nav-pilot-opus`, ikke modell. «Escalate to a stronger model» skjer ikke av seg selv.

Raden for `@research` («Luna koster omtrent en tiendedel av Codex») beskriver dermed en sti de fleste ikke går, siden personaens hovedvei er delegering. Raden er presisert, ikke fjernet: gevinsten er reell når agenten startes direkte.

## Den deterministiske overstyringen finnes

Ikke i agentfila, men i klientkonfigurasjonen. `copilot help config` dokumenterer `subagents.agents.<agent-name>` med `model`, `effortLevel` og `contextTier`.

**Nøkkelen er filnavnet, ikke `name:` i frontmatteren.** Målt med kontroll, forelderen på `--model gpt-5.6-sol` i alle tre:

| Nøkkel | Subagentens modell |
|---|---|
| `research` (filnavnet) | gpt-5.6-luna |
| `research-agent` (frontmatterens `name:`) | gpt-5.6-sol |
| `tullball` (kontroll) | gpt-5.6-sol |

Seks av agentene våre heter `<navn>-agent` i frontmatteren mens fila heter `<navn>.agent.md`. Feil nøkkel gir ingen feilmelding, bare ingen effekt. Det er notert i #500 sammen med at trigger-betingelsen det issuet venter på nå finnes for Copilot CLI.

Alternativet, en instruks i personaen om å oppgi modellen ved delegering, er avvist i teksten. Verktøyet tar imot en modell hvis den som kaller ber om det, men det hviler på at modellen velger å gjøre det. Samme slag som soft-sjekk 2b i golden-harnessen, aldri innfridd over tre persona-revisjoner og fire modeller.

## AI-kreditter skiller ikke modeller

Samme agent, samme oppgave, 10,0k input-tokens:

| Modell | AI Credits |
|---|---|
| GPT-5.6 Luna | 0,26 |
| GPT-5.6 Sol | 0,26 |
| Claude Opus 5 | 0,26 |

Kredittene følger tokenforbruk, ikke modellklasse: en nav-pilot-tur på 52k tokens kostet omtrent 18. Tallet CLI-en viser kan altså ikke brukes til å vise gevinsten av et modellbytte, og vi vet ikke hvilken enhet Nav faktisk faktureres i. Det står nå i dokumentet, ved siden av pristabellen det gjelder.

## Hva som ikke er endret

Ingen `model:`-frontmatter, ingen pinner, ingen agentnavn, ingenting i harnessen.

`@nav-pilot` står fortsatt upinnet, og det er nå bedre begrunnet enn før: benchmarken fra august skiller ingen modeller på noen påstand uten gjennom artefakter, så det finnes ikke grunnlag for en pinne. Under arv er orkestratorens modell dessuten brukerens valg for hele treet, og det valget bør ligge hos den som ser regningen.

`@nav-pilot-opus` er heller ikke rørt, selv om navnet lover en Opus-modell og agenten er pinnet til GPT-5.6 Sol. En omdøping treffer `RE_OPUS` i golden-harnessen og de 28 kalibrerte t6-transkriptene, begge genererte manifester, fem dokumenter og fire testfiler, og sync fjerner ikke foreldreløse filer, så installerte brukere ville sittet igjen med begge håndtakene. Ikke verdt en egen PR.

Bare dokumentasjon. `mise run check` er grønn.
