### PR TITLE
docs(nav-pilot): presiser hvem som bevarer ukjente nøkler

### DIFF
--- a/cli/nav-pilot/DESIGN.md
+++ b/cli/nav-pilot/DESIGN.md
@@ -616,8 +616,9 @@ som faktisk skrives i dag, ikke bare `path` og `hash`: `source` navngir
 agentpakken en fil kom fra når det ikke er scopets egen kilde (#571),
 `revision` hvilken revisjon som skrev den (#729), og `status` skiller en
 ignorert oppføring fra en aktiv. Ukjente nøkler bevares uendret ved skriving
-(#588), så en kollega på en eldre nav-pilot ikke fjerner et felt binæren deres
-ikke kjenner.
+(#588), altså av enhver binær som selv har den bevaringslogikken: en kollega på
+en nav-pilot fra etter #588 fjerner ikke et felt binæren deres ikke kjenner. En
+binær fra før den rettelsen dropper dem fortsatt, som er nettopp det #588 fant.
 
 ```json
 {


### PR DESCRIPTION
Oppfølging av #736, som rakk å bli merget før denne rettelsen ble pushet til grenen.

Review på #736 påpekte at formuleringen kunne leses som at enhver eldre binær lar et ukjent felt stå. Det er bevaringslogikken fra #588 som gjør det, og en binær fra før den rettelsen dropper dem fortsatt, som er nettopp det #588 fant.

Setningen sier nå det.

Bare dokumentasjon.