### PR TITLE
feat(agentpakke): payload-manifestet får et publisert skjema

### DIFF
--- a/cli/nav-pilot/internal/agentpakke/payload.go
+++ b/cli/nav-pilot/internal/agentpakke/payload.go
@@ -1,6 +1,7 @@
 package agentpakke
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -98,6 +99,29 @@ func (r FileRecord) perm() (fs.FileMode, error) {
 // manifest. Every record is checked here, before a single file is hashed, so a
 // malformed manifest is reported as such rather than as a digest mismatch.
 func ParsePayloadManifest(data []byte) (*PayloadManifest, error) {
+	// The version gate runs before the schema, for the reason #504 U1 gave for
+	// the top-level manifest: the schema pins schemaVersion to 1, so a payload
+	// on a future version would surface as "value must be 1" and tell the author
+	// to fix a manifest that is not wrong. The party who has to act is the user,
+	// by upgrading nav-pilot.
+	var gate struct {
+		SchemaVersion *int `json:"schemaVersion"`
+	}
+	if err := json.Unmarshal(data, &gate); err == nil && gate.SchemaVersion != nil && *gate.SchemaVersion != PayloadSchemaVersion {
+		return nil, fmt.Errorf(
+			"payload manifest declares schemaVersion %d; this nav-pilot verifies payload schemaVersion %d. "+
+				"Upgrade nav-pilot (nav-pilot update) or ask the agentpakke to publish a payload manifest on a supported version",
+			*gate.SchemaVersion, PayloadSchemaVersion)
+	}
+
+	// Then the published schema, then the hand-written checks. The schema is the
+	// shape an agentpakke author lints against in their own CI, so it decides
+	// conformance; the checks below still run, because they name the offending
+	// path and the remedy in a way a schema error cannot (#704 T4).
+	if err := validatePayloadSchema(data, PayloadManifestFile); err != nil {
+		return nil, err
+	}
+
 	// Files is decoded per record below so a malformed record can name the path
 	// it belongs to; encoding/json's own error for a map value does not.
 	var doc struct {
@@ -155,10 +179,18 @@ func parseFileRecord(rel string, raw json.RawMessage) (FileRecord, error) {
 			"payload manifest lists %q, which is not a normalized payload-relative path; write it without \".\", \"..\", duplicate or trailing slashes",
 			rel)
 	}
+	// DisallowUnknownFields, so the Go side refuses exactly what the schema's
+	// additionalProperties:false refuses (#704). A stray key in a digest entry
+	// — "sha256sum", "Mode", "perm" — is far likelier a typo that silently does
+	// nothing than a deliberate extension, and this is the trust boundary. The
+	// contract's ignore-unknown rule is about the manifest's own top level, not
+	// about the records that bind the bytes.
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
 	var rec FileRecord
-	if err := json.Unmarshal(raw, &rec); err != nil {
+	if err := dec.Decode(&rec); err != nil {
 		return FileRecord{}, fmt.Errorf(
-			"payload manifest record for %q is malformed; expected {\"sha256\": …, \"mode\": …}: %w", rel, err)
+			"payload manifest record for %q is malformed; expected exactly {\"sha256\": …, \"mode\": …}: %w", rel, err)
 	}
 	if !isSHA256Hex(rec.SHA256) {
 		return FileRecord{}, fmt.Errorf(

--- a/cli/nav-pilot/internal/agentpakke/payload.go
+++ b/cli/nav-pilot/internal/agentpakke/payload.go
@@ -118,7 +118,7 @@ func ParsePayloadManifest(data []byte) (*PayloadManifest, error) {
 	// shape an agentpakke author lints against in their own CI, so it decides
 	// conformance; the checks below still run, because they name the offending
 	// path and the remedy in a way a schema error cannot (#704 T4).
-	if err := validatePayloadSchema(data, PayloadManifestFile); err != nil {
+	if err := validatePayloadSchema(data); err != nil {
 		return nil, err
 	}
 
@@ -181,7 +181,7 @@ func parseFileRecord(rel string, raw json.RawMessage) (FileRecord, error) {
 	}
 	// DisallowUnknownFields, so the Go side refuses exactly what the schema's
 	// additionalProperties:false refuses (#704). A stray key in a digest entry
-	// — "sha256sum", "Mode", "perm" — is far likelier a typo that silently does
+	// ("sha256sum", "Mode", "perm") is far likelier a typo that silently does
 	// nothing than a deliberate extension, and this is the trust boundary. The
 	// contract's ignore-unknown rule is about the manifest's own top level, not
 	// about the records that bind the bytes.

--- a/cli/nav-pilot/internal/agentpakke/payload_schema.go
+++ b/cli/nav-pilot/internal/agentpakke/payload_schema.go
@@ -1,0 +1,80 @@
+package agentpakke
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/navikt/copilot/cli/nav-pilot/schemas"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// PayloadSchemaID is the $id of the published payload manifest schema.
+const PayloadSchemaID = "https://github.com/navikt/copilot/cli/nav-pilot/schemas/agentpakke-payload-v1.json"
+
+// PayloadSchemaJSON returns the published payload schema bytes, for a caller
+// that wants to vendor or serve it. A copy, so a caller cannot mutate the
+// embedded contract.
+func PayloadSchemaJSON() []byte {
+	out := make([]byte, len(schemas.AgentpakkePayloadV1))
+	copy(out, schemas.AgentpakkePayloadV1)
+	return out
+}
+
+var (
+	payloadCompileOnce sync.Once
+	payloadCompiled    *jsonschema.Schema
+	payloadCompileErr  error
+)
+
+// payloadSchema compiles the embedded payload schema once. A compile failure is
+// a defect in this repo, not something a payload author can fix.
+func payloadSchema() (*jsonschema.Schema, error) {
+	payloadCompileOnce.Do(func() {
+		doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(schemas.AgentpakkePayloadV1))
+		if err != nil {
+			payloadCompileErr = fmt.Errorf("parsing embedded payload schema: %w", err)
+			return
+		}
+		c := jsonschema.NewCompiler()
+		if err := c.AddResource(PayloadSchemaID, doc); err != nil {
+			payloadCompileErr = fmt.Errorf("loading embedded payload schema: %w", err)
+			return
+		}
+		payloadCompiled, err = c.Compile(PayloadSchemaID)
+		if err != nil {
+			payloadCompileErr = fmt.Errorf("compiling embedded payload schema: %w", err)
+		}
+	})
+	return payloadCompiled, payloadCompileErr
+}
+
+// validatePayloadSchema checks raw payload-manifest bytes against the published
+// schema.
+//
+// It runs before the hand-written checks in [ParsePayloadManifest], not instead
+// of them. The schema is the published shape, so it is what an agentpakke
+// author lints against and what must decide whether a manifest conforms; the Go
+// checks that follow keep naming the offending path and the remedy, which a
+// schema error cannot do as well. The two must therefore agree, and the tests
+// pin the places where agreement is easy to lose: unknown keys in a file
+// record, and the path grammar.
+func validatePayloadSchema(data []byte, manifestPath string) error {
+	sch, err := payloadSchema()
+	if err != nil {
+		return err
+	}
+	inst, err := jsonschema.UnmarshalJSON(bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("payload manifest %s is not valid JSON: %w", manifestPath, err)
+	}
+	if err := sch.Validate(inst); err != nil {
+		var verr *jsonschema.ValidationError
+		if !errors.As(err, &verr) {
+			return fmt.Errorf("payload manifest %s failed schema validation: %w", manifestPath, err)
+		}
+		return schemaErrorFor(manifestPath, PayloadSchemaID, schemaViolations(verr))
+	}
+	return nil
+}

--- a/cli/nav-pilot/internal/agentpakke/payload_schema.go
+++ b/cli/nav-pilot/internal/agentpakke/payload_schema.go
@@ -53,6 +53,13 @@ func payloadSchema() (*jsonschema.Schema, error) {
 // validatePayloadSchema checks raw payload-manifest bytes against the published
 // schema.
 //
+// It names no file. [ParsePayloadManifest] takes bytes and does not know where
+// they came from: the payload manifest is at <payload>/manifest.json by
+// convention, but a client entry's `manifest` field can point anywhere, so a
+// hardcoded "manifest.json" here would be wrong exactly for the packages that
+// moved it. Every caller that has the real path already wraps the error with
+// it.
+//
 // It runs before the hand-written checks in [ParsePayloadManifest], not instead
 // of them. The schema is the published shape, so it is what an agentpakke
 // author lints against and what must decide whether a manifest conforms; the Go
@@ -60,21 +67,21 @@ func payloadSchema() (*jsonschema.Schema, error) {
 // schema error cannot do as well. The two must therefore agree, and the tests
 // pin the places where agreement is easy to lose: unknown keys in a file
 // record, and the path grammar.
-func validatePayloadSchema(data []byte, manifestPath string) error {
+func validatePayloadSchema(data []byte) error {
 	sch, err := payloadSchema()
 	if err != nil {
 		return err
 	}
 	inst, err := jsonschema.UnmarshalJSON(bytes.NewReader(data))
 	if err != nil {
-		return fmt.Errorf("payload manifest %s is not valid JSON: %w", manifestPath, err)
+		return fmt.Errorf("payload manifest is not valid JSON: %w", err)
 	}
 	if err := sch.Validate(inst); err != nil {
 		var verr *jsonschema.ValidationError
 		if !errors.As(err, &verr) {
-			return fmt.Errorf("payload manifest %s failed schema validation: %w", manifestPath, err)
+			return fmt.Errorf("payload manifest failed schema validation: %w", err)
 		}
-		return schemaErrorFor(manifestPath, PayloadSchemaID, schemaViolations(verr))
+		return schemaErrorFor("payload manifest", PayloadSchemaID, schemaViolations(verr))
 	}
 	return nil
 }

--- a/cli/nav-pilot/internal/agentpakke/payload_test.go
+++ b/cli/nav-pilot/internal/agentpakke/payload_test.go
@@ -44,15 +44,40 @@ func TestParsePayloadManifest(t *testing.T) {
 func TestParsePayloadManifestIgnoresUnknownFields(t *testing.T) {
 	// The reference generator emits generator/counts/agents/skills alongside
 	// files; they are descriptive and must not make the manifest unreadable.
+	//
+	// Top level only. The ignore-unknown rule is about the document growing new
+	// descriptive keys, not about the records that bind the bytes: see
+	// TestParsePayloadManifestRejectsUnknownRecordFields.
 	doc := payloadManifestDoc(refPayloadFiles)
 	doc["generator"] = map[string]any{"path": "scripts/generate_copilot_manifest.py", "version": 1}
 	doc["counts"] = map[string]any{"agents": 1, "skills": 0}
 	doc["agents"] = []any{"barista"}
 	doc["futureField"] = true
-	doc["files"].(map[string]any)["LICENSE"].(map[string]any)["size"] = 4
 
 	if _, err := ParsePayloadManifest(payloadManifestBytes(t, doc)); err != nil {
 		t.Fatalf("ParsePayloadManifest = %v, want nil (unknown fields must be ignored, not rejected)", err)
+	}
+}
+
+// TestParsePayloadManifestRejectsUnknownRecordFields pins the half of the
+// ignore-unknown rule that #704 narrowed. A file record binds a path to bytes
+// and a mode; a key that is not one of those cannot mean anything, and the
+// likeliest reason for one is a typo that leaves the real field absent.
+// "sha256sum" instead of "sha256" would otherwise decode to an empty digest.
+//
+// This reverses an assertion that used to live in the test above, where a
+// record carrying an extra "size" was required to parse. That was the contract
+// rule applied one level too deep.
+func TestParsePayloadManifestRejectsUnknownRecordFields(t *testing.T) {
+	doc := payloadManifestDoc(refPayloadFiles)
+	doc["files"].(map[string]any)["LICENSE"].(map[string]any)["size"] = 4
+
+	_, err := ParsePayloadManifest(payloadManifestBytes(t, doc))
+	if err == nil {
+		t.Fatal("ParsePayloadManifest = nil for a record with an unknown key, want a refusal")
+	}
+	if !strings.Contains(err.Error(), "LICENSE") {
+		t.Errorf("error %q does not name the record it refused", err)
 	}
 }
 
@@ -66,17 +91,19 @@ func TestParsePayloadManifestFailsClosed(t *testing.T) {
 		{
 			name:     "not JSON",
 			raw:      `not json at all`,
-			wantErrs: []string{"payload manifest is not a JSON object"},
+			wantErrs: []string{"payload manifest", "not valid JSON"},
 		},
 		{
+			// The schema names the offending key and its type now, where the Go
+			// decoder could only say the document was not the shape it wanted.
 			name:     "files is not an object",
 			raw:      `{"schemaVersion": 1, "files": "everything"}`,
-			wantErrs: []string{"payload manifest is not a JSON object"},
+			wantErrs: []string{"files", "want object"},
 		},
 		{
 			name:     "no files map",
 			raw:      `{"schemaVersion": 1, "target": "copilot-full-v1"}`,
-			wantErrs: []string{"no \"files\" map", "exact contents"},
+			wantErrs: []string{"files", "exact contents"},
 		},
 		{
 			name:     "unsupported schemaVersion",
@@ -86,21 +113,21 @@ func TestParsePayloadManifestFailsClosed(t *testing.T) {
 		{
 			name:     "missing schemaVersion",
 			raw:      `{"files": {}}`,
-			wantErrs: []string{"schemaVersion 0"},
+			wantErrs: []string{"missing property", "schemaVersion"},
 		},
 		{
 			name: "record is not an object",
 			patch: func(doc map[string]any) {
 				doc["files"].(map[string]any)["LICENSE"] = 7
 			},
-			wantErrs: []string{`record for "LICENSE" is malformed`},
+			wantErrs: []string{"files.LICENSE", "want object"},
 		},
 		{
 			name: "sha256 is not a digest",
 			patch: func(doc map[string]any) {
 				doc["files"].(map[string]any)["LICENSE"].(map[string]any)["sha256"] = "deadbeef"
 			},
-			wantErrs: []string{`record for "LICENSE"`, "64 lowercase hex"},
+			wantErrs: []string{"LICENSE", "64 lowercase hex"},
 		},
 		{
 			name: "sha256 in uppercase",
@@ -115,42 +142,42 @@ func TestParsePayloadManifestFailsClosed(t *testing.T) {
 			patch: func(doc map[string]any) {
 				doc["files"].(map[string]any)["scripts/hook.sh"].(map[string]any)["mode"] = "0777"
 			},
-			wantErrs: []string{`record for "scripts/hook.sh"`, `mode "0777"`},
+			wantErrs: []string{"scripts/hook.sh", "0644", "0755"},
 		},
 		{
 			name: "key escapes the payload",
 			patch: func(doc map[string]any) {
 				doc["files"].(map[string]any)["../../etc/passwd"] = fileRecordFor("x")
 			},
-			wantErrs: []string{`"../../etc/passwd"`, "escapes"},
+			wantErrs: []string{"../../etc/passwd", "not a payload-relative path"},
 		},
 		{
 			name: "absolute key",
 			patch: func(doc map[string]any) {
 				doc["files"].(map[string]any)["/etc/passwd"] = fileRecordFor("x")
 			},
-			wantErrs: []string{`"/etc/passwd"`, "absolute"},
+			wantErrs: []string{"/etc/passwd", "leading slash"},
 		},
 		{
 			name: "key with a backslash separator",
 			patch: func(doc map[string]any) {
 				doc["files"].(map[string]any)[`agents\barista.agent.md`] = fileRecordFor("x")
 			},
-			wantErrs: []string{"forward slashes"},
+			wantErrs: []string{"backslashes"},
 		},
 		{
 			name: "non-normalized key that stays inside",
 			patch: func(doc map[string]any) {
 				doc["files"].(map[string]any)["agents/../LICENSE.txt"] = fileRecordFor("x")
 			},
-			wantErrs: []string{"not a normalized payload-relative path"},
+			wantErrs: []string{"not a payload-relative path"},
 		},
 		{
 			name: "empty key",
 			patch: func(doc map[string]any) {
 				doc["files"].(map[string]any)[""] = fileRecordFor("x")
 			},
-			wantErrs: []string{"must not be empty"},
+			wantErrs: []string{"not a payload-relative path"},
 		},
 	}
 	for _, tt := range tests {
@@ -302,14 +329,14 @@ func TestVerifyPayload(t *testing.T) {
 			mutate: func(_ *testing.T, _ string, doc map[string]any) {
 				doc["files"].(map[string]any)["LICENSE"] = "adc37366"
 			},
-			wantErrs: []string{`record for "LICENSE" is malformed`},
+			wantErrs: []string{"files.LICENSE", "want object"},
 		},
 		{
 			name: "manifest lists a path outside the payload",
 			mutate: func(_ *testing.T, _ string, doc map[string]any) {
 				doc["files"].(map[string]any)["../secrets.env"] = fileRecordFor("x")
 			},
-			wantErrs: []string{`"../secrets.env"`, "escapes"},
+			wantErrs: []string{"../secrets.env", "not a payload-relative path"},
 		},
 		{
 			name: "manifest lists itself",
@@ -751,5 +778,30 @@ func assertErrMentions(t *testing.T, err error, want []string) {
 		if !strings.Contains(err.Error(), w) {
 			t.Errorf("error %q does not mention %q", err, w)
 		}
+	}
+}
+
+// TestParseFileRecordRejectsUnknownKeys tests the Go decoder directly, because
+// going through ParsePayloadManifest cannot: the schema refuses an unknown
+// record key first, so removing DisallowUnknownFields leaves every test through
+// that door green. Two layers enforce this rule and the claim is that they
+// agree, so each needs its own control.
+func TestParseFileRecordRejectsUnknownKeys(t *testing.T) {
+	good := `{"sha256":"` + strings.Repeat("a", 64) + `","mode":"0644"}`
+	if _, err := parseFileRecord("LICENSE", []byte(good)); err != nil {
+		t.Fatalf("parseFileRecord on a well-formed record = %v, want nil", err)
+	}
+
+	// An extra key on an otherwise valid record. "sha256sum" instead of
+	// "sha256" would be caught anyway, by the empty-digest check, so it cannot
+	// tell this rule from that one: the first version of this test used it and
+	// stayed green with DisallowUnknownFields removed.
+	extra := `{"sha256":"` + strings.Repeat("a", 64) + `","mode":"0644","size":4}`
+	_, err := parseFileRecord("LICENSE", []byte(extra))
+	if err == nil {
+		t.Fatal("parseFileRecord accepted an unknown key, want a refusal")
+	}
+	if !strings.Contains(err.Error(), "LICENSE") {
+		t.Errorf("error %q does not name the record", err)
 	}
 }

--- a/cli/nav-pilot/internal/agentpakke/schema.go
+++ b/cli/nav-pilot/internal/agentpakke/schema.go
@@ -98,10 +98,37 @@ func schemaError(verr *jsonschema.ValidationError) error {
 		lines = append(lines, line)
 	}
 	sort.Strings(lines)
+	return schemaErrorFor(ManifestPath, SchemaID, lines)
+}
+
+// schemaErrorFor renders the violation list for one document. Both manifests go
+// through here so a reader gets the same shape, and neither can name the other
+// one's file by accident: the payload manifest used to inherit the top-level
+// manifest's wording and told the author to fix .nav-pilot/agentpakke.json for a
+// fault in a payload tree.
+func schemaErrorFor(docPath, schemaID string, lines []string) error {
 	return fmt.Errorf(
 		"%s does not conform to the agentpakke contract (schema %s):\n%s\n"+
 			"fix the manifest, or lint it against the published schema in your own CI before pushing",
-		ManifestPath, SchemaID, strings.Join(lines, "\n"))
+		docPath, schemaID, strings.Join(lines, "\n"))
+}
+
+// schemaViolations is schemaError's list half, for a caller that renders its
+// own heading.
+func schemaViolations(verr *jsonschema.ValidationError) []string {
+	causes := leafCauses(verr, nil)
+	lines := make([]string, 0, len(causes))
+	seen := make(map[string]bool, len(causes))
+	for _, c := range causes {
+		line := "  - " + describeCause(c)
+		if seen[line] {
+			continue
+		}
+		seen[line] = true
+		lines = append(lines, line)
+	}
+	sort.Strings(lines)
+	return lines
 }
 
 // leafCauses flattens a ValidationError tree to its most specific failures;
@@ -120,6 +147,32 @@ func leafCauses(verr *jsonschema.ValidationError, acc []*jsonschema.ValidationEr
 func describeCause(c *jsonschema.ValidationError) string {
 	loc := instanceLocation(c.InstanceLocation)
 	msg := strings.TrimSpace(c.ErrorKind.LocalizedString(errPrinter))
+	// A pattern failure renders the whole regex, which for the payload path
+	// grammar is forty characters of escaped RE2 and tells an author nothing
+	// they can act on. The rule it encodes is one sentence, so say the sentence.
+	// Without this, "../secrets.env" reported a regex dump where it used to say
+	// the path escapes the payload (#704).
+	// A pattern failure renders the whole regex. For the payload path grammar
+	// that is forty characters of escaped RE2 and tells an author nothing they
+	// can act on, so those two patterns get the sentence they encode instead.
+	//
+	// Keyed on the schema definition that failed, not on the message or the
+	// field name. Two earlier versions were keyed more loosely and both
+	// misfired: the first rewrote every pattern failure, so an invalid sha256
+	// said a digest "is not a payload-relative path"; the second still caught
+	// the top-level manifest's `name`, which has its own pattern and its own
+	// hint (#704).
+	if i := strings.Index(msg, "does not match pattern"); i >= 0 {
+		value := strings.TrimSpace(msg[:i])
+		switch {
+		case strings.HasSuffix(c.SchemaURL, "/$defs/payloadRelativePath"):
+			return fmt.Sprintf("%s: %s is not a payload-relative path: write it without a leading slash, "+
+				"\"~\", \".\" or \"..\" segments, backslashes, or duplicate or trailing slashes",
+				loc, value)
+		case strings.HasSuffix(c.SchemaURL, "/sha256"):
+			return fmt.Sprintf("%s: %s is not a content digest: write 64 lowercase hex characters", loc, value)
+		}
+	}
 	if hint := hintFor(c.InstanceLocation, msg); hint != "" {
 		return fmt.Sprintf("%s: %s (%s)", loc, msg, hint)
 	}
@@ -143,6 +196,11 @@ func hintFor(loc []string, msg string) string {
 			return "supported contract versions: " + strings.Join(SupportedContractMajors, ", ")
 		case strings.Contains(msg, "clients"):
 			return `declare at least one client, e.g. "clients": {"opencode": {"primaryAgents": ["nav-pilot"]}}`
+		case strings.Contains(msg, "'files'"):
+			// The payload manifest's own required key. The schema can only say
+			// which key is missing; the reason it is required is the whole point
+			// of the document, so it is worth saying (#704).
+			return "a payload manifest declares the exact contents of its tree; nav-pilot refuses to verify a payload that does not"
 		}
 		return ""
 	}

--- a/cli/nav-pilot/internal/agentpakke/schema.go
+++ b/cli/nav-pilot/internal/agentpakke/schema.go
@@ -147,11 +147,6 @@ func leafCauses(verr *jsonschema.ValidationError, acc []*jsonschema.ValidationEr
 func describeCause(c *jsonschema.ValidationError) string {
 	loc := instanceLocation(c.InstanceLocation)
 	msg := strings.TrimSpace(c.ErrorKind.LocalizedString(errPrinter))
-	// A pattern failure renders the whole regex, which for the payload path
-	// grammar is forty characters of escaped RE2 and tells an author nothing
-	// they can act on. The rule it encodes is one sentence, so say the sentence.
-	// Without this, "../secrets.env" reported a regex dump where it used to say
-	// the path escapes the payload (#704).
 	// A pattern failure renders the whole regex. For the payload path grammar
 	// that is forty characters of escaped RE2 and tells an author nothing they
 	// can act on, so those two patterns get the sentence they encode instead.

--- a/cli/nav-pilot/internal/agentpakke/stage_test.go
+++ b/cli/nav-pilot/internal/agentpakke/stage_test.go
@@ -186,11 +186,28 @@ func TestStagePayloadFailsClosed(t *testing.T) {
 			wantErrs: []string{`"LICENSE"`, "0666"},
 		},
 		{
+			// A key the record contract does not carry is refused, by the schema
+			// and by the Go decoder alike (#704). "sha256sum" instead of
+			// "sha256" is a typo that would otherwise leave the digest field
+			// absent and the entry silently unbound.
+			name: "unknown key in a file record",
+			mutate: func(_ *testing.T, _ string, doc map[string]any) {
+				rec := doc["files"].(map[string]any)["LICENSE"].(map[string]any)
+				rec["sha256sum"] = rec["sha256"]
+			},
+			wantErrs: []string{"LICENSE"},
+		},
+		{
+			// The wording moved to the schema in #704: the published schema now
+			// decides conformance, so this reports "files.LICENSE: got number,
+			// want object" rather than the hand-written record error. The
+			// assertion is on what the message must still do, name the entry
+			// and the shape, not on which layer produced it.
 			name: "malformed manifest record",
 			mutate: func(_ *testing.T, _ string, doc map[string]any) {
 				doc["files"].(map[string]any)["LICENSE"] = 7
 			},
-			wantErrs: []string{`record for "LICENSE" is malformed`},
+			wantErrs: []string{"files.LICENSE", "want object"},
 		},
 		{
 			name: "unsupported payload schemaVersion",

--- a/cli/nav-pilot/schemas/agentpakke-payload-v1.json
+++ b/cli/nav-pilot/schemas/agentpakke-payload-v1.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/navikt/copilot/cli/nav-pilot/schemas/agentpakke-payload-v1.json",
+  "title": "nav-pilot agentpakke payload manifest (v1)",
+  "description": "Contract for the payload manifest of a Tier 2 agentpakke payload. Lives at <payload>/manifest.json, or wherever the client entry's `manifest` field points. Describes the payload tree exactly: nav-pilot refuses a tree that holds a file the manifest does not list, or lacks one it does. Parenthesised ids such as (A7) are decision ids defined in the PRD at https://github.com/navikt/copilot/issues/435. Unknown top-level fields are ignored, so a generator may add descriptive keys without invalidating the manifest on an older binary.",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "files"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "description": "Payload-manifest contract version. nav-pilot verifies version 1 and refuses anything else, naming `nav-pilot update` as the remedy rather than telling the author to change the manifest.",
+      "type": "integer",
+      "const": 1
+    },
+    "target": {
+      "description": "The payload's own build-target name, e.g. \"copilot-full-v1\". Parsed and exposed but never asserted against: an agentpakke names its payloads by client and context, not by build target, so the digest chain is what binds the tree and this is a label. Optional.",
+      "type": "string",
+      "minLength": 1
+    },
+    "files": {
+      "description": "Every file in the payload tree, keyed by payload-relative path. Exhaustive in both directions: the tree must contain all of these and nothing else, save the payload manifest itself. An empty map is legal and describes an empty payload.",
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/payloadRelativePath"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/fileRecord"
+      }
+    }
+  },
+  "$defs": {
+    "payloadRelativePath": {
+      "description": "A normalized, contained, payload-relative path. Forward slashes only, no backslashes; not absolute; no \"~\" prefix; no \".\" or \"..\" segments; no duplicate or trailing slashes. Three or more dots is an ordinary file name and is allowed. JSON Schema patterns compile under Go's RE2, which has no lookahead, so one rule the Go validator applies is not expressible here and stays in nav-pilot alone: a path may not be padded with leading or trailing whitespace. A manifest that passes this schema can still be refused for that reason.",
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?:\\.*[^./\\\\~][^/\\\\]*|\\.{3,})(?:/(?:\\.*[^./\\\\][^/\\\\]*|\\.{3,}))*$"
+    },
+    "fileRecord": {
+      "description": "What one file must hash to, and which mode it must carry.",
+      "type": "object",
+      "required": [
+        "sha256",
+        "mode"
+      ],
+      "properties": {
+        "sha256": {
+          "description": "The file's content digest, 64 lowercase hex characters.",
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "mode": {
+          "description": "The file's permission bits as an octal string. Only these two are allowed: a payload may ship a regular file or an executable, and nothing else (A7).",
+          "type": "string",
+          "enum": [
+            "0644",
+            "0755"
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/cli/nav-pilot/schemas/schemas.go
+++ b/cli/nav-pilot/schemas/schemas.go
@@ -14,3 +14,15 @@ import _ "embed"
 //
 //go:embed agentpakke-v1.json
 var AgentpakkeV1 []byte
+
+// AgentpakkePayloadV1 is the payload manifest schema, contract version 1. Its
+// $id is
+// https://github.com/navikt/copilot/cli/nav-pilot/schemas/agentpakke-payload-v1.json.
+//
+// The payload manifest is the other half of the trust boundary: the top-level
+// manifest says which trees exist, this one says exactly what each tree holds.
+// It had no published schema, so an agentpakke author had nothing to lint
+// against in their own CI (#704 T4).
+//
+//go:embed agentpakke-payload-v1.json
+var AgentpakkePayloadV1 []byte


### PR DESCRIPTION
T4 fra #704, med begge beslutningene fra issuet: skjemaet publiseres, nav-pilot validerer mot det selv, og Go strammes der de to var uenige.

## Hva skjemaet er utledet fra

Koden, ikke fantasien. Hver regel fantes som en avvisning i `ParsePayloadManifest`, `parseFileRecord` eller `checkRelPath` før denne PR-en.

## To regler er strammet, så kode og skjema sier det samme

**Ukjente nøkler i en filoppføring avvises.** En oppføring binder en sti til bytes og en modus. En nøkkel som ikke er en av dem kan ikke bety noe, og den mest sannsynlige grunnen til at en dukker opp er en skrivefeil som lar det ekte feltet stå tomt: `"sha256sum"` gir en oppføring med tom digest.

Ignore-unknown-regelen i kontrakten gjelder dokumentets **toppnivå**, der referansegeneratoren faktisk legger til `generator`, `counts`, `agents` og `skills`. Den gjaldt ett nivå for dypt.

Dette snur en påstand som sto i testene: `TestParsePayloadManifestIgnoresUnknownFields` krevde at en oppføring med et ekstra `size`-felt skulle parse. Testen er **delt i to** framfor slettet, så begge halvdelene av regelen er pinnet: toppnivå ignoreres fortsatt, oppføringer avvises.

⚠️ Verdt et blikk fra noen som kjenner referansegeneratoren: hvis den emitterer per-oppføring-felter vi ikke vet om, bryter dette dem. Kommentaren i koden sier at den emitterer de fire toppnivåfeltene; jeg har ikke kunnet verifisere oppføringene mot generatoren selv.

**Versjonsporten kjører før skjemaet**, av samme grunn som #504 U1 ga for toppnivåmanifestet. Skjemaet pinner `schemaVersion` til 1, så en payload på versjon 2 ville blitt meldt som «value must be 1» og bedt forfatteren rette et manifest som ikke er galt. Den som må handle er brukeren, ved å oppgradere.

## Sti-grammatikken måtte skrives om for RE2

Første utkast brukte lookahead. JSON Schema-mønstre kompileres av Go, som ikke har det, så skjemaet kompilerte ikke i det hele tatt. Omskrevet uten, og testet mot 26 tilfeller under RE2 før det ble lagt inn.

Én regel lar seg ikke uttrykke: en sti kan ikke være polstret med mellomrom. Den står igjen i Go alene, og skjemaets egen beskrivelse sier det rett ut, så ingen tror et grønt skjema er hele sannheten.

## Feilmeldingene beholder det de var gode på

En mønsterfeil rendrer hele regexen, altså førti tegn escaped RE2. De to mønstrene får nå setningen de koder.

Nøkkelen er **skjemadefinisjonen som feilet**, ikke meldingen og ikke feltnavnet. To tidligere forsøk bommet, og begge ble fanget av eksisterende tester:

- keyet på meldingen: en ugyldig `sha256` meldte at en digest «is not a payload-relative path»
- keyet på feltnavnet: traff toppnivåmanifestets `name`, som har sitt eget mønster og sitt eget hint

`missing property 'files'` beholder også prinsippet det gamle Go-svaret uttrykte, via `hintFor`: et payload-manifest erklærer det eksakte innholdet i treet, og nav-pilot nekter å verifisere en payload som ikke gjør det.

## Kontrollene

| Fjernet | Rødt |
|---|---|
| skjemavalideringen | 12 undertester |
| versjonsporten | `unsupported schemaVersion` |
| `DisallowUnknownFields` | `TestParseFileRecordRejectsUnknownKeys` |

Den siste er verdt en merknad. Første versjon av den testen brukte `sha256sum`-skrivefeilen og ble **grønn** med regelen fjernet, fordi tom digest fanges av digest-sjekken uansett. Den tester nå en ellers gyldig oppføring med et ekstra `size`-felt, som er det eneste som skiller denne regelen fra naboen. Den går dessuten rett på `parseFileRecord`, siden skjemaet ellers avviser først og gjør Go-laget utestbart gjennom hoveddøra.

`mise run check` er grønn.
