### PR TITLE
fix(nav-pilot): sync flytter pinnen i én kilde, kildebytte er en install

### DIFF
--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -256,10 +256,14 @@ func installArtifact(resolver *SourceResolver, scope *InstallScope, stateHashes 
 
 // printConflictHint says what a conflict is and how it ends. "Skipped" on its
 // own reads as permanent, and --force reads as "throw my edits away": neither
-// says that a sync --apply takes the upstream version of exactly these files.
+// says that a sync --apply takes the source's version of exactly these files.
+//
+// It says "kept" and not "kept as you edited them" (#692): a file installed
+// from an older revision of the source differs without anyone having touched
+// it, and the hash comparison behind this cannot tell the two apart.
 func printConflictHint(n int) {
-	fmt.Printf("%s %d file(s) kept as you edited them.\n", yellow("⚠"), n)
-	fmt.Printf("  %s to take the upstream version, or %s to overwrite on the next install.\n",
+	fmt.Printf("%s %d file(s) kept, differing from what nav-pilot installed.\n", yellow("⚠"), n)
+	fmt.Printf("  %s to take the source's version, or %s to overwrite on the next install.\n",
 		bold("nav-pilot sync --apply"), bold("--force"))
 }
 

--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -190,9 +190,16 @@ func installArtifact(resolver *SourceResolver, scope *InstallScope, stateHashes 
 	}
 
 	if conflicted && !force {
-		// The file exists and the user changed it — skip the overwrite but
-		// track as conflict so it's not lost from state or reported as "new".
-		fmt.Printf("  %s %s (locally modified — kept; %s takes the upstream version)\n",
+		// The file exists and its content differs from the hash nav-pilot
+		// recorded. Skip the overwrite but track as conflict so it is not lost
+		// from state or reported as "new".
+		//
+		// "differs from what nav-pilot installed" and not "locally modified"
+		// (#692): the hash comparison cannot tell an edit from a file that was
+		// installed by an older revision of the source, and saying "you changed
+		// this" to someone who did not is how a reader learns to ignore the
+		// warning.
+		fmt.Printf("  %s %s (differs from what nav-pilot installed, kept; %s takes the source's version)\n",
 			yellow("⚠"), name, bold("nav-pilot sync --apply"))
 		existingHash, hashErr := rawArtifactHash(dst, art.IsDir)
 		if hashErr == nil {

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -82,8 +82,54 @@ func cmdSync(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bool
 	return nil
 }
 
+// refuseSourceSwitch stops a sync that names a different source than the one
+// the scope is recorded against (#691).
+//
+// sync moves the pin within one source; changing source is an install. That is
+// what [syncPakkePin] already says for a pakke scope, and this is the same rule
+// for a content scope, which never reached that guard: it lives past the
+// installsContent gate.
+//
+// Two things went wrong without it, and the second is the damaging one:
+//
+//  1. Only SourceSHA and Version are written back (see the state block at the
+//     end of this file). SourceRepo is written by install alone. So
+//     `sync --source X --apply` left the scope recorded against the old source
+//     with the new source's revision, and the next plain sync read the old
+//     source again and offered to roll every file back.
+//  2. The file diff is computed against the new source, but it is not an
+//     install: a file the new source does not ship is reported as "deleted in
+//     source" and --apply removes it, while a file only the new source ships is
+//     never added. The result is neither source, which is worse than either.
+//
+// An empty recorded source is the adoption path (B3) and passes: that scope has
+// no source to switch away from.
+func refuseSourceSwitch(scope *InstallScope, sourceRepo string) error {
+	if sourceRepo == "" {
+		return nil
+	}
+	state, err := readScopedState(scope)
+	if err != nil || state == nil || state.SourceRepo == "" {
+		return nil
+	}
+	if sameSourceRepo(state.SourceRepo, sourceRepo) {
+		return nil
+	}
+	return fmt.Errorf(
+		"the %s scope is installed from %s, and %s names %s.\n"+
+			"sync updates the source a scope already has; switching sources is an install.\n\n"+
+			"  Sync the recorded source:  %s\n"+
+			"  Switch this scope over:    %s",
+		scope.Name, bold(state.SourceRepo), bold("--source"), bold(sourceRepo),
+		bold("nav-pilot sync"),
+		bold("nav-pilot install --"+scope.Name+" --source "+sourceRepo))
+}
+
 // syncScope is the sync itself, once the source question is settled.
 func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bool) error {
+	if err := refuseSourceSwitch(scope, sourceRepo); err != nil {
+		return err
+	}
 	// The source a scope was installed from wins over the persisted default:
 	// selection is per scope (B4), so syncing one scope never drags another
 	// scope's agentpakke into it.
@@ -377,7 +423,13 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 	}
 
 	if len(conflictPaths) > 0 && !apply {
-		fmt.Printf("%s %d file(s) hold your own edits and are left alone by a plain sync (source: %s)\n\n",
+		// "differs from what nav-pilot installed" and not "your own edits"
+		// (#692). The status says content changed since the recorded hash; it
+		// says nothing about who changed it. A reader who knows they edited
+		// nothing rightly rejects the sentence, and the only remedy offered is
+		// --apply, which then takes the source's version whether that is newer
+		// or older than what is on disk.
+		fmt.Printf("%s %d file(s) differ from what nav-pilot installed and are left alone by a plain sync (source: %s)\n\n",
 			yellow("⚠"), len(conflictPaths), shortSHA(src.SHA))
 		for _, p := range conflictPaths {
 			fmt.Printf("  %s %s\n", dim("⊘"), p)

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -434,7 +434,7 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 		for _, p := range conflictPaths {
 			fmt.Printf("  %s %s\n", dim("⊘"), p)
 		}
-		fmt.Printf("%s to take the upstream version of these too.\n\n", bold("nav-pilot sync --apply"))
+		fmt.Printf("%s to take the source's version of these too.\n\n", bold("nav-pilot sync --apply"))
 	}
 
 	if !apply {

--- a/cli/nav-pilot/internal/cli/sync_test.go
+++ b/cli/nav-pilot/internal/cli/sync_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -1214,4 +1215,97 @@ func TestAdd_PlainAddIntoForeignScopeIsStamped(t *testing.T) {
 	if state.SourceSHA != "team-sha" {
 		t.Errorf("SourceSHA = %q, want the scope's own %q", state.SourceSHA, "team-sha")
 	}
+}
+
+// TestRefuseSourceSwitch covers #691: sync moves the pin within one source, and
+// changing source is an install. Without the guard, sync wrote the new source's
+// SHA into a state still naming the old source, and the next plain sync read
+// the old source and offered to roll every file back.
+func TestRefuseSourceSwitch(t *testing.T) {
+	newScope := func(t *testing.T, recorded string) *InstallScope {
+		t.Helper()
+		scope := ScopeRepo(t.TempDir())
+		if recorded == "" {
+			return scope
+		}
+		state := &StateFile{
+			Collection: "pakke",
+			Scope:      scope.Name,
+			SourceRepo: recorded,
+			SourceSHA:  "abc1234",
+		}
+		if err := writeScopedState(scope, state); err != nil {
+			t.Fatal(err)
+		}
+		return scope
+	}
+
+	t.Run("a different source is refused and names install", func(t *testing.T) {
+		err := refuseSourceSwitch(newScope(t, "navikt/copilot"), "navikt/grillmester")
+		if err == nil {
+			t.Fatal("refuseSourceSwitch = nil for a different source, want a refusal")
+		}
+		for _, want := range []string{"navikt/copilot", "navikt/grillmester", "install"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("refusal %q does not mention %q", err, want)
+			}
+		}
+	})
+
+	t.Run("the recorded source is allowed", func(t *testing.T) {
+		if err := refuseSourceSwitch(newScope(t, "navikt/copilot"), "navikt/copilot"); err != nil {
+			t.Errorf("refuseSourceSwitch over the recorded source = %v, want nil", err)
+		}
+	})
+
+	t.Run("case does not make it a different source", func(t *testing.T) {
+		if err := refuseSourceSwitch(newScope(t, "navikt/copilot"), "Navikt/Copilot"); err != nil {
+			t.Errorf("refuseSourceSwitch = %v for the same source in another case, want nil", err)
+		}
+	})
+
+	t.Run("no --source is allowed", func(t *testing.T) {
+		if err := refuseSourceSwitch(newScope(t, "navikt/copilot"), ""); err != nil {
+			t.Errorf("refuseSourceSwitch with no --source = %v, want nil", err)
+		}
+	})
+
+	// The adoption path (B3): a scope with no recorded source has nothing to
+	// switch away from, and refusing there would break the sync that teaches
+	// the scope which source it belongs to.
+	t.Run("a scope with no recorded source adopts", func(t *testing.T) {
+		if err := refuseSourceSwitch(newScope(t, ""), "navikt/grillmester"); err != nil {
+			t.Errorf("refuseSourceSwitch on an unsourced scope = %v, want nil", err)
+		}
+	})
+
+	// The guard has to be wired in, not merely written. Removing the call from
+	// syncScope leaves every subtest above green, because they call the guard
+	// directly — so this one goes through cmdSync, which is the door a user
+	// comes in by. It must refuse before resolving anything: a source switch
+	// that clones first has already paid for the answer it is about to refuse.
+	t.Run("cmdSync refuses before it resolves", func(t *testing.T) {
+		scope := newScope(t, "navikt/copilot")
+		// resolveSourceForSync, not resolveSource: sync goes through the
+		// former, and hooking the wrong seam makes this test pass with the
+		// guard removed, which is exactly the vacuum it exists to avoid.
+		orig := resolveSourceForSync
+		t.Cleanup(func() { resolveSourceForSync = orig })
+		resolved := false
+		resolveSourceForSync = func(string, string) (*source.Source, error) {
+			resolved = true
+			return nil, fmt.Errorf("resolved-anyway")
+		}
+
+		err := cmdSync(scope, "", "navikt/grillmester", false, false)
+		if err == nil {
+			t.Fatal("cmdSync = nil for a source switch, want a refusal")
+		}
+		if !strings.Contains(err.Error(), "install") {
+			t.Errorf("refusal %q does not name install as the way to switch", err)
+		}
+		if resolved {
+			t.Error("the refusal came after resolving, which is the clone this guard exists to skip")
+		}
+	})
 }


### PR DESCRIPTION
Lukker #691 og #692. De to hører sammen: den ene fikk meg til å kjøre `--apply`, den andre gjorde `--apply` destruktiv.

## #691 Sync flyttet pinnen, men ikke kilden

`sync.go` skriver bare `SourceSHA` og `Version` tilbake. `SourceRepo` skrives av install alene. `sync --source X --apply` mot et scope installert fra Y ga derfor en state som navnga Y med X sin revisjon, og neste vanlige sync leste Y igjen og tilbød å rulle hver fil tilbake.

Målt på min egen maskin tidligere i dag: scopet pekte på en worktree på en ikke-merget gren, `--source` mot main flyttet SHA-en, og neste `sync --dry-run` ville tatt tilbake `agent` fra `nav-pilot.agent.md` som #688 nettopp la inn.

Vakten som skulle fanget det, `sameSourceRepo` i `syncPakkePin`, ligger bak `installsContent`-porten og ser aldri et innholds-scope.

### Hvorfor nekte framfor å skrive `SourceRepo`

Å skrive begge feltene ville rettet mismatchen uten å rette det mismatchen forårsaker. Fildiffen regnes mot den nye kilden, men sync er ingen install:

- en fil den nye kilden ikke har meldes som «deleted in source», og `--apply` fjerner den
- en fil bare den nye kilden har legges aldri til

Resultatet er hverken den gamle eller den nye kilden. `install` gjør dette riktig, med foreldreløse filer og det hele, så sync viser dit. Det er også regelen `syncPakkePin` allerede har: «sync updates the pinned source; switching sources is an install».

Et scope uten registrert kilde slipper gjennom. Det er adopsjonsstien (B3), og der finnes ingen kilde å bytte fra.

## #692 «hold your own edits» påsto noe porten ikke kan vite

Statusen sier at innholdet avviker fra hashen nav-pilot noterte. Den sier ingenting om hvem som endret det.

Det er ikke pedanteri. 23 filer ble meldt slik på min maskin, ingen av dem redigert; de var installert fra en eldre revisjon og inneholdt agenthåndtak pensjonert i #481. Den som vet at hen ikke har rørt filene avviser forklaringen som umulig, og eneste utvei meldingen tilbyr er `--apply` — som med en gammel pinne skriver eldre filer over nyere.

Samme påstand sto i install (`locally modified`), der den er like feil av samme grunn. Begge sier nå at fila avviker fra det nav-pilot installerte.

Nedgraderingsvarselet jeg først skisserte er droppet med vilje: med #691 på plass flytter sync bare pinnen innenfor én kilde, så «eldre» krever en force-push, og å oppdage det krever ancestry som depth-1-fetchen ikke har.

## Testen fanget seg selv i å være tom

Enhetstestene kaller `refuseSourceSwitch` direkte. Med vakten fjernet fra `syncScope` var de fortsatt grønne, altså blinde for den faktiske feilen.

Wiring-testen går derfor gjennom `cmdSync`. Første forsøk hektet `resolveSource` og var grønt med vakten borte, fordi sync bruker `resolveSourceForSync`. Rettet seam, og kontrollen sier nå det den skal:

```
--- FAIL: TestRefuseSourceSwitch/cmdSync_refuses_before_it_resolves
    refusal "resolved-anyway" does not name install as the way to switch
```

Testen krever også at nektelsen kommer *før* resolvingen. En kildebytte som kloner først har allerede betalt for svaret den er i ferd med å nekte.

`mise run check` er grønn.
