### PR TITLE
feat(web): show English articles in the news feed

### DIFF
--- a/apps/my-copilot/src/app/(nb)/(home)/page.tsx
+++ b/apps/my-copilot/src/app/(nb)/(home)/page.tsx
@@ -14,10 +14,13 @@ import { NavPill } from "@/components/navigation/nav-pill";
 
 export default async function Home() {
   const [user, videos] = await Promise.all([getUser(false), getPublicVideoFeed(5)]);
-  const news = getNewsItems({ frontPage: true });
-  // Count what /en/news actually lists: that page shows articles only, so a
-  // link item would make the count promise more than the page delivers.
-  const englishNews = getNewsItems({ lang: "en" }).filter((item) => item.type === "article");
+  // English articles sit in the same feed as the Norwegian ones, sorted by date
+  // like everything else. A separate link beside the category chips read as a
+  // filter that did nothing, and the piece most worth reading was the one the
+  // front page did not show.
+  const news = [...getNewsItems({ frontPage: true }), ...getNewsItems({ lang: "en", frontPage: true })].sort(
+    (a, b) => Number(b.featured ?? false) - Number(a.featured ?? false) || b.date.localeCompare(a.date)
+  );
 
   return (
     <main>
@@ -68,7 +71,6 @@ export default async function Home() {
                 <div className="flex-1 min-w-0">
                   <NewsFeed
                     items={news}
-                    englishCount={englishNews.length}
                     compact
                     afterFeatured={
                       videos.length > 0 ? (

--- a/apps/my-copilot/src/components/news-card.tsx
+++ b/apps/my-copilot/src/components/news-card.tsx
@@ -30,7 +30,8 @@ function AuthorAvatar({ author }: { author: string }) {
 export function NewsCard({ item, span = 1 }: { item: NewsItem; span?: number }) {
   const categoryConfig = CATEGORY_CONFIG[item.category] ?? DEFAULT_CATEGORY_CONFIG;
   const isLink = item.type === "link";
-  const href = isLink ? safeHref(item.url!) : `/nyheter/${item.slug}`;
+  const isEnglish = item.lang === "en";
+  const href = isLink ? safeHref(item.url!) : isEnglish ? `/en/news/${item.slug}` : `/nyheter/${item.slug}`;
   const isExternal = isLink && !href.startsWith("/");
   const linkProps = isExternal ? { target: "_blank" as const, rel: "noopener noreferrer" } : {};
   const isWide = span >= 2;
@@ -51,14 +52,21 @@ export function NewsCard({ item, span = 1 }: { item: NewsItem; span?: number }) 
         href={href}
         {...linkProps}
         className={`no-underline hover:shadow-md transition-shadow news-card news-card-${item.category}`}
+        hrefLang={isEnglish ? "en" : undefined}
+        lang={isEnglish ? "en" : undefined}
       >
         <div className="flex flex-col gap-3 h-full">
           <HStack gap="space-4" align="center" wrap>
             <Tag size="xsmall" data-color={categoryConfig.variant} variant="moderate">
-              {categoryConfig.label}
+              <span lang="nb">{categoryConfig.label}</span>
             </Tag>
+            {isEnglish && (
+              <Tag size="xsmall" data-color="neutral" variant="moderate">
+                English
+              </Tag>
+            )}
             <BodyShort size="small" className="text-text-subtle">
-              {formatDate(item.date)}
+              {formatDate(item.date, isEnglish ? "en-GB" : "nb-NO")}
             </BodyShort>
             {item.author && <AuthorAvatar author={item.author} />}
           </HStack>
@@ -80,7 +88,8 @@ export function NewsCard({ item, span = 1 }: { item: NewsItem; span?: number }) 
 export function FeaturedNewsCard({ item }: { item: NewsItem }) {
   const categoryConfig = CATEGORY_CONFIG[item.category] ?? DEFAULT_CATEGORY_CONFIG;
   const isLink = item.type === "link";
-  const href = isLink ? safeHref(item.url!) : `/nyheter/${item.slug}`;
+  const isEnglish = item.lang === "en";
+  const href = isLink ? safeHref(item.url!) : isEnglish ? `/en/news/${item.slug}` : `/nyheter/${item.slug}`;
   const isExternal = isLink && !href.startsWith("/");
   const linkProps = isExternal ? { target: "_blank" as const, rel: "noopener noreferrer" } : {};
 
@@ -90,14 +99,21 @@ export function FeaturedNewsCard({ item }: { item: NewsItem }) {
         href={href}
         {...linkProps}
         className="no-underline hover:shadow-lg transition-shadow featured-card news-card"
+        hrefLang={isEnglish ? "en" : undefined}
+        lang={isEnglish ? "en" : undefined}
       >
         <div className="flex flex-col gap-5">
           <HStack gap="space-4" align="center" wrap>
             <Tag size="xsmall" data-color={categoryConfig.variant} variant="moderate">
-              {categoryConfig.label}
+              <span lang="nb">{categoryConfig.label}</span>
             </Tag>
+            {isEnglish && (
+              <Tag size="xsmall" data-color="neutral" variant="moderate">
+                English
+              </Tag>
+            )}
             <BodyShort size="small" className="text-text-subtle">
-              {formatDate(item.date)}
+              {formatDate(item.date, isEnglish ? "en-GB" : "nb-NO")}
             </BodyShort>
             {item.author && <AuthorAvatar author={item.author} />}
           </HStack>

--- a/apps/my-copilot/src/components/news-feed.test.tsx
+++ b/apps/my-copilot/src/components/news-feed.test.tsx
@@ -17,22 +17,24 @@ function makeItem(over: Partial<NewsItem> = {}): NewsItem {
   };
 }
 
-describe("NewsFeed English link", () => {
-  it("links to the English articles when there are some", () => {
-    render(<NewsFeed items={[makeItem()]} englishCount={2} />);
+describe("NewsFeed with English articles", () => {
+  it("shows an English article in the feed, linking to the English route", () => {
+    render(<NewsFeed items={[makeItem({ slug: "in-english", lang: "en", title: "In English" })]} />);
     const link = screen.getByRole("link", { name: /In English/ });
-    expect(link).toHaveAttribute("href", "/en/news");
-    expect(link).toHaveTextContent("In English (2)");
+    expect(link).toHaveAttribute("href", "/en/news/in-english");
+    expect(link).toHaveAttribute("lang", "en");
+    expect(link).toHaveAttribute("hreflang", "en");
   });
 
-  it("says nothing when there are none", () => {
-    render(<NewsFeed items={[makeItem()]} englishCount={0} />);
-    expect(screen.queryByRole("link", { name: /In English/ })).toBeNull();
+  it("marks it so a Norwegian reader knows before clicking", () => {
+    render(<NewsFeed items={[makeItem({ slug: "in-english", lang: "en", title: "In English" })]} />);
+    expect(screen.getByText("English")).toBeInTheDocument();
   });
 
-  it("says nothing when the count is not given", () => {
-    render(<NewsFeed items={[makeItem()]} />);
-    expect(screen.queryByRole("link", { name: /In English/ })).toBeNull();
+  it("leaves Norwegian items on the Norwegian route and unmarked", () => {
+    render(<NewsFeed items={[makeItem({ slug: "en-sak", title: "En sak" })]} />);
+    expect(screen.getByRole("link", { name: /En sak/ })).toHaveAttribute("href", "/nyheter/en-sak");
+    expect(screen.queryByText("English")).toBeNull();
   });
 });
 

--- a/apps/my-copilot/src/components/news-feed.tsx
+++ b/apps/my-copilot/src/components/news-feed.tsx
@@ -4,16 +4,12 @@ import { useState, useMemo, type ReactNode } from "react";
 import { Chips, HStack, VStack, BodyShort, Heading } from "@navikt/ds-react";
 import type { NewsItem, NewsCategory } from "@/lib/news-types";
 import { CATEGORY_CONFIG } from "@/lib/news-types";
-import NextLink from "next/link";
 import { NewsCard, FeaturedNewsCard } from "./news-card";
 
 interface NewsFeedProps {
   items: NewsItem[];
   compact?: boolean;
   afterFeatured?: ReactNode;
-  // Articles published in English. They are not in `items`, which is Norwegian
-  // only, so without this link nothing on the site leads to /en/news.
-  englishCount?: number;
 }
 
 const COLS = 3;
@@ -74,7 +70,7 @@ export function computeGridSpans(count: number, cols: number = COLS): number[] {
   return spans;
 }
 
-export function NewsFeed({ items, compact = false, afterFeatured, englishCount = 0 }: NewsFeedProps) {
+export function NewsFeed({ items, compact = false, afterFeatured }: NewsFeedProps) {
   const [selected, setSelected] = useState<NewsCategory | null>(null);
 
   const availableCategories = useMemo(() => {
@@ -110,11 +106,6 @@ export function NewsFeed({ items, compact = false, afterFeatured, englishCount =
             </Chips.Toggle>
           ))}
         </Chips>
-        {englishCount > 0 && (
-          <NextLink href="/en/news" hrefLang="en" lang="en" className="text-sm text-text-action">
-            In English ({englishCount})
-          </NextLink>
-        )}
       </HStack>
 
       {filtered.length === 0 && <BodyShort className="text-text-subtle">Ingen nyheter i denne kategorien.</BodyShort>}


### PR DESCRIPTION
#698 added an "In English (n)" link next to the category chips. Sitting there it reads as a filter, and clicking it leaves the page. Meanwhile the article it pointed at was the one item the front page did not show.

English articles now appear in the feed itself, sorted by date with the rest. Each card gets:

- `lang="en"` and `hrefLang="en"`, so a screen reader switches voice and a crawler knows what it is getting (WCAG 3.1.2)
- an `English` tag, so a Norwegian reader knows before clicking
- an English date format
- a link to `/en/news/<slug>`, not the Norwegian route

The category label keeps `lang="nb"` inside an English card, because the label is still Norwegian.

The link is gone, along with its `englishCount` prop. `/en/news` is still reachable from an article's own back link.

Three tests replace the ones for the old link: an English item links to the English route with the language attributes, it carries the marker, and a Norwegian item stays on the Norwegian route unmarked. 518 tests pass, route guard passes.

Verified on a production build: the front page renders the card with `href="/en/news/sandbox-confines-the-process-not-the-token"`, `lang="en"` and the English tag, and no "In English" link remains.