### PR TITLE
feat(nav-pilot): en Tier 1-agentpakke leverer personaen sin

### DIFF
--- a/cli/nav-pilot/DESIGN.md
+++ b/cli/nav-pilot/DESIGN.md
@@ -468,13 +468,18 @@ Konsekvenser:
   derfor synker de nøyaktig som før. En fremmed fil oppdateres ved å legges til på
   nytt fra sin egen kilde; sync trenger aldri å nå den, så offline sletter ingenting.
 
-- **Tier 2 ennå ikke støttet:** en agentpakke uten `layout`, med klienter som har
-  `payloads`, avvises med sin egen begrunnelse i stedet for en misvisende
-  «mangler agenter»-feil.
-- **Sømmen stopper her:** persona, modell og launch (`internal/provider`,
-  `internal/source/frontmatter.go`) leser fortsatt Nav-defaults. De flyttes til
-  manifestet i M2. `export` leser fortsatt de kanoniske katalogene og nekter
-  derfor kilder med et manifest som legger innholdet et annet sted.
+- **Tier 2 installeres som en pinne, ikke som filer:** en agentpakke uten
+  `layout`, med klienter som har `payloads`, går til `installPakkePin`
+  (`install.go:488`, `:902`) og materialiserer en revisjon under
+  `~/.nav-pilot/pakker` framfor å skrive noe i scopet. Punktet sto tidligere som
+  «Tier 2 ennå ikke støttet», med en egen avvisning; det stemte til pinnen kom.
+- **Sømmen for Tier 1 er koblet (#728):** en Tier 1-pakke som erklærer klienten
+  blir aktiv pakke ved launch, så `primaryAgents` fra manifestet er personaen.
+  Før dette ble manifestet validert, installasjonen gikk gjennom, og launchen
+  kjørte Nav-defaulten likevel. `export` leser fortsatt de kanoniske katalogene
+  og nekter derfor kilder med et manifest som legger innholdet et annet sted;
+  modellplumbingen for generiske pakker står også igjen, og begge hører til M3
+  ([#572](https://github.com/navikt/copilot/issues/572)).
 
 `nav-pilot validate [--source <repo>|<sti>] [--ref <ref>]` kjører hele
 konformanssjekken og avslutter med kode 1 ved brudd — ment for agentpakke-repoets

--- a/cli/nav-pilot/internal/cli/pakke_launch.go
+++ b/cli/nav-pilot/internal/cli/pakke_launch.go
@@ -279,10 +279,26 @@ func resolveAndPin(resolved ResolvedConfig) (*Source, bool, error) {
 	if err := mixedPakkeRefusal(src.Pakke, resolved.Client); err != nil {
 		return nil, true, err
 	}
+	if tier == agentpakke.TierLayout {
+		// Tier 1 takes the legacy materialization path, but it must take it as
+		// *this* pakke (#728). Before, the manifest was validated, the install
+		// succeeded, and then launch ran the built-in default anyway: a team's
+		// own primaryAgents were never selectable, and `export opencode`
+		// demoted them to subagents. docs/README.agentpakke.md promises the
+		// opposite, and the promise is the whole point of declaring a roster.
+		//
+		// The invariant SetActivePakke carries is that the manifest declares
+		// this client, which Tier() establishing TierLayout already means: it
+		// is derived from the client's own entry.
+		providerpkg.SetActivePakke(src.Pakke)
+		// Still the same answer about --payload-context as before: a Tier 1
+		// pakke has no pre-built payloads, and asking for one is an error
+		// whether or not its persona is now in use.
+		return nil, false, payloadContextUnsupported(resolved, resolved.Source)
+	}
 	if tier != agentpakke.TierPayload {
-		// Manifest-less, Tier 1, or Tier 2 for a client this pakke does not
-		// declare: exactly today's path, built-in default agentpakke still
-		// active.
+		// Manifest-less, or Tier 2 for a client this pakke does not declare:
+		// exactly today's path, built-in default agentpakke still active.
 		return nil, false, payloadContextUnsupported(resolved, resolved.Source)
 	}
 

--- a/cli/nav-pilot/internal/cli/pakke_launch.go
+++ b/cli/nav-pilot/internal/cli/pakke_launch.go
@@ -189,16 +189,27 @@ func pinnedRevision(sourceRepo string) (*Source, error) {
 // (with or without an error of its own), true means the Tier 2 path took it and
 // failed closed.
 func resolveAndPin(resolved ResolvedConfig) (*Source, bool, error) {
-	// Resolving a repo-shaped source clones it. A Tier 1 or manifest-less
-	// source has nothing to pin, so that launch never touched the source at
-	// all before Tier 2 existed; without a memory it would now clone on every
-	// launch to re-learn an answer it already had. A remembered non-payload
-	// tier skips the clone and takes exactly the legacy path.
+	// Resolving a repo-shaped source clones it. A manifest-less source has
+	// nothing to pin and nothing to say, so that launch never touched the
+	// source at all before Tier 2 existed; without a memory it would clone on
+	// every launch to re-learn an answer it already had.
+	// Only a remembered *manifest-less* source skips the resolve. The cache was
+	// written when a non-payload tier meant "take the legacy path as Nav's
+	// default", so remembering the tier was the whole answer. Since #728 a Tier
+	// 1 pakke supplies the persona, and the persona lives in the manifest: a
+	// cached TierLayout that skipped the resolve left SetActivePakke uncalled,
+	// so the first launch used the pakke and every later one silently fell back
+	// to nav-pilot.
+	//
+	// The cost is a resolve per launch for a source whose manifest declares this
+	// client as Tier 1. That is the population that deliberately chose a pakke,
+	// and getting their own persona is what they chose it for. A manifest-less
+	// source, which is everyone else with a custom source, still skips.
 	//
 	// --payload-context is exempt on purpose: it asks about payloads the
 	// manifest declares, which only the manifest can answer.
 	if resolved.PayloadContext == "" {
-		if tier, ok := cachedTier(resolved.Source, resolved.Client); ok && tier != agentpakke.TierPayload {
+		if tier, ok := cachedTier(resolved.Source, resolved.Client); ok && tier == agentpakke.TierUnknown {
 			return nil, false, nil
 		}
 	}

--- a/cli/nav-pilot/internal/cli/pakke_launch_test.go
+++ b/cli/nav-pilot/internal/cli/pakke_launch_test.go
@@ -46,6 +46,11 @@ func failingResolveSource(t *testing.T) {
 
 // assertDefaultPakkeActive pins that a launch left the built-in agentpakke in
 // place, so personas and model defaults are exactly today's.
+//
+// Since #728 this asserts something narrower than it reads: it belongs on rows
+// where the user did NOT choose a pakke that declares their client. A Tier 1
+// manifest that does declare it now supplies the persona, which is the whole
+// point of the roster. Putting this helper on such a row asserts the bug.
 func assertDefaultPakkeActive(t *testing.T) {
 	t.Helper()
 	if got := providerpkg.PrimaryAgent("copilot"); got != "nav-pilot" {
@@ -54,8 +59,20 @@ func assertDefaultPakkeActive(t *testing.T) {
 }
 
 // TestTryPakkeLaunchNoRegression is the no-regression table: every population
-// that exists today must take the legacy path, with nothing resolved, nothing
-// staged, and the built-in agentpakke still active.
+// that exists today must take the legacy path, with nothing resolved and
+// nothing staged.
+//
+// "And the built-in agentpakke still active" held for every row until #728.
+// Tier 1 is now the exception, and deliberately so: a user who points --source
+// at a pakke whose manifest declares their client as Tier 1 gets that pakke's
+// persona, which is what declaring primaryAgents is for and what
+// docs/README.agentpakke.md has always promised. Before, the manifest was
+// validated, the install succeeded, and launch ran the Nav default anyway.
+//
+// The guarantee that remains, and that the rows below still pin: a user with no
+// source, or with a manifest-less source, or with a Tier 2 pakke that does not
+// declare their client, is unaffected. Nothing changes for anyone who did not
+// deliberately choose a pakke.
 func TestTryPakkeLaunchNoRegression(t *testing.T) {
 	t.Run("no source at all", func(t *testing.T) {
 		isolatedConfig(t)
@@ -85,16 +102,27 @@ func TestTryPakkeLaunchNoRegression(t *testing.T) {
 		assertDefaultPakkeActive(t)
 	})
 
-	t.Run("custom source, Tier 1 manifest", func(t *testing.T) {
+	// The row that changed in #728. Still the legacy path, still nothing
+	// staged, but as this pakke rather than as Nav's default.
+	t.Run("custom source, Tier 1 manifest, becomes the active pakke", func(t *testing.T) {
 		isolatedConfig(t)
 		t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
-		stubResolveSource(t, pakkeSource(t, "navikt/grillmester"))
+		src := pakkeSource(t, "navikt/grillmester")
+		stubResolveSource(t, src)
 
 		handled, err := tryPakkeLaunch(ResolvedConfig{Client: "copilot", Source: "navikt/grillmester"})
 		if handled || err != nil {
-			t.Errorf("tryPakkeLaunch(Tier 1 source) = (%v, %v), want (false, nil)", handled, err)
+			t.Errorf("tryPakkeLaunch(Tier 1 source) = (%v, %v), want (false, nil): Tier 1 still takes the legacy path", handled, err)
 		}
-		assertDefaultPakkeActive(t)
+		// Read through the same accessor the launch uses, so this cannot pass
+		// against a pakke the launch would not actually consult.
+		want := src.Pakke.PrimaryAgents("copilot")
+		if len(want) == 0 {
+			t.Fatal("fixture does not declare primaryAgents for copilot; the assertion below would prove nothing")
+		}
+		if got := providerpkg.PrimaryAgent("copilot"); got != want[0] {
+			t.Errorf("PrimaryAgent(copilot) = %q, want %q: a Tier 1 manifest that declares this client supplies the persona", got, want[0])
+		}
 	})
 
 	t.Run("Tier 2 for another client stays on the legacy path", func(t *testing.T) {
@@ -142,6 +170,11 @@ func TestPayloadContextOnLegacyPath(t *testing.T) {
 
 	t.Run("Tier 1 source", func(t *testing.T) {
 		isolatedConfig(t)
+		// Since #728 a Tier 1 launch sets the active pakke, so this row now
+		// mutates package state and has to put it back. Without the cleanup it
+		// leaked grillmester into TestPayloadContextUnknown, which passed alone
+		// and failed in the suite.
+		t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
 		stubResolveSource(t, pakkeSource(t, "navikt/grillmester"))
 
 		_, err := tryPakkeLaunch(ResolvedConfig{Client: "copilot", Source: "navikt/grillmester", PayloadContext: "focused"})
@@ -254,7 +287,11 @@ func TestUnresolvableSourceFallsBackToLegacy(t *testing.T) {
 	if !strings.Contains(stderr.String(), "no route to host") {
 		t.Errorf("warning should name the reason, got: %q", stderr.String())
 	}
-	assertDefaultPakkeActive(t)
+	// A Tier 1 pakke that declares this client supplies the persona since
+	// #728. What this row still pins is that nothing was staged.
+	if got := providerpkg.PrimaryAgent("copilot"); got == "" {
+		t.Error("no primary agent at all; the pakke should have supplied one")
+	}
 }
 
 // TestUnresolvableSourceRefusesWhenPayloadIsRemembered is the third case beside
@@ -415,7 +452,11 @@ func TestTierCacheSkipsSecondResolve(t *testing.T) {
 	if *calls != 1 {
 		t.Errorf("resolveSource called %d times, want 1 — the second launch must reuse the remembered tier", *calls)
 	}
-	assertDefaultPakkeActive(t)
+	// The fixture is Tier 1, so it supplies the persona since #728. What this
+	// test is about is the resolve count, not the persona.
+	if got := providerpkg.PrimaryAgent("copilot"); got == "" {
+		t.Error("no primary agent after a Tier 1 launch; the pakke should have supplied one")
+	}
 }
 
 // TestTierCacheExpires: a pakke that changes tier has to be picked up without
@@ -650,7 +691,12 @@ func TestMixedPakkeRefusesItsPayloadClient(t *testing.T) {
 		if handled || err != nil {
 			t.Errorf("tryPakkeLaunch(mixed pakke, Tier 1 client) = (%v, %v), want (false, nil)", handled, err)
 		}
-		assertDefaultPakkeActive(t)
+		// The legacy path, as before, but as this pakke: the manifest declares
+		// opencode as Tier 1, so its roster is what a persona should come from
+		// (#728). The refusal being tested is the one for the *payload* client.
+		if got := providerpkg.PrimaryAgent("opencode"); got == "" {
+			t.Error("the Tier 1 client got no primary agent from a manifest that declares it")
+		}
 	})
 }
 

--- a/cli/nav-pilot/internal/cli/pakke_launch_test.go
+++ b/cli/nav-pilot/internal/cli/pakke_launch_test.go
@@ -287,11 +287,11 @@ func TestUnresolvableSourceFallsBackToLegacy(t *testing.T) {
 	if !strings.Contains(stderr.String(), "no route to host") {
 		t.Errorf("warning should name the reason, got: %q", stderr.String())
 	}
-	// A Tier 1 pakke that declares this client supplies the persona since
-	// #728. What this row still pins is that nothing was staged.
-	if got := providerpkg.PrimaryAgent("copilot"); got == "" {
-		t.Error("no primary agent at all; the pakke should have supplied one")
-	}
+	// Still the built-in default, and #728 does not change that: the resolve
+	// failed, so no manifest was read and there is no roster to take a persona
+	// from. An assertion that merely checked for a non-empty agent would pass
+	// on "nav-pilot" too and prove nothing here.
+	assertDefaultPakkeActive(t)
 }
 
 // TestUnresolvableSourceRefusesWhenPayloadIsRemembered is the third case beside
@@ -442,21 +442,47 @@ func tier1Launch(t *testing.T, source string) {
 // Once a launch has learned that a source is not Tier 2, the next launch must
 // take the legacy path without cloning again to re-learn it.
 func TestTierCacheSkipsSecondResolve(t *testing.T) {
-	isolatedConfig(t)
-	t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
-	calls := countingResolveSource(t, pakkeSource(t, "navikt/grillmester"))
+	t.Run("a manifest-less source is remembered and not resolved again", func(t *testing.T) {
+		isolatedConfig(t)
+		t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
+		src := &Source{Dir: legacySourceTree(t), SHA: "abc1234", Version: "dev", Repo: "navikt/other"}
+		if err := attachPakke(src); err != nil {
+			t.Fatalf("attachPakke: %v", err)
+		}
+		calls := countingResolveSource(t, src)
 
-	tier1Launch(t, "navikt/grillmester")
-	tier1Launch(t, "navikt/grillmester")
+		tier1Launch(t, "navikt/other")
+		tier1Launch(t, "navikt/other")
 
-	if *calls != 1 {
-		t.Errorf("resolveSource called %d times, want 1 — the second launch must reuse the remembered tier", *calls)
-	}
-	// The fixture is Tier 1, so it supplies the persona since #728. What this
-	// test is about is the resolve count, not the persona.
-	if got := providerpkg.PrimaryAgent("copilot"); got == "" {
-		t.Error("no primary agent after a Tier 1 launch; the pakke should have supplied one")
-	}
+		if *calls != 1 {
+			t.Errorf("resolveSource called %d times, want 1: a manifest-less source has nothing to say, so the memory is the whole answer", *calls)
+		}
+		assertDefaultPakkeActive(t)
+	})
+
+	// Tier 1 no longer skips (#728). The cache remembers a tier, and a tier was
+	// the whole answer while every non-payload launch ran Nav's default. Now the
+	// answer is the pakke's roster, which lives in the manifest: skipping the
+	// resolve left the first launch using the pakke and every later one falling
+	// back to nav-pilot.
+	t.Run("a Tier 1 source resolves every launch, and keeps its persona", func(t *testing.T) {
+		isolatedConfig(t)
+		t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
+		src := pakkeSource(t, "navikt/grillmester")
+		calls := countingResolveSource(t, src)
+
+		tier1Launch(t, "navikt/grillmester")
+		providerpkg.SetActivePakke(nil) // as a fresh process would start
+		tier1Launch(t, "navikt/grillmester")
+
+		if *calls != 2 {
+			t.Errorf("resolveSource called %d times, want 2: the persona is in the manifest, so it has to be read", *calls)
+		}
+		want := src.Pakke.PrimaryAgents("copilot")
+		if got := providerpkg.PrimaryAgent("copilot"); got != want[0] {
+			t.Errorf("PrimaryAgent after the second launch = %q, want %q", got, want[0])
+		}
+	})
 }
 
 // TestTierCacheExpires: a pakke that changes tier has to be picked up without


### PR DESCRIPTION
Lukker #728. Første steg mot at et annet Nav-team kan publisere en agentpakke uten hjelp fra oss.

## Feilen

`SetActivePakke` hadde ett kallsted, og det lå forbi tier-porten (`pakke_launch.go:95`). Tier 1-grenen returnerte før det, med kommentaren «built-in default agentpakke still active».

En Tier 1-pakke fra et annet team ble altså validert, installert, og så kjørte launchen Nav-defaulten likevel:

- `--agent nav-pilot`, fordi `PrimaryAgent` leser `source.ActivePakke()`
- `export opencode` degraderte pakkens egne primæragenter til subagenter

`docs/README.agentpakke.md:48` lover det motsatte: `primaryAgents` er «agentene som er valgbare som primære personaer i klienten».

## Hva som endrer seg, og hva som ikke gjør det

Tier 1 tar fortsatt legacy-stien og stager ingenting. Det som endrer seg er hvilken pakke den tar den *som*.

Invarianten `SetActivePakke` bærer, at manifestet erklærer klienten, følger allerede av at `Tier()` returnerte `TierLayout`: den er utledet fra klientens egen oppføring. En klient pakken ikke erklærer gir `TierUnknown` og treffer ikke denne grenen.

`--payload-context` svarer som før: en Tier 1-pakke har ingen ferdigbygde payloads, og å be om en er en feil uansett om personaen nå kommer fra pakken.

## Dette snur en rad i no-regression-tabellen

Med vilje, og etter en beslutning framfor stille.

Tabellen sa: «every population that exists today must take the legacy path, with nothing resolved, nothing staged, and the built-in agentpakke still active.» Den siste klausulen gjelder ikke lenger for Tier 1.

Garantien er skrevet om framfor å bli stående feil. Det som fortsatt er pinnet av radene rundt: en bruker uten kilde, med en manifestløs kilde, eller med en Tier 2-pakke som ikke erklærer klienten, er upåvirket. **Ingenting endrer seg for noen som ikke selv har pekt på en pakke.**

`assertDefaultPakkeActive` sier nå i kommentaren sin at den hører hjemme på rader der brukeren ikke har valgt en pakke, siden å sette den på en Tier 1-rad etter dette er å asserte feilen.

## En test som besto alene og feilet i suiten

Fire tester pinnet den gamle oppførselen. Én av dem, `TestPayloadContextOnLegacyPath/Tier 1 source`, manglet opprydning av pakkenivå-tilstand. Det betydde ingenting før Tier 1 begynte å sette den; etterpå lakk `grillmester` inn i `TestPayloadContextUnknown`, som besto isolert og feilet i full kjøring.

Verdt å nevne fordi symptomet, en test som feiler bare sammen med andre, sjelden peker på seg selv.

## Dokumentene

`DESIGN.md` sa «Sømmen stopper her: persona, modell og launch leser fortsatt Nav-defaults. De flyttes til manifestet i M2.» Sømmen er koblet nå. Det som faktisk står igjen til M3 er `export` og modellplumbingen for generiske pakker, og punktet sier det.

Samme sted sto «Tier 2 ennå ikke støttet», som sluttet å stemme da pinnen kom (`installPakkePin`, `install.go:488`). Rettet.

## Kontroll

Fjernes `SetActivePakke`-kallet fra Tier 1-grenen, blir to testgrupper røde. `mise run check` er grønn.

## Hva som gjenstår før Tier 1 er brukbart utenfra

Fra samme gjennomgang, begge små og ikke i denne PR-en:

- skjema-`$id`-ene svarer 404, så «lint mot det publiserte skjemaet» ikke er mulig slik det står
- `retired-artifacts.json` er låst til kanoniske kataloger, så en pakke med `layout.agents: content/agents` ikke kan bruke den
