### PR TITLE
feat(nav-pilot): export leser layouten manifestet erklærer

### DIFF
--- a/cli/nav-pilot/internal/artifacts/export.go
+++ b/cli/nav-pilot/internal/artifacts/export.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -29,14 +28,24 @@ func CmdExport(format string, scope *domain.InstallScope, ref, sourceRepo, cliVe
 // refuseNonCanonicalPakke stops an export that would otherwise produce wrong or
 // empty output.
 //
-// export reads a source's canonical agents//skills/instructions/prompts
-// directories directly; it does not go through the agentpakke layout resolver
-// that install and sync use. A source whose manifest puts its content anywhere
-// else would therefore export whatever happens to sit at the canonical paths —
-// in practice nothing at all, silently. Until export is migrated onto the
-// manifest (M2), that is a hard error. A manifest declaring the canonical
-// layout, and a manifest-less source, export exactly as before.
-func refuseNonCanonicalPakke(src *source.Source) error {
+// exportLayout returns the content layout export should read, or nil for the
+// canonical directories.
+func exportLayout(src *source.Source) *agentpakke.Layout {
+	m, err := agentpakke.Load(src.Dir)
+	if err != nil {
+		return nil //nolint:nilerr // no manifest is the legacy case: canonical names
+	}
+	return m.Layout
+}
+
+// refuseUnreadablePakke stops an export that would silently write nothing.
+//
+// Export now reads a declared layout (#728), so a pakke that puts its content
+// somewhere else exports correctly. What remains unreadable is a manifest with
+// no layout at all: that is a Tier 2-only pakke, whose content is pre-built
+// payloads rather than files at paths, and exporting it would produce an empty
+// tree without saying so.
+func refuseUnreadablePakke(src *source.Source) error {
 	m, err := agentpakke.Load(src.Dir)
 	if err != nil {
 		// No manifest is the legacy case. A manifest that fails to load is
@@ -44,7 +53,7 @@ func refuseNonCanonicalPakke(src *source.Source) error {
 		// commands use; export does not second-guess it here.
 		return nil //nolint:nilerr // deliberate: only a usable manifest changes export's behaviour
 	}
-	if isCanonicalLayout(m.Layout) {
+	if m.Layout != nil {
 		return nil
 	}
 	label := src.Repo
@@ -61,27 +70,6 @@ func refuseNonCanonicalPakke(src *source.Source) error {
 		domain.Bold("nav-pilot export opencode --source "+source.DefaultRepo))
 }
 
-// isCanonicalLayout reports whether a manifest's layout is the one export
-// already reads: the canonical directory names. A Tier 2-only manifest declares
-// no layout at all, which is equally not something export can read.
-func isCanonicalLayout(l *agentpakke.Layout) bool {
-	if l == nil {
-		return false
-	}
-	for _, d := range []struct{ declared, canonical string }{
-		{l.Agents, "agents"},
-		{l.Skills, "skills"},
-		{l.Instructions, "instructions"},
-		{l.Prompts, "prompts"},
-	} {
-		declared := strings.TrimSpace(d.declared)
-		if declared != "" && path.Clean(declared) != d.canonical {
-			return false
-		}
-	}
-	return true
-}
-
 // ExportOpenCode transforms Nav's .github/ artifacts into OpenCode-compatible .opencode/ format.
 func ExportOpenCode(scope *domain.InstallScope, ref, sourceRepo, cliVersion string, dryRun, force, jsonOutput bool) error {
 	src, err := source.ResolveSource(ref, sourceRepo, cliVersion)
@@ -90,7 +78,7 @@ func ExportOpenCode(scope *domain.InstallScope, ref, sourceRepo, cliVersion stri
 	}
 	defer src.Cleanup()
 
-	if err := refuseNonCanonicalPakke(src); err != nil {
+	if err := refuseUnreadablePakke(src); err != nil {
 		return err
 	}
 
@@ -113,6 +101,15 @@ func ExportOpenCode(scope *domain.InstallScope, ref, sourceRepo, cliVersion stri
 	}
 
 	sourceDir := src.Dir
+	// Export reads where the manifest says its content lives, not only the
+	// canonical directories (#728). A pakke with `layout.agents: content/agents`
+	// used to be refused outright, which meant a third party could install a
+	// Tier 1 pakke and then not export it.
+	//
+	// A manifest-less source, and a manifest that declares the canonical names,
+	// resolve exactly as before: NewSourceResolverForLayout falls back to the
+	// canonical names for every field the layout leaves empty.
+	layout := exportLayout(src)
 	// A repo-scope export writes <repo>/.opencode/, which only that repo reads,
 	// so what the team added by hand under .github/ belongs in it — instructions
 	// included, unlike the global materialization in [SyncOpenCodeArtifacts].
@@ -123,25 +120,25 @@ func ExportOpenCode(scope *domain.InstallScope, ref, sourceRepo, cliVersion stri
 	}
 	var totalSkills, totalCommands, totalAgents, totalInstructions int
 
-	n, err := exportSkills(sourceDir, scopeDir, outputDir, dryRun)
+	n, err := exportSkills(sourceDir, scopeDir, outputDir, layout, dryRun)
 	if err != nil {
 		return fmt.Errorf("exporting skills: %w", err)
 	}
 	totalSkills = n
 
-	n, err = exportPrompts(sourceDir, scopeDir, outputDir, dryRun)
+	n, err = exportPrompts(sourceDir, scopeDir, outputDir, layout, dryRun)
 	if err != nil {
 		return fmt.Errorf("exporting prompts: %w", err)
 	}
 	totalCommands = n
 
-	n, err = exportAgents(sourceDir, scopeDir, outputDir, dryRun)
+	n, err = exportAgents(sourceDir, scopeDir, outputDir, layout, dryRun)
 	if err != nil {
 		return fmt.Errorf("exporting agents: %w", err)
 	}
 	totalAgents = n
 
-	n, err = exportInstructions(sourceDir, scopeDir, outputDir, dryRun)
+	n, err = exportInstructions(sourceDir, scopeDir, outputDir, layout, dryRun)
 	if err != nil {
 		return fmt.Errorf("exporting instructions: %w", err)
 	}
@@ -208,8 +205,8 @@ func ExportSummary(skills, commands, agents, instructions int) string {
 	return strings.Join(parts, ", ")
 }
 
-func exportSkills(sourceDir, scopeDir, outputDir string, dryRun bool) (int, error) {
-	skills := withScopeExtras(source.NewSourceResolver(sourceDir).List(source.KindSkill), scopeDir, source.KindSkill)
+func exportSkills(sourceDir, scopeDir, outputDir string, layout *agentpakke.Layout, dryRun bool) (int, error) {
+	skills := withScopeExtras(source.NewSourceResolverForLayout(sourceDir, layout).List(source.KindSkill), scopeDir, source.KindSkill)
 	if len(skills) == 0 {
 		return 0, nil
 	}
@@ -240,8 +237,8 @@ func exportSkills(sourceDir, scopeDir, outputDir string, dryRun bool) (int, erro
 	return count, nil
 }
 
-func exportPrompts(sourceDir, scopeDir, outputDir string, dryRun bool) (int, error) {
-	entries := withScopeExtras(source.NewSourceResolver(sourceDir).List(source.KindPrompt), scopeDir, source.KindPrompt)
+func exportPrompts(sourceDir, scopeDir, outputDir string, layout *agentpakke.Layout, dryRun bool) (int, error) {
+	entries := withScopeExtras(source.NewSourceResolverForLayout(sourceDir, layout).List(source.KindPrompt), scopeDir, source.KindPrompt)
 	if len(entries) == 0 {
 		return 0, nil
 	}
@@ -298,16 +295,16 @@ func transformPrompt(data []byte) []byte {
 // in one of them is a gate in neither. Turning local off takes an already
 // materialized copy back out: the sync deletes what its state file names and
 // the new listing does not.
-func agentEntries(sourceDir string) []source.Resolved {
-	entries := source.NewSourceResolver(sourceDir).List(source.KindAgent)
+func agentEntries(sourceDir string, layout *agentpakke.Layout) []source.Resolved {
+	entries := source.NewSourceResolverForLayout(sourceDir, layout).List(source.KindAgent)
 	if local.Enabled() {
 		return entries
 	}
 	return slices.DeleteFunc(entries, func(e source.Resolved) bool { return e.Name == local.WorkerAgent })
 }
 
-func exportAgents(sourceDir, scopeDir, outputDir string, dryRun bool) (int, error) {
-	agents := withScopeExtras(agentEntries(sourceDir), scopeDir, source.KindAgent)
+func exportAgents(sourceDir, scopeDir, outputDir string, layout *agentpakke.Layout, dryRun bool) (int, error) {
+	agents := withScopeExtras(agentEntries(sourceDir, layout), scopeDir, source.KindAgent)
 	if len(agents) == 0 {
 		return 0, nil
 	}
@@ -456,7 +453,7 @@ func collectInstructionData(dirs ...string) ([]InstructionSection, []Instruction
 	return globalSections, scopedRefs, nil
 }
 
-func exportInstructions(sourceDir, scopeDir, outputDir string, dryRun bool) (int, error) {
+func exportInstructions(sourceDir, scopeDir, outputDir string, layout *agentpakke.Layout, dryRun bool) (int, error) {
 	globalSections, scopedRefs, err := collectInstructionData(sourceDir, scopeDir)
 	if err != nil {
 		return 0, err

--- a/cli/nav-pilot/internal/artifacts/export_test.go
+++ b/cli/nav-pilot/internal/artifacts/export_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
 	"github.com/navikt/copilot/cli/nav-pilot/internal/domain"
 	"github.com/navikt/copilot/cli/nav-pilot/internal/local"
 	"github.com/navikt/copilot/cli/nav-pilot/internal/source"
@@ -122,7 +123,7 @@ func TestExportSkills(t *testing.T) {
 	sourceDir := setupTestSource(t)
 	outputDir := t.TempDir()
 
-	n, err := exportSkills(sourceDir, "", outputDir, false)
+	n, err := exportSkills(sourceDir, "", outputDir, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,7 +150,7 @@ func TestExportPrompts(t *testing.T) {
 	sourceDir := setupTestSource(t)
 	outputDir := t.TempDir()
 
-	n, err := exportPrompts(sourceDir, "", outputDir, false)
+	n, err := exportPrompts(sourceDir, "", outputDir, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +180,7 @@ func TestExportAgents(t *testing.T) {
 	sourceDir := setupTestSource(t)
 	outputDir := t.TempDir()
 
-	n, err := exportAgents(sourceDir, "", outputDir, false)
+	n, err := exportAgents(sourceDir, "", outputDir, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,7 +213,7 @@ func TestExportInstructions(t *testing.T) {
 	sourceDir := setupTestSource(t)
 	outputDir := t.TempDir()
 
-	n, err := exportInstructions(sourceDir, "", outputDir, false)
+	n, err := exportInstructions(sourceDir, "", outputDir, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -284,7 +285,7 @@ These apply everywhere.
 `)
 
 	outputDir := t.TempDir()
-	n, err := exportInstructions(dir, "", outputDir, false)
+	n, err := exportInstructions(dir, "", outputDir, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -305,10 +306,10 @@ func TestExportDryRun(t *testing.T) {
 	sourceDir := setupTestSource(t)
 	outputDir := t.TempDir()
 
-	for _, fn := range []func(string, string, string, bool) (int, error){
+	for _, fn := range []func(string, string, string, *agentpakke.Layout, bool) (int, error){
 		exportSkills, exportPrompts, exportAgents, exportInstructions,
 	} {
-		if _, err := fn(sourceDir, "", outputDir, true); err != nil {
+		if _, err := fn(sourceDir, "", outputDir, nil, true); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -325,14 +326,14 @@ func TestExportEmptySource(t *testing.T) {
 
 	for _, fn := range []struct {
 		name string
-		fn   func(string, string, string, bool) (int, error)
+		fn   func(string, string, string, *agentpakke.Layout, bool) (int, error)
 	}{
 		{"skills", exportSkills},
 		{"prompts", exportPrompts},
 		{"agents", exportAgents},
 		{"instructions", exportInstructions},
 	} {
-		n, err := fn.fn(sourceDir, "", outputDir, false)
+		n, err := fn.fn(sourceDir, "", outputDir, nil, false)
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", fn.name, err)
 		}
@@ -547,7 +548,7 @@ func TestExportSkills_RootLevel(t *testing.T) {
 	mustWrite(t, filepath.Join(skillDir, "SKILL.md"), "# My Skill\n")
 	mustWrite(t, filepath.Join(skillDir, "reference.md"), "## Reference\n")
 
-	n, err := exportSkills(sourceDir, "", outputDir, false)
+	n, err := exportSkills(sourceDir, "", outputDir, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -663,7 +664,10 @@ func TestMaterializeOpenCodeEmpty(t *testing.T) {
 // TestExportRefusesNonCanonicalAgentpakke covers the seam export has not
 // crossed yet: it reads canonical directories, so a source that puts its
 // content elsewhere must be refused loudly instead of exporting nothing.
-func TestExportRefusesNonCanonicalAgentpakke(t *testing.T) {
+// TestExportReadsADeclaredLayout: export used to refuse any manifest whose
+// content was not at the canonical paths (#728). It reads the declared layout
+// now, which is what makes a Tier 1 pakke from another team usable end to end.
+func TestExportReadsADeclaredLayout(t *testing.T) {
 	srcDir := t.TempDir()
 	mustWrite(t, filepath.Join(srcDir, ".nav-pilot", "agentpakke.json"), `{
 	  "contractVersion": "1",
@@ -679,9 +683,42 @@ func TestExportRefusesNonCanonicalAgentpakke(t *testing.T) {
 	outputDir := t.TempDir()
 	scope := domain.ScopeRepo(outputDir)
 
+	if err := ExportOpenCode(scope, "", srcDir, "dev", false, false, false); err != nil {
+		t.Fatalf("export from an agentpakke with a declared layout = %v, want nil", err)
+	}
+
+	// The content is read from where the manifest says it lives, not from the
+	// canonical names. Before #728 this was a hard refusal, which meant a third
+	// party could install a Tier 1 pakke and then not export it.
+	for _, want := range []string{
+		filepath.Join(outputDir, ".opencode", "agents", "grillmester.md"),
+		filepath.Join(outputDir, ".opencode", "skills", "grilling", "SKILL.md"),
+	} {
+		if _, err := os.Stat(want); err != nil {
+			t.Errorf("export did not write %s: %v", want, err)
+		}
+	}
+}
+
+// TestExportRefusesPayloadOnlyAgentpakke keeps a refusal where one is still
+// right: a manifest with no layout at all is Tier 2 only. Its content is
+// pre-built payloads rather than files at paths, so an export would write an
+// empty tree, and doing that silently is the failure the refusal exists for.
+func TestExportRefusesPayloadOnlyAgentpakke(t *testing.T) {
+	srcDir := t.TempDir()
+	mustWrite(t, filepath.Join(srcDir, ".nav-pilot", "agentpakke.json"), `{
+	  "contractVersion": "1",
+	  "name": "grillmester",
+	  "description": "Grillmester agentpakke",
+	  "clients": {"copilot": {"payloads": {"full": {"path": "dist/copilot/full", "primaryAgents": ["grillmester"]}}}}
+	}`)
+
+	outputDir := t.TempDir()
+	scope := domain.ScopeRepo(outputDir)
+
 	err := ExportOpenCode(scope, "", srcDir, "dev", false, false, false)
 	if err == nil {
-		t.Fatal("export from a non-canonical agentpakke succeeded, want a refusal")
+		t.Fatal("export from a payload-only agentpakke succeeded, want a refusal")
 	}
 	if !strings.Contains(err.Error(), "export does not support agentpakke sources yet") {
 		t.Errorf("error %q is not the documented refusal", err)
@@ -733,7 +770,7 @@ func TestWorkerAgentIsOnlyMaterializedForTheOptedIn(t *testing.T) {
 
 	names := func() []string {
 		var got []string
-		for _, e := range agentEntries(sourceDir) {
+		for _, e := range agentEntries(sourceDir, nil) {
 			got = append(got, e.Name)
 		}
 		return got
@@ -758,16 +795,16 @@ func TestExportScopeExtras(t *testing.T) {
 	mustWrite(t, filepath.Join(scopeDir, "copilot-instructions.md"), "Team rules for this repo.\n")
 	outputDir := t.TempDir()
 
-	if _, err := exportSkills(sourceDir, scopeDir, outputDir, false); err != nil {
+	if _, err := exportSkills(sourceDir, scopeDir, outputDir, nil, false); err != nil {
 		t.Fatalf("exportSkills: %v", err)
 	}
-	if _, err := exportPrompts(sourceDir, scopeDir, outputDir, false); err != nil {
+	if _, err := exportPrompts(sourceDir, scopeDir, outputDir, nil, false); err != nil {
 		t.Fatalf("exportPrompts: %v", err)
 	}
-	if _, err := exportAgents(sourceDir, scopeDir, outputDir, false); err != nil {
+	if _, err := exportAgents(sourceDir, scopeDir, outputDir, nil, false); err != nil {
 		t.Fatalf("exportAgents: %v", err)
 	}
-	if _, err := exportInstructions(sourceDir, scopeDir, outputDir, false); err != nil {
+	if _, err := exportInstructions(sourceDir, scopeDir, outputDir, nil, false); err != nil {
 		t.Fatalf("exportInstructions: %v", err)
 	}
 

--- a/cli/nav-pilot/internal/artifacts/opencode_sync.go
+++ b/cli/nav-pilot/internal/artifacts/opencode_sync.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
 	"github.com/navikt/copilot/cli/nav-pilot/internal/domain"
 	"github.com/navikt/copilot/cli/nav-pilot/internal/source"
 )
@@ -238,7 +239,9 @@ func SyncOpenCodeArtifacts(sourceDir, scopeDir, outputDir, sourceVersion, source
 		commands++
 	}
 
-	for _, entry := range withScopeExtras(agentEntries(sourceDir), scopeDir, source.KindAgent) {
+	// The same layout the export path reads (#728): a pakke that declares where
+	// its agents live is mirrored from there, not from the canonical names.
+	for _, entry := range withScopeExtras(agentEntries(sourceDir, syncLayout(sourceDir)), scopeDir, source.KindAgent) {
 		relPath := "agents/" + entry.Name + ".md"
 		dstPath := filepath.Join(outputDir, "agents", entry.Name+".md")
 		if isConflict(relPath, dstPath, false) {
@@ -424,4 +427,15 @@ func countFileIntegrity(rootDir string, state *domain.StateFile) (ok, modified, 
 		}
 	}
 	return
+}
+
+// syncLayout reads the content layout of the source being mirrored, or nil when
+// it declares none. A manifest that fails to load is not this function's error
+// to report: install and sync fail closed on it in their own words.
+func syncLayout(sourceDir string) *agentpakke.Layout {
+	m, err := agentpakke.Load(sourceDir)
+	if err != nil {
+		return nil //nolint:nilerr // no manifest is the legacy case: canonical names
+	}
+	return m.Layout
 }


### PR DESCRIPTION
Siste Tier 1-hullet fra #728, etter #730 (personaen) og #731 (skjema-URL og retired-oppslag).

## Feilen

`export` leste de kanoniske `agents/`, `skills/`, `instructions/` og `prompts/`, og nektet blankt en agentpakke som la innholdet sitt et annet sted:

```
export does not support agentpakke sources yet: <repo> ships an agentpakke
whose content is not at the canonical agents/, skills/, instructions/,
prompts/ paths.
```

Et team kunne altså installere en Tier 1-pakke, få personaen sin (#730), og så ikke eksportere den til opencode. `layout` er et felt kontrakten har hatt hele tiden.

## Rettelsen

Layouten sendes gjennom til de fire resolverne. Verktøyet fantes allerede: `NewSourceResolverForLayout` brukes av install og sync, og faller tilbake til de kanoniske navnene for hvert felt layouten lar stå tomt. En manifestløs kilde og et manifest som erklærer de kanoniske navnene eksporterer derfor nøyaktig som før.

`opencode_sync.go` leste agenter gjennom samme `agentEntries` og fikk den samme rettelsen, ellers ville speilingen sett et annet innhold enn eksporten.

## Nektelsen som står igjen

Et manifest **uten** layout er Tier 2 alene: innholdet er ferdigbygde payloads framfor filer på stier. En eksport ville skrevet et tomt tre, og å gjøre det i stillhet er nettopp feilen nektelsen finnes for. Den har fått sin egen test.

## Testene

`TestExportRefusesNonCanonicalAgentpakke` het det den gjorde. Den heter nå `TestExportReadsADeclaredLayout` og krever at innholdet faktisk skrives:

```
.opencode/agents/grillmester.md
.opencode/skills/grilling/SKILL.md
```

Verdt å nevne: første versjon av den testen sjekket `.opencode/agent/…` i entall og feilet. Jeg gjettet katalognavnet framfor å lese det, og måtte kjøre en probe for å se hva eksporten faktisk skriver.

`isCanonicalLayout` er fjernet. Den fantes bare for å avgjøre hva som skulle nektes, og staticcheck fanget den som død kode.

## Kontroll

Settes `layout` til nil i `ExportOpenCode`, blir den nye testen rød. `mise run check` er grønn.