### PR TITLE
fix(nav-pilot): meldingen sa at OpenCode ikke kan nekte, og det er målt feil

### DIFF
--- a/cli/nav-pilot/internal/artifacts/opencode_sync.go
+++ b/cli/nav-pilot/internal/artifacts/opencode_sync.go
@@ -161,17 +161,30 @@ func SyncOpenCodeArtifacts(sourceDir, scopeDir, outputDir, sourceVersion, source
 	var files []domain.InstalledFile
 	resolver := source.NewSourceResolver(sourceDir)
 
-	// OpenCode has no tool-deny mechanism, so a preToolUse gate has nothing to
-	// attach to there. Said out loud rather than skipped in silence: a user who
-	// installed an enforcement hook and then exported to opencode would
-	// otherwise believe the gate came along. ValidateOpenCodeStatePath keeps
-	// refusing hooks/ regardless, so nothing can slip in through state either.
+	// Hooks are not exported, and the message says why without claiming more
+	// than we know.
+	//
+	// It used to say OpenCode has no tool-deny mechanism. That is false, and was
+	// measured false (#709): a plugin's `tool.execute.before` hook aborts the
+	// call when it throws, the message reaches the model, and a probe ran the
+	// unmodified Python gate through it. `~/.config/opencode/plugins/rtk.ts`
+	// already uses that same hook to rewrite commands, so the shape was in front
+	// of us the whole time.
+	//
+	// What is missing is the plumbing, not the capability: a plugin has to be
+	// registered under `plugin` in the user's own opencode.json, and whether
+	// nav-pilot writes client configuration is #500's open question.
+	//
+	// Said out loud rather than skipped in silence: a user who installed an
+	// enforcement gate and then exported to opencode would otherwise believe it
+	// came along. ValidateOpenCodeStatePath keeps refusing hooks/ regardless, so
+	// nothing can slip in through state either.
 	if skipped := resolver.List(source.KindHook); len(skipped) > 0 {
 		names := make([]string, len(skipped))
 		for i, h := range skipped {
 			names[i] = h.Name
 		}
-		fmt.Printf("  %s %d hook(s) not exported: %s. OpenCode has no tool-deny mechanism, so the gate cannot run there.\n",
+		fmt.Printf("  %s %d hook(s) not exported: %s. nav-pilot does not yet install them for OpenCode; see navikt/copilot#709.\n",
 			domain.Yellow("⚠"), len(names), strings.Join(names, ", "))
 	}
 

--- a/cli/nav-pilot/internal/cli/hooks_test.go
+++ b/cli/nav-pilot/internal/cli/hooks_test.go
@@ -210,8 +210,14 @@ func contains(list []string, s string) bool {
 	return false
 }
 
-// OpenCode has no tool-deny mechanism, so a hook cannot run there. It must stay
-// out of the exported scope, and the state path validator is the backstop.
+// Hooks stay out of the exported opencode scope, and the state path validator
+// is the backstop.
+//
+// The reason is plumbing, not capability. OpenCode can deny a tool call: a
+// plugin's `tool.execute.before` throws and the call is aborted, measured in
+// #709 by running the unmodified Python gate through one. What nav-pilot does
+// not do is register a plugin in the user's opencode.json, which is #500's open
+// question. This test pins the current behaviour, not a limitation of OpenCode.
 func TestOpenCodeRefusesHooks(t *testing.T) {
 	if err := artifacts.ValidateOpenCodeStatePath("hooks/klarsprak-gate.py"); err == nil {
 		t.Error("opencode state accepted a hook path")


### PR DESCRIPTION
Sync skrev dette på hver eneste kjøring:

```
⚠ 3 hook(s) not exported: ask-first-aria, gh-poll-gate, klarsprak-gate.
  OpenCode has no tool-deny mechanism, so the gate cannot run there.
```

Andre halvdel er feil, og #709 målte den feil.

## Målingen

OpenCode 1.18.29, den uendrede `hooks/gh-poll-gate.py` kalt fra en tynn plugin:

```
$ opencode run --auto "Kjør: for i in 1 2 3; do gh run list --limit 1; sleep 30; done"
✗ failed
Error: Dette venter på GitHub Actions ved å spørre om igjen ...
Kommandoen ble blokkert av miljøets polling-vern og ble ikke kjørt.
```

Kallet blir stoppet, ikke bare logget, og teksten når fram til modellen. Kontroll i samme økt: den riktige formen slipper gjennom, og uten porten konfigurert er plugin-en inert.

`~/.config/opencode/plugins/rtk.ts` bruker allerede samme `tool.execute.before` til å skrive om kommandoer. Formen har ligget på maskinen hele tiden.

## Hva som faktisk mangler

Rørlegging, ikke evne. En plugin må registreres under `plugin` i brukerens egen `opencode.json`, og om nav-pilot skal skrive klientkonfigurasjon er det åpne spørsmålet i #500.

Denne PR-en tar ikke stilling til det. Den retter bare påstanden, siden en melding som sier «umulig» om noe vi bare ikke har bygget, avslutter en samtale som burde stå åpen.

## Endringen

Meldingen sier nå at nav-pilot ikke installerer dem for OpenCode ennå, og peker på #709.

Kommentaren over `TestOpenCodeRefusesHooks` bar samme påstand som begrunnelse for at testen finnes. Den sier nå at testen fester dagens oppførsel, ikke en begrensning i OpenCode. Testen selv er urørt: hooks skal fortsatt holdes ute av det eksporterte scopet, og `ValidateOpenCodeStatePath` er fortsatt bakstopperen.

`mise run check` er grønn.