### PR TITLE
fix(agents): Claude Sonnet 4.6 finnes ikke lenger, tre agenter repinnes

### DIFF
--- a/agents/accessibility.agent.md
+++ b/agents/accessibility.agent.md
@@ -1,7 +1,7 @@
 ---
 name: accessibility-agent
 description: WCAG 2.1/2.2, universell utforming, Aksel-tilgjengelighet og automatisert UU-testing
-model: Claude Sonnet 4.6
+model: Claude Sonnet 5
 tools:
   - execute
   - read

--- a/agents/aksel.agent.md
+++ b/agents/aksel.agent.md
@@ -1,7 +1,7 @@
 ---
 name: aksel-agent
 description: Ekspert på Navs Aksel designsystem (v8+) — bygger og refaktorerer UI med @navikt/ds-react, tokens, layout-primitives, theming, versjon/migrering og tilgjengelighet, og oversetter Figma-design til Aksel-kode. Drevet av aksel-builder-skillen og Aksel MCP som fasit.
-model: Claude Sonnet 4.6
+model: Claude Sonnet 5
 tools:
   - execute
   - read

--- a/agents/forfatter.agent.md
+++ b/agents/forfatter.agent.md
@@ -1,7 +1,7 @@
 ---
 name: forfatter
 description: "Norsk teknisk redaktør, tekstforfatter eller innholdsdesigner: klarspråk, AI-markører, anglisismer, fagtermer, mikrotekst."
-model: Claude Sonnet 4.6
+model: Claude Sonnet 5
 tools:
   - read
   - edit

--- a/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
+++ b/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
@@ -16,7 +16,7 @@
         "ui"
       ],
       "filePath": "agents/accessibility.agent.md",
-      "contentHash": "fa2f415a551dcdc45c3f3eb8079f83e9131ff9222c4b412dd8ad26884195f766",
+      "contentHash": "db12f2f3d0734ca4244b5f9aea6ef1a73edb94cc77c2cd0ba85d897c768a631a",
       "useCases": [
         "Converting Tailwind to Aksel tokens",
         "Responsive layouts"
@@ -38,7 +38,7 @@
         "ui"
       ],
       "filePath": "agents/aksel.agent.md",
-      "contentHash": "a85a02b7740368a92ca293e01b8dfaab97203609008deec2c31a8f29bdf759b1",
+      "contentHash": "6b14f77aa95b4b834f6dcc39a950e7876e962b13a8484ccae85a642aee29d45c",
       "useCases": [
         "Converting Tailwind to Aksel tokens",
         "Responsive layouts"
@@ -75,7 +75,7 @@
       "displayName": "@forfatter",
       "description": "Norsk teknisk redaktør, tekstforfatter eller innholdsdesigner: klarspråk, AI-markører, anglisismer, fagtermer, mikrotekst.",
       "filePath": "agents/forfatter.agent.md",
-      "contentHash": "64b2deb8108f8964b636ee4ba82e43183bb2fd7045d24a7ab1052585e1ddaa36",
+      "contentHash": "48c56daf3992a30e3e4ba180869f8af3a7e449c9d248883bab3600944f7731f0",
       "useCases": [
         "Creating .nais/app.yaml manifests",
         "Adding PostgreSQL/Kafka",

--- a/apps/my-copilot/src/lib/copilot-manifest.json
+++ b/apps/my-copilot/src/lib/copilot-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-09-07T13:23:52.962Z",
+  "generatedAt": "2026-09-07T14:07:05.440Z",
   "items": [
     {
       "id": "accessibility-agent",
@@ -10,7 +10,7 @@
       "domain": "frontend",
       "filePath": ".github/agents/accessibility.agent.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/agents/accessibility.agent.md",
-      "contentHash": "fa2f415a551dcdc45c3f3eb8079f83e9131ff9222c4b412dd8ad26884195f766",
+      "contentHash": "db12f2f3d0734ca4244b5f9aea6ef1a73edb94cc77c2cd0ba85d897c768a631a",
       "installUrl": "/install/agent?url=vscode%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fagents%2Faccessibility.agent.md",
       "insidersInstallUrl": "/install/agent?url=vscode-insiders%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fagents%2Faccessibility.agent.md",
       "tools": [
@@ -24,7 +24,7 @@
         "com.figma/figma-mcp/get_design_context",
         "com.figma/figma-mcp/get_screenshot"
       ],
-      "model": ["Claude Sonnet 4.6"],
+      "model": ["Claude Sonnet 5"],
       "tags": ["wcag", "a11y", "universell-utforming", "aksel", "aria"],
       "examples": [
         "Sjekk denne komponenten for tilgjengelighetsfeil",
@@ -42,7 +42,7 @@
       "domain": "frontend",
       "filePath": ".github/agents/aksel.agent.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/agents/aksel.agent.md",
-      "contentHash": "a85a02b7740368a92ca293e01b8dfaab97203609008deec2c31a8f29bdf759b1",
+      "contentHash": "6b14f77aa95b4b834f6dcc39a950e7876e962b13a8484ccae85a642aee29d45c",
       "installUrl": "/install/agent?url=vscode%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fagents%2Faksel.agent.md",
       "insidersInstallUrl": "/install/agent?url=vscode-insiders%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fagents%2Faksel.agent.md",
       "tools": [
@@ -73,7 +73,7 @@
         "io.github.navikt/github-mcp/get_latest_release",
         "io.github.navikt/github-mcp/list_releases"
       ],
-      "model": ["Claude Sonnet 4.6"],
+      "model": ["Claude Sonnet 5"],
       "tags": [
         "aksel",
         "design-system",
@@ -163,7 +163,7 @@
       "domain": "general",
       "filePath": ".github/agents/forfatter.agent.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/agents/forfatter.agent.md",
-      "contentHash": "64b2deb8108f8964b636ee4ba82e43183bb2fd7045d24a7ab1052585e1ddaa36",
+      "contentHash": "48c56daf3992a30e3e4ba180869f8af3a7e449c9d248883bab3600944f7731f0",
       "installUrl": "/install/agent?url=vscode%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fagents%2Fforfatter.agent.md",
       "insidersInstallUrl": "/install/agent?url=vscode-insiders%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fagents%2Fforfatter.agent.md",
       "tools": [
@@ -174,7 +174,7 @@
         "io.github.navikt/github-mcp/get_file_contents",
         "io.github.navikt/github-mcp/search_code"
       ],
-      "model": ["Claude Sonnet 4.6"],
+      "model": ["Claude Sonnet 5"],
       "tags": ["norsk", "teknisk-skriving", "redigering", "språk", "klarspråk", "ai-markører"],
       "examples": [
         {

--- a/cli/nav-pilot/internal/cli/config_cmd.go
+++ b/cli/nav-pilot/internal/cli/config_cmd.go
@@ -245,7 +245,7 @@ version = 1
 # source = "navikt/copilot"
 
 # Model id. Common Copilot models: auto, claude-opus-5, claude-sonnet-5,
-# claude-sonnet-4.6, claude-haiku-4.5, claude-opus-4.8, claude-opus-4.7,
+# claude-haiku-4.5, claude-opus-4.8, claude-opus-4.7,
 # gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5.4, gpt-5.3-codex,
 # gpt-5.4-mini, gpt-5-mini, gemini-3.6-flash, gemini-3.5-flash,
 # kimi-k2.7-code, kimi-k3.

--- a/docs/modellvalg.md
+++ b/docs/modellvalg.md
@@ -146,15 +146,22 @@ anslag, ikke noe vi har målt**, og forholdet varierer med oppgaven.
 ### Hva som ikke flyttes hit
 
 - `@code-review` og `@accessibility` står igjen på henholdsvis GPT-5.3-Codex og
-  Claude Sonnet 4.6. De ble opprinnelig foreslått til Luna som lesende
+  Anthropic-modellen sin. De ble opprinnelig foreslått til Luna som lesende
   mønsteranvendere, men det stemmer ikke: `@code-review` har `execute`, og
-  `@accessibility` har `execute`, `edit` og `runSubagent`. De kjører altså
-  kommandoer, skriver filer og starter underagenter. GitHub plasserer Luna i
-  Lightweight-klassen, og målingen dekket bare nav-pilot-personaen, aldri en
-  verktøytung agent. Byttet er derfor ubelagt og måles separat.
-- `@forfatter` beholder Claude Sonnet 4.6. Jobben er å skille bokmål fra
+  `@accessibility` har `execute` og `edit`. De kjører altså kommandoer og
+  skriver filer. GitHub plasserer Luna i Lightweight-klassen, og målingen dekket
+  bare nav-pilot-personaen, aldri en verktøytung agent. Byttet er derfor ubelagt
+  og måles separat.
+- `@forfatter` beholder Anthropic-modellen sin. Jobben er å skille bokmål fra
   nynorsk og luke ut norske AI-markører. Målingen sier ingenting om det, og
   gevinsten er nær null mot en kjent nedside.
+
+> To rettelser i ettertid, som ikke endrer beslutningen over. Modellen disse tre
+> sto på het Claude Sonnet 4.6; den er trukket tilbake av GitHub og pinnene er
+> flyttet til Claude Sonnet 5 (#715). Og `@accessibility` hadde aldri
+> `runSubagent`: navnet er ikke et verktøy noen klient kjenner, så grantet var en
+> stille null og er fjernet (#689). Argumentet står likevel, siden `execute` og
+> `edit` alene gjør agenten verktøytung.
 - Resten av GPT-5.3-Codex-pinningene står urørt. Å flytte dem er en egen
   beslutning som denne målingen ikke gir grunnlag for.
 

--- a/docs/modellvalg.md
+++ b/docs/modellvalg.md
@@ -19,9 +19,9 @@ De fleste agenter og prompts har et eksplisitt `model:`-felt i YAML-frontmatter.
 | `@kafka` | GPT-5.3-Codex | Teknisk presis på hendelsesdrevne mønstre |
 | `@research` | GPT-5.6 Luna | Leser og søker uten å skrive kode. Luna er omtrent en tiendedel av Codex i listepris. Gjelder bare når agenten startes direkte, ikke når `@nav-pilot` delegerer til den |
 | `@rust` | GPT-5.3-Codex | Terminal-Bench-leder for kompilert kode |
-| `@aksel` | Claude Sonnet 4.6 | Sterk på komponentstruktur og designsystem-konvensjoner |
-| `@accessibility` | Claude Sonnet 4.6 | God på WCAG-tolkning og semantisk HTML |
-| `@forfatter` | Claude Sonnet 4.6 | Anthropic-modellene er best på norsk klarspråk |
+| `@aksel` | Claude Sonnet 5 | Sterk på komponentstruktur og designsystem-konvensjoner |
+| `@accessibility` | Claude Sonnet 5 | God på WCAG-tolkning og semantisk HTML |
+| `@forfatter` | Claude Sonnet 5 | Anthropic-modellene er best på norsk klarspråk |
 
 ### Prompts
 

--- a/docs/nav-pilot-changelog.md
+++ b/docs/nav-pilot-changelog.md
@@ -4,6 +4,12 @@ Endringslogg for nav-pilot agent harness — agenter, skills, instruksjoner, pro
 
 ## 2026-09-07
 
+### Claude Sonnet 4.6 finnes ikke lenger
+
+- **`@aksel`, `@accessibility` og `@forfatter` er repinnet til Claude Sonnet 5**: Copilot CLI avviser den gamle id-en, med "Model 'Claude Sonnet 4.6' is not available" og en liste over hva som finnes. Agentene feilet altså ved oppstart, ikke ved bruk. Sonnet 5 er etterfølgeren og koster $2.00 / $10.00 mot 4.6-ens $3.00 / $15.00 i listepris, så begrunnelsene i modellvalg.md står uendret.
+- **Modellvelgeren tilbyr fortsatt modeller klienten avviser**: Katalogen genereres fra models.dev, som er global, mens tilgjengeligheten er knyttet til konto og plan. På maskinen dette ble målt på mangler 14 av oppføringene i den levende katalogen. `PINNED` i generatoren dekker det motsatte tilfellet, en modell som er tatt av prislista men fortsatt starter. Ingen oppføringer er fjernet på grunnlag av én konto; avviket er beskrevet i eget issue.
+
+
 ### Subagenter arver modellen, og pinnen leses ikke
 
 - **`model:` i frontmatteren gjelder bare når agenten startes direkte**: Startet som subagent arver den forelderens modell. Målt begge veier med samme agent: `--model gpt-5.6-terra` ga `● Research (model: gpt-5.6-terra)`, `--model gpt-5.6-sol` ga `● Research (model: gpt-5.6-sol)`. Pinnen sier `gpt-5.6-luna`. Konsekvensen er at modellen `@nav-pilot` kjører på i praksis er modellen for hele delegeringstreet, og at modellporten bytter persona ved eskalering, ikke modell (#688).


### PR DESCRIPTION
`@aksel`, `@accessibility` og `@forfatter` var pinnet til `Claude Sonnet 4.6`. Copilot CLI avviser id-en:

```
Model 'Claude Sonnet 4.6' is not available. Available models: claude-sonnet-5,
claude-opus-5, claude-opus-4.8, gpt-6-astra, gpt-5.6-sol, gpt-5.6-terra, ...
```

Agentene feilet altså ved oppstart, ikke ved bruk, som er den varianten ingen oppdager før noen prøver.

Sonnet 5 er etterfølgeren og koster $2.00 / $10.00 mot 4.6-ens $3.00 / $15.00 i listepris, så begrunnelsene i `modellvalg.md` står uendret: komponentstruktur for aksel, WCAG-tolkning for accessibility, norsk klarspråk for forfatter.

Hjelpeteksten i `nav-pilot config` listet også den døde id-en blant «Common Copilot models». Fjernet der.

## Hva denne PR-en bevisst ikke gjør

Modellvelgeren tilbyr fortsatt modeller klienten avviser. Målt ved å hente den levende katalogen ut av CLI-ens egen debug-logg og sammenlikne med `known_models_gen.go`:

```
i vår velger, ikke i klientens katalog:
  claude-fable-5, claude-fable-5.1, claude-haiku-4.5, claude-opus-4.6,
  claude-opus-4.7, claude-sonnet-4.6, gemini-3.5-flash, gemini-3.6-flash,
  gemini-3.7-flash, gpt-5.4, gpt-5.5, grok-4.5, grok-4.6, mai-code-1-flash-picker
```

14 oppføringer, `auto` holdt utenfor siden den er en pseudo-modell og pinnet med vilje.

Ingen av dem er fjernet her, og det er et bevisst valg: katalogen genereres fra models.dev, som er global, mens tilgjengelighet henger på konto og plan. `gpt-5.6-sol` krever for eksempel Pro+. En modell som mangler på min maskin kan være tilgjengelig for en annen utvikler, og å beskjære velgeren etter én måling ville tatt fra dem noe som virker.

`claude-sonnet-4.6` er unntaket fordi den har to uavhengige bevis: klientens egen feilmelding, og fravær fra katalogen.

Verdt å merke seg for den som ser på dette videre: generatorens `PINNED` finnes for det motsatte tilfellet, en modell tatt av prislista som fortsatt starter (`claude-opus-4.6` står der nå, og den er også borte fra katalogen). Det finnes ingen mekanisme for «i katalogen, men avvist av klienten». Beskrevet i eget issue framfor å bygges her.

`mise run check` er grønn.
