### PR TITLE
feat(nav-pilot): tilstanden husker hvilken revisjon som skrev hver fil

### DIFF
--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -575,7 +575,7 @@ func cmdInstallFromSource(collection string, src *Source, scope *InstallScope, d
 		SourceRepo:  src.Repo,
 		SourceSHA:   src.SHA,
 		InstalledAt: timeNow().UTC().Format("2006-01-02T15:04:05Z07:00"),
-		Files:       result.Files,
+		Files:       stampRevision(result.Files, src.SHA),
 	}
 	// A re-install over a checked-in state file must not throw away the keys a
 	// newer nav-pilot put there; the fresh struct has none of them (#588). Nor
@@ -973,7 +973,7 @@ func installAllFromSource(scope *InstallScope, src *Source, manifest *Manifest, 
 		SourceRepo:  src.Repo,
 		SourceSHA:   src.SHA,
 		InstalledAt: timeNow().UTC().Format("2006-01-02T15:04:05Z07:00"),
-		Files:       result.Files,
+		Files:       stampRevision(result.Files, src.SHA),
 	}
 
 	// Append items the user explicitly deselected in the picker as ignored.
@@ -1342,4 +1342,22 @@ func removeOrphans(scope *InstallScope, prior *StateFile, installed []InstalledF
 		fmt.Printf("  %s %s %s\n", red("×"), f.Path, dim("(no longer in the collection)"))
 	}
 	return kept
+}
+
+// stampRevision records which source revision wrote each file this install
+// produced (#729).
+//
+// Only files with content: an ignored entry has no bytes and therefore no
+// provenance, and stamping one would claim a revision put something on disk
+// that it never did.
+func stampRevision(files []InstalledFile, revision string) []InstalledFile {
+	if revision == "" {
+		return files
+	}
+	for i := range files {
+		if files[i].Hash != "" {
+			files[i].Revision = revision
+		}
+	}
+	return files
 }

--- a/cli/nav-pilot/internal/cli/main_test.go
+++ b/cli/nav-pilot/internal/cli/main_test.go
@@ -1379,7 +1379,7 @@ func TestUpdateStateHashes_OnlyUpdatesApplied(t *testing.T) {
 		{Path: relA, CurrentHash: "oldhash-a", SourceHash: hashA},
 	}
 
-	if err := updateStateHashes(dir, appliedUpdates); err != nil {
+	if err := updateStateHashes(dir, appliedUpdates, "rev1234"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cli/nav-pilot/internal/cli/retired.go
+++ b/cli/nav-pilot/internal/cli/retired.go
@@ -241,3 +241,23 @@ func reportIgnoredButInstalled(paths []string) {
 	fmt.Printf("  that may no longer exist. %s takes the source's version and\n", bold("nav-pilot add <type> <name> --force"))
 	fmt.Printf("  starts tracking it again.\n\n")
 }
+
+// installedRevisions maps each tracked path to the source revision it was
+// written from, for the entries that carry one (#729).
+//
+// A path with no recorded revision is absent from the map rather than present
+// with an empty value: the caller must be able to tell "installed from an older
+// revision" from "we do not know", and those lead to different sentences.
+func installedRevisions(scope *InstallScope) map[string]string {
+	state, err := readScopedState(scope)
+	if err != nil || state == nil {
+		return nil
+	}
+	out := make(map[string]string, len(state.Files))
+	for _, f := range state.Files {
+		if f.Revision != "" {
+			out[f.Path] = f.Revision
+		}
+	}
+	return out
+}

--- a/cli/nav-pilot/internal/cli/retired.go
+++ b/cli/nav-pilot/internal/cli/retired.go
@@ -261,3 +261,33 @@ func installedRevisions(scope *InstallScope) map[string]string {
 	}
 	return out
 }
+
+// sameRevision reports whether two revision strings name the same commit.
+//
+// Prefix comparison, the way git resolves an abbreviated object id, because the
+// two sides come from different places: a state file may carry a short sha
+// written by an older nav-pilot or by hand, while the source resolves to the
+// full 40 characters. Comparing them for equality reported every such file as
+// "installed from <rev>" even when it came from exactly the revision the scope
+// is on, which is the false positive this suffix exists to avoid.
+//
+// An empty string matches nothing: absence is not agreement. So is a prefix
+// shorter than git's own minimum, since four hex characters agree by accident
+// often enough to be worthless as evidence.
+func sameRevision(a, b string) bool {
+	const minAbbrev = 7
+	if a == "" || b == "" {
+		return false
+	}
+	if strings.EqualFold(a, b) {
+		return true
+	}
+	short, long := a, b
+	if len(short) > len(long) {
+		short, long = long, short
+	}
+	if len(short) < minAbbrev {
+		return false
+	}
+	return strings.EqualFold(short, long[:len(short)])
+}

--- a/cli/nav-pilot/internal/cli/retired_test.go
+++ b/cli/nav-pilot/internal/cli/retired_test.go
@@ -383,3 +383,36 @@ func TestRevisionIsRecordedAndSurfaced(t *testing.T) {
 		}
 	})
 }
+
+// TestSameRevision covers the false positive review found in #732: a state file
+// may carry a short sha while the source resolves to the full 40 characters, so
+// comparing them for equality labelled a file "installed from <rev>" even when
+// it came from exactly the revision the scope is on.
+func TestSameRevision(t *testing.T) {
+	full := "def5678901234567890123456789012345678901"
+	tests := []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{"identical", full, full, true},
+		{"abbreviated state, full source", "def5678", full, true},
+		{"full state, abbreviated source", full, "def5678", true},
+		{"case differs", "DEF5678", full, true},
+		{"different commits", "abc1234", full, false},
+		// Absence is not agreement: a file with no recorded revision must not
+		// read as "same as the source".
+		{"empty either side", "", full, false},
+		{"empty both sides", "", "", false},
+		// Four hex characters agree by accident often enough to be worthless,
+		// which is why git has a minimum too.
+		{"prefix shorter than git's minimum", "def5", full, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sameRevision(tt.a, tt.b); got != tt.want {
+				t.Errorf("sameRevision(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/nav-pilot/internal/cli/retired_test.go
+++ b/cli/nav-pilot/internal/cli/retired_test.go
@@ -336,3 +336,50 @@ func TestRetiredHonoursDeclaredLayout(t *testing.T) {
 		t.Errorf("findRetiredOrphans with a declared layout = %+v, want the one orphan", got)
 	}
 }
+
+// TestRevisionIsRecordedAndSurfaced covers #729: the state file recorded a hash
+// and nothing about where the bytes came from, so "differs from what nav-pilot
+// installed" could not tell an edit from a file installed by an older revision.
+// Both look identical to a hash comparison.
+func TestRevisionIsRecordedAndSurfaced(t *testing.T) {
+	t.Run("an install stamps the revision on every file it wrote", func(t *testing.T) {
+		files := []InstalledFile{
+			{Path: "agents/a.agent.md", Hash: "abc"},
+			// Ignored entries have no bytes, so they have no provenance either.
+			// Stamping one would claim a revision put something on disk.
+			{Path: "agents/b.agent.md", Status: fileStatusIgnored},
+		}
+		got := stampRevision(files, "def5678")
+		if got[0].Revision != "def5678" {
+			t.Errorf("written file revision = %q, want def5678", got[0].Revision)
+		}
+		if got[1].Revision != "" {
+			t.Errorf("ignored entry got revision %q, want none", got[1].Revision)
+		}
+	})
+
+	t.Run("an unknown revision is absent, not empty", func(t *testing.T) {
+		scope, _ := userScopeWithAgents(t)
+		if err := writeScopedState(scope, &StateFile{
+			Collection: "pakke",
+			Scope:      scope.Name,
+			SourceRepo: "navikt/copilot",
+			SourceSHA:  "def5678",
+			Files: []InstalledFile{
+				{Path: "agents/ny.agent.md", Hash: "h1", Revision: "abc1234"},
+				{Path: "agents/gammel.agent.md", Hash: "h2"},
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		got := installedRevisions(scope)
+		if got["agents/ny.agent.md"] != "abc1234" {
+			t.Errorf("revision = %q, want abc1234", got["agents/ny.agent.md"])
+		}
+		// The distinction that matters: a state file written before provenance
+		// must not be reported as "installed from ''".
+		if _, present := got["agents/gammel.agent.md"]; present {
+			t.Error("a file with no recorded revision is present in the map; the caller cannot then tell it from a known one")
+		}
+	})
+}

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -483,7 +483,7 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 		revisions := installedRevisions(scope)
 		for _, p := range conflictPaths {
 			line := fmt.Sprintf("  %s %s", dim("⊘"), p)
-			if rev := revisions[p]; rev != "" && !strings.EqualFold(rev, src.SHA) {
+			if rev := revisions[p]; rev != "" && !sameRevision(rev, src.SHA) {
 				line += dim(fmt.Sprintf("  (installed from %s)", shortSHA(rev)))
 			}
 			fmt.Println(line)

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -475,8 +475,18 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 		// or older than what is on disk.
 		fmt.Printf("%s %d file(s) differ from what nav-pilot installed and are left alone by a plain sync (source: %s)\n\n",
 			yellow("⚠"), len(conflictPaths), shortSHA(src.SHA))
+		// Per-file provenance turns a bare path into a fact the reader can act
+		// on (#729): a file installed from an older revision than the one the
+		// scope is on is behind, not edited, and those are different problems
+		// with the same hash symptom. A file with no recorded revision predates
+		// provenance and says nothing extra rather than guessing.
+		revisions := installedRevisions(scope)
 		for _, p := range conflictPaths {
-			fmt.Printf("  %s %s\n", dim("⊘"), p)
+			line := fmt.Sprintf("  %s %s", dim("⊘"), p)
+			if rev := revisions[p]; rev != "" && !strings.EqualFold(rev, src.SHA) {
+				line += dim(fmt.Sprintf("  (installed from %s)", shortSHA(rev)))
+			}
+			fmt.Println(line)
 		}
 		fmt.Printf("%s to take the source's version of these too.\n\n", bold("nav-pilot sync --apply"))
 	}
@@ -530,7 +540,7 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 	}
 
 	// Update state with new hashes
-	if err := updateScopedStateHashes(scope, appliedUpdates); err != nil {
+	if err := updateScopedStateHashes(scope, appliedUpdates, src.SHA); err != nil {
 		fmt.Fprintf(os.Stderr, "%s Could not update state file: %v\n", yellow("⚠"), err)
 	}
 
@@ -1020,7 +1030,7 @@ func applySyncUpdate(scope *InstallScope, sourceDir string, u syncUpdate) error 
 }
 
 // updateScopedStateHashes updates the state file with new hashes after applying updates.
-func updateScopedStateHashes(scope *InstallScope, updates []syncUpdate) error {
+func updateScopedStateHashes(scope *InstallScope, updates []syncUpdate, revision string) error {
 	state, err := readScopedState(scope)
 	if err != nil || state == nil {
 		return nil // no state file, nothing to update
@@ -1042,6 +1052,9 @@ func updateScopedStateHashes(scope *InstallScope, updates []syncUpdate) error {
 		}
 		state.Files[i].Hash = hash
 		state.Files[i].Status = ""
+		// The revision this content came from, which is what a later sync needs
+		// to tell an edit from an older install (#729).
+		state.Files[i].Revision = revision
 	}
 
 	return writeScopedState(scope, state)
@@ -1098,8 +1111,8 @@ func clearResolvedConflicts(scope *InstallScope, resolver *SourceResolver, confl
 }
 
 // updateStateHashes is a backward-compatible wrapper for repo scope.
-func updateStateHashes(targetDir string, updates []syncUpdate) error {
-	return updateScopedStateHashes(ScopeRepo(targetDir), updates)
+func updateStateHashes(targetDir string, updates []syncUpdate, revision string) error {
+	return updateScopedStateHashes(ScopeRepo(targetDir), updates, revision)
 }
 
 // markFilesIgnored updates the state file to mark the given paths as "ignored".

--- a/cli/nav-pilot/internal/cli/sync_test.go
+++ b/cli/nav-pilot/internal/cli/sync_test.go
@@ -242,7 +242,7 @@ func TestUpdateStateHashes(t *testing.T) {
 	newHash, _ := fileHash(filepath.Join(dir, rel))
 	updates := []syncUpdate{{Path: rel, CurrentHash: "oldhash", SourceHash: newHash}}
 
-	if err := updateStateHashes(dir, updates); err != nil {
+	if err := updateStateHashes(dir, updates, "rev1234"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -271,7 +271,7 @@ func TestUpdateStateHashes_ClearsConflictStatus(t *testing.T) {
 	newHash, _ := fileHash(filepath.Join(dir, rel))
 	updates := []syncUpdate{{Path: rel, CurrentHash: "oldhash", SourceHash: newHash}}
 
-	if err := updateStateHashes(dir, updates); err != nil {
+	if err := updateStateHashes(dir, updates, "rev1234"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -284,7 +284,7 @@ func TestUpdateStateHashes_ClearsConflictStatus(t *testing.T) {
 func TestUpdateStateHashes_NoState(t *testing.T) {
 	dir := t.TempDir()
 	// Should not error when no state file exists
-	err := updateStateHashes(dir, []syncUpdate{{Path: "x", CurrentHash: "a", SourceHash: "b"}})
+	err := updateStateHashes(dir, []syncUpdate{{Path: "x", CurrentHash: "a", SourceHash: "b"}}, "rev1234")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -386,7 +386,7 @@ func TestUpdateScopedStateHashes(t *testing.T) {
 	newHash, _ := fileHash(filepath.Join(dir, rel))
 	updates := []syncUpdate{{Path: rel, CurrentHash: "oldhash", SourceHash: newHash}}
 
-	if err := updateScopedStateHashes(scope, updates); err != nil {
+	if err := updateScopedStateHashes(scope, updates, "rev1234"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cli/nav-pilot/internal/domain/domain.go
+++ b/cli/nav-pilot/internal/domain/domain.go
@@ -431,6 +431,18 @@ type InstalledFile struct {
 	// every state file written before per-file origins says about all of its
 	// files — so they keep syncing exactly as they did.
 	Source string `json:"source,omitempty"`
+	// Revision is the source revision this file was written from, when it is
+	// known. Empty means a state file older than per-file provenance, or a file
+	// nav-pilot did not write.
+	//
+	// The state file's own SourceSHA says which revision the scope last synced
+	// to, which is not the same question: a file that has not changed upstream
+	// in months still carries the revision that last rewrote it. Without this,
+	// "the content differs from the hash we recorded" is all the model can say,
+	// and it cannot tell an edit from a file installed by an older revision
+	// (#729). Both look identical to a hash comparison, and telling a user they
+	// changed a file they never touched is how a warning stops being read.
+	Revision string `json:"revision,omitempty"`
 	// Unknown carries every key of this entry that the running binary does not
 	// understand, and writes it back out unchanged.
 	//


### PR DESCRIPTION
Første del av #729, som arkitekturgjennomgangen kalte den egentlige rettelsen bak tre lapper.

## Problemet

Tilstandsfila noterer en hash og ingenting om hvor bytene kom fra. Eierskapspredikatet er «stien står i `Files` og hashen på disk er lik den noterte», som svarer på ett spørsmål: skrev jeg denne fila, og er den uendret siden.

Det er ikke spørsmålet som stilles. En fil kan avvike fordi noen redigerte den, eller fordi den ble installert av en eldre revisjon og aldri oppdatert. For en hash-sammenlikning ser de to helt like ut.

Konsekvensen så vi i #692: 23 filer meldt som «dine egne endringer» der ingen var redigert. De var installert fra en eldre revisjon og bar agenthåndtak pensjonert i #481. Meldingen er omformulert siden, men modellen kunne fortsatt ikke si hvilket av de to tilfellene den så.

## Endringen

`InstalledFile` har et `revision`-felt, satt der tilstanden settes sammen: ved install fra `src.SHA`, ved `sync --apply` fra revisjonen som ble hentet.

Konfliktrapporten viser det:

```
⚠ 2 file(s) differ from what nav-pilot installed and are left alone by a plain sync (source: def5678)

  ⊘ agents/kafka.agent.md  (installed from abc1234)
  ⊘ agents/rust.agent.md
```

Første linje er en fil som ligger bak. Andre linje er en fil uten notert revisjon, og den sier ingenting ekstra framfor å gjette.

## Tre valg det er verdt å se på

**Bare filer med innhold merkes.** En ignorert oppføring har ingen bytes og dermed ingen opprinnelse. Å merke den ville påstått at en revisjon la noe på disk som den aldri gjorde.

**Ukjent revisjon er fraværende fra kartet, ikke tom.** Kalleren må kunne skille «installert fra en eldre revisjon» fra «vet ikke», og de to fører til ulike setninger. Et kart med tom verdi kollapser skillet.

**Ingen migrering.** Tilstandsfiler skrevet før dette har ingen revisjon og synker nøyaktig som før. Ukjente nøkler bevares allerede (#588), så en kollega på en eldre nav-pilot skriver ikke feltet bort igjen.

## Hva dette ikke gjør ennå

Det svarer på «hvilken revisjon skrev denne fila», ikke på «er innholdet uendret siden den revisjonen». Det andre krever bytene fra den revisjonen, altså å generalisere blob-indeksen fra #722 til kontraktsnivå. Det er neste steg i #729, og det er også det som ville latt oss slutte å slette utenfor tilstanden.

## Kontroller

| Fjernet | Rødt |
|---|---|
| `Hash != ""`-vakten i `stampRevision` | ignorerte oppføringer blir merket |
| `Revision != ""`-vakten i `installedRevisions` | ukjent blir umulig å skille fra kjent |

`mise run check` er grønn.