### PR TITLE
fix(nav-pilot): installasjonen navngir pakkens egen persona, ikke vår

### DIFF
--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -1007,7 +1007,8 @@ func installAllFromSource(scope *InstallScope, src *Source, manifest *Manifest, 
 		green("✓"), result.Installed, scope.Label(), stateVersion, shortSHA(src.SHA))
 	fmt.Println()
 	fmt.Println(dim("Agents and skills are now available across all your repos."))
-	fmt.Println(dim("Use @nav-pilot in Copilot Chat or copilot --agent nav-pilot"))
+	agent := installedPrimaryAgent(src)
+	fmt.Println(dim(fmt.Sprintf("Use @%s in Copilot Chat or copilot --agent %s", agent, agent)))
 
 	if len(manifest.Instructions) > 0 && scope.IsUser() {
 		fmt.Println()

--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -603,14 +603,19 @@ func cmdInstallFromSource(collection string, src *Source, scope *InstallScope, d
 	fmt.Printf("%s Installed %d items from %q (v%s, %s).\n",
 		green("✓"), result.Installed, collection, stateVersion, shortSHA(src.SHA))
 	fmt.Println()
+	// The pakke's own persona, not ours. A team that installs their agentpakke
+	// and is then told to use @nav-pilot has been handed the wrong name for
+	// what they just installed, which is the same mistake the launch path made
+	// before #728.
+	agent := installedPrimaryAgent(src)
 	if scope.IsUser() {
 		fmt.Println(dim("Agents and skills are now available across all your repos."))
-		fmt.Println(dim("Use @nav-pilot in Copilot Chat or copilot --agent nav-pilot"))
+		fmt.Println(dim(fmt.Sprintf("Use @%s in Copilot Chat or copilot --agent %s", agent, agent)))
 	} else {
 		fmt.Println(dim("Next steps:"))
 		fmt.Println(dim("  1. Review the installed files in .github/"))
 		fmt.Println(dim("  2. Commit and push to enable Copilot customization"))
-		fmt.Println(dim("  3. Use @nav-pilot in Copilot to start planning"))
+		fmt.Println(dim(fmt.Sprintf("  3. Use @%s in Copilot to start planning", agent)))
 	}
 
 	return nil
@@ -1360,4 +1365,22 @@ func stampRevision(files []InstalledFile, revision string) []InstalledFile {
 		}
 	}
 	return files
+}
+
+// installedPrimaryAgent names the persona a user should reach for after an
+// install: the first primaryAgents entry the source's manifest declares for
+// Copilot, or nav-pilot when the source declares none.
+//
+// A manifest-less source, and Nav's own agentpakke, both answer nav-pilot, so
+// the ordinary message is unchanged.
+func installedPrimaryAgent(src *Source) string {
+	const fallback = "nav-pilot"
+	if src == nil || src.Pakke == nil {
+		return fallback
+	}
+	agents := src.Pakke.PrimaryAgents("copilot")
+	if len(agents) == 0 {
+		return fallback
+	}
+	return agents[0]
 }

--- a/cli/nav-pilot/internal/cli/install_persona_test.go
+++ b/cli/nav-pilot/internal/cli/install_persona_test.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
+)
+
+// TestInstalledPrimaryAgent covers the last places an install named Nav's own
+// persona to a team installing someone else's pakke. Found by installing a
+// synthetic third-party agentpakke end to end, where the closing line read "Use
+// @nav-pilot in Copilot to start planning" over a pakke whose only agent is
+// called kokken.
+//
+// Both call sites print it: the one that installs a named pakke and the one
+// that installs everything a source ships. Review caught that the first fix
+// only reached one of them.
+func TestInstalledPrimaryAgent(t *testing.T) {
+	tests := []struct {
+		name string
+		src  *Source
+		want string
+	}{
+		{"no source at all", nil, "nav-pilot"},
+		{"manifest-less source", &Source{Repo: "navikt/other"}, "nav-pilot"},
+		{
+			"a pakke that declares its own roster",
+			&Source{Repo: "navikt/annet-team", Pakke: &agentpakke.Manifest{
+				Name:    "annet-team",
+				Clients: map[string]agentpakke.ClientEntry{"copilot": {PrimaryAgents: []string{"kokken", "baker"}}},
+			}},
+			"kokken",
+		},
+		{
+			// A pakke that declares no agents for this client falls back rather
+			// than printing an empty handle.
+			"a pakke with no copilot roster",
+			&Source{Repo: "navikt/annet-team", Pakke: &agentpakke.Manifest{
+				Name:    "annet-team",
+				Clients: map[string]agentpakke.ClientEntry{"opencode": {PrimaryAgents: []string{"kokken"}}},
+			}},
+			"nav-pilot",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := installedPrimaryAgent(tt.src); got != tt.want {
+				t.Errorf("installedPrimaryAgent = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Funnet ved å kjøre hele kjeden på en syntetisk tredjeparts-agentpakke, framfor å konkludere fra testene.

## Hva som ble prøvd

En pakke fra «et annet team» med sin egen katalogstruktur:

```json
{
  "contractVersion": "1",
  "name": "annet-team",
  "clients": { "copilot": { "primaryAgents": ["kokken"] } },
  "layout": { "agents": "innhold/agenter", "skills": "innhold/skills" }
}
```

| Steg | Resultat |
|---|---|
| `nav-pilot validate --source <pakke>` | conforms, tier 1 |
| `nav-pilot install --repo --source <pakke> annet-team` | `innhold/agenter/kokken.agent.md` → `.github/agents/kokken.agent.md` |
| per-fil-opphav i tilstandsfila | `revision: 853e1078...` på hver fil |
| `nav-pilot export opencode` | 1 agent, 1 skill (hard nektelse før #733) |

Alt virket. Og så avsluttet installasjonen slik:

```
Next steps:
  1. Review the installed files in .github/
  2. Commit and push to enable Copilot customization
  3. Use @nav-pilot in Copilot to start planning
```

Pakkens eneste agent heter `kokken`.

## Rettelsen

Meldingen leser første `primaryAgents`-oppføring manifestet erklærer for copilot. Det er samme feil launch-stien hadde før #728, bare i en linje tekst: vi forteller et team som nettopp installerte sin egen pakke at de skal bruke vår agent.

To tilfeller faller tilbake til `nav-pilot`, begge dekket av tester:

- en manifestløs kilde, altså dagens vanlige tilfelle, som er uendret
- en pakke som ikke erklærer noen agent for copilot, framfor å skrive ut et tomt håndtak

## Sidenotat

Installasjonen lagret `--source` som varig kilde i `~/.nav-pilot/config.toml`. Det er dokumentert oppførsel og den sier fra om det, men verdt å vite når man tester med en midlertidig katalog: min egen konfigurasjon pekte etterpå på en `mktemp`-sti. Ryddet med `nav-pilot config set source ""`.

`mise run check` er grønn.