### PR TITLE
fix(nav-pilot): en lokal økt overlever at forfatteren committer

### DIFF
--- a/cli/nav-pilot/internal/cli/pakke_install.go
+++ b/cli/nav-pilot/internal/cli/pakke_install.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
 )
@@ -267,6 +268,44 @@ func stageRevision(src *Source, dest string) error {
 		}
 	}
 	return nil
+}
+
+// previousRevision names the most recently published revision of a source other
+// than current, or "" when there is none.
+//
+// The pinned path knows what it replaced: it reads the outgoing pin out of
+// state and hands both SHAs to [prunePakkeRevisions]. A local source is never
+// pinned and writes no state, so the only record of what came before is the
+// directory itself, and mtime is what publishing leaves behind: [os.Rename]
+// onto the revision path sets it.
+//
+// Without this the local path kept exactly one revision, and every launch after
+// a commit removed the tree the previous launch is still reading (#703). The
+// two-revision rule is not a nicety there; it is the whole of what lets a
+// running opencode session survive its author committing.
+//
+// Ties do not matter: two revisions published in the same mtime tick are both
+// old enough that either is a defensible thing to keep.
+func previousRevision(repo, current string) string {
+	entries, err := os.ReadDir(pakkeSourceDir(repo))
+	if err != nil {
+		return ""
+	}
+	var newest string
+	var newestAt time.Time
+	for _, e := range entries {
+		if !e.IsDir() || e.Name() == current || strings.HasPrefix(e.Name(), revisionTmpPrefix) {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if newest == "" || info.ModTime().After(newestAt) {
+			newest, newestAt = e.Name(), info.ModTime()
+		}
+	}
+	return newest
 }
 
 // prunePakkeRevisions removes every revision of a source except the named ones,

--- a/cli/nav-pilot/internal/cli/pakke_install.go
+++ b/cli/nav-pilot/internal/cli/pakke_install.go
@@ -276,8 +276,14 @@ func stageRevision(src *Source, dest string) error {
 // The pinned path knows what it replaced: it reads the outgoing pin out of
 // state and hands both SHAs to [prunePakkeRevisions]. A local source is never
 // pinned and writes no state, so the only record of what came before is the
-// directory itself, and mtime is what publishing leaves behind: [os.Rename]
-// onto the revision path sets it.
+// directory itself, and mtime is the only ordering it carries.
+//
+// That mtime comes from staging, not from publishing: [os.Rename] moves a
+// directory without touching its own mtime (it updates the parent's). Staging
+// writes the tree and the rename follows immediately, so the two orders agree
+// for every sequence this cares about — a launch, later another launch. They
+// would disagree only if a tree were staged long before it was published, which
+// nothing here does.
 //
 // Without this the local path kept exactly one revision, and every launch after
 // a commit removed the tree the previous launch is still reading (#703). The

--- a/cli/nav-pilot/internal/cli/pakke_install_test.go
+++ b/cli/nav-pilot/internal/cli/pakke_install_test.go
@@ -9,11 +9,13 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
 	providerpkg "github.com/navikt/copilot/cli/nav-pilot/internal/provider"
@@ -1310,7 +1312,7 @@ func TestLocalSourceIsNeverPinned(t *testing.T) {
 		}
 	})
 
-	t.Run("a new commit does not leave the old revision behind", func(t *testing.T) {
+	t.Run("a new commit keeps the previous revision and no more", func(t *testing.T) {
 		pinEnv(t)
 		tree := tier2PinSourceTree(t)
 
@@ -1336,9 +1338,26 @@ func TestLocalSourceIsNeverPinned(t *testing.T) {
 		sha = "commit-two"
 		launch()
 
+		// Two, not one (#703). A local source's payload directory is a live
+		// session's OPENCODE_CONFIG_DIR, so removing the revision the previous
+		// launch handed over pulls the tree out from under a session that is
+		// still reading it. This is the rule pinned sources already have
+		// (prunePakkeRevisions keeps the pin and the one it replaced): a
+		// session survives one update.
 		names := revisionNames(t, tree)
-		if len(names) != 1 || names[0] != "commit-two" {
-			t.Errorf("revisions after launching two commits = %v, want only [commit-two]: nothing else ever removes a local source's revisions", names)
+		if want := []string{"commit-one", "commit-two"}; !reflect.DeepEqual(names, want) {
+			t.Errorf("revisions after launching two commits = %v, want %v", names, want)
+		}
+
+		// The bound is what the single-revision rule was really protecting: a
+		// local source writes no state, so uninstall can never reach these and
+		// only the launch itself prunes. A third commit must therefore drop the
+		// oldest rather than accumulate.
+		sha = "commit-three"
+		launch()
+		names = revisionNames(t, tree)
+		if want := []string{"commit-three", "commit-two"}; !reflect.DeepEqual(names, want) {
+			t.Errorf("revisions after a third commit = %v, want %v: the set must stay bounded at two", names, want)
 		}
 	})
 
@@ -1525,5 +1544,68 @@ func TestFailedStateWriteLosesNothing(t *testing.T) {
 	}
 	if len(after.Files) != len(before.Files) {
 		t.Errorf("state tracks %d files after the failed install, want the outgoing install's %d intact", len(after.Files), len(before.Files))
+	}
+}
+
+// TestLocalLaunchKeepsThePreviousRevision covers #703: a local source resolves
+// to the working tree's HEAD, so an author who commits between two launches
+// produces a second revision. The prune used to keep only the new one, which
+// removed the tree the first session still has open as its
+// OPENCODE_CONFIG_DIR.
+//
+// The rename-aside in materializeRevision does not cover this: it protects a
+// rebuild of the SAME sha, and here the sha moved.
+func TestLocalLaunchKeepsThePreviousRevision(t *testing.T) {
+	isolatedConfig(t)
+	repo := t.TempDir() // an absolute path is never pinnable, which is the case under test
+
+	dir := pakkeSourceDir(repo)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Three revisions, oldest first, with distinct mtimes so "previous" is not
+	// decided by directory order.
+	for i, sha := range []string{"eldst", "forrige", "naa"} {
+		p := filepath.Join(dir, sha)
+		if err := os.MkdirAll(p, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		when := time.Now().Add(time.Duration(i-3) * time.Minute)
+		if err := os.Chtimes(p, when, when); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if got := previousRevision(repo, "naa"); got != "forrige" {
+		t.Fatalf("previousRevision = %q, want %q", got, "forrige")
+	}
+
+	prunePakkeRevisions(repo, "naa", previousRevision(repo, "naa"))
+
+	got := revisionNames(t, repo)
+	want := []string{"forrige", "naa"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("revisions after prune = %v, want %v", got, want)
+	}
+}
+
+// The other half: with nothing to keep, the prune must not be confused by the
+// empty string previousRevision returns on a first launch.
+func TestLocalLaunchFirstRevisionSurvives(t *testing.T) {
+	isolatedConfig(t)
+	repo := t.TempDir()
+
+	dir := pakkeSourceDir(repo)
+	if err := os.MkdirAll(filepath.Join(dir, "forste"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := previousRevision(repo, "forste"); got != "" {
+		t.Errorf("previousRevision with only the current revision = %q, want empty", got)
+	}
+	prunePakkeRevisions(repo, "forste", previousRevision(repo, "forste"))
+
+	if got, want := revisionNames(t, repo), []string{"forste"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("revisions = %v, want %v", got, want)
 	}
 }

--- a/cli/nav-pilot/internal/cli/pakke_launch.go
+++ b/cli/nav-pilot/internal/cli/pakke_launch.go
@@ -323,14 +323,20 @@ func autoPin(src *Source) (*Source, error) {
 	// rebuild — a local source is rebuilt in place on every launch, and its
 	// payload directory is a live session's OPENCODE_CONFIG_DIR — which is why
 	// [materializeRevision] renames the old tree aside instead of removing it.
-	// The prune below removes the SHA directories this launch left behind, not
-	// the tree a session already has open.
+	//
+	// That covers a rebuild of the same SHA. It does not cover a moved one, and
+	// a local source resolves to the working tree's HEAD, so an author who
+	// commits between two launches gets a second SHA and a prune that used to
+	// keep only the new one (#703). The previous revision is kept too, which is
+	// the rule pinned sources already have: a session survives one update, and
+	// only a second one pulls the tree out from under a very old session.
 	if !pinnable(src.Repo) {
+		previous := previousRevision(src.Repo, src.SHA)
 		revDir, err := materializeRevision(src)
 		if err != nil {
 			return nil, err
 		}
-		prunePakkeRevisions(src.Repo, src.SHA)
+		prunePakkeRevisions(src.Repo, src.SHA, previous)
 		return &Source{Dir: revDir, SHA: src.SHA, Repo: src.Repo, Pakke: src.Pakke}, nil
 	}
 


### PR DESCRIPTION
Lukker #703, resten av #504 U9.

## Feilen

En lokal kilde løses opp til arbeidstreets HEAD (`source/source.go:117,150`), så SHA-en flytter seg med hver commit. Prunen i autoPin-stien fikk bare den nye å beholde:

```go
if !pinnable(src.Repo) {
    revDir, err := materializeRevision(src)
    ...
    prunePakkeRevisions(src.Repo, src.SHA)   // én å beholde
}
```

Rekkefølgen som gjør vondt:

1. Forfatteren starter en opencode-økt mot den lokale kilden på `abc`. Payload-katalogen er øktas `OPENCODE_CONFIG_DIR` og cplts `--allow-read` (`provider/staged_launch.go:227`).
2. Forfatteren committer. HEAD er nå `def`.
3. Ny økt i et annet vindu. Prunen fjerner `<dir>/abc/` under den første.

Rename-aside i `materializeRevision` (#542) dekker ikke dette: den beskytter en gjenoppbygging av **samme** SHA, og her har SHA-en flyttet seg. Kommentaren på `pakke_launch.go:322-327` sa at prunen ikke rører treet en økt har åpent. Det stemte ikke for denne stien.

## Rettelsen

Forrige revisjon beholdes også, som er regelen pinnede kilder alltid har hatt (`pakke_install.go:272-276`): «at most two survive: the current pin and the one it replaced. A session running the old revision therefore survives one update».

Pinnede kilder vet hva de erstattet, fra state. En lokal kilde skriver ingen state, så det eneste sporet av hva som kom før er katalogen selv, og `os.Rename` på revisjonsstien setter mtime. `previousRevision` leser den.

## Denne PR-en snur en påstand som sto i testene

Verdt å lese nøye. Subtesten het «a new commit does not leave the old revision behind» og krevde nøyaktig **én** revisjon, med denne begrunnelsen:

> A git-backed working tree resolves to its short HEAD, so the SHA moves with every commit its author launches from — and a local source records no state, so uninstall can never reach what those launches materialize. Only the launch itself can.

Den bekymringen er reell, men den handler om **grensen**, ikke om tallet. To er like begrenset som én: hver launch beholder nøyaktig nåværende og forrige, så settet vokser ikke. Pinnede kilder har levd med to hele tiden, med samme hygieneargument.

Testen er derfor endret framfor slettet, og krever nå begge deler:

- etter to commits: `[commit-one, commit-two]`
- etter en tredje: `[commit-three, commit-two]`, altså at den eldste faktisk droppes

Den andre halvdelen er den som holder den opprinnelige bekymringen i live. Uten den ville «behold to» kunne råtne til «behold alt» uten at noe ble rødt.

## Kontroll

`previousRevision` og prunen er dessuten dekket direkte, med mtime satt eksplisitt så «forrige» ikke avgjøres av katalogrekkefølge. Verifisert ved å sette tilbake enkelt-keep:

```
--- FAIL: TestLocalLaunchKeepsThePreviousRevision
    revisions after prune = [naa], want [forrige naa]
```

Og førstegangstilfellet: `previousRevision` gir tom streng når det ikke finnes noen forrige, og prunen skal ikke la seg forvirre av den.

`mise run check` er grønn.
