### PR TITLE
feat(agentpakke): pensjonerte artefakter er en del av den publiserte kontrakten

### DIFF
--- a/cli/nav-pilot/internal/agentpakke/retired_schema.go
+++ b/cli/nav-pilot/internal/agentpakke/retired_schema.go
@@ -1,0 +1,78 @@
+package agentpakke
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/navikt/copilot/cli/nav-pilot/schemas"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// RetiredSchemaID is the $id of the published retired-artifact record schema.
+const RetiredSchemaID = "https://raw.githubusercontent.com/navikt/copilot/main/cli/nav-pilot/schemas/agentpakke-retired-v1.json"
+
+// RetiredRecordPath is where an agentpakke publishes the record, relative to
+// the repo root.
+const RetiredRecordPath = ".nav-pilot/retired-artifacts.json"
+
+// RetiredSchemaJSON returns the published schema bytes, for a caller that wants
+// to vendor or serve it. A copy, so a caller cannot mutate the embedded
+// contract.
+func RetiredSchemaJSON() []byte {
+	out := make([]byte, len(schemas.AgentpakkeRetiredV1))
+	copy(out, schemas.AgentpakkeRetiredV1)
+	return out
+}
+
+var (
+	retiredCompileOnce sync.Once
+	retiredCompiled    *jsonschema.Schema
+	retiredCompileErr  error
+)
+
+func retiredSchema() (*jsonschema.Schema, error) {
+	retiredCompileOnce.Do(func() {
+		doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(schemas.AgentpakkeRetiredV1))
+		if err != nil {
+			retiredCompileErr = fmt.Errorf("parsing embedded retired-artifact schema: %w", err)
+			return
+		}
+		c := jsonschema.NewCompiler()
+		if err := c.AddResource(RetiredSchemaID, doc); err != nil {
+			retiredCompileErr = fmt.Errorf("loading embedded retired-artifact schema: %w", err)
+			return
+		}
+		retiredCompiled, err = c.Compile(RetiredSchemaID)
+		if err != nil {
+			retiredCompileErr = fmt.Errorf("compiling embedded retired-artifact schema: %w", err)
+		}
+	})
+	return retiredCompiled, retiredCompileErr
+}
+
+// ValidateRetired checks a retired-artifact record against the published
+// schema.
+//
+// The record drives deletion, so the shape has to be certain before any of it
+// is acted on: a hash that is not a blob id, or a path that escapes the repo,
+// must not reach the code that removes files.
+func ValidateRetired(data []byte) error {
+	sch, err := retiredSchema()
+	if err != nil {
+		return err
+	}
+	inst, err := jsonschema.UnmarshalJSON(bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("%s is not valid JSON: %w", RetiredRecordPath, err)
+	}
+	if err := sch.Validate(inst); err != nil {
+		var verr *jsonschema.ValidationError
+		if !errors.As(err, &verr) {
+			return fmt.Errorf("%s failed schema validation: %w", RetiredRecordPath, err)
+		}
+		return schemaErrorFor(RetiredRecordPath, RetiredSchemaID, schemaViolations(verr))
+	}
+	return nil
+}

--- a/cli/nav-pilot/internal/agentpakke/retired_schema_test.go
+++ b/cli/nav-pilot/internal/agentpakke/retired_schema_test.go
@@ -1,0 +1,53 @@
+package agentpakke
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateRetired tests the validator directly, because going through
+// findRetiredOrphans cannot: every malformed record there also fails to match a
+// real file for unrelated reasons, so that test stays green with validation
+// removed. The first version of this coverage did exactly that and proved
+// nothing.
+func TestValidateRetired(t *testing.T) {
+	blob := strings.Repeat("a", 40)
+	tests := []struct {
+		name    string
+		record  string
+		wantErr string // substring, or "" when the record must be accepted
+	}{
+		{"conforming", `{"paths":{"agents/a.agent.md":["` + blob + `"]}}`, ""},
+		{"a declared layout's nested path", `{"paths":{"content/agents/a.agent.md":["` + blob + `"]}}`, ""},
+		{"empty paths says nothing is retired", `{"paths":{}}`, ""},
+		{"comment is ignored", `{"_comment":"generated","paths":{}}`, ""},
+
+		{"paths is required", `{"_comment":"x"}`, "paths"},
+		{"hash is not a blob id", `{"paths":{"agents/a.agent.md":["deadbeef"]}}`, "not a git blob id"},
+		{"hash is uppercase", `{"paths":{"agents/a.agent.md":["` + strings.ToUpper(blob) + `"]}}`, "not a git blob id"},
+		{"no hashes at all", `{"paths":{"agents/a.agent.md":[]}}`, "minItems"},
+
+		// The path rules are the ones that decide which file gets removed.
+		{"path escapes the repo", `{"paths":{"../../etc/passwd":["` + blob + `"]}}`, "not a repo-relative path"},
+		{"absolute path", `{"paths":{"/etc/passwd":["` + blob + `"]}}`, "not a repo-relative path"},
+		{"home-relative path", `{"paths":{"~/secrets":["` + blob + `"]}}`, "not a repo-relative path"},
+		{"not an object", `["agents/a.agent.md"]`, "got array"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateRetired([]byte(tt.record))
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("ValidateRetired = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ValidateRetired accepted %s, want a refusal", tt.name)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q does not mention %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cli/nav-pilot/internal/agentpakke/schema.go
+++ b/cli/nav-pilot/internal/agentpakke/schema.go
@@ -164,6 +164,12 @@ func describeCause(c *jsonschema.ValidationError) string {
 	if i := strings.Index(msg, "does not match pattern"); i >= 0 {
 		value := strings.TrimSpace(msg[:i])
 		switch {
+		case strings.HasSuffix(c.SchemaURL, "/$defs/repoRelativePath"):
+			return fmt.Sprintf("%s: %s is not a repo-relative path: write it without a leading slash, "+
+				"\"~\", \".\" or \"..\" segments, backslashes, or duplicate or trailing slashes",
+				loc, value)
+		case strings.HasSuffix(c.SchemaURL, "/$defs/blobHash"):
+			return fmt.Sprintf("%s: %s is not a git blob id: write 40 lowercase hex characters", loc, value)
 		case strings.HasSuffix(c.SchemaURL, "/$defs/payloadRelativePath"):
 			return fmt.Sprintf("%s: %s is not a payload-relative path: write it without a leading slash, "+
 				"\"~\", \".\" or \"..\" segments, backslashes, or duplicate or trailing slashes",

--- a/cli/nav-pilot/internal/cli/retired.go
+++ b/cli/nav-pilot/internal/cli/retired.go
@@ -38,6 +38,15 @@ func loadRetired(sourceDir string) *retiredManifest {
 	if err != nil {
 		return nil
 	}
+	// Validated against the published schema, like both manifests, because this
+	// file now belongs to the contract: any agentpakke may publish one, and a
+	// malformed record must not lead to a deletion (#729). A record that does
+	// not conform is treated as absent, which removes nothing. Failing the sync
+	// instead would let a third party's broken file block an update that has
+	// nothing to do with it.
+	if err := agentpakke.ValidateRetired(data); err != nil {
+		return nil
+	}
 	var m retiredManifest
 	if err := json.Unmarshal(data, &m); err != nil {
 		return nil

--- a/cli/nav-pilot/internal/cli/retired.go
+++ b/cli/nav-pilot/internal/cli/retired.go
@@ -16,7 +16,11 @@ import (
 
 // retiredManifestPath is where the source publishes the record of what it has
 // retired, relative to the source checkout.
-const retiredManifestPath = ".nav-pilot/retired-artifacts.json"
+//
+// Aliased from the contract rather than restated: the constant the validator
+// uses and the constant the reader uses must be the same one, or nav-pilot can
+// end up validating a file it does not read.
+const retiredManifestPath = agentpakke.RetiredRecordPath
 
 // retiredManifest is the generated record: artifact path to every content hash
 // that path ever held before it was deleted.

--- a/cli/nav-pilot/internal/cli/retired_test.go
+++ b/cli/nav-pilot/internal/cli/retired_test.go
@@ -459,3 +459,13 @@ func TestRetiredRecordIsValidatedAgainstTheSchema(t *testing.T) {
 		})
 	}
 }
+
+// TestRetiredPathMatchesTheContract pins what review caught in #734: the path
+// the validator names and the path the reader opens were two separate
+// constants, so they could drift and nav-pilot would validate a file it never
+// reads.
+func TestRetiredPathMatchesTheContract(t *testing.T) {
+	if retiredManifestPath != agentpakke.RetiredRecordPath {
+		t.Errorf("the reader opens %q while the contract publishes %q", retiredManifestPath, agentpakke.RetiredRecordPath)
+	}
+}

--- a/cli/nav-pilot/internal/cli/retired_test.go
+++ b/cli/nav-pilot/internal/cli/retired_test.go
@@ -416,3 +416,46 @@ func TestSameRevision(t *testing.T) {
 		})
 	}
 }
+
+// TestRetiredRecordIsValidatedAgainstTheSchema covers the contract half of
+// #729. The record drives deletion, and any agentpakke may now publish one, so
+// a malformed record must not reach the code that removes files.
+//
+// A record that does not conform is treated as absent rather than as a sync
+// failure: a third party's broken file must not block an update that has
+// nothing to do with it.
+func TestRetiredRecordIsValidatedAgainstTheSchema(t *testing.T) {
+	published := []byte("---\nname: gammel\n---\n")
+	good := blobHash(published)
+
+	tests := []struct {
+		name   string
+		record string
+		want   int
+	}{
+		{"conforming record", `{"paths":{"agents/gammel.agent.md":["` + good + `"]}}`, 1},
+		// A hash that is not a blob id could never match a real file, but it
+		// says the producer is not emitting what the contract asks for.
+		{"hash is not a blob id", `{"paths":{"agents/gammel.agent.md":["deadbeef"]}}`, 0},
+		// The path rules matter most: this is the field that decides which file
+		// gets removed.
+		{"path escapes the repo", `{"paths":{"../../etc/passwd":["` + good + `"]}}`, 0},
+		{"absolute path", `{"paths":{"/etc/passwd":["` + good + `"]}}`, 0},
+		{"paths is missing", `{"_comment":"nothing here"}`, 0},
+		{"empty hash list", `{"paths":{"agents/gammel.agent.md":[]}}`, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scope, agentDir := userScopeWithAgents(t)
+			if err := os.WriteFile(filepath.Join(agentDir, "gammel.agent.md"), published, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			sourceDir := t.TempDir()
+			writeRetired(t, sourceDir, tt.record)
+
+			if got := len(findRetiredOrphans(scope, sourceDir, nil)); got != tt.want {
+				t.Errorf("findRetiredOrphans found %d orphan(s), want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/nav-pilot/schemas/agentpakke-retired-v1.json
+++ b/cli/nav-pilot/schemas/agentpakke-retired-v1.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/navikt/copilot/main/cli/nav-pilot/schemas/agentpakke-retired-v1.json",
+  "title": "nav-pilot agentpakke retired-artifact record (v1)",
+  "description": "Optional record of artifacts an agentpakke has published and since deleted, at .nav-pilot/retired-artifacts.json. nav-pilot removes such an artifact from an installed scope only when the file's content matches one of the listed hashes, which is proof the pakke published those exact bytes: a file the user wrote never matches. Without this record a retired artifact stays installed forever, because sync removes only what its state file tracks and an older install may have recorded nothing. Generate it from the repo's own history rather than maintaining it by hand; see scripts/generate-retired in navikt/copilot.",
+  "type": "object",
+  "required": ["paths"],
+  "properties": {
+    "_comment": {
+      "description": "Free text, ignored. Generators use it to say how the file is produced.",
+      "type": "string"
+    },
+    "paths": {
+      "description": "Repo-relative path of each retired artifact, mapped to every content hash that path ever held. Paths are as the agentpakke names them, so a declared layout applies: an agentpakke with layout.agents \"content/agents\" lists \"content/agents/old.agent.md\". An empty object is legal and says nothing has been retired.",
+      "type": "object",
+      "propertyNames": { "$ref": "#/$defs/repoRelativePath" },
+      "additionalProperties": {
+        "description": "Every content hash this path has held, as git blob ids: sha1 over the header \"blob <length>\\u0000\" and then the bytes. Git blob ids rather than plain sha256 because a repo's history already holds them, which is what makes the record generatable instead of maintained.",
+        "type": "array",
+        "minItems": 1,
+        "items": { "$ref": "#/$defs/blobHash" }
+      }
+    }
+  },
+  "$defs": {
+    "repoRelativePath": {
+      "description": "A normalized, contained, repo-relative path. Forward slashes only, no backslashes; not absolute; no \"~\" prefix; no \".\" or \"..\" segments; no duplicate or trailing slashes.",
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?:\\.*[^./\\\\~][^/\\\\]*|\\.{3,})(?:/(?:\\.*[^./\\\\][^/\\\\]*|\\.{3,}))*$"
+    },
+    "blobHash": {
+      "description": "A git blob id: 40 lowercase hex characters.",
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    }
+  }
+}

--- a/cli/nav-pilot/schemas/schemas.go
+++ b/cli/nav-pilot/schemas/schemas.go
@@ -28,3 +28,16 @@ var AgentpakkeV1 []byte
 //
 //go:embed agentpakke-payload-v1.json
 var AgentpakkePayloadV1 []byte
+
+// AgentpakkeRetiredV1 is the retired-artifact record schema, contract version 1.
+// Its $id is
+// https://raw.githubusercontent.com/navikt/copilot/main/cli/nav-pilot/schemas/agentpakke-retired-v1.json
+//
+// The record itself is optional: an agentpakke that has never deleted an
+// artifact needs none. It exists because sync removes only what its state file
+// tracks, so an artifact retired upstream stays installed forever on a machine
+// whose state predates it (#716). Publishing the hashes the pakke once shipped
+// is what lets nav-pilot tell its own bytes from a file the user wrote (#729).
+//
+//go:embed agentpakke-retired-v1.json
+var AgentpakkeRetiredV1 []byte

--- a/docs/README.agentpakke.md
+++ b/docs/README.agentpakke.md
@@ -86,6 +86,38 @@ Regelen har to halvdeler, og de gjelder samtidig:
 
 Et repo helt uten `.nav-pilot/agentpakke.json` er ikke en feil. Det behandles som en legacy-samlingskilde (`collections/<navn>/manifest.json`) akkurat som før. Merk at navikt/copilot selv ikke lenger er en slik kilde: siden [#468](https://github.com/navikt/copilot/issues/468) skipper repoet sitt eget manifest, og de fem samlingene er kollapset til den ene pakka `nav-pilot`.
 
+## Pensjonerte artefakter
+
+Valgfritt. En agentpakke som aldri har slettet en artefakt trenger ingen slik fil.
+
+`nav-pilot sync` fjerner bare det tilstandsfila i scopet sporer. En artefakt som ble installert av en eldre nav-pilot, eller av en installasjon som noterte mindre, står derfor igjen for alltid etter at pakken har sluttet å publisere den. Tre agenter pensjonert i august lå fortsatt installert i september, én av dem pinnet til en modell som var trukket tilbake ([#716](https://github.com/navikt/copilot/issues/716)).
+
+En pakke kan publisere `.nav-pilot/retired-artifacts.json` og la nav-pilot rydde:
+
+```json
+{
+  "paths": {
+    "content/agents/gammel.agent.md": [
+      "811b4abbecd5127391a18402837429c7fcb4f1dc",
+      "9629bdfd8f667ad380469689a6119ecd772c734e"
+    ]
+  }
+}
+```
+
+| Felt | Type | Påkrevd | Betydning |
+| --- | --- | --- | --- |
+| `paths` | objekt | ja | Repo-relativ sti til hver pensjonerte artefakt, med hver innholdshash stien har hatt. Tomt objekt er lovlig og sier at ingenting er pensjonert |
+| `_comment` | string | nei | Fritekst, ignoreres. Generatorer bruker den til å si hvordan fila lages |
+
+Stiene navngis slik pakken selv navngir dem, så en erklært `layout` gjelder: en pakke med `layout.agents` lik `content/agents` lister `content/agents/gammel.agent.md`.
+
+Hashene er git blob-id-er, altså sha1 over `blob <lengde>\0` og deretter bytene. Det er ikke tilfeldig: en pakkes egen historikk inneholder dem allerede, så fila kan **genereres** framfor å vedlikeholdes for hånd. Ingen skal måtte huske å føre opp et navn i det øyeblikket de sletter det. `scripts/generate-retired` i navikt/copilot leser dem ut av git-loggen og er omtrent hundre linjer.
+
+**nav-pilot sletter bare når innholdet stemmer.** «Kilden har ikke lenger en artefakt med dette navnet» er ikke tillatelse til å fjerne noe: noen kan ha skrevet sin egen fil på den stien, og den er deres. Et treff mot en hash pakken faktisk har publisert er derimot bevis på at nav-pilot skrev fila og at den er uendret siden.
+
+Fila valideres mot [det publiserte skjemaet](../cli/nav-pilot/schemas/agentpakke-retired-v1.json). En fil som ikke er gyldig behandles som fraværende, altså fjernes ingenting: en ødelagt fil i én pakke skal ikke blokkere en sync som ikke har noe med den å gjøre.
+
 ## Stiregler
 
 Alle repo-relative stier i manifestet (`layout.*`, `policies.*`, `profiles.dir`, `payloads.*.path`, `payloads.*.manifest`) valideres etter samme regler:


### PR DESCRIPTION
Andre halvdel av #729, og det som gjør #722 brukbar for andre enn oss.

## Hva som var galt

`#722` lot nav-pilot fjerne en artefakt kilden har pensjonert, ved å sammenlikne innholdet mot blobber stien en gang hadde. Fila den leste, `.nav-pilot/retired-artifacts.json`, var vår egen: udokumentert, uten skjema, generert av et skript i dette repoet, og nevnt i ingen kontraktstekst.

Arkitekturgjennomgangen kalte det den nye sidekanalen: første gang sync fjerner en fil tilstanden aldri har sporet, via en fil utenfor kontrakten.

## Hva som er gjort

Fila er nå en del av kontrakten:

- **Publisert skjema**, `agentpakke-retired-v1.json`, med samme `$id`-form som de to andre
- **Seksjon i `README.agentpakke.md`** med feltreferanse og et eksempel
- **Validering før noe handles på**: en sti eller en hash som ikke er velformet når aldri koden som sletter filer

Enhver agentpakke kan legge ved en, og nav-pilot rydder etter den på samme vilkår som etter oss: bare når innholdet stemmer med noe pakken faktisk har publisert.

## To valg det er verdt å se på

**En ugyldig fil behandles som fraværende, ikke som en feil.** Da fjernes ingenting, og synken går videre. Alternativet ville gjort en tredjeparts skrivefeil til et problem for en oppdatering som ikke har noe med den å gjøre.

**Hashene er git blob-id-er, ikke sha256.** Det er ikke tilfeldig: en pakkes egen historikk inneholder dem allerede, så fila kan **genereres** framfor å vedlikeholdes. Det var innvendingen mot en pensjonsliste, at noen må huske å føre opp et navn i det øyeblikket de sletter det, og genererbarhet er svaret på den.

## Feilmeldingene

Mønsterfeil for sti og blob-id rendres som setninger framfor escaped regex, samme rettelse payload-skjemaet fikk, keyet på skjemadefinisjonen som feilet:

```
paths.agents/a.agent.md.0: 'deadbeef' is not a git blob id: write 40 lowercase hex characters
paths./etc/passwd: '/etc/passwd' is not a repo-relative path: write it without a leading slash, ...
```

## Testen måtte flyttes et lag ned

Første versjon gikk gjennom `findRetiredOrphans` og var **grønn med valideringen fjernet**: hver ugyldig oppføring bommer også på filmatchingen av andre grunner, så den kunne ikke se validering i det hele tatt.

Den går rett på `ValidateRetired` nå, med tolv tilfeller. Kontrollen: nøytraliseres valideringen, blir åtte av dem røde.

(Første forsøk på selve kontrollen var også ubrukelig, siden mutasjonen ikke kompilerte og «0 feil» derfor bare betydde at ingenting kjørte.)

`mise run check` er grønn.