### PR TITLE
fix(nav-pilot): installert og ignorert samtidig blir ikke lenger stille

### DIFF
--- a/cli/nav-pilot/internal/cli/agentpakke.go
+++ b/cli/nav-pilot/internal/cli/agentpakke.go
@@ -448,9 +448,18 @@ func adoptPakkeIdentity(scope *InstallScope, src *Source, state *StateFile, reso
 			}
 			for _, art := range resolver.List(kind) {
 				relPath := kind.RelPathForName(scope, art.Name)
-				if !installed[relPath] {
-					ignored = append(ignored, relPath)
+				if installed[relPath] {
+					continue
 				}
+				// Not in state is not the same as not installed (#724). An
+				// artifact put there by an older nav-pilot, or by a collection
+				// install that recorded less, is on disk and in use. Marking it
+				// ignored told sync to skip it forever, and one such file sat on
+				// a model GitHub had withdrawn until doctor noticed.
+				if _, err := os.Stat(filepath.Join(scope.RootDir, relPath)); err == nil {
+					continue
+				}
+				ignored = append(ignored, relPath)
 			}
 		}
 	}

--- a/cli/nav-pilot/internal/cli/doctor_models.go
+++ b/cli/nav-pilot/internal/cli/doctor_models.go
@@ -239,8 +239,21 @@ func reportModelPins() {
 	if len(unavailable) > 0 {
 		fmt.Printf("    %s %d of %d pinned model(s) are not available to this account\n",
 			yellow("⚠"), len(unavailable), len(pins))
+		// Naming the reason where there is one (#724). doctor found the symptom
+		// on a file whose pin had been dead for weeks, and said nothing about
+		// why it was never updated: it was marked ignored, so sync had been
+		// skipping it by design. Without that line the obvious next step,
+		// running sync, does nothing and looks broken.
+		ignored := map[string]bool{}
+		for _, rel := range ignoredButInstalled(scope) {
+			ignored[rel] = true
+		}
 		for _, p := range unavailable {
-			fmt.Printf("      %s %s pins %q\n", yellow("⚠"), p.Agent, p.Label)
+			line := fmt.Sprintf("      %s %s pins %q", yellow("⚠"), p.Agent, p.Label)
+			if ignored[relPathForAgent(scope, p.Agent)] {
+				line += dim("  (marked ignored, so sync skips it)")
+			}
+			fmt.Println(line)
 		}
 		fmt.Printf("      %s The client launches these agents with a model it will reject. Repin them, or\n",
 			yellow("Solution:"))
@@ -257,4 +270,10 @@ func reportModelPins() {
 			fmt.Printf("      %s %s pins %q\n", dim("-"), p.Agent, p.Label)
 		}
 	}
+}
+
+// relPathForAgent is the scope-relative path of an installed agent, for
+// matching against the state file's own path form.
+func relPathForAgent(scope *InstallScope, name string) string {
+	return scope.RelPath(source.KindAgent.Dir, name+source.KindAgent.Suffix)
 }

--- a/cli/nav-pilot/internal/cli/retired.go
+++ b/cli/nav-pilot/internal/cli/retired.go
@@ -169,3 +169,45 @@ func reportRetired(orphans []retiredOrphan, apply bool) {
 		fmt.Printf("so nothing you wrote yourself is touched.\n\n")
 	}
 }
+
+// ignoredButInstalled lists artifacts the state marks as ignored while the file
+// sits in the scope.
+//
+// That combination is one nobody chooses (#724). `nav-pilot ignore` marks
+// something the user does not want, and it is normally not on disk; the
+// collection fold-in in #468 marked every artifact missing from state, which
+// included files an older nav-pilot had installed without recording. Sync then
+// skips them by design, so they never update: one carried a model GitHub had
+// withdrawn for weeks, and only doctor's catalogue check found it.
+//
+// Reported, never removed. The file may be exactly what someone wants; what is
+// wrong is that nothing says it has stopped being maintained.
+func ignoredButInstalled(scope *InstallScope) []string {
+	state, err := readScopedState(scope)
+	if err != nil || state == nil {
+		return nil
+	}
+	var found []string
+	for _, f := range state.Files {
+		if f.Status != fileStatusIgnored {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(scope.RootDir, f.Path)); err == nil {
+			found = append(found, f.Path)
+		}
+	}
+	sort.Strings(found)
+	return found
+}
+
+// reportIgnoredButInstalled prints the section for those artifacts.
+func reportIgnoredButInstalled(paths []string) {
+	fmt.Printf("%s %d installed artifact(s) are marked ignored, so sync leaves them as they are\n\n",
+		yellow("⚠"), len(paths))
+	for _, p := range paths {
+		fmt.Printf("  %s %s\n", dim("⊘"), p)
+	}
+	fmt.Printf("\n  They keep whatever version they were installed with, including a model pin\n")
+	fmt.Printf("  that may no longer exist. %s takes the source's version and\n", bold("nav-pilot add <type> <name> --force"))
+	fmt.Printf("  starts tracking it again.\n\n")
+}

--- a/cli/nav-pilot/internal/cli/retired_test.go
+++ b/cli/nav-pilot/internal/cli/retired_test.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
 	"github.com/navikt/copilot/cli/nav-pilot/internal/source"
 )
 
@@ -212,5 +214,96 @@ func TestSyncWithTrackedFilesIsNotUpToDateWithOrphans(t *testing.T) {
 	}
 	if _, statErr := os.Stat(filepath.Join(agentDir, "kept.agent.md")); statErr != nil {
 		t.Errorf("sync removed a file the source still ships: %v", statErr)
+	}
+}
+
+// TestIgnoredButInstalled covers #724: an artifact the state marks ignored
+// while the file is on disk. Sync skips it by design, so it never updates, and
+// nothing said so until doctor's model check tripped over one that had been
+// pinned to a withdrawn model for weeks.
+func TestIgnoredButInstalled(t *testing.T) {
+	scope, agentDir := userScopeWithAgents(t)
+	if err := os.WriteFile(filepath.Join(agentDir, "opus.agent.md"), []byte("---\nname: opus\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeScopedState(scope, &StateFile{
+		Collection: "pakke",
+		Scope:      scope.Name,
+		SourceRepo: "navikt/copilot",
+		SourceSHA:  "abc1234",
+		Files: []InstalledFile{
+			// On disk and ignored: the combination nobody chooses.
+			{Path: "agents/opus.agent.md", Status: fileStatusIgnored},
+			// Ignored and genuinely absent, which is the ordinary case and must
+			// not be reported: nothing has stopped being maintained.
+			{Path: "agents/finnes-ikke.agent.md", Status: fileStatusIgnored},
+			// On disk and tracked, which sync updates normally.
+			{Path: "agents/kept.agent.md", Hash: "abc"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := ignoredButInstalled(scope)
+	if len(got) != 1 || got[0] != "agents/opus.agent.md" {
+		t.Errorf("ignoredButInstalled = %v, want exactly agents/opus.agent.md", got)
+	}
+}
+
+// TestFoldInSparesInstalledArtifacts covers the cause behind #724. The
+// collection fold-in marked every artifact missing from the state file as
+// ignored, on the assumption that missing from state means not installed. It
+// does not: an artifact written by an older nav-pilot, or by a collection
+// install that recorded less, is on disk and in use.
+//
+// Marking such a file ignored told sync to skip it forever. One then sat on a
+// model GitHub had withdrawn until doctor's catalogue check found it.
+func TestFoldInSparesInstalledArtifacts(t *testing.T) {
+	scope, agentDir := userScopeWithAgents(t)
+
+	// The source ships two agents. One is on disk but untracked, the other is
+	// genuinely absent.
+	sourceDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(sourceDir, "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"onDisk", "absent"} {
+		body := "---\nname: " + name + "\n---\n"
+		if err := os.WriteFile(filepath.Join(sourceDir, "agents", name+".agent.md"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "onDisk.agent.md"), []byte("installed by an older nav-pilot\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	state := &StateFile{
+		Collection: "fullstack",
+		Scope:      scope.Name,
+		SourceRepo: "navikt/copilot",
+		SourceSHA:  "abc1234",
+	}
+	src := &Source{
+		Dir:   sourceDir,
+		SHA:   "abc1234",
+		Repo:  "navikt/copilot",
+		Pakke: &agentpakke.Manifest{Name: "nav-pilot"},
+	}
+
+	adoptPakkeIdentity(scope, src, state, NewSourceResolver(sourceDir), true)
+
+	var ignored []string
+	for _, f := range state.Files {
+		if f.Status == fileStatusIgnored {
+			ignored = append(ignored, f.Path)
+		}
+	}
+	for _, p := range ignored {
+		if strings.Contains(p, "onDisk") {
+			t.Errorf("the fold-in marked an installed artifact as ignored: %v", ignored)
+		}
+	}
+	if len(ignored) == 0 {
+		t.Error("the fold-in marked nothing as ignored; the genuinely absent agent should be")
 	}
 }

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -440,6 +440,13 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 		reportRetired(retired, apply)
 	}
 
+	// Reported, not acted on: an ignored artifact is one nav-pilot was told to
+	// leave alone, and sync must keep leaving it alone. Saying so is the whole
+	// fix (#724) — silence is what let one sit on a withdrawn model.
+	if stale := ignoredButInstalled(scope); len(stale) > 0 {
+		reportIgnoredButInstalled(stale)
+	}
+
 	// Report deletions
 	if len(deletedPaths) > 0 {
 		fmt.Printf("%s %d file(s) deleted in source and will be removed (source: %s)\n\n",

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -442,7 +442,7 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 
 	// Reported, not acted on: an ignored artifact is one nav-pilot was told to
 	// leave alone, and sync must keep leaving it alone. Saying so is the whole
-	// fix (#724) — silence is what let one sit on a withdrawn model.
+	// fix (#724), since silence is what let one sit on a withdrawn model.
 	if stale := ignoredButInstalled(scope); len(stale) > 0 {
 		reportIgnoredButInstalled(stale)
 	}


### PR DESCRIPTION
Lukker #724, med alle tre retningene fra issuet. De utfyller hverandre: den ene retter årsaken, den andre rydder i det som allerede står slik, den tredje forklarer det når noen møter det.

## Årsaken

Fold-inn i #468 merket hver artefakt som manglet i tilstandsfila som ignorert:

```go
if !installed[relPath] {
    ignored = append(ignored, relPath)
}
```

Antakelsen er at «ikke i state» betyr «ikke installert». Det stemmer ikke. En artefakt skrevet av en eldre nav-pilot, eller av en samlingsinstallasjon som noterte mindre, ligger på disk og er i bruk. Fold-inn ser nå på disken før den merker noe.

## Symptomet

Sync melder nå ignorerte artefakter som faktisk ligger i scopet, hva det betyr, og hvordan man tar dem tilbake:

```
⚠ 1 installed artifact(s) are marked ignored, so sync leaves them as they are

  ⊘ agents/nav-pilot-opus.agent.md

  They keep whatever version they were installed with, including a model pin
  that may no longer exist. nav-pilot add <type> <name> --force takes the
  source's version and starts tracking it again.
```

Rapportert, aldri fjernet. En ignorert fil er en nav-pilot har fått beskjed om å la være, og den beskjeden gjelder fortsatt. Det gale er ikke at fila finnes, men at ingenting sa at den hadde sluttet å bli vedlikeholdt.

## Diagnosen

`doctor` fant pinnen på den tilbaketrukne modellen, men sa ingenting om hvorfor fila aldri ble oppdatert. Nå står grunnen ved siden av:

```
⚠ nav-pilot-opus pins "Claude Opus 4.6"  (marked ignored, so sync skips it)
```

Uten den linja gjør det åpenbare neste steget, å kjøre `sync`, ingenting, og ser ødelagt ut.

## Hvordan det ble funnet

Ikke ved lesing. `doctor`-sjekken fra #719 spurte klienten hvilke modeller kontoen kan starte, og meldte at `nav-pilot-opus` sto på `Claude Opus 4.6`. Kilden har sagt `GPT-5.6 Sol` siden august. Sync meldte samtidig «User scope synced» uten å nevne fila.

Det er tredje variant av samme familie, etter #716 (usporet og pensjonert) og #692 (sporet, avviker fra hashen).

## Kontroller

| Fjernet | Rødt |
|---|---|
| disk-sjekken i fold-inn | `TestFoldInSparesInstalledArtifacts` |
| disk-sjekken i `ignoredButInstalled` | `TestIgnoredButInstalled` |

Den andre testen har med en ignorert artefakt som *ikke* ligger på disk, siden det er det vanlige tilfellet og ikke skal meldes: ingenting har sluttet å bli vedlikeholdt der.

`mise run check` er grønn.
