### PR TITLE
fix(nav-pilot): add godtar hook, som scopet alltid har gjort

### DIFF
--- a/cli/nav-pilot/internal/cli/add.go
+++ b/cli/nav-pilot/internal/cli/add.go
@@ -4,21 +4,29 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
-// cmdAdd installs a single agent, skill, instruction, or prompt from the source repo.
+// cmdAdd installs a single artifact of any declared kind from the source repo.
 // It appends to the existing state file if one exists.
+//
+// The kind list is derived from [source.KindByName] rather than written out
+// here. A hardcoded copy is the defect that #649 and #650 were both about, and
+// this was the third one: `hook` became a kind in #569, every bulk path learned
+// it, and this switch did not — so `nav-pilot install --user --type hook` and
+// `nav-pilot add hook <navn>` refused a kind the scope itself supports, which
+// is the command `sync` prints when it finds an uninstalled hook.
 func cmdAdd(itemType, name string, scope *InstallScope, ref, sourceRepo string, dryRun, force bool, jsonOutput bool) error {
-	// Validate type
-	switch itemType {
-	case "agent", "skill", "instruction", "prompt":
-		// ok
-	default:
-		return fmt.Errorf("unknown type %q. Valid types: agent, skill, instruction, prompt", itemType)
+	if _, ok := kindByName[itemType]; !ok {
+		return fmt.Errorf("unknown type %q. Valid types: %s", itemType, strings.Join(kindNames(), ", "))
 	}
 
+	// What a scope supports is the scope's own answer, and the two scopes
+	// differ: repo takes prompts, user does not. Naming the supported kinds
+	// beats naming three of them and going stale again.
 	if !scope.SupportsType(itemType) {
-		return fmt.Errorf("type %q is not supported in user scope. Only agents, skills, and instructions can be installed to ~/.copilot", itemType)
+		return fmt.Errorf("type %q is not supported in %s scope. Supported here: %s",
+			itemType, scope.Name, strings.Join(scope.SupportedTypes, ", "))
 	}
 
 	if err := validateName(name); err != nil {
@@ -190,4 +198,14 @@ func noteForeignSource(scope *InstallScope, foreign, updateCmd string) {
 	state, _ := readScopedState(scope)
 	fmt.Printf("\n%s It comes from %s, not this scope's %s. `nav-pilot sync` leaves it alone —\n  re-run %s to update it.\n",
 		dim("ℹ"), bold(foreign), bold(scopeSourceRepo(state)), bold(updateCmd))
+}
+
+// kindNames lists every declared artifact kind in the order AllKinds declares
+// them, for error messages that cannot drift from the kinds themselves.
+func kindNames() []string {
+	names := make([]string, 0, len(AllKinds))
+	for _, k := range AllKinds {
+		names = append(names, k.Name)
+	}
+	return names
 }

--- a/cli/nav-pilot/internal/cli/add_test.go
+++ b/cli/nav-pilot/internal/cli/add_test.go
@@ -39,6 +39,49 @@ func TestCmdAdd_InvalidType(t *testing.T) {
 	}
 }
 
+// TestCmdAdd_AcceptsEveryDeclaredKind walks source.AllKinds rather than naming
+// the kinds, because a hardcoded list here would repeat the defect it tests
+// for: `hook` became a kind in #569, every bulk path learned it, and cmdAdd's
+// own switch did not. A kind added later is covered without editing this test.
+func TestCmdAdd_AcceptsEveryDeclaredKind(t *testing.T) {
+	for _, kind := range AllKinds {
+		t.Run(kind.Name, func(t *testing.T) {
+			scope := ScopeRepo(t.TempDir())
+			if !scope.SupportsType(kind.Name) {
+				t.Skipf("repo scope does not take %q", kind.Name)
+			}
+			// A dry run stops before any source resolution, so this reaches the
+			// type gate and nothing that needs a checkout.
+			err := cmdAdd(kind.Name, "finnes-ikke", scope, "", "", true, false, false)
+			if err != nil && strings.Contains(err.Error(), "unknown type") {
+				t.Errorf("cmdAdd rejected the declared kind %q: %v", kind.Name, err)
+			}
+		})
+	}
+}
+
+// The user scope takes a narrower set than the repo scope, and the refusal has
+// to name what that scope actually supports rather than a list written by hand.
+func TestCmdAdd_UnsupportedKindNamesTheScopesOwnSet(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	scope, err := ScopeUser()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scope.SupportsType("prompt") {
+		t.Skip("user scope now takes prompts; this test has nothing to say")
+	}
+	err = cmdAdd("prompt", "noe", scope, "", "", true, false, false)
+	if err == nil {
+		t.Fatal("cmdAdd took a prompt in user scope, want a refusal")
+	}
+	for _, want := range scope.SupportedTypes {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal %q does not name the supported kind %q", err, want)
+		}
+	}
+}
+
 func TestCmdAdd_InvalidName(t *testing.T) {
 	err := cmdAdd("agent", "../etc/passwd", ScopeRepo(t.TempDir()), "", "", true, false, false)
 	if err == nil {


### PR DESCRIPTION
`nav-pilot sync` finner en uinstallert hook og skriver ut hva man skal gjøre. Kommandoen den peker på virket ikke.

```
$ nav-pilot sync
ℹ 1 new item(s) in source not yet installed:
    hook: gh-poll-gate
  Run nav-pilot install --user to add them.

$ nav-pilot add hook gh-poll-gate --user
Error: unknown type "hook". Valid types: agent, skill, instruction, prompt
```

`cmdAdd` hadde sin egen switch over artefakttyper (`add.go:13-18`) og lærte aldri `hook`. Alt annet gjorde det: `install.go:307` godtar den, user-scopet lister den i `SupportedTypes` (`domain.go:233`), og bulkstien installerer alle tre hookene fint. Bare enkeltvei-installasjonen nektet.

Konsekvensen var at eneste vei til én hook var `nav-pilot install --user`, som på denne maskinen ville tatt 61 artefakter, inkludert 11 brukeren bevisst ikke hadde.

## Tredje gang

#649 og #650 handlet begge om en hardkodet typeliste som ikke lærte `hook` da den ble en type i #569. Dette er den tredje kopien. Lista utledes nå fra `source.AllKinds`, og avvisningen for feil scope navngir scopets egne `SupportedTypes` framfor å skrive ut tre av dem for hånd (den gamle teksten sa «Only agents, skills, and instructions can be installed to ~/.copilot», som var feil i det øyeblikket hooks ble støttet).

## Testen kan ikke gjenta feilen den tester for

`TestCmdAdd_AcceptsEveryDeclaredKind` går over `AllKinds` framfor å nevne typene. Det var nettopp rettelsen i #650: en test som skriver ut lista på nytt er den samme defekten en gang til, og en type lagt til senere er dekket uten at testen røres.

Verifisert ved å sette tilbake den hardkodede switchen:

```
--- FAIL: TestCmdAdd_AcceptsEveryDeclaredKind/hook
    cmdAdd rejected the declared kind "hook": unknown type "hook". Valid types: agent, skill, instruction, prompt
```

Bare `hook`-undertesten blir rød, med nøyaktig den feilmeldingen brukeren fikk. De fire andre står.

`TestCmdAdd_UnsupportedKindNamesTheScopesOwnSet` dekker den andre halvdelen: en `prompt` i user-scope skal fortsatt nektes, og avvisningen skal navngi det scopet faktisk støtter.

## Verifisert etterpå

De tre portene er installert i user-scope med den rettede binæren, og porten fra #706 er kjørt i en ekte økt uten repo-scope inne i bildet:

```
$ copilot -p "Kjør: for i in $(seq 1 3); do gh run list --limit 1; sleep 30; done"
Kunne ikke kjøre kommandoen: miljøet blokkerer gjentatt polling av GitHub Actions.
```

`mise run check` er grønn.
