### PR TITLE
fix(agentpakke): to ting en ekstern pakkeforfatter treffer først

### DIFF
--- a/cli/nav-pilot/internal/agentpakke/payload_schema.go
+++ b/cli/nav-pilot/internal/agentpakke/payload_schema.go
@@ -11,7 +11,7 @@ import (
 )
 
 // PayloadSchemaID is the $id of the published payload manifest schema.
-const PayloadSchemaID = "https://github.com/navikt/copilot/cli/nav-pilot/schemas/agentpakke-payload-v1.json"
+const PayloadSchemaID = "https://raw.githubusercontent.com/navikt/copilot/main/cli/nav-pilot/schemas/agentpakke-payload-v1.json"
 
 // PayloadSchemaJSON returns the published payload schema bytes, for a caller
 // that wants to vendor or serve it. A copy, so a caller cannot mutate the

--- a/cli/nav-pilot/internal/agentpakke/schema.go
+++ b/cli/nav-pilot/internal/agentpakke/schema.go
@@ -14,12 +14,12 @@ import (
 	"golang.org/x/text/message"
 )
 
-// SchemaID is the published identity of the agentpakke manifest schema — the
-// $id an agentpakke repo references when linting its manifest in CI.
-// SchemaID is the $id of the published manifest schema, and a URL that
-// actually resolves: the error messages tell an agentpakke author to lint
-// against it, so it has to be fetchable (#728). github.com/<owner>/<repo>/<path>
-// is not a raw path and answers 404.
+// SchemaID is the published identity of the agentpakke manifest schema: the $id
+// an agentpakke repo references when linting its manifest in CI.
+//
+// It is a raw URL because the error messages tell an author to fetch it, and
+// github.com/<owner>/<repo>/<path> is not a raw path: it answered 404 until
+// #728.
 const SchemaID = "https://raw.githubusercontent.com/navikt/copilot/main/cli/nav-pilot/schemas/agentpakke-v1.json"
 
 // SchemaJSON returns the published JSON Schema bytes. They come from the file

--- a/cli/nav-pilot/internal/agentpakke/schema.go
+++ b/cli/nav-pilot/internal/agentpakke/schema.go
@@ -16,7 +16,11 @@ import (
 
 // SchemaID is the published identity of the agentpakke manifest schema — the
 // $id an agentpakke repo references when linting its manifest in CI.
-const SchemaID = "https://github.com/navikt/copilot/cli/nav-pilot/schemas/agentpakke-v1.json"
+// SchemaID is the $id of the published manifest schema, and a URL that
+// actually resolves: the error messages tell an agentpakke author to lint
+// against it, so it has to be fetchable (#728). github.com/<owner>/<repo>/<path>
+// is not a raw path and answers 404.
+const SchemaID = "https://raw.githubusercontent.com/navikt/copilot/main/cli/nav-pilot/schemas/agentpakke-v1.json"
 
 // SchemaJSON returns the published JSON Schema bytes. They come from the file
 // that ships in the repo (cli/nav-pilot/schemas/agentpakke-v1.json), so the

--- a/cli/nav-pilot/internal/cli/retired.go
+++ b/cli/nav-pilot/internal/cli/retired.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
 	"github.com/navikt/copilot/cli/nav-pilot/internal/source"
 )
 
@@ -74,15 +75,18 @@ type retiredOrphan struct {
 // a published revision is proof nav-pilot wrote the file and that the user has
 // not since changed it, which is the same standard the ordinary delete path
 // uses (#716).
-func findRetiredOrphans(scope *InstallScope, sourceDir string) []retiredOrphan {
+func findRetiredOrphans(scope *InstallScope, sourceDir string, pakke *agentpakke.Manifest) []retiredOrphan {
 	m := loadRetired(sourceDir)
 	if m == nil {
 		return nil
 	}
+	var layout *agentpakke.Layout
+	if pakke != nil {
+		layout = pakke.Layout
+	}
 	var found []retiredOrphan
 	for srcPath, blobs := range m.Paths {
-		dir, file := path2DirFile(srcPath)
-		kind := kindForDir(dir)
+		kind, file := kindForPath(srcPath, layout)
 		if kind == nil {
 			continue
 		}
@@ -103,13 +107,51 @@ func findRetiredOrphans(scope *InstallScope, sourceDir string) []retiredOrphan {
 	return found
 }
 
-// path2DirFile splits "agents/auth.agent.md" into its directory and file name.
-func path2DirFile(p string) (string, string) {
-	i := strings.IndexByte(p, '/')
-	if i < 0 {
-		return "", p
+// kindForPath maps a retired source path to its artifact kind and the file
+// under it, or nil when the path belongs to no kind this scope knows.
+//
+// Matching is by directory prefix rather than by splitting on the first slash.
+// A declared layout may nest, so "content/agents/gammel.agent.md" has to resolve
+// to the agent kind with "gammel.agent.md" under it; splitting on the first
+// slash gave "content" and matched nothing (#728).
+//
+// The kinds come from AllKinds rather than a written-out list, the lesson of
+// #649, #650 and #708: three hardcoded kind lists have gone stale in this CLI
+// already. The directory names come from the manifest when it declares a
+// layout, and from the canonical names otherwise, because a Tier 1 agentpakke
+// may put its content anywhere. Matching only the canonical names made the
+// retired-artifact record usable by this repo alone.
+func kindForPath(srcPath string, layout *agentpakke.Layout) (*source.ArtifactKind, string) {
+	type candidate struct {
+		dir  string
+		kind *source.ArtifactKind
 	}
-	return p[:i], p[i+1:]
+	var candidates []candidate
+	if layout != nil {
+		for _, m := range []candidate{
+			{layout.Agents, source.KindAgent},
+			{layout.Skills, source.KindSkill},
+			{layout.Instructions, source.KindInstruction},
+			{layout.Prompts, source.KindPrompt},
+			{layout.Hooks, source.KindHook},
+		} {
+			if m.dir != "" {
+				candidates = append(candidates, candidate{strings.Trim(m.dir, "/"), m.kind})
+			}
+		}
+	}
+	for _, k := range AllKinds {
+		candidates = append(candidates, candidate{k.Dir, k})
+	}
+	// Longest first, so a layout that nests one kind inside another cannot be
+	// shadowed by the shorter prefix.
+	sort.Slice(candidates, func(i, j int) bool { return len(candidates[i].dir) > len(candidates[j].dir) })
+	for _, c := range candidates {
+		if rest, ok := strings.CutPrefix(srcPath, c.dir+"/"); ok && rest != "" {
+			return c.kind, rest
+		}
+	}
+	return nil, ""
 }
 
 // removeRetiredOrphans deletes the given files, returning how many went away.
@@ -130,18 +172,6 @@ func removeRetiredOrphans(orphans []retiredOrphan, quiet bool) int {
 		removed++
 	}
 	return removed
-}
-
-// kindForDir maps a source directory to its artifact kind. Derived from
-// AllKinds rather than written out, the lesson of #649, #650 and #708: three
-// separate hardcoded kind lists have gone stale in this CLI already.
-func kindForDir(dir string) *source.ArtifactKind {
-	for _, k := range AllKinds {
-		if k.Dir == dir {
-			return k
-		}
-	}
-	return nil
 }
 
 // retiredPaths is the orphan list as source paths, for the JSON document.

--- a/cli/nav-pilot/internal/cli/retired_test.go
+++ b/cli/nav-pilot/internal/cli/retired_test.go
@@ -65,7 +65,7 @@ func TestFindRetiredOrphans(t *testing.T) {
 		"agents/nevermind.agent.md":["`+blobHash(published)+`"]
 	}}`)
 
-	got := findRetiredOrphans(scope, sourceDir)
+	got := findRetiredOrphans(scope, sourceDir, nil)
 	if len(got) != 1 || got[0].Path != "agents/auth.agent.md" {
 		t.Fatalf("findRetiredOrphans = %+v, want exactly agents/auth.agent.md: "+
 			"mine.agent.md is retired upstream but holds different bytes, and nevermind is not installed", got)
@@ -85,7 +85,7 @@ func TestFindRetiredOrphansSparesEditedFiles(t *testing.T) {
 	sourceDir := t.TempDir()
 	writeRetired(t, sourceDir, `{"paths":{"agents/auth.agent.md":["`+blobHash(published)+`"]}}`)
 
-	if got := findRetiredOrphans(scope, sourceDir); len(got) != 0 {
+	if got := findRetiredOrphans(scope, sourceDir, nil); len(got) != 0 {
 		t.Errorf("findRetiredOrphans = %+v, want none: an edited file is the user's", got)
 	}
 }
@@ -94,7 +94,7 @@ func TestFindRetiredOrphansSparesEditedFiles(t *testing.T) {
 // not this repo, and for older revisions of this one. Silent, not an error.
 func TestFindRetiredOrphansWithoutManifest(t *testing.T) {
 	scope, _ := userScopeWithAgents(t)
-	if got := findRetiredOrphans(scope, t.TempDir()); got != nil {
+	if got := findRetiredOrphans(scope, t.TempDir(), nil); got != nil {
 		t.Errorf("findRetiredOrphans without a record = %+v, want nil", got)
 	}
 }
@@ -305,5 +305,34 @@ func TestFoldInSparesInstalledArtifacts(t *testing.T) {
 	}
 	if len(ignored) == 0 {
 		t.Error("the fold-in marked nothing as ignored; the genuinely absent agent should be")
+	}
+}
+
+// TestRetiredHonoursDeclaredLayout covers the half of #722 that only worked for
+// this repo (#728): a Tier 1 agentpakke may declare where its content lives, so
+// a retired path can read "content/agents/gammel.agent.md". Matching the
+// canonical name alone meant such a pakke could never retire anything.
+func TestRetiredHonoursDeclaredLayout(t *testing.T) {
+	scope, agentDir := userScopeWithAgents(t)
+	published := []byte("---\nname: gammel\n---\n\nretired\n")
+	if err := os.WriteFile(filepath.Join(agentDir, "gammel.agent.md"), published, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sourceDir := t.TempDir()
+	writeRetired(t, sourceDir, `{"paths":{"content/agents/gammel.agent.md":["`+blobHash(published)+`"]}}`)
+
+	// Without the manifest the directory is unknown, so nothing is found: the
+	// control that keeps the layout lookup from being a no-op.
+	if got := findRetiredOrphans(scope, sourceDir, nil); len(got) != 0 {
+		t.Fatalf("findRetiredOrphans without a layout = %+v, want none", got)
+	}
+
+	pakke := &agentpakke.Manifest{
+		Name:   "annet-team",
+		Layout: &agentpakke.Layout{Agents: "content/agents", Skills: "content/skills"},
+	}
+	got := findRetiredOrphans(scope, sourceDir, pakke)
+	if len(got) != 1 || got[0].Path != "content/agents/gammel.agent.md" {
+		t.Errorf("findRetiredOrphans with a declared layout = %+v, want the one orphan", got)
 	}
 }

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -178,7 +178,7 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 	// placed later is a scan the two "nothing to do" paths jump over: sync
 	// printed "All N files up to date" over three orphans and --apply removed
 	// none of them. That is the state the machine which found #716 was in.
-	retired := findRetiredOrphans(scope, src.Dir)
+	retired := findRetiredOrphans(scope, src.Dir, src.Pakke)
 
 	// What the committed pin would become. Computed before the file diff
 	// because it is a change in its own right: a revision the repo tracks can

--- a/cli/nav-pilot/schemas/agentpakke-payload-v1.json
+++ b/cli/nav-pilot/schemas/agentpakke-payload-v1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/navikt/copilot/cli/nav-pilot/schemas/agentpakke-payload-v1.json",
+  "$id": "https://raw.githubusercontent.com/navikt/copilot/main/cli/nav-pilot/schemas/agentpakke-payload-v1.json",
   "title": "nav-pilot agentpakke payload manifest (v1)",
   "description": "Contract for the payload manifest of a Tier 2 agentpakke payload. Lives at <payload>/manifest.json, or wherever the client entry's `manifest` field points. Describes the payload tree exactly: nav-pilot refuses a tree that holds a file the manifest does not list, or lacks one it does. Parenthesised ids such as (A7) are decision ids defined in the PRD at https://github.com/navikt/copilot/issues/435. Unknown top-level fields are ignored, so a generator may add descriptive keys without invalidating the manifest on an older binary.",
   "type": "object",

--- a/cli/nav-pilot/schemas/agentpakke-v1.json
+++ b/cli/nav-pilot/schemas/agentpakke-v1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/navikt/copilot/cli/nav-pilot/schemas/agentpakke-v1.json",
+  "$id": "https://raw.githubusercontent.com/navikt/copilot/main/cli/nav-pilot/schemas/agentpakke-v1.json",
   "title": "nav-pilot agentpakke manifest (v1)",
   "description": "Contract between an agentpakke repo and the nav-pilot binary. Lives at .nav-pilot/agentpakke.json in the agentpakke repo. Unknown client keys, context keys, and additional fields are ignored by consumers (A3/A4), so growth of the ecosystem never invalidates an existing manifest on an older binary. Parenthesised ids such as (A1) and (G3) are decision ids defined in the PRD at https://github.com/navikt/copilot/issues/435.",
   "type": "object",

--- a/cli/nav-pilot/schemas/schemas.go
+++ b/cli/nav-pilot/schemas/schemas.go
@@ -10,14 +10,16 @@ package schemas
 import _ "embed"
 
 // AgentpakkeV1 is the agentpakke manifest schema, contract version 1.
-// Its $id is https://github.com/navikt/copilot/cli/nav-pilot/schemas/agentpakke-v1.json.
+// Its $id is
+// https://raw.githubusercontent.com/navikt/copilot/main/cli/nav-pilot/schemas/agentpakke-v1.json,
+// which is a URL that resolves: an agentpakke repo is told to lint against it.
 //
 //go:embed agentpakke-v1.json
 var AgentpakkeV1 []byte
 
 // AgentpakkePayloadV1 is the payload manifest schema, contract version 1. Its
 // $id is
-// https://github.com/navikt/copilot/cli/nav-pilot/schemas/agentpakke-payload-v1.json.
+// https://raw.githubusercontent.com/navikt/copilot/main/cli/nav-pilot/schemas/agentpakke-payload-v1.json.
 //
 // The payload manifest is the other half of the trust boundary: the top-level
 // manifest says which trees exist, this one says exactly what each tree holds.


### PR DESCRIPTION
To små funn fra arkitekturgjennomgangen i #728. Begge treffer en pakkeforfatter utenfor dette repoet før noe annet gjør det.

## Skjema-ID-ene svarte 404

`$id` i begge skjemaene pekte på `https://github.com/navikt/copilot/cli/nav-pilot/schemas/...`, som ikke er en rå sti:

```
404  github.com/navikt/copilot/cli/nav-pilot/schemas/agentpakke-v1.json
200  raw.githubusercontent.com/navikt/copilot/main/cli/nav-pilot/schemas/agentpakke-v1.json
```

Feilmeldingene våre avslutter med «fix the manifest, or lint it against the published schema in your own CI before pushing». Det rådet var ikke mulig å følge.

Begge skjemaene, `SchemaID`, `PayloadSchemaID` og kommentarene i `schemas.go` peker nå på en URL som svarer.

## Retired-artifacts virket bare for dette repoet

`#722` lot nav-pilot fjerne en artefakt kilden har pensjonert, ved å sammenlikne innholdet mot blobber stien en gang hadde. Oppslaget matchet kanoniske katalognavn.

En Tier 1-agentpakke kan legge innholdet sitt hvor som helst. `layout.agents: content/agents` er lovlig og dokumentert, og da ser en pensjonert sti slik ut:

```json
"content/agents/gammel.agent.md": ["..."]
```

Det matchet ingenting, så mekanismen var i praksis vår egen.

Oppslaget leser nå `layout` fra manifestet når det finnes, med de kanoniske navnene som fallback. To detaljer det er verdt å se på i review:

- **Prefiksmatching framfor split på første skråstrek.** En erklært layout kan være nestet, og `strings.IndexByte(p, '/')` ga «content», som ikke er noen kjent katalog.
- **Lengste prefiks først.** En layout som legger én type inni en annen, for eksempel `agents: content` og `skills: content/skills`, skal ikke skygges av det korteste prefikset.

## Kontroll

Testen har kontrollen inni seg: samme pensjonerte sti slås opp først uten manifest, og skal da ikke finne noe. Fjernes layout-grenen fra oppslaget, blir testen rød.

`mise run check` er grønn.

## Hva som gjenstår før Tier 1 er brukbart utenfra

- #730, i review: en Tier 1-pakke leverer personaen sin
- #729: tilstandsmodellen, per-fil provenans
- #572: M3-komposisjon