### PR TITLE
feat(nav-pilot): modellvelgeren merker det kontoen ikke kan starte

### DIFF
--- a/cli/nav-pilot/internal/cli/config_page_test.go
+++ b/cli/nav-pilot/internal/cli/config_page_test.go
@@ -128,7 +128,7 @@ func TestModelPickerOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("providerFor: %v", err)
 	}
-	opts := modelPickerOptions(p)
+	opts := modelPickerOptions(p, nil)
 
 	if len(opts) != len(p.KnownModels())+2 {
 		t.Fatalf("got %d options, want %d known models + unset + custom", len(opts), len(p.KnownModels()))

--- a/cli/nav-pilot/internal/cli/interactive.go
+++ b/cli/nav-pilot/internal/cli/interactive.go
@@ -66,7 +66,7 @@ const (
 
 // modelPickerOptions builds the curated model picker for a provider: unset
 // first, then the known models, then a custom entry for anything else.
-func modelPickerOptions(p Provider) []huh.Option[string] {
+func modelPickerOptions(p Provider, available map[string]bool) []huh.Option[string] {
 	defLabel := "Unset (agent default)"
 	if def := p.DefaultModel(); def != "" {
 		defLabel = "Unset (Nav default: " + def + ")"
@@ -74,11 +74,19 @@ func modelPickerOptions(p Provider) []huh.Option[string] {
 	opts := []huh.Option[string]{huh.NewOption(defLabel, "")}
 	for _, m := range p.KnownModels() {
 		// Marked, not hidden (#717). The list is generated from a global
-		// catalogue while availability follows the account and plan, so an entry
-		// missing here may work for a colleague. Hiding it would take that away;
-		// saying so tells the truth for the reader without claiming anything
-		// about anyone else. Availability unknown means no annotation at all.
-		opts = append(opts, huh.NewOption(m.Label+"  "+dim(m.ID)+dim(unavailableSuffix(m.ID)), m.ID))
+		// catalogue while availability follows the account, so an entry missing
+		// here may work for a colleague. Hiding it would take that away; saying
+		// so tells the truth for the reader without claiming anything about
+		// anyone else. Unknown availability annotates nothing.
+		//
+		// The suffix is dimmed only when there is one: dim("") is not the empty
+		// string, it is an empty pair of escape codes, and appending it
+		// unconditionally put stray \033[2m\033[0m on every label.
+		label := m.Label + "  " + dim(m.ID)
+		if suffix := unavailableSuffix(available, m.ID); suffix != "" {
+			label += dim(suffix)
+		}
+		opts = append(opts, huh.NewOption(label, m.ID))
 	}
 	return append(opts, huh.NewOption("Custom (type manually)…", customModelSentinel))
 }
@@ -102,7 +110,7 @@ func promptModel(p Provider, title, description, current string) (string, error)
 		return strings.TrimSpace(value), err
 	}
 
-	opts := modelPickerOptions(p)
+	opts := modelPickerOptions(p, availableModelIDs())
 	choice := current
 	if current != "" {
 		known := false

--- a/cli/nav-pilot/internal/cli/interactive.go
+++ b/cli/nav-pilot/internal/cli/interactive.go
@@ -73,7 +73,12 @@ func modelPickerOptions(p Provider) []huh.Option[string] {
 	}
 	opts := []huh.Option[string]{huh.NewOption(defLabel, "")}
 	for _, m := range p.KnownModels() {
-		opts = append(opts, huh.NewOption(m.Label+"  "+dim(m.ID), m.ID))
+		// Marked, not hidden (#717). The list is generated from a global
+		// catalogue while availability follows the account and plan, so an entry
+		// missing here may work for a colleague. Hiding it would take that away;
+		// saying so tells the truth for the reader without claiming anything
+		// about anyone else. Availability unknown means no annotation at all.
+		opts = append(opts, huh.NewOption(m.Label+"  "+dim(m.ID)+dim(unavailableSuffix(m.ID)), m.ID))
 	}
 	return append(opts, huh.NewOption("Custom (type manually)…", customModelSentinel))
 }

--- a/cli/nav-pilot/internal/cli/model_availability.go
+++ b/cli/nav-pilot/internal/cli/model_availability.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"os/exec"
+	"strings"
+	"sync"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/domain"
+)
+
+// The picker is generated from models.dev, which is global, while what a person
+// can actually launch depends on their account and plan. So the list offers
+// models the client refuses: on the machine this was written on, 14 of them,
+// including one the generator's PINNED list still described as "delisted but
+// still launches" (#717).
+//
+// Marking beats pruning. A model missing from one account may be present for
+// another, so removing entries would take away something that works for a
+// colleague on a different plan. An annotated entry tells the truth for the
+// person reading it and no lies about anyone else.
+
+var (
+	availabilityOnce sync.Once
+	availableIDs     map[string]bool
+)
+
+// availableModelIDs returns the ids this account can launch, or nil when the
+// question could not be answered.
+//
+// Asked once per process. The probe costs a client start (~2s) and no AI
+// credits, but a picker that pays it per keystroke would be unusable, and the
+// answer cannot change while a picker is open.
+//
+// nil is not "nothing is available": it is "unknown", and every caller must
+// treat it as a reason to annotate nothing. An offline developer gets the plain
+// list they had before, never a list where everything is marked unavailable.
+func availableModelIDs() map[string]bool {
+	availabilityOnce.Do(func() {
+		copilotPath, err := exec.LookPath("copilot")
+		if err != nil {
+			return
+		}
+		ids, ok := clientChatModels(copilotPath)
+		if !ok {
+			return
+		}
+		availableIDs = make(map[string]bool, len(ids))
+		for _, id := range ids {
+			availableIDs[strings.ToLower(id)] = true
+		}
+	})
+	return availableIDs
+}
+
+// unavailableSuffix is what the picker appends to a model the account cannot
+// launch, or "" when it can, or when availability is unknown.
+func unavailableSuffix(modelID string) string {
+	have := availableModelIDs()
+	if len(have) == 0 {
+		return ""
+	}
+	id := strings.ToLower(strings.TrimPrefix(modelID, domain.OpenCodeProviderPrefix))
+	if id == "" || id == "auto" || have[id] {
+		return ""
+	}
+	return "  (not available to this account)"
+}

--- a/cli/nav-pilot/internal/cli/model_availability.go
+++ b/cli/nav-pilot/internal/cli/model_availability.go
@@ -20,10 +20,7 @@ import (
 // person reading it and no lies about anyone else.
 
 var (
-	// A pointer so a test can install a fresh one. sync.Once cannot be reset,
-	// and a test that seeds the cache would otherwise leak into whatever runs
-	// after it in this package.
-	availabilityOnce = &sync.Once{}
+	availabilityOnce sync.Once
 	availableIDs     map[string]bool
 )
 

--- a/cli/nav-pilot/internal/cli/model_availability.go
+++ b/cli/nav-pilot/internal/cli/model_availability.go
@@ -20,7 +20,10 @@ import (
 // person reading it and no lies about anyone else.
 
 var (
-	availabilityOnce sync.Once
+	// A pointer so a test can install a fresh one. sync.Once cannot be reset,
+	// and a test that seeds the cache would otherwise leak into whatever runs
+	// after it in this package.
+	availabilityOnce = &sync.Once{}
 	availableIDs     map[string]bool
 )
 
@@ -54,9 +57,13 @@ func availableModelIDs() map[string]bool {
 
 // unavailableSuffix is what the picker appends to a model the account cannot
 // launch, or "" when it can, or when availability is unknown.
-func unavailableSuffix(modelID string) string {
-	have := availableModelIDs()
-	if len(have) == 0 {
+//
+// have is the answer from [availableModelIDs]: nil for "not known", which is
+// the only value that means unknown. An empty non-nil map is a catalogue that
+// was read and holds nothing, and every model is then genuinely unavailable;
+// conflating the two would hide a real answer behind the offline case.
+func unavailableSuffix(have map[string]bool, modelID string) string {
+	if have == nil {
 		return ""
 	}
 	id := strings.ToLower(strings.TrimPrefix(modelID, domain.OpenCodeProviderPrefix))

--- a/cli/nav-pilot/internal/cli/model_availability_test.go
+++ b/cli/nav-pilot/internal/cli/model_availability_test.go
@@ -2,23 +2,8 @@ package cli
 
 import (
 	"strings"
-	"sync"
 	"testing"
 )
-
-// seedAvailability installs a known catalogue and restores whatever was there,
-// so seeding it here cannot change what another test in this package sees.
-// availabilityOnce is a pointer for this reason: sync.Once has no reset, and a
-// test that burned the real one would leave the probe permanently skipped.
-func seedAvailability(t *testing.T, ids map[string]bool) {
-	t.Helper()
-	prevOnce, prevIDs := availabilityOnce, availableIDs
-	t.Cleanup(func() { availabilityOnce, availableIDs = prevOnce, prevIDs })
-
-	availabilityOnce = &sync.Once{}
-	availabilityOnce.Do(func() {}) // burn it, so the real probe never runs
-	availableIDs = ids
-}
 
 func TestUnavailableSuffix(t *testing.T) {
 	t.Run("unknown availability annotates nothing", func(t *testing.T) {

--- a/cli/nav-pilot/internal/cli/model_availability_test.go
+++ b/cli/nav-pilot/internal/cli/model_availability_test.go
@@ -1,0 +1,46 @@
+package cli
+
+import "testing"
+
+func TestUnavailableSuffix(t *testing.T) {
+	reset := func(ids map[string]bool) {
+		availabilityOnce.Do(func() {}) // burn the once so the probe never runs
+		availableIDs = ids             // and inject the answer
+	}
+
+	t.Run("unknown availability annotates nothing", func(t *testing.T) {
+		reset(nil)
+		// The important case. An offline developer, or one on a client that
+		// stops writing the catalogue, must get the plain list they had before,
+		// never a list where every entry is marked unavailable.
+		if got := unavailableSuffix("claude-sonnet-4.6"); got != "" {
+			t.Errorf("unavailableSuffix with no catalogue = %q, want empty", got)
+		}
+	})
+
+	t.Run("marks what the account cannot launch", func(t *testing.T) {
+		reset(map[string]bool{"claude-sonnet-5": true})
+		if got := unavailableSuffix("claude-sonnet-4.6"); got == "" {
+			t.Error("a model outside the catalogue was not marked")
+		}
+		if got := unavailableSuffix("claude-sonnet-5"); got != "" {
+			t.Errorf("an available model was marked: %q", got)
+		}
+	})
+
+	t.Run("opencode ids carry a provider prefix", func(t *testing.T) {
+		reset(map[string]bool{"claude-sonnet-5": true})
+		if got := unavailableSuffix("github-copilot/claude-sonnet-5"); got != "" {
+			t.Errorf("prefixed id was marked unavailable: %q; the prefix must be stripped before comparing", got)
+		}
+	})
+
+	t.Run("auto is never marked", func(t *testing.T) {
+		reset(map[string]bool{"claude-sonnet-5": true})
+		// "auto" is a pseudo-model the client resolves itself; it is not in the
+		// catalogue and never will be.
+		if got := unavailableSuffix("auto"); got != "" {
+			t.Errorf("auto was marked unavailable: %q", got)
+		}
+	})
+}

--- a/cli/nav-pilot/internal/cli/model_availability_test.go
+++ b/cli/nav-pilot/internal/cli/model_availability_test.go
@@ -1,46 +1,88 @@
 package cli
 
-import "testing"
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+// seedAvailability installs a known catalogue and restores whatever was there,
+// so seeding it here cannot change what another test in this package sees.
+// availabilityOnce is a pointer for this reason: sync.Once has no reset, and a
+// test that burned the real one would leave the probe permanently skipped.
+func seedAvailability(t *testing.T, ids map[string]bool) {
+	t.Helper()
+	prevOnce, prevIDs := availabilityOnce, availableIDs
+	t.Cleanup(func() { availabilityOnce, availableIDs = prevOnce, prevIDs })
+
+	availabilityOnce = &sync.Once{}
+	availabilityOnce.Do(func() {}) // burn it, so the real probe never runs
+	availableIDs = ids
+}
 
 func TestUnavailableSuffix(t *testing.T) {
-	reset := func(ids map[string]bool) {
-		availabilityOnce.Do(func() {}) // burn the once so the probe never runs
-		availableIDs = ids             // and inject the answer
-	}
-
 	t.Run("unknown availability annotates nothing", func(t *testing.T) {
-		reset(nil)
 		// The important case. An offline developer, or one on a client that
 		// stops writing the catalogue, must get the plain list they had before,
 		// never a list where every entry is marked unavailable.
-		if got := unavailableSuffix("claude-sonnet-4.6"); got != "" {
+		if got := unavailableSuffix(nil, "claude-sonnet-4.6"); got != "" {
 			t.Errorf("unavailableSuffix with no catalogue = %q, want empty", got)
 		}
 	})
 
+	t.Run("an empty catalogue is an answer, not a shrug", func(t *testing.T) {
+		// Distinct from nil on purpose: a catalogue that was read and holds
+		// nothing means nothing is launchable, and saying so beats pretending
+		// the question was never answered.
+		if got := unavailableSuffix(map[string]bool{}, "claude-sonnet-5"); got == "" {
+			t.Error("an empty non-nil catalogue annotated nothing; that is the offline case, not this one")
+		}
+	})
+
 	t.Run("marks what the account cannot launch", func(t *testing.T) {
-		reset(map[string]bool{"claude-sonnet-5": true})
-		if got := unavailableSuffix("claude-sonnet-4.6"); got == "" {
+		have := map[string]bool{"claude-sonnet-5": true}
+		if got := unavailableSuffix(have, "claude-sonnet-4.6"); got == "" {
 			t.Error("a model outside the catalogue was not marked")
 		}
-		if got := unavailableSuffix("claude-sonnet-5"); got != "" {
+		if got := unavailableSuffix(have, "claude-sonnet-5"); got != "" {
 			t.Errorf("an available model was marked: %q", got)
 		}
 	})
 
 	t.Run("opencode ids carry a provider prefix", func(t *testing.T) {
-		reset(map[string]bool{"claude-sonnet-5": true})
-		if got := unavailableSuffix("github-copilot/claude-sonnet-5"); got != "" {
+		have := map[string]bool{"claude-sonnet-5": true}
+		if got := unavailableSuffix(have, "github-copilot/claude-sonnet-5"); got != "" {
 			t.Errorf("prefixed id was marked unavailable: %q; the prefix must be stripped before comparing", got)
 		}
 	})
 
 	t.Run("auto is never marked", func(t *testing.T) {
-		reset(map[string]bool{"claude-sonnet-5": true})
-		// "auto" is a pseudo-model the client resolves itself; it is not in the
-		// catalogue and never will be.
-		if got := unavailableSuffix("auto"); got != "" {
+		// A pseudo-model the client resolves itself. It is not in the catalogue
+		// and never will be.
+		if got := unavailableSuffix(map[string]bool{"claude-sonnet-5": true}, "auto"); got != "" {
 			t.Errorf("auto was marked unavailable: %q", got)
 		}
 	})
+}
+
+// TestModelPickerLabelsCarryNoStrayEscapes pins the bug review found: dim("")
+// is not the empty string, it is an empty pair of escape codes, so appending
+// the suffix unconditionally decorated every label with \033[2m\033[0m.
+func TestModelPickerLabelsCarryNoStrayEscapes(t *testing.T) {
+	p, err := providerFor("copilot")
+	if err != nil || p == nil || len(p.KnownModels()) == 0 {
+		t.Skip("no copilot provider in this build")
+	}
+	// Availability known, and everything in it available: no option should be
+	// annotated, so no option should carry an escape sequence around nothing.
+	have := map[string]bool{}
+	for _, m := range p.KnownModels() {
+		have[strings.ToLower(m.ID)] = true
+	}
+
+	for _, opt := range modelPickerOptions(p, have) {
+		if strings.Contains(opt.Key, "\033[2m\033[0m") {
+			t.Errorf("option %q carries an empty escape pair", opt.Key)
+		}
+	}
 }

--- a/docs/modellvalg.md
+++ b/docs/modellvalg.md
@@ -183,7 +183,7 @@ tallene her har et tidsstempel og ikke evig gyldighet.
 | GPT-5.3-Codex | Powerful | $1.75 | $14.00 | Kodeforståelse, terminal, infrastruktur |
 | GPT-5.6 Luna | Lightweight | $0.20 | $1.20 | Raske rutineoppgaver, enkel autofullfør. OpenAI plasserer den i nano-sjiktet fra tidligere GPT-5-familier, men med høy reasoning-rating og justerbar effort |
 | GPT-5.6 Terra | Versatile | $2.00 | $12.00 | Allround daglig koding i GPT-familien |
-| GPT-5.6 Sol | Powerful | $4.00 | $20.00 | Tung reasoning over store kodebaser (krever Pro+). Listepris; kampanjen gikk ut 3. sep 2026. Lang kontekst over 272K: $8.00 / $30.00 |
+| GPT-5.6 Sol | Powerful | $4.00 | $20.00 | Tung reasoning over store kodebaser. Listepris; kampanjen gikk ut 3. sep 2026. Lang kontekst over 272K: $8.00 / $30.00 |
 | Gemini 2.5 Pro | Powerful | (utgått) | (utgått) | 🚫 Utfaset 31. juli 2026. Gemini 3.1 Pro, som overtok rollen, falt ut av prislista 5. sep 2026. Google har ingen Powerful-modell igjen hos GitHub. Bruk GPT-5.3-Codex eller Kimi K3 til research over lang kontekst |
 | Gemini 3.5 Flash | Lightweight | $1.50 | $9.00 | Rask og billig for enkle oppgaver |
 | Gemini 3.6 Flash | Versatile | $0.75 | $3.75 | Agentiske workflows med parallell verktøybruk. Kampanjepris t.o.m. 31. des 2026 |
@@ -292,7 +292,7 @@ resonnerer bedre enn GPT-5.3-Codex eller Kimi K3 på oppgavene disse to agentene
 gjør, og ingen som viser at den holder Opus-nivået. Argumentet er ubelagt, og
 skal leses som det.
 
-Merk at Sol krever Copilot Pro+ eller høyere plan.
+Sol er tilgjengelig på Copilot Business. Målt 7. september 2026: `gpt-5.6-sol` står i modellkatalogen klienten henter for en konto med `copilot_plan: business`. Dokumentet sa tidligere at Sol krever Pro+, og motsa seg selv i notatet under, som lister Business blant planene GA-utrullingen dekket.
 
 ## Kriterier for å bytte modell
 


### PR DESCRIPTION
Andre del av #717. Første del, `nav-pilot doctor`, landet i #719 og fanger en foreldet pinne. Denne hindrer at man velger en død modell i utgangspunktet.

## Problemet

Velgeren genereres fra models.dev, som er global. Tilgjengelighet henger på konto og plan. Målt ved å hente klientens levende katalog ut av dens egen debug-logg:

```
i velgeren, ikke i katalogen:
  claude-fable-5, claude-fable-5.1, claude-haiku-4.5, claude-opus-4.6,
  claude-opus-4.7, claude-sonnet-4.6, gemini-3.5-flash, gemini-3.6-flash,
  gemini-3.7-flash, gpt-5.4, gpt-5.5, grok-4.5, grok-4.6, mai-code-1-flash-picker
```

14 oppføringer. Én av dem, `claude-opus-4.6`, står i generatorens `PINNED`-liste med kommentaren «Delisted from GitHub's price list but still launches. Remove once it stops resolving at launch.» Den har sluttet å resolve.

## Merket, ikke skjult

En modell som mangler for meg kan finnes for en kollega på en annen plan eller i en annen utrullingsbølge. Vi vet ikke hvorfor de 14 mangler, bare at de gjør det på én konto, og det er nettopp derfor de ikke fjernes: å beskjære lista på ett måleresultat ville tatt fra andre noe som virker.

PR-en sa opprinnelig at `gpt-5.6-sol` krever Pro+, som eksempel på plan-avhengighet. Det er feil, og min egen måling sa det: Sol står i katalogen for denne Business-kontoen. Påstanden kom fra `docs/modellvalg.md`, som motsa seg selv, og er rettet i denne PR-en.

En merket oppføring er sann for den som leser den, og påstår ingenting om andre.

## Kostnaden du godtok, holdt nede

Katalogen hentes **én gang per prosess**, ikke per tastetrykk. Proben er en klientoppstart med en modell-sentinel som ikke finnes: klienten henter katalogen, avviser modellen og avslutter før den kjører noe, så den koster ingen AI-kreditter. Svaret kan uansett ikke endre seg mens en velger står åpen.

## Ukjent er ikke utilgjengelig

Den viktigste greina. Uten nett, uten auth, eller på en klient som slutter å skrive katalogen til loggen, merkes **ingenting**: utvikleren får den vanlige lista de hadde før.

En liste der alt er merket utilgjengelig ville vært verre enn ingen merking, siden den lærer folk å overse merket.

## Kontroller

| Fjernet | Rødt |
|---|---|
| prefiks-strippingen (`github-copilot/…`) | `opencode_ids_carry_a_provider_prefix` |
| vakten mot ukjent katalog | `unknown_availability_annotates_nothing` |

Den første måtte muteres slik at koden fortsatt kompilerer: å fjerne `TrimPrefix` gjorde `domain`-importen ubrukt, og en test som ikke bygger er ingen kontroll.

`mise run check` er grønn.
