### PR TITLE
docs(nav-pilot): brukerscopet tar hooks også

### DIFF
--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -50,7 +50,7 @@ tilstandsfila `.github/.nav-pilot-state.json`.
 
 Dette får du bare her:
 
-- **Prompts.** Brukerscopet støtter `agent`, `skill` og `instruction`, ikke `prompt`
+- **Prompts.** Brukerscopet støtter `agent`, `skill`, `instruction` og `hook`, ikke `prompt`
   (`ScopeUser()` i `cli/nav-pilot/internal/domain/domain.go`). Installerer du pakka med
   `--user`, hoppes promptene over og rapporteres som ikke støttet. Ber du om én enkelt prompt
   med `--type prompt --user`, er det en feilmelding.


### PR DESCRIPTION
Lista over hva brukerscopet støtter var skrevet før hooks ble en artefakttype (#569):

```
- Prompts. Brukerscopet støtter `agent`, `skill` og `instruction`, ikke `prompt`
```

`SupportedTypes` i `domain.go:233` har `agent`, `skill`, `instruction` og `hook` for brukerscopet. Prompt er fortsatt bare repo-scope, som er det avsnittet faktisk handler om, så bare oppramsingen var feil.

Funnet mens jeg sjekket om «dokumentér installasjonsscope» fra #572 gjensto. Det gjør det ikke: seksjonen dekker de tre formene, hva hver enkelt gir, og hooks har sitt eget avsnitt om hvorfor de ikke kan installeres inne i cplt. Bare denne ene oppramsingen hadde blitt liggende igjen.