### PR TITLE
feat(doctor): spør klienten hvilke modeller kontoen faktisk kan starte

### DIFF
--- a/cli/nav-pilot/internal/cli/doctor.go
+++ b/cli/nav-pilot/internal/cli/doctor.go
@@ -233,6 +233,16 @@ func cmdDoctor() error {
 	}
 	fmt.Println()
 
+	// 3b. Model pins
+	//
+	// Asks the client which models this account can launch, rather than
+	// trusting the generated picker: availability is per account and per plan,
+	// and the picker is generated from a global catalogue (#717). Warn-only,
+	// and an unanswerable question says so.
+	fmt.Printf("[i] Model pins\n")
+	reportModelPins()
+	fmt.Println()
+
 	// 4. Project Security
 	fmt.Printf("[i] Project Security (.cplt.toml)\n")
 	if cpltPath != "" {

--- a/cli/nav-pilot/internal/cli/doctor_models.go
+++ b/cli/nav-pilot/internal/cli/doctor_models.go
@@ -1,0 +1,240 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/domain"
+	"github.com/navikt/copilot/cli/nav-pilot/internal/source"
+)
+
+// The client's model catalogue is per account and per plan, so a curated list
+// in this repo can only ever be a guess about someone else's entitlement
+// (#717). `known_models_gen.go` is generated from models.dev, which is global:
+// it offered `claude-sonnet-4.6` for days after GitHub withdrew it, and three
+// agents pinned to it failed at launch rather than at use (#715).
+//
+// So doctor asks the client instead of consulting a list.
+//
+// The probe is a launch that is designed to fail: `--model` with a sentinel the
+// catalogue cannot contain. The client fetches the catalogue, rejects the
+// model, and exits before running a completion, so it costs no AI credits
+// (measured: the run prints no credits line). Debug logging puts the catalogue
+// on disk, in a directory this process owns and removes.
+//
+// Everything here is warn-only. nav-pilot does not control the catalogue, and a
+// developer who is offline, unauthenticated, or on a client that stops writing
+// this log must get "could not check" rather than a red cross or, worse, a
+// green tick that checked nothing. Same discipline as the cplt version skew.
+
+// modelProbeSentinel is the model id the probe asks for. It has to be a value
+// the catalogue can never hold and the client's own flag validation will not
+// reject before the fetch: the shape is legal, the name is not real.
+const modelProbeSentinel = "nav-pilot-model-probe"
+
+// modelProbeTimeout bounds the catalogue probe. It fetches over the network, so
+// it needs more room than the local version checks: measured at 2.3s, given 15
+// to survive a slow link without hanging a health check.
+const modelProbeTimeout = 15 * time.Second
+
+// chatModelID matches an id inside a chat-model record in the client's debug
+// log. The log holds the catalogue as escaped JSON on one line, so this reads
+// the `"type":"chat"` marker and then the id that follows it within the same
+// record. Anchoring on the type is what keeps embedding models out: they carry
+// the same id shape and would otherwise be reported as available chat models.
+//
+// Derived from a real log (Copilot CLI 1.0.83-4), not from the documented
+// shape: 29 chat models matched, zero embedding ids leaked.
+var chatModelID = regexp.MustCompile(`type\\?":\\?"chat\\?".{0,60}?id\\?":\\?"([a-zA-Z0-9._-]+)`)
+
+// clientChatModels asks the client which chat models this account can launch.
+//
+// A nil slice means the question could not be answered, which is different from
+// an empty catalogue and is reported differently. The bool says which.
+func clientChatModels(copilotPath string) ([]string, bool) {
+	logDir, err := os.MkdirTemp("", "nav-pilot-models-")
+	if err != nil {
+		return nil, false
+	}
+	defer os.RemoveAll(logDir)
+
+	// The error is expected: the sentinel is rejected by design. What matters is
+	// whether the catalogue reached the log on the way there.
+	//
+	// Its own deadline, not cpltCommandTimeout. That one is 2s, tuned for `cplt
+	// --version`, and this probe measured 2.3s on the machine it was written on:
+	// under the shared budget it was killed just before writing the log, and
+	// doctor reported "could not read the catalogue" every time. A network round
+	// trip needs room that a local version string does not.
+	ctx, cancel := context.WithTimeout(context.Background(), modelProbeTimeout)
+	defer cancel()
+	_ = exec.CommandContext(ctx, copilotPath,
+		"--log-level", "debug", "--log-dir", logDir,
+		"--model", modelProbeSentinel, "-p", "probe").Run()
+
+	entries, err := os.ReadDir(logDir)
+	if err != nil {
+		return nil, false
+	}
+	seen := map[string]bool{}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(logDir, e.Name()))
+		if err != nil {
+			continue
+		}
+		for _, m := range chatModelID.FindAllSubmatch(data, -1) {
+			seen[string(m[1])] = true
+		}
+	}
+	if len(seen) == 0 {
+		return nil, false
+	}
+	ids := make([]string, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids, true
+}
+
+// pinnedModel is one agent's model pin, as installed.
+type pinnedModel struct {
+	Agent string
+	Label string // as written in frontmatter
+	ID    string // resolved Copilot id, or "" when the label resolves to nothing
+}
+
+// installedModelPins reads the model pin of every agent installed in a scope.
+// An agent with no pin inherits the client's model and is not listed: there is
+// nothing that can be stale.
+func installedModelPins(scope *InstallScope) []pinnedModel {
+	dir := scope.DstPath(source.KindAgent.Dir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var pins []pinnedModel
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), source.KindAgent.Suffix) {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		label := frontmatterModel(data)
+		if label == "" {
+			continue
+		}
+		id := strings.TrimPrefix(domain.OpenCodeModelForLabel(label), domain.OpenCodeProviderPrefix)
+		pins = append(pins, pinnedModel{
+			Agent: strings.TrimSuffix(e.Name(), source.KindAgent.Suffix),
+			Label: label,
+			ID:    id,
+		})
+	}
+	sort.Slice(pins, func(i, j int) bool { return pins[i].Agent < pins[j].Agent })
+	return pins
+}
+
+// frontmatterModelLine reads the `model:` key out of YAML frontmatter without
+// pulling in a YAML parser for one field. It stops at the closing delimiter so
+// a `model:` inside the prose body is never mistaken for a pin.
+var frontmatterModelLine = regexp.MustCompile(`(?m)^model:[ \t]*(.+?)[ \t]*$`)
+
+func frontmatterModel(data []byte) string {
+	text := string(data)
+	if !strings.HasPrefix(text, "---") {
+		return ""
+	}
+	end := strings.Index(text[3:], "\n---")
+	if end < 0 {
+		return ""
+	}
+	m := frontmatterModelLine.FindStringSubmatch(text[:end+3])
+	if m == nil {
+		return ""
+	}
+	return strings.Trim(strings.TrimSpace(m[1]), `"'`)
+}
+
+// unavailablePins returns the pins the client cannot launch, given the
+// catalogue it reported. A label that resolves to no known id is included too:
+// the client is asked for the label verbatim in that case, and a name the
+// catalogue does not carry fails the same way.
+func unavailablePins(pins []pinnedModel, catalogue []string) []pinnedModel {
+	have := make(map[string]bool, len(catalogue))
+	for _, id := range catalogue {
+		have[strings.ToLower(id)] = true
+	}
+	var bad []pinnedModel
+	for _, p := range pins {
+		want := p.ID
+		if want == "" {
+			want = p.Label
+		}
+		if !have[strings.ToLower(want)] {
+			bad = append(bad, p)
+		}
+	}
+	return bad
+}
+
+// reportModelPins prints the model-pin section of doctor.
+//
+// It never sets hasErrors. A stale pin is worth saying out loud, but nav-pilot
+// neither owns the catalogue nor the agent files a user may have written
+// themselves, and failing the whole health check over someone else's
+// entitlement would teach people to ignore the exit code.
+func reportModelPins() {
+	scope, err := ScopeUser()
+	if err != nil {
+		fmt.Printf("    %s Could not resolve the user scope: %v\n", dim("-"), err)
+		return
+	}
+	pins := installedModelPins(scope)
+	if len(pins) == 0 {
+		fmt.Printf("    %s No installed agent pins a model (all inherit the client's)\n", green("✓"))
+		return
+	}
+
+	copilotPath, _ := exec.LookPath("copilot")
+	if copilotPath == "" {
+		fmt.Printf("    %s %d agent(s) pin a model; Copilot CLI is not on PATH, so availability was not checked\n",
+			dim("-"), len(pins))
+		return
+	}
+
+	catalogue, ok := clientChatModels(copilotPath)
+	if !ok {
+		// Offline, unauthenticated, or a client that no longer writes the
+		// catalogue to its debug log. "Unknown" and never "fine".
+		fmt.Printf("    %s %d agent(s) pin a model; could not read the client's model catalogue\n",
+			dim("-"), len(pins))
+		return
+	}
+
+	bad := unavailablePins(pins, catalogue)
+	if len(bad) == 0 {
+		fmt.Printf("    %s All %d pinned model(s) are available to this account\n", green("✓"), len(pins))
+		return
+	}
+	fmt.Printf("    %s %d of %d pinned model(s) are not available to this account\n",
+		yellow("⚠"), len(bad), len(pins))
+	for _, p := range bad {
+		fmt.Printf("      %s %s pins %q\n", yellow("⚠"), p.Agent, p.Label)
+	}
+	fmt.Printf("      %s The client launches these agents with a model it will reject. Repin them, or\n",
+		yellow("Solution:"))
+	fmt.Printf("          run %s to take the current pins from the source.\n", bold("nav-pilot sync --apply"))
+}

--- a/cli/nav-pilot/internal/cli/doctor_models.go
+++ b/cli/nav-pilot/internal/cli/doctor_models.go
@@ -168,26 +168,33 @@ func frontmatterModel(data []byte) string {
 	return strings.Trim(strings.TrimSpace(m[1]), `"'`)
 }
 
-// unavailablePins returns the pins the client cannot launch, given the
-// catalogue it reported. A label that resolves to no known id is included too:
-// the client is asked for the label verbatim in that case, and a name the
-// catalogue does not carry fails the same way.
-func unavailablePins(pins []pinnedModel, catalogue []string) []pinnedModel {
+// classifyPins splits pins into the ones the client cannot launch and the ones
+// this check cannot speak for.
+//
+// The catalogue is a list of ids. A pin whose label resolves to a known id can
+// be compared against it and answered. A label that resolves to nothing cannot:
+// comparing the display label against an id list would report "not available to
+// this account" for every label the picker has not learned yet, which includes
+// every model GitHub adds before the next `mise run models:sync`. That is a
+// different claim, and a wrong one.
+//
+// So an unresolvable label is reported as unverified rather than as broken. It
+// is still worth printing: the client resolves the label itself, so a typo
+// there fails at launch, and nothing else in doctor would mention it.
+func classifyPins(pins []pinnedModel, catalogue []string) (unavailable, unverified []pinnedModel) {
 	have := make(map[string]bool, len(catalogue))
 	for _, id := range catalogue {
 		have[strings.ToLower(id)] = true
 	}
-	var bad []pinnedModel
 	for _, p := range pins {
-		want := p.ID
-		if want == "" {
-			want = p.Label
-		}
-		if !have[strings.ToLower(want)] {
-			bad = append(bad, p)
+		switch {
+		case p.ID == "":
+			unverified = append(unverified, p)
+		case !have[strings.ToLower(p.ID)]:
+			unavailable = append(unavailable, p)
 		}
 	}
-	return bad
+	return unavailable, unverified
 }
 
 // reportModelPins prints the model-pin section of doctor.
@@ -224,17 +231,30 @@ func reportModelPins() {
 		return
 	}
 
-	bad := unavailablePins(pins, catalogue)
-	if len(bad) == 0 {
+	unavailable, unverified := classifyPins(pins, catalogue)
+	if len(unavailable) == 0 && len(unverified) == 0 {
 		fmt.Printf("    %s All %d pinned model(s) are available to this account\n", green("✓"), len(pins))
 		return
 	}
-	fmt.Printf("    %s %d of %d pinned model(s) are not available to this account\n",
-		yellow("⚠"), len(bad), len(pins))
-	for _, p := range bad {
-		fmt.Printf("      %s %s pins %q\n", yellow("⚠"), p.Agent, p.Label)
+	if len(unavailable) > 0 {
+		fmt.Printf("    %s %d of %d pinned model(s) are not available to this account\n",
+			yellow("⚠"), len(unavailable), len(pins))
+		for _, p := range unavailable {
+			fmt.Printf("      %s %s pins %q\n", yellow("⚠"), p.Agent, p.Label)
+		}
+		fmt.Printf("      %s The client launches these agents with a model it will reject. Repin them, or\n",
+			yellow("Solution:"))
+		fmt.Printf("          run %s to take the current pins from the source.\n", bold("nav-pilot sync --apply"))
 	}
-	fmt.Printf("      %s The client launches these agents with a model it will reject. Repin them, or\n",
-		yellow("Solution:"))
-	fmt.Printf("          run %s to take the current pins from the source.\n", bold("nav-pilot sync --apply"))
+	if len(unverified) > 0 {
+		// Not a warning. The label may name a model this binary's picker has not
+		// learned yet, which is the ordinary state of affairs between catalogue
+		// syncs, and calling that "unavailable" would cry wolf on every new model.
+		fmt.Printf("    %s %d pinned model(s) could not be checked: the label is not one nav-pilot knows,\n",
+			dim("-"), len(unverified))
+		fmt.Printf("        so the client resolves it alone\n")
+		for _, p := range unverified {
+			fmt.Printf("      %s %s pins %q\n", dim("-"), p.Agent, p.Label)
+		}
+	}
 }

--- a/cli/nav-pilot/internal/cli/doctor_models_test.go
+++ b/cli/nav-pilot/internal/cli/doctor_models_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/source"
 )
 
 func TestFrontmatterModel(t *testing.T) {
@@ -32,24 +34,32 @@ func TestFrontmatterModel(t *testing.T) {
 	}
 }
 
-func TestUnavailablePins(t *testing.T) {
+func TestClassifyPins(t *testing.T) {
 	catalogue := []string{"claude-sonnet-5", "gpt-5.6-sol"}
 	pins := []pinnedModel{
 		{Agent: "ok-label", Label: "Claude Sonnet 5", ID: "claude-sonnet-5"},
 		{Agent: "dead", Label: "Claude Sonnet 4.6", ID: "claude-sonnet-4.6"},
-		// A label the picker does not know resolves to no id, so the client is
-		// asked for the label verbatim and fails the same way. Reported, not
-		// skipped: skipping would hide exactly the pin most likely to be wrong.
+		// A label the picker has not learned resolves to no id. The catalogue is
+		// a list of ids, so there is nothing to compare it against: reporting it
+		// as unavailable would cry wolf on every model GitHub adds before the
+		// next models:sync. Unverified is a different claim, and the true one.
 		{Agent: "unknown-label", Label: "Fantasimodell 9", ID: ""},
 		{Agent: "case", Label: "GPT-5.6 Sol", ID: "GPT-5.6-SOL"},
 	}
-	got := unavailablePins(pins, catalogue)
-	var names []string
-	for _, p := range got {
-		names = append(names, p.Agent)
+	unavailable, unverified := classifyPins(pins, catalogue)
+
+	names := func(ps []pinnedModel) []string {
+		var out []string
+		for _, p := range ps {
+			out = append(out, p.Agent)
+		}
+		return out
 	}
-	if want := []string{"dead", "unknown-label"}; !reflect.DeepEqual(names, want) {
-		t.Errorf("unavailablePins = %v, want %v", names, want)
+	if want := []string{"dead"}; !reflect.DeepEqual(names(unavailable), want) {
+		t.Errorf("unavailable = %v, want %v", names(unavailable), want)
+	}
+	if want := []string{"unknown-label"}; !reflect.DeepEqual(names(unverified), want) {
+		t.Errorf("unverified = %v, want %v", names(unverified), want)
 	}
 }
 
@@ -59,7 +69,7 @@ func TestInstalledModelPins(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dir := scope.DstPath("agents")
+	dir := scope.DstPath(source.KindAgent.Dir)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatal(err)
 	}

--- a/cli/nav-pilot/internal/cli/doctor_models_test.go
+++ b/cli/nav-pilot/internal/cli/doctor_models_test.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestFrontmatterModel(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+		want string
+	}{
+		{"plain pin", "---\nname: a\nmodel: Claude Sonnet 5\n---\n\nbody\n", "Claude Sonnet 5"},
+		{"quoted pin", "---\nmodel: \"GPT-5.6 Sol\"\n---\n", "GPT-5.6 Sol"},
+		{"no pin means inherit", "---\nname: a\ntools:\n  - read\n---\n\nbody\n", ""},
+		{"not frontmatter at all", "# Overskrift\n\nmodel: noe\n", ""},
+		// The reason this reads the delimiter rather than grepping the file: a
+		// persona that discusses model choice in its prose must not be read as
+		// pinning one.
+		{"model: in the body is not a pin", "---\nname: a\n---\n\nmodel: Claude Sonnet 5\n", ""},
+		{"unterminated frontmatter", "---\nmodel: Claude Sonnet 5\n", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := frontmatterModel([]byte(tt.doc)); got != tt.want {
+				t.Errorf("frontmatterModel = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnavailablePins(t *testing.T) {
+	catalogue := []string{"claude-sonnet-5", "gpt-5.6-sol"}
+	pins := []pinnedModel{
+		{Agent: "ok-label", Label: "Claude Sonnet 5", ID: "claude-sonnet-5"},
+		{Agent: "dead", Label: "Claude Sonnet 4.6", ID: "claude-sonnet-4.6"},
+		// A label the picker does not know resolves to no id, so the client is
+		// asked for the label verbatim and fails the same way. Reported, not
+		// skipped: skipping would hide exactly the pin most likely to be wrong.
+		{Agent: "unknown-label", Label: "Fantasimodell 9", ID: ""},
+		{Agent: "case", Label: "GPT-5.6 Sol", ID: "GPT-5.6-SOL"},
+	}
+	got := unavailablePins(pins, catalogue)
+	var names []string
+	for _, p := range got {
+		names = append(names, p.Agent)
+	}
+	if want := []string{"dead", "unknown-label"}; !reflect.DeepEqual(names, want) {
+		t.Errorf("unavailablePins = %v, want %v", names, want)
+	}
+}
+
+func TestInstalledModelPins(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	scope, err := ScopeUser()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := scope.DstPath("agents")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	write := func(name, body string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("pinned.agent.md", "---\nname: pinned\nmodel: Claude Sonnet 5\n---\n")
+	write("inherits.agent.md", "---\nname: inherits\n---\n")
+	write("notanagent.md", "---\nmodel: Claude Sonnet 5\n---\n")
+
+	pins := installedModelPins(scope)
+	if len(pins) != 1 {
+		t.Fatalf("installedModelPins = %+v, want exactly the one pinned agent", pins)
+	}
+	if pins[0].Agent != "pinned" || pins[0].Label != "Claude Sonnet 5" {
+		t.Errorf("pin = %+v, want agent \"pinned\" on \"Claude Sonnet 5\"", pins[0])
+	}
+	if pins[0].ID != "claude-sonnet-5" {
+		t.Errorf("pin id = %q, want the resolved Copilot id", pins[0].ID)
+	}
+}
+
+// The parser is measured against a real client debug line, not against the
+// shape the format is assumed to have. Anchoring on "type":"chat" is what keeps
+// embedding models out; without it they are reported as launchable chat models.
+func TestChatModelIDSkipsEmbeddings(t *testing.T) {
+	line := `x \"type\":\"chat\",\"id\":\"claude-sonnet-5\",y ` +
+		`\"type\":\"embeddings\",\"id\":\"text-embedding-3-small\",z ` +
+		`\"type\":\"chat\",\"id\":\"gpt-5.6-luna\",w`
+	var got []string
+	for _, m := range chatModelID.FindAllStringSubmatch(line, -1) {
+		got = append(got, m[1])
+	}
+	want := []string{"claude-sonnet-5", "gpt-5.6-luna"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("chat model ids = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Første del av #717, og den delen som lukker feilen som startet det hele.

## Problemet

Modellvelgeren genereres fra models.dev, som er global. Tilgjengelighet henger på konto og plan. Velgeren tilbød `claude-sonnet-4.6` i dagevis etter at GitHub trakk den, og tre agenter pinnet til den feilet **ved oppstart** framfor ved bruk (#715). En kuratert liste i dette repoet kan bare gjette på andres rettigheter.

Så doctor spør klienten framfor å slå opp i en liste.

## Proben

En oppstart laget for å feile: `--model` med et sentinelnavn katalogen ikke kan inneholde. Klienten henter katalogen, avviser modellen, og avslutter før den kjører noe.

Det koster ingen AI-kreditter. Målt, ikke antatt: kjøringen skriver ingen kredittlinje i det hele tatt, i motsetning til enhver kjøring som faktisk svarer.

Katalogen havner i debug-loggen, i en katalog prosessen selv oppretter og fjerner.

## To ting som var feil før de var riktige

**Tidsfristen.** Første versjon brukte `cpltCommandTimeout`, som er 2 sekunder og laget for `cplt --version`. Proben ble målt til 2,3 sekunder, altså drept rett før den skrev loggen, og doctor meldte «could not read the catalogue» hver eneste gang. Den har nå sin egen frist på 15: et nettverkskall trenger rom en lokal versjonsstreng ikke gjør.

**Embedding-modellene.** Regexen ankres på `"type":"chat"` framfor bare å plukke id-er. Uten ankeret rapporteres `text-embedding-3-small` som en startbar chat-modell. Kontrollen finnes i testen: fjern ankeret, og den blir rød med nøyaktig den id-en i lista.

## Kjørt mot en ekte installasjon

```
[i] Model pins
    ⚠ 4 of 9 pinned model(s) are not available to this account
      ⚠ accessibility pins "Claude Sonnet 4.6"
      ⚠ aksel pins "Claude Sonnet 4.6"
      ⚠ forfatter pins "Claude Sonnet 4.6"
      ⚠ nav-pilot-opus pins "Claude Opus 4.6"
```

De tre første er lokale kopier fra før #715. Den fjerde er nytt: `claude-opus-4.6` står i generatorens `PINNED`-liste med kommentaren «Delisted from GitHub's price list 2026-09-05 but still launches. Remove once it stops resolving at launch.» Den har sluttet å resolve, og ingen hadde oppdaget det.

## Warn-only, med vilje

Sjekken setter aldri `hasErrors`. nav-pilot eier hverken katalogen eller agentfilene en bruker kan ha skrevet selv, og å felle hele helsesjekken på andres rettigheter lærer folk å overse exitkoden.

Offline, uten auth, eller på en klient som slutter å skrive katalogen til loggen: den sier «vet ikke». Aldri en grønn hake som ikke har sjekket noe. Samme disiplin som cplt-versjonssjekken rett over.

## Testene er offline

Ingen av dem starter en klient. De dekker frontmatter-lesing (inkludert at `model:` i brødteksten ikke er en pinne), sammenlikningen mot katalogen (inkludert en etikett velgeren ikke kjenner, som rapporteres framfor å hoppes over), og parseren.

`mise run check` er grønn.
