### PR TITLE
feat(agentpakke): extensions er en artefakttype

### DIFF
--- a/cli/nav-pilot/internal/agentpakke/agentpakke.go
+++ b/cli/nav-pilot/internal/agentpakke/agentpakke.go
@@ -207,6 +207,7 @@ type Layout struct {
 	Instructions string `json:"instructions,omitempty"`
 	Prompts      string `json:"prompts,omitempty"`
 	Hooks        string `json:"hooks,omitempty"`
+	Extensions   string `json:"extensions,omitempty"`
 }
 
 // Provenance records the base and overlays a composed agentpakke was built from.

--- a/cli/nav-pilot/internal/agentpakke/declaration.go
+++ b/cli/nav-pilot/internal/agentpakke/declaration.go
@@ -42,7 +42,7 @@ var ErrNoDeclaration = errors.New("no agentpakke declaration")
 // DeclaredItemTypes are the artifact types an entry in [Declaration.Items] may
 // name. It mirrors the CLI's artifact kinds; the list lives here because the
 // declaration is parsed before any resolver exists.
-var DeclaredItemTypes = []string{"agent", "skill", "instruction", "prompt", "hook"}
+var DeclaredItemTypes = []string{"agent", "skill", "instruction", "prompt", "hook", "extension"}
 
 // Declaration is a repo's committed statement of which agentpakke it uses and
 // at which revision.

--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -28,17 +28,19 @@ func installItems(resolver *SourceResolver, scope *InstallScope, manifest *Manif
 	result := &installResult{}
 	stateHashes := scopeStateHashes(scope)
 
-	for _, group := range []struct {
-		label string
-		names []string
-		kind  *ArtifactKind
-	}{
-		{"Agents", manifest.Agents, KindAgent},
-		{"Skills", manifest.Skills, KindSkill},
-		{"Instructions", manifest.Instructions, KindInstruction},
-		{"Prompts", manifest.Prompts, KindPrompt},
-		{"Hooks", manifest.Hooks, KindHook},
-	} {
+	// Derived from AllKinds rather than listed here, the lesson of #649, #650
+	// and #708: a kind added to the resolver and forgotten in a table like this
+	// installs nothing, silently.
+	for _, kind := range AllKinds {
+		names, ok := manifest.NamesByKind(kind)
+		if !ok {
+			continue
+		}
+		group := struct {
+			label string
+			names []string
+			kind  *ArtifactKind
+		}{kindLabel(kind), names, kind}
 		if len(group.names) == 0 {
 			continue
 		}
@@ -1384,4 +1386,13 @@ func installedPrimaryAgent(src *Source) string {
 		return fallback
 	}
 	return agents[0]
+}
+
+// kindLabel is the plural heading an install prints for a kind: "Agents",
+// "Skills", "Extensions".
+func kindLabel(kind *ArtifactKind) string {
+	if kind.Dir == "" {
+		return kind.Name
+	}
+	return strings.ToUpper(kind.Dir[:1]) + kind.Dir[1:]
 }

--- a/cli/nav-pilot/internal/domain/domain.go
+++ b/cli/nav-pilot/internal/domain/domain.go
@@ -214,7 +214,7 @@ func ScopeRepo(targetDir string) *InstallScope {
 		RootDir:        targetDir,
 		StateFile:      ".github/.nav-pilot-state.json",
 		PathPrefix:     ".github/",
-		SupportedTypes: []string{"agent", "skill", "instruction", "prompt", "hook"},
+		SupportedTypes: []string{"agent", "skill", "instruction", "prompt", "hook", "extension"},
 	}
 }
 
@@ -230,7 +230,7 @@ func ScopeUser() (*InstallScope, error) {
 		RootDir:        rootDir,
 		StateFile:      ".nav-pilot-state.json",
 		PathPrefix:     "",
-		SupportedTypes: []string{"agent", "skill", "instruction", "hook"},
+		SupportedTypes: []string{"agent", "skill", "instruction", "hook", "extension"},
 	}, nil
 }
 

--- a/cli/nav-pilot/internal/source/extension_test.go
+++ b/cli/nav-pilot/internal/source/extension_test.go
@@ -1,0 +1,72 @@
+package source
+
+import "testing"
+
+// TestKindByNameIsDerived pins the change that made adding a kind a one-line
+// edit. KindByName used to be a map literal written out beside AllKinds, which
+// is how `hook` came to be missing from three separate places after it was
+// added (#649, #650, #708).
+func TestKindByNameIsDerived(t *testing.T) {
+	if len(KindByName) != len(AllKinds) {
+		t.Errorf("KindByName has %d entries, AllKinds has %d: the map is not derived", len(KindByName), len(AllKinds))
+	}
+	for _, kind := range AllKinds {
+		got, ok := KindByName[kind.Name]
+		if !ok {
+			t.Errorf("KindByName has no entry for %q", kind.Name)
+			continue
+		}
+		if got != kind {
+			t.Errorf("KindByName[%q] is not the kind from AllKinds", kind.Name)
+		}
+	}
+}
+
+// TestExtensionKind covers the shape #572 asked for: a team's own executable
+// code, which had no artifact type at all and therefore could not be
+// distributed. watson-developer's .github/extensions/auto-format/extension.mjs
+// is the case this is derived from.
+func TestExtensionKind(t *testing.T) {
+	if !KindExtension.IsDir {
+		t.Error("an extension is a directory: an extension is rarely one module")
+	}
+	if KindExtension.Marker != "extension.mjs" {
+		t.Errorf("marker = %q, want extension.mjs: the marker is what makes a directory an extension rather than a stray folder", KindExtension.Marker)
+	}
+	if KindExtension.Suffix != "" {
+		t.Errorf("suffix = %q, want empty for a directory kind", KindExtension.Suffix)
+	}
+
+	// Registered, not merely declared. Defining the kind and forgetting to put
+	// it in AllKinds gives a type that exists in Go and nowhere else: the
+	// resolver never lists it, install-everything never sees it, and nothing
+	// fails. Every other assertion here passes in that state.
+	if _, ok := KindByName[KindExtension.Name]; !ok {
+		t.Error("extension is not in AllKinds, so nothing that iterates kinds will find it")
+	}
+}
+
+// TestManifestNamesEveryKind pins that the source manifest can carry every kind
+// the resolver knows. A kind the manifest cannot name is a kind "install
+// everything" silently skips, which is what happened to extensions before #572:
+// the resolver would have found them and the install table listed five kinds.
+func TestManifestNamesEveryKind(t *testing.T) {
+	m := &Manifest{
+		Agents:       []string{"a"},
+		Skills:       []string{"s"},
+		Instructions: []string{"i"},
+		Prompts:      []string{"p"},
+		Hooks:        []string{"h"},
+		Extensions:   []string{"e"},
+	}
+	for _, kind := range AllKinds {
+		names, ok := m.NamesByKind(kind)
+		if !ok {
+			t.Errorf("the manifest cannot name %q, so install-everything would skip it", kind.Name)
+			continue
+		}
+		if len(names) != 1 {
+			t.Errorf("NamesByKind(%q) = %v, want the one fixture entry", kind.Name, names)
+		}
+	}
+}

--- a/cli/nav-pilot/internal/source/manifest.go
+++ b/cli/nav-pilot/internal/source/manifest.go
@@ -18,6 +18,32 @@ type Manifest struct {
 	Instructions []string `json:"instructions"`
 	Prompts      []string `json:"prompts"`
 	Hooks        []string `json:"hooks,omitempty"`
+	Extensions   []string `json:"extensions,omitempty"`
+}
+
+// NamesByKind returns the manifest's entries for one kind, and whether the kind
+// is one this manifest carries at all.
+//
+// One place maps a kind to its list. Before this, the mapping was written out
+// in ValidateManifest, in the builder below and again in install's group table,
+// which is how `hook` came to be missing from three separate places after it
+// was added (#649, #650, #708).
+func (m *Manifest) NamesByKind(kind *ArtifactKind) ([]string, bool) {
+	switch kind {
+	case KindAgent:
+		return m.Agents, true
+	case KindSkill:
+		return m.Skills, true
+	case KindInstruction:
+		return m.Instructions, true
+	case KindPrompt:
+		return m.Prompts, true
+	case KindHook:
+		return m.Hooks, true
+	case KindExtension:
+		return m.Extensions, true
+	}
+	return nil, false
 }
 
 // CollectionAll is the collection name used in state files for "install everything".
@@ -29,16 +55,15 @@ func ValidateManifest(m *Manifest) error {
 		return fmt.Errorf("manifest has empty name")
 	}
 	seen := make(map[string]bool)
-	for _, list := range []struct {
-		kind  string
-		names []string
-	}{
-		{"agent", m.Agents},
-		{"skill", m.Skills},
-		{"instruction", m.Instructions},
-		{"prompt", m.Prompts},
-		{"hook", m.Hooks},
-	} {
+	for _, kind := range AllKinds {
+		names, ok := m.NamesByKind(kind)
+		if !ok {
+			continue
+		}
+		list := struct {
+			kind  string
+			names []string
+		}{kind.Name, names}
 		for _, name := range list.names {
 			if err := ValidateName(name); err != nil {
 				return fmt.Errorf("invalid %s in manifest: %w", list.kind, err)
@@ -113,11 +138,15 @@ func CollectAllItemsWith(resolver *SourceResolver) (*Manifest, error) {
 	for _, i := range resolver.List(KindInstruction) {
 		m.Instructions = append(m.Instructions, i.Name)
 	}
-	// Hooks come along with "install everything" for the same reason the other
-	// kinds do: an enforcement gate that only ships to people who name it
-	// explicitly is the gap #569 was filed for.
+	// Hooks and extensions come along with "install everything" for the same
+	// reason the other kinds do: an enforcement gate that only ships to people
+	// who name it explicitly is the gap #569 was filed for, and an extension a
+	// team cannot distribute is the gap in #572.
 	for _, h := range resolver.List(KindHook) {
 		m.Hooks = append(m.Hooks, h.Name)
+	}
+	for _, e := range resolver.List(KindExtension) {
+		m.Extensions = append(m.Extensions, e.Name)
 	}
 	return m, nil
 }

--- a/cli/nav-pilot/internal/source/resolver.go
+++ b/cli/nav-pilot/internal/source/resolver.go
@@ -14,8 +14,8 @@ import (
 
 // ArtifactKind describes the filesystem shape of one artifact type.
 type ArtifactKind struct {
-	Name     string // singular: "agent", "skill", "instruction", "prompt", "hook"
-	Dir      string // plural directory: "agents", "skills", "instructions", "prompts", "hooks"
+	Name     string // singular: "agent", "skill", "instruction", "prompt", "hook", "extension"
+	Dir      string // plural directory: "agents", "skills", "instructions", "prompts", "hooks", "extensions"
 	Suffix   string // file extension: ".agent.md", ".instructions.md", ".prompt.md"
 	IsDir    bool   // always a directory (skills)
 	CanBeDir bool   // may be file or directory (prompts)
@@ -36,17 +36,34 @@ var (
 	// hook merge, and hooks/<name>.hook.json carries its matcher.
 	KindHook = &ArtifactKind{Name: "hook", Dir: "hooks", Suffix: ".py"}
 
+	// KindExtension is the second kind that is executable code: a directory
+	// holding extension.mjs, which the client loads and runs. Same trust
+	// decision as a hook, and the same reason it needs a type at all: a team
+	// that has written one today cannot distribute it, because nav-pilot does
+	// not know the shape exists (#572).
+	//
+	// A directory rather than a file, because an extension is rarely one module:
+	// watson-developer's auto-format ships helpers beside its entry point. The
+	// marker is what makes a directory an extension rather than a stray folder,
+	// exactly as SKILL.md does for a skill.
+	KindExtension = &ArtifactKind{Name: "extension", Dir: "extensions", IsDir: true, Marker: "extension.mjs"}
+
 	// AllKinds lists all artifact kinds for iteration.
-	AllKinds = []*ArtifactKind{KindAgent, KindSkill, KindInstruction, KindPrompt, KindHook}
+	AllKinds = []*ArtifactKind{KindAgent, KindSkill, KindInstruction, KindPrompt, KindHook, KindExtension}
 
 	// KindByName maps singular names to their ArtifactKind.
-	KindByName = map[string]*ArtifactKind{
-		"agent":       KindAgent,
-		"skill":       KindSkill,
-		"instruction": KindInstruction,
-		"prompt":      KindPrompt,
-		"hook":        KindHook,
-	}
+	// KindByName maps a singular kind name to its kind, derived from AllKinds
+	// rather than written out beside it. A second hand-maintained list is how
+	// `hook` ended up missing from three separate places after it was added
+	// (#649, #650, #708); adding a kind should mean editing AllKinds and
+	// nothing else.
+	KindByName = func() map[string]*ArtifactKind {
+		m := make(map[string]*ArtifactKind, len(AllKinds))
+		for _, k := range AllKinds {
+			m[k.Name] = k
+		}
+		return m
+	}()
 )
 
 // Resolved represents a found artifact in the source repo.
@@ -113,6 +130,7 @@ func NewSourceResolverForLayout(sourceDir string, layout *agentpakke.Layout) *So
 		KindInstruction.Dir: layout.Instructions,
 		KindPrompt.Dir:      layout.Prompts,
 		KindHook.Dir:        layout.Hooks,
+		KindExtension.Dir:   layout.Extensions,
 	}
 	for canonical, dir := range declared {
 		dir = strings.TrimSpace(dir)

--- a/cli/nav-pilot/schemas/agentpakke-v1.json
+++ b/cli/nav-pilot/schemas/agentpakke-v1.json
@@ -102,7 +102,8 @@
         "skills": { "$ref": "#/$defs/relativePath" },
         "instructions": { "$ref": "#/$defs/relativePath" },
         "prompts": { "$ref": "#/$defs/relativePath" },
-        "hooks": { "$ref": "#/$defs/relativePath" }
+        "hooks": { "$ref": "#/$defs/relativePath" },
+        "extensions": { "$ref": "#/$defs/relativePath" }
       }
     },
     "provenance": {

--- a/docs/README.agentpakke.md
+++ b/docs/README.agentpakke.md
@@ -15,10 +15,30 @@ Dette dokumentet er for team som lager en agentpakke. Interndesignet, altså hvo
 ├── agents/                  # layout.agents:        <navn>.agent.md
 ├── skills/                  # layout.skills:        <navn>/SKILL.md
 ├── instructions/            # layout.instructions:  <navn>.instructions.md
-└── prompts/                 # layout.prompts:       <navn>.prompt.md eller <navn>/
+├── prompts/                 # layout.prompts:       <navn>.prompt.md eller <navn>/
+├── hooks/                   # layout.hooks:         <navn>.py + <navn>.hook.json
+└── extensions/              # layout.extensions:    <navn>/extension.mjs
 ```
 
 Katalognavnene er ikke låst. `layout` peker på hvor innholdet faktisk ligger, og nav-pilot leser kun der. Filnavnkonvensjonene inne i katalogene er derimot låst, fordi det er dem nav-pilot bruker til å finne og navngi artefaktene. Agentfiler må åpne med en `---`-avgrenset YAML-frontmatter som minst deklarerer `name` og `description`.
+
+## Kjørbare artefakter: hooks og extensions
+
+Fire av artefekttypene er tekst modellen leser. To er kode som kjører på maskinen til den som installerer:
+
+| Type | Form | Hva som kjører |
+| --- | --- | --- |
+| `hook` | `<navn>.py` med `<navn>.hook.json` ved siden | Et preToolUse-skript klienten kjører på hvert kall som matcher |
+| `extension` | `<navn>/extension.mjs` | En modul klienten laster |
+
+Det er en annen tillitsbeslutning enn de fire andre. Å installere en agentpakke som sender med en av disse er å si ja til at et annet team kjører kode hos deg, og det er verdt å vite før man gjør det, ikke etterpå.
+
+To ting følger av det:
+
+- **De kommer med i «installer alt».** En port som bare når dem som navngir den eksplisitt, er ingen port. Det var begrunnelsen for at hooks ble en type ([#569](https://github.com/navikt/copilot/issues/569)), og den gjelder likt for extensions.
+- **cplt nekter skriving til begge katalogene.** Kjører du `nav-pilot install` fra en agentsesjon inne i sandboxen, stopper installasjonen med en feil som sier hvorfor. En prosess i sandboxen skal ikke kunne legge igjen kode som kjører utenfor den senere. Se [README.nav-pilot.md](README.nav-pilot.md#hooks-kan-ikke-installeres-inne-i-cplt).
+
+Extensions fikk en type fordi et team som hadde skrevet en, ikke kunne distribuere den: nav-pilot kjente ikke formen, så den ble hverken installert, synket eller eksportert ([#572](https://github.com/navikt/copilot/issues/572)).
 
 ## Feltreferanse
 


### PR DESCRIPTION
Siste ubegynte punkt i #572. De to andre som gjenstår der er blokkert på svar fra folk, ikke på arbeid.

## Problemet

watson-developer har `.github/extensions/auto-format/extension.mjs` i dag. nav-pilot kjenner ikke formen, så den blir hverken installert, synket eller eksportert. Fra tråden i #572:

> To artefakttyper nav-pilot ikke kjenner. `.github/hooks/frontend-format-fix.json` og `.github/extensions/auto-format`. Hooks er sporet i #569. **Extensions har ingen type i det hele tatt.**

Hooks fikk sin type. Dette er den andre halvdelen.

## Formen

`KindExtension` er en katalog med `extension.mjs` som markør, samme form som skills med `SKILL.md`. En katalog framfor en fil, fordi en extension sjelden er én modul: watsons `auto-format` har hjelpere ved siden av inngangspunktet. `layout.extensions` kan peke den et annet sted, som de andre typene.

## Tre hardkodede typelister er borte

Underveis, fordi det er nøyaktig det #649, #650 og #708 handlet om: en type lagt til i resolveren og glemt i en tabell installerer ingenting, i stillhet.

| Før | Nå |
| --- | --- |
| `KindByName` skrevet ut ved siden av `AllKinds` | utledet fra `AllKinds` |
| `ValidateManifest` og manifest-byggeren koblet type til liste hver for seg | `Manifest.NamesByKind`, ett sted |
| Installasjonens gruppetabell listet fem typer | itererer `AllKinds` |

Å legge til en type skal bety å redigere `AllKinds` og ingenting annet. Det gjenstår ett unntak: `DeclaredItemTypes` i `agentpakke` kan ikke utledes, siden `source` importerer `agentpakke` og ikke omvendt. Testen fra #650 fanger den, og gjorde det her også.

## Verifisert ende til ende

Lagt til i den syntetiske tredjeparts-pakka fra i går, med egen katalogstruktur:

```
Extensions (1):
✓ Installed 3 items from "annet-team" (vdev, ec53edc).

.github/agents/kokken.agent.md
.github/extensions/auto-format/extension.mjs
.github/skills/grilling/SKILL.md
```

Før denne endringen installerte samme pakke 2 artefakter og hoppet stille over den tredje.

## Dokumentasjon

Ny seksjon om kjørbare artefakter, siden hooks og extensions deler tillitsbeslutning: å installere en pakke med en av dem er å si ja til at et annet team kjører kode hos deg. Repoform-treet manglet `hooks` også, og har begge nå.

## Kontroll

Fjernes `KindExtension` fra `AllKinds`, blir testen rød.

Første versjon av den testen sjekket bare at typen fantes, altså noe som er sant også når den ikke er registrert noe sted, og var grønn med kontrollen kjørende. Den sjekker nå at typen er i `KindByName`, som er utledet fra `AllKinds`.

`mise run check` er grønn.