### PR TITLE
feat(agentpakke): en pakke kan gjenbruke en annen (#572)

### DIFF
--- a/cli/nav-pilot/internal/cli/compose.go
+++ b/cli/nav-pilot/internal/cli/compose.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
+	"github.com/navikt/copilot/cli/nav-pilot/internal/source"
+)
+
+// Composition: an agentpakke that reuses another one.
+//
+// There is no `extends` field. A pakke that reuses another is a repo that ships
+// a manifest *and* commits the same declaration a consumer repo commits — the
+// declaration already says which pakke, at which revision, and optionally which
+// items. [agentpakke.Declaration]'s own doc says a repo can hold both, and this
+// is the case it was talking about.
+//
+// The collision rule is that the nearest wins, and it wins by being asked
+// first: composeResolver hangs the reused pakke *behind* this source, so a
+// pakke that ships its own agent named "grillmester" shadows the reused one.
+// That mirrors `overrides` in .github/copilot-sync.json one level up — what a
+// team keeps for itself, they keep.
+//
+// Binding time follows the manifest's shape, not a separate mechanism: a layout
+// pakke resolves its declaration here, on every install and sync, while a
+// payload pakke resolved it at build time and ships the result. That is why
+// this is wired into the Tier 1 path only.
+
+// composeResolver returns the resolver to install from. When this source
+// reuses another agentpakke, the returned resolver falls back to it, and the
+// second return value is the reused source so callers can report it.
+//
+// A source that reuses nothing — which is nearly all of them — gets its own
+// resolver back unchanged and a nil base.
+func composeResolver(resolver *SourceResolver, src *Source) (*SourceResolver, *Source, error) {
+	return composeResolverSeen(resolver, src, map[string]bool{sourceLabelFor(src): true})
+}
+
+// composeResolverSeen carries the labels already on the chain. A pakke that
+// reuses one that reuses it back would otherwise fetch the two forever; the
+// cycle is reported rather than silently cut, because either half of it is a
+// mistake someone has to fix in a committed file.
+func composeResolverSeen(resolver *SourceResolver, src *Source, seen map[string]bool) (*SourceResolver, *Source, error) {
+	decl, err := agentpakke.LoadDeclaration(src.Dir)
+	if err != nil {
+		if errors.Is(err, agentpakke.ErrNoDeclaration) {
+			return resolver, nil, nil
+		}
+		return nil, nil, fmt.Errorf("reading the reuse declaration of %s: %w", sourceLabelFor(src), err)
+	}
+	if decl.Source == "" {
+		return resolver, nil, nil
+	}
+	// A pakke whose declaration names itself is a consumer repo that happens to
+	// ship a manifest, not a composition. Chaining it to itself would resolve
+	// every artifact twice and, at a different revision, shadow the checkout
+	// being installed with an older copy of itself.
+	if decl.Source == sourceLabelFor(src) {
+		return resolver, nil, nil
+	}
+
+	if seen[decl.Source] {
+		return nil, nil, fmt.Errorf("agentpakke %s reuses %q, which already reuses it back.\nA reuse cycle has no order to resolve in, so nothing was installed.\nBreak the cycle in %s in one of the two repos",
+			sourceLabelFor(src), decl.Source, agentpakke.DeclarationPath)
+	}
+	seen[decl.Source] = true
+
+	baseSrc, err := source.ResolveSource(decl.SHA, decl.Source, "")
+	if err != nil {
+		return nil, nil, fmt.Errorf("%s reuses agentpakke %q, which could not be resolved at %s: %w\n\nNothing was installed",
+			sourceLabelFor(src), decl.Source, shortSHA(decl.SHA), err)
+	}
+	if err := attachPakke(baseSrc); err != nil {
+		return nil, nil, err
+	}
+	// A reused pakke may itself reuse one. The chain is built depth-first, so
+	// by the time this source's resolver is wrapped, everything behind it is
+	// already in place.
+	baseResolver, _, err := composeResolverSeen(resolverFor(baseSrc.Dir, baseSrc.Pakke), baseSrc, seen)
+	if err != nil {
+		return nil, nil, err
+	}
+	return resolver.WithBase(baseResolver), baseSrc, nil
+}

--- a/cli/nav-pilot/internal/cli/compose.go
+++ b/cli/nav-pilot/internal/cli/compose.go
@@ -34,6 +34,14 @@ import (
 // A source that reuses nothing, which is nearly all of them, gets its own
 // resolver back unchanged and a nil base.
 func composeResolver(resolver *SourceResolver, src *Source) (*SourceResolver, *Source, error) {
+	// Only a manifest-bearing source composes. A collection-era source has no
+	// agentpakke identity to reuse from, and one that happens to carry a
+	// declaration is a consumer repo that also serves content: composing it
+	// would fetch a second repo mid-install for a source that never asked for
+	// it.
+	if src.Pakke == nil {
+		return resolver, nil, nil
+	}
 	return composeResolverSeen(resolver, src, map[string]bool{sourceLabelFor(src): true})
 }
 

--- a/cli/nav-pilot/internal/cli/compose.go
+++ b/cli/nav-pilot/internal/cli/compose.go
@@ -11,7 +11,7 @@ import (
 // Composition: an agentpakke that reuses another one.
 //
 // There is no `extends` field. A pakke that reuses another is a repo that ships
-// a manifest *and* commits the same declaration a consumer repo commits — the
+// a manifest *and* commits the same declaration a consumer repo commits. That
 // declaration already says which pakke, at which revision, and optionally which
 // items. [agentpakke.Declaration]'s own doc says a repo can hold both, and this
 // is the case it was talking about.
@@ -19,7 +19,7 @@ import (
 // The collision rule is that the nearest wins, and it wins by being asked
 // first: composeResolver hangs the reused pakke *behind* this source, so a
 // pakke that ships its own agent named "grillmester" shadows the reused one.
-// That mirrors `overrides` in .github/copilot-sync.json one level up — what a
+// That mirrors `overrides` in .github/copilot-sync.json one level up: what a
 // team keeps for itself, they keep.
 //
 // Binding time follows the manifest's shape, not a separate mechanism: a layout
@@ -31,7 +31,7 @@ import (
 // reuses another agentpakke, the returned resolver falls back to it, and the
 // second return value is the reused source so callers can report it.
 //
-// A source that reuses nothing — which is nearly all of them — gets its own
+// A source that reuses nothing, which is nearly all of them, gets its own
 // resolver back unchanged and a nil base.
 func composeResolver(resolver *SourceResolver, src *Source) (*SourceResolver, *Source, error) {
 	return composeResolverSeen(resolver, src, map[string]bool{sourceLabelFor(src): true})
@@ -65,6 +65,15 @@ func composeResolverSeen(resolver *SourceResolver, src *Source, seen map[string]
 			sourceLabelFor(src), decl.Source, agentpakke.DeclarationPath)
 	}
 	seen[decl.Source] = true
+
+	// A repo-shaped reuse without a pin would clone whatever main happens to
+	// hold, so two installs a week apart would compose different content while
+	// both reported the same declaration. A local path has no revision to pin
+	// and is a working tree by definition, so only the repo form is refused.
+	if pinnable(decl.Source) && decl.SHA == "" {
+		return nil, nil, fmt.Errorf("agentpakke %s reuses %q without a revision.\nReuse resolves at install and sync, so an unpinned base would compose whatever that repo's main branch holds at the time.\nNothing was installed. Add the 40-character sha of the revision to reuse to %s and commit it",
+			sourceLabelFor(src), decl.Source, agentpakke.DeclarationPath)
+	}
 
 	baseSrc, err := source.ResolveSource(decl.SHA, decl.Source, "")
 	if err != nil {

--- a/cli/nav-pilot/internal/cli/compose_test.go
+++ b/cli/nav-pilot/internal/cli/compose_test.go
@@ -118,3 +118,39 @@ func TestPakkeWithoutDeclarationIsUnchanged(t *testing.T) {
 		t.Error("testpakka har en erklæring, da tester dette noe annet enn det står")
 	}
 }
+
+// En gjenbruk av et repo uten sha ville klonet det main tilfeldigvis holder,
+// så to installasjoner en uke fra hverandre komponerte ulikt innhold mens
+// begge rapporterte samme erklæring.
+func TestUnpinnedRepoReuseIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	writePakke(t, dir, "egen", "eget")
+	declareReuse(t, dir, "navikt/basepakke")
+
+	src := loadSource(t, dir)
+	_, _, err := composeResolver(resolverFor(src.Dir, src.Pakke), src)
+	if err == nil {
+		t.Fatal("en gjenbruk uten revisjon ble godtatt")
+	}
+	if !strings.Contains(err.Error(), "without a revision") {
+		t.Errorf("feilmeldinga sier ikke hva som mangler: %v", err)
+	}
+}
+
+// Kontroll: en lokal sti har ingen revisjon å pinne, og skal fortsatt virke.
+// Uten denne ville testen over passert selv om vakta nektet alt.
+func TestUnpinnedLocalPathReuseIsAllowed(t *testing.T) {
+	baseDir, ownDir := t.TempDir(), t.TempDir()
+	writePakke(t, baseDir, "basepakke", "felles")
+	writePakke(t, ownDir, "egenpakke", "eget")
+	declareReuse(t, ownDir, baseDir)
+
+	src := loadSource(t, ownDir)
+	_, reused, err := composeResolver(resolverFor(src.Dir, src.Pakke), src)
+	if err != nil {
+		t.Fatalf("en lokal sti uten sha ble nektet: %v", err)
+	}
+	if reused == nil {
+		t.Fatal("den lokale basen ble ikke gjenbrukt")
+	}
+}

--- a/cli/nav-pilot/internal/cli/compose_test.go
+++ b/cli/nav-pilot/internal/cli/compose_test.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
+)
+
+// writePakke lays down a minimal conforming agentpakke with the named agents.
+func writePakke(t *testing.T, dir, name string, agents ...string) {
+	t.Helper()
+	for _, sub := range []string{".nav-pilot", "agents", "skills"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	manifest := `{"contractVersion":"1","name":"` + name + `","description":"` + name +
+		`","layout":{"agents":"agents","skills":"skills"},"clients":{"copilot":{"primaryAgents":["` + agents[0] + `"]}}}`
+	if err := os.WriteFile(filepath.Join(dir, ".nav-pilot", "agentpakke.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, a := range agents {
+		body := "---\nname: " + a + "\ndescription: fra " + name + "\n---\n" + name + "\n"
+		if err := os.WriteFile(filepath.Join(dir, "agents", a+".agent.md"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func declareReuse(t *testing.T, dir, base string) {
+	t.Helper()
+	body := `{"contractVersion":"1","source":"` + base + `"}`
+	if err := os.WriteFile(filepath.Join(dir, ".nav-pilot", "agentpakke.lock.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func loadSource(t *testing.T, dir string) *Source {
+	t.Helper()
+	src := &Source{Dir: dir, Repo: dir}
+	if err := attachPakke(src); err != nil {
+		t.Fatal(err)
+	}
+	return src
+}
+
+// En pakke som gjenbruker en annen installerer begges innhold, og sitt eget
+// vinner der navnene kolliderer (#572).
+func TestComposedInstallInheritsAndShadows(t *testing.T) {
+	baseDir, ownDir := t.TempDir(), t.TempDir()
+	writePakke(t, baseDir, "basepakke", "felles", "grillmester")
+	writePakke(t, ownDir, "egenpakke", "eget", "grillmester")
+	declareReuse(t, ownDir, baseDir)
+
+	src := loadSource(t, ownDir)
+	resolver, reused, err := composeResolver(resolverFor(src.Dir, src.Pakke), src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reused == nil || reused.Dir != baseDir {
+		t.Fatalf("gjenbrukt kilde = %v, ventet %s", reused, baseDir)
+	}
+	manifest, err := pakkeContents(resolver, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(manifest.Agents, ","); got != "eget,felles,grillmester" {
+		t.Errorf("agenter = %q, ventet eget,felles,grillmester", got)
+	}
+	got, ok := resolver.Get(KindAgent, "grillmester")
+	if !ok {
+		t.Fatal("grillmester ble ikke løst")
+	}
+	if !strings.HasPrefix(got.AbsPath, ownDir) {
+		t.Errorf("grillmester løste til %s, ventet pakkens eget under %s", got.AbsPath, ownDir)
+	}
+}
+
+// To pakker som gjenbruker hverandre har ingen rekkefølge å løses i. Uten
+// vakta henter composeResolver dem vekselvis til stacken tar slutt.
+func TestReuseCycleIsRefused(t *testing.T) {
+	aDir, bDir := t.TempDir(), t.TempDir()
+	writePakke(t, aDir, "a", "en")
+	writePakke(t, bDir, "b", "to")
+	declareReuse(t, aDir, bDir)
+	declareReuse(t, bDir, aDir)
+
+	src := loadSource(t, aDir)
+	_, _, err := composeResolver(resolverFor(src.Dir, src.Pakke), src)
+	if err == nil {
+		t.Fatal("en gjenbrukssyklus ble godtatt")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Errorf("feilmeldinga nevner ikke syklusen: %v", err)
+	}
+}
+
+// En pakke uten erklæring skal løses nøyaktig som før kjedinga fantes.
+func TestPakkeWithoutDeclarationIsUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	writePakke(t, dir, "alene", "en")
+	src := loadSource(t, dir)
+	own := resolverFor(src.Dir, src.Pakke)
+	composed, reused, err := composeResolver(own, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reused != nil {
+		t.Errorf("fant en gjenbrukt kilde der ingen er erklært: %v", reused)
+	}
+	if composed.Base() != nil {
+		t.Error("resolveren fikk en base uten at noe er erklært")
+	}
+	if _, err := agentpakke.LoadDeclaration(dir); err == nil {
+		t.Error("testpakka har en erklæring, da tester dette noe annet enn det står")
+	}
+}

--- a/cli/nav-pilot/internal/cli/compose_test.go
+++ b/cli/nav-pilot/internal/cli/compose_test.go
@@ -154,3 +154,54 @@ func TestUnpinnedLocalPathReuseIsAllowed(t *testing.T) {
 		t.Fatal("den lokale basen ble ikke gjenbrukt")
 	}
 }
+
+// Sync må løse den samme gjenbruken install løste. Uten det slutter hvert
+// arvede artefakt å resolve så snart installasjonen er over, og sync ser en
+// sporet fil kilden ikke lenger sender, altså formen på et pensjonert
+// artefakt.
+func TestSyncResolverComposesToo(t *testing.T) {
+	baseDir, ownDir := t.TempDir(), t.TempDir()
+	writePakke(t, baseDir, "basepakke", "felles")
+	writePakke(t, ownDir, "egenpakke", "eget")
+	declareReuse(t, ownDir, baseDir)
+
+	src := loadSource(t, ownDir)
+	state := &StateFile{Collection: "egenpakke"}
+	resolver, reused, err := composeResolver(resolverForState(src, state), src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reused == nil {
+		t.Fatal("sync-resolveren gjenbrukte ingenting")
+	}
+	if _, ok := resolver.Get(KindAgent, "felles"); !ok {
+		t.Error("det arvede artefaktet resolver ikke under sync, og ville blitt lest som pensjonert")
+	}
+}
+
+// En kilde uten manifest komponerer ikke, selv om den skulle ha en erklæring
+// liggende. Ellers ville en collection-kilde hentet et fremmed repo midt i en
+// installasjon som aldri ba om det.
+func TestLegacySourceDoesNotCompose(t *testing.T) {
+	baseDir, ownDir := t.TempDir(), t.TempDir()
+	writePakke(t, baseDir, "basepakke", "felles")
+	if err := os.MkdirAll(filepath.Join(ownDir, ".nav-pilot"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	declareReuse(t, ownDir, baseDir)
+
+	src := &Source{Dir: ownDir, Repo: ownDir}
+	if err := attachPakke(src); err != nil {
+		t.Fatal(err)
+	}
+	if src.Pakke != nil {
+		t.Fatal("kilden fikk et manifest, da tester dette noe annet enn det står")
+	}
+	_, reused, err := composeResolver(resolverFor(src.Dir, src.Pakke), src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reused != nil {
+		t.Errorf("en manifestløs kilde komponerte %s", reused.Dir)
+	}
+}

--- a/cli/nav-pilot/internal/cli/declaration.go
+++ b/cli/nav-pilot/internal/cli/declaration.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
-	"github.com/navikt/copilot/cli/nav-pilot/internal/source"
 )
 
 // This file wires the committed declaration ([agentpakke.Declaration]) into the
@@ -126,7 +125,7 @@ func applyDeclaredItems(manifest *Manifest, items map[string]string) (*Manifest,
 	// place a kind list lived, and #739 added extension to the other three
 	// without it, so declaring an extension failed as "not shipped" (#742).
 	available := map[string]map[string]bool{}
-	for _, kind := range source.AllKinds {
+	for _, kind := range AllKinds {
 		names, ok := manifest.NamesByKind(kind)
 		if !ok {
 			continue
@@ -151,7 +150,7 @@ func applyDeclaredItems(manifest *Manifest, items map[string]string) (*Manifest,
 	}
 
 	narrowed := *manifest
-	for _, kind := range source.AllKinds {
+	for _, kind := range AllKinds {
 		narrowed.SetNamesByKind(kind, selected[kind.Name])
 	}
 	return &narrowed, nil

--- a/cli/nav-pilot/internal/cli/declaration.go
+++ b/cli/nav-pilot/internal/cli/declaration.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
+	"github.com/navikt/copilot/cli/nav-pilot/internal/source"
 )
 
 // This file wires the committed declaration ([agentpakke.Declaration]) into the
@@ -121,12 +122,16 @@ func applyDeclaredItems(manifest *Manifest, items map[string]string) (*Manifest,
 	if len(items) == 0 {
 		return manifest, nil
 	}
-	available := map[string]map[string]bool{
-		KindAgent.Name:       nameSet(manifest.Agents),
-		KindSkill.Name:       nameSet(manifest.Skills),
-		KindInstruction.Name: nameSet(manifest.Instructions),
-		KindPrompt.Name:      nameSet(manifest.Prompts),
-		KindHook.Name:        nameSet(manifest.Hooks),
+	// Derived from AllKinds, not written out again: this map was the fourth
+	// place a kind list lived, and #739 added extension to the other three
+	// without it, so declaring an extension failed as "not shipped" (#742).
+	available := map[string]map[string]bool{}
+	for _, kind := range source.AllKinds {
+		names, ok := manifest.NamesByKind(kind)
+		if !ok {
+			continue
+		}
+		available[kind.Name] = nameSet(names)
 	}
 
 	var unknown []string
@@ -146,11 +151,9 @@ func applyDeclaredItems(manifest *Manifest, items map[string]string) (*Manifest,
 	}
 
 	narrowed := *manifest
-	narrowed.Agents = selected[KindAgent.Name]
-	narrowed.Skills = selected[KindSkill.Name]
-	narrowed.Instructions = selected[KindInstruction.Name]
-	narrowed.Prompts = selected[KindPrompt.Name]
-	narrowed.Hooks = selected[KindHook.Name]
+	for _, kind := range source.AllKinds {
+		narrowed.SetNamesByKind(kind, selected[kind.Name])
+	}
 	return &narrowed, nil
 }
 

--- a/cli/nav-pilot/internal/cli/declared_items_kinds_test.go
+++ b/cli/nav-pilot/internal/cli/declared_items_kinds_test.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/source"
+)
+
+// Et utvalg i erklæringa må kunne navngi enhver artefakttype pakka sender.
+// applyDeclaredItems hadde sin egen liste over typer, og #739 la til extension
+// uten å røre den, slik #647 gjorde med hook i tre andre lister (#649, #650,
+// #708). Typene hentes fra source.AllKinds, ikke skrevet opp på nytt: en test
+// som gjentar lista arver feilen den skal fange.
+func TestDeclaredItemsAcceptsEveryKind(t *testing.T) {
+	for _, kind := range source.AllKinds {
+		m := &Manifest{Name: "testpakke"}
+		if !m.SetNamesByKind(kind, []string{"noe"}) {
+			t.Fatalf("manifestet kjenner ikke typen %q", kind.Name)
+		}
+		got, err := applyDeclaredItems(m, map[string]string{"noe": kind.Name})
+		if err != nil {
+			t.Errorf("artefakttypen %q kan ikke velges i en erklæring: %v", kind.Name, err)
+			continue
+		}
+		names, _ := got.NamesByKind(kind)
+		if len(names) != 1 || names[0] != "noe" {
+			t.Errorf("typen %q: utvalget ga %v, ventet [noe]", kind.Name, names)
+		}
+	}
+}

--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -64,6 +64,22 @@ func installItems(resolver *SourceResolver, scope *InstallScope, manifest *Manif
 // manifest the installer already knows how to walk. It is the manifest-bearing
 // counterpart to loadManifest: the agentpakke manifest supersedes
 // collections/<name>/manifest.json rather than declaring entries in it.
+// manifestItemCount is how many artifacts a manifest names, derived from
+// AllKinds rather than summed by hand. The hand-written sums it replaces each
+// missed extensions after #739, so a pakke shipping only extensions counted as
+// shipping nothing.
+func manifestItemCount(m *Manifest) int {
+	total := 0
+	for _, kind := range AllKinds {
+		names, ok := m.NamesByKind(kind)
+		if !ok {
+			continue
+		}
+		total += len(names)
+	}
+	return total
+}
+
 func pakkeContents(resolver *SourceResolver, src *Source) (*Manifest, error) {
 	pakke := src.Pakke
 	manifest, err := collectAllItemsWith(resolver)
@@ -84,7 +100,7 @@ func pakkeContents(resolver *SourceResolver, src *Source) (*Manifest, error) {
 	// carries the name and description `nav-pilot list` prints. Only a manifest
 	// that declares a layout and then ships nothing at it is an error, and the
 	// message says exactly that.
-	total := len(manifest.Agents) + len(manifest.Skills) + len(manifest.Instructions) + len(manifest.Prompts) + len(manifest.Hooks)
+	total := manifestItemCount(manifest)
 	if total == 0 && pakke.Layout != nil {
 		return nil, fmt.Errorf("agentpakke %q declares a layout but ships no agents, skills, instructions, or prompts.\n"+
 			"Check the layout paths in %s", pakke.Name, agentpakke.ManifestPath)
@@ -496,6 +512,14 @@ func cmdInstallFromSource(collection string, src *Source, scope *InstallScope, d
 		return err
 	}
 
+	// A pakke that reuses another resolves it here, before its contents are
+	// collected: pakkeContents lists through the resolver, so the reused
+	// artifacts are part of the manifest without a second merge step.
+	resolver, reused, err := composeResolver(resolver, src)
+	if err != nil {
+		return err
+	}
+
 	var manifest *Manifest
 	if src.Pakke != nil {
 		manifest, err = pakkeContents(resolver, src)
@@ -519,6 +543,9 @@ func cmdInstallFromSource(collection string, src *Source, scope *InstallScope, d
 			fmt.Println(bold(fmt.Sprintf("Installing: %s", collection)))
 		}
 		fmt.Printf("%s %s\n", dim("Source:"), dim(fmt.Sprintf("%s@%s", sourceLabel, shortSHA(src.SHA))))
+		if reused != nil {
+			fmt.Printf("%s %s\n", dim("Reuses:"), dim(fmt.Sprintf("%s@%s", sourceLabelFor(reused), shortSHA(reused.SHA))))
+		}
 		fmt.Printf("%s %s\n", dim("Target:"), dim(scope.Label()))
 		printManifestContents(manifest)
 		fmt.Println()
@@ -718,7 +745,7 @@ func cmdList(scope *InstallScope, ref, sourceRepo string, showItems bool, jsonOu
 		collections = append(collections, collectionInfo{
 			Name:        m.Name,
 			Description: m.Description,
-			Items:       len(m.Agents) + len(m.Skills) + len(m.Instructions) + len(m.Prompts) + len(m.Hooks),
+			Items:       manifestItemCount(m),
 			agents:      m.Agents,
 		})
 	}

--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -102,7 +102,7 @@ func pakkeContents(resolver *SourceResolver, src *Source) (*Manifest, error) {
 	// message says exactly that.
 	total := manifestItemCount(manifest)
 	if total == 0 && pakke.Layout != nil {
-		return nil, fmt.Errorf("agentpakke %q declares a layout but ships no agents, skills, instructions, or prompts.\n"+
+		return nil, fmt.Errorf("agentpakke %q declares a layout but ships nothing at it.\n"+
 			"Check the layout paths in %s", pakke.Name, agentpakke.ManifestPath)
 	}
 	return manifest, nil

--- a/cli/nav-pilot/internal/cli/interactive.go
+++ b/cli/nav-pilot/internal/cli/interactive.go
@@ -712,7 +712,7 @@ func interactiveRepoInstall(src *Source, scope *InstallScope, flagSource string)
 		if err != nil {
 			continue
 		}
-		total := len(m.Agents) + len(m.Skills) + len(m.Instructions) + len(m.Prompts) + len(m.Hooks)
+		total := manifestItemCount(m)
 		label := fmt.Sprintf("%-20s %s (%d items)", name, m.Description, total)
 		options = append(options, huh.NewOption(label, name))
 	}

--- a/cli/nav-pilot/internal/cli/pakke_install_test.go
+++ b/cli/nav-pilot/internal/cli/pakke_install_test.go
@@ -935,7 +935,7 @@ func TestEmptyTier1LayoutStillErrors(t *testing.T) {
 	if err == nil {
 		t.Fatal("pakkeContents = nil for a layout that ships nothing, want an error")
 	}
-	if !strings.Contains(err.Error(), "declares a layout but ships no agents") {
+	if !strings.Contains(err.Error(), "declares a layout but ships nothing at it") {
 		t.Errorf("error %q is not the empty-layout message", err)
 	}
 }

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -197,6 +197,18 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 
 	resolver := resolverForState(src, syncState)
 
+	// The same reuse install resolved. Without it, every artifact inherited
+	// from a reused pakke stops resolving the moment the install is over: sync
+	// sees a tracked file its source no longer ships, which is the shape of a
+	// retired artifact, and offers to delete what install just put there.
+	resolver, reusedInSync, err := composeResolver(resolver, src)
+	if err != nil {
+		return err
+	}
+	if reusedInSync != nil && !jsonOutput {
+		fmt.Printf("%s %s\n", dim("Reuses:"), dim(fmt.Sprintf("%s@%s", sourceLabelFor(reusedInSync), shortSHA(reusedInSync.SHA))))
+	}
+
 	// A collection-era scope meets its source's manifest here first: rewrite
 	// it onto the pakke identity before the diff, so this sync already runs —
 	// and reports new items — as the pakke install it now is.

--- a/cli/nav-pilot/internal/source/compose_test.go
+++ b/cli/nav-pilot/internal/source/compose_test.go
@@ -1,0 +1,87 @@
+package source
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// En pakke som gjenbruker en annen arver det den ikke har selv, og skygger det
+// den har. Kollisjonsregelen er at nærmest vinner, og den vinner ved at egen
+// kilde spørres først (#572).
+func writeAgent(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "agents", name+".agent.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func composed(t *testing.T) (*SourceResolver, string, string) {
+	t.Helper()
+	baseDir, ownDir := t.TempDir(), t.TempDir()
+	writeAgent(t, baseDir, "felles", "fra basen")
+	writeAgent(t, baseDir, "grillmester", "basens grillmester")
+	writeAgent(t, ownDir, "grillmester", "egen grillmester")
+	writeAgent(t, ownDir, "eget", "bare her")
+	return NewSourceResolver(ownDir).WithBase(NewSourceResolver(baseDir)), baseDir, ownDir
+}
+
+func TestReusedArtifactIsInherited(t *testing.T) {
+	r, _, _ := composed(t)
+	got, ok := r.Get(KindAgent, "felles")
+	if !ok {
+		t.Fatal("artefakt bare basen har ble ikke funnet")
+	}
+	body, err := os.ReadFile(got.AbsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "fra basen" {
+		t.Errorf("innhold = %q, ventet basens", body)
+	}
+}
+
+func TestOwnArtifactShadowsReused(t *testing.T) {
+	r, _, ownDir := composed(t)
+	got, ok := r.Get(KindAgent, "grillmester")
+	if !ok {
+		t.Fatal("grillmester ble ikke funnet")
+	}
+	body, _ := os.ReadFile(got.AbsPath)
+	if string(body) != "egen grillmester" {
+		t.Errorf("innhold = %q, ventet pakkens eget", body)
+	}
+	if filepath.Dir(filepath.Dir(got.AbsPath)) != ownDir {
+		t.Errorf("løste til %s, ventet noe under egen kilde %s", got.AbsPath, ownDir)
+	}
+}
+
+func TestListUnionsBothSourcesOnce(t *testing.T) {
+	r, _, _ := composed(t)
+	seen := map[string]int{}
+	for _, res := range r.List(KindAgent) {
+		seen[res.Name]++
+	}
+	for _, name := range []string{"felles", "grillmester", "eget"} {
+		if seen[name] != 1 {
+			t.Errorf("%s listet %d ganger, ventet 1 (alle: %v)", name, seen[name], seen)
+		}
+	}
+}
+
+// Uten base skal ingenting endres. Kontrollen finnes fordi hele kjedingen er
+// lagt inn i Get og List, som alle installasjoner går gjennom.
+func TestNoBaseResolvesAsBefore(t *testing.T) {
+	dir := t.TempDir()
+	writeAgent(t, dir, "eneste", "x")
+	r := NewSourceResolver(dir)
+	if _, ok := r.Get(KindAgent, "finnes-ikke"); ok {
+		t.Error("fant et artefakt som ikke finnes")
+	}
+	if got := len(r.List(KindAgent)); got != 1 {
+		t.Errorf("listet %d artefakter, ventet 1", got)
+	}
+}

--- a/cli/nav-pilot/internal/source/manifest.go
+++ b/cli/nav-pilot/internal/source/manifest.go
@@ -46,6 +46,30 @@ func (m *Manifest) NamesByKind(kind *ArtifactKind) ([]string, bool) {
 	return nil, false
 }
 
+// SetNamesByKind replaces the manifest's entries for one kind, reporting
+// whether the kind is one this manifest carries. It is the write half of
+// [Manifest.NamesByKind], so narrowing a manifest to a declared selection can
+// iterate [AllKinds] instead of naming each list again.
+func (m *Manifest) SetNamesByKind(kind *ArtifactKind, names []string) bool {
+	switch kind {
+	case KindAgent:
+		m.Agents = names
+	case KindSkill:
+		m.Skills = names
+	case KindInstruction:
+		m.Instructions = names
+	case KindPrompt:
+		m.Prompts = names
+	case KindHook:
+		m.Hooks = names
+	case KindExtension:
+		m.Extensions = names
+	default:
+		return false
+	}
+	return true
+}
+
 // CollectionAll is the collection name used in state files for "install everything".
 const CollectionAll = "(all)"
 

--- a/cli/nav-pilot/internal/source/resolver.go
+++ b/cli/nav-pilot/internal/source/resolver.go
@@ -118,9 +118,9 @@ type SourceResolver struct {
 }
 
 // WithBase returns a resolver that falls back to base for artifacts this source
-// does not ship itself. Chaining is one level deep by construction — a base's
-// own base is resolved when that base is built — so a cycle in declarations
-// cannot loop here.
+// does not ship itself. A base may carry its own base; the chain is built
+// depth-first by the caller, which refuses a declaration cycle before it
+// recurses.
 func (r *SourceResolver) WithBase(base *SourceResolver) *SourceResolver {
 	chained := *r
 	chained.base = base

--- a/cli/nav-pilot/internal/source/resolver.go
+++ b/cli/nav-pilot/internal/source/resolver.go
@@ -301,7 +301,7 @@ func (r *SourceResolver) List(kind *ArtifactKind) []Resolved {
 	names := r.discoverNames(kind)
 	// A reused pakke's artifacts are listed too, minus the ones this source
 	// shadows. Get resolves each name, so a shadowed one still comes from
-	// here — the union decides what exists, Get decides where it comes from.
+	// here. The union decides what exists, Get decides where it comes from.
 	if r.base != nil {
 		seen := make(map[string]bool, len(names))
 		for _, name := range names {

--- a/cli/nav-pilot/internal/source/resolver.go
+++ b/cli/nav-pilot/internal/source/resolver.go
@@ -107,7 +107,28 @@ type SourceResolver struct {
 	// ship content at the canonical paths — which is what the legacy adapter
 	// synthesizes, so manifest-less sources resolve byte-for-byte as before.
 	layout map[string]string
+
+	// base is the agentpakke this one reuses, resolved at its pinned revision,
+	// or nil for the overwhelming majority that reuse nothing. It is consulted
+	// only after this source misses, which is the whole of the collision rule:
+	// a pakke that ships its own agent named "grillmester" shadows the reused
+	// one without saying anything, the same way `overrides` in
+	// .github/copilot-sync.json lets a repo keep its own copy of a synced file.
+	base *SourceResolver
 }
+
+// WithBase returns a resolver that falls back to base for artifacts this source
+// does not ship itself. Chaining is one level deep by construction — a base's
+// own base is resolved when that base is built — so a cycle in declarations
+// cannot loop here.
+func (r *SourceResolver) WithBase(base *SourceResolver) *SourceResolver {
+	chained := *r
+	chained.base = base
+	return &chained
+}
+
+// Base returns the reused resolver, or nil.
+func (r *SourceResolver) Base() *SourceResolver { return r.base }
 
 // NewSourceResolver creates a resolver for the given source directory, reading
 // content from the canonical directories (agents/, skills/, …).
@@ -165,6 +186,18 @@ func (r *SourceResolver) dirFor(canonical string) string {
 
 // Get finds a single named artifact. Checks root first, then .github/.
 func (r *SourceResolver) Get(kind *ArtifactKind, name string) (Resolved, bool) {
+	if res, ok := r.get(kind, name); ok {
+		return res, true
+	}
+	// Only now the reused pakke: this source's own content wins every
+	// collision, and it wins by being asked first.
+	if r.base != nil {
+		return r.base.Get(kind, name)
+	}
+	return Resolved{}, false
+}
+
+func (r *SourceResolver) get(kind *ArtifactKind, name string) (Resolved, bool) {
 	if kind.IsDir {
 		return r.getDir(kind, name)
 	}
@@ -266,6 +299,22 @@ func (r *SourceResolver) GetFile(typeDir, fileName string) (absPath, relPath str
 // machines that never opted in.
 func (r *SourceResolver) List(kind *ArtifactKind) []Resolved {
 	names := r.discoverNames(kind)
+	// A reused pakke's artifacts are listed too, minus the ones this source
+	// shadows. Get resolves each name, so a shadowed one still comes from
+	// here — the union decides what exists, Get decides where it comes from.
+	if r.base != nil {
+		seen := make(map[string]bool, len(names))
+		for _, name := range names {
+			seen[name] = true
+		}
+		for _, inherited := range r.base.List(kind) {
+			if !seen[inherited.Name] {
+				seen[inherited.Name] = true
+				names = append(names, inherited.Name)
+			}
+		}
+		sort.Strings(names)
+	}
 	var results []Resolved
 	for _, name := range names {
 		if kind == KindAgent && name == local.WorkerAgent && !local.Enabled() {

--- a/docs/README.agentpakke.md
+++ b/docs/README.agentpakke.md
@@ -4,7 +4,7 @@ En **agentpakke** er et innholdsrepo som beskriver seg selv for nav-pilot: agent
 
 Manifestet ligger på `.nav-pilot/agentpakke.json` i agentpakke-repoet og er hele kontrakten mellom repoet og binæren. Den er publisert som JSON Schema i [`cli/nav-pilot/schemas/agentpakke-v1.json`](../cli/nav-pilot/schemas/agentpakke-v1.json), og nøyaktig samme fil er kompilert inn i nav-pilot-binæren, så repoets egen CI-lint og nav-pilot validerer mot identiske bytes.
 
-Dette dokumentet er for team som lager en agentpakke. Interndesignet, altså hvordan manifestet trådes gjennom install og sync, står i [cli/nav-pilot/DESIGN.md](../cli/nav-pilot/DESIGN.md).
+Dette dokumentet er referansen. Skal du lage din første pakke, følg oppskrifta i [lag-en-agentpakke.md](lag-en-agentpakke.md) og slå opp her underveis. Interndesignet, altså hvordan manifestet trådes gjennom install og sync, står i [cli/nav-pilot/DESIGN.md](../cli/nav-pilot/DESIGN.md).
 
 ## Repoform
 

--- a/docs/README.agentpakke.md
+++ b/docs/README.agentpakke.md
@@ -459,14 +459,14 @@ Reuses: navikt/copilot@4946a27
 `grillmester`, er det den gjenbrukende pakkas egen som installeres. Den vinner ved å bli
 spurt først, og det er samme regel som `overrides` i `.github/copilot-sync.json` ett nivå
 opp: det teamet eier selv, eier de. Å skygge et artefakt er den normale måten å endre én
-ting fra en pakke du ellers tar rått — det er ikke en feil, og varsles ikke.
+ting fra en pakke du ellers tar rått. Det er ikke en feil, og varsles ikke.
 
 **En gjenbrukssyklus nektes.** Gjenbruker to pakker hverandre, finnes det ingen rekkefølge å
 løse dem i, og feilen ber om at syklusen brytes i én av dem.
 
 **Bindingstidspunktet følger formen på manifestet**, ikke en egen mekanisme. En layout-pakke
 løser erklæringa si ved hver `install` og `sync`. En payload-pakke løste den ved byggetid, og
-payloaden bærer resultatet — `provenance.base` og `provenance.overlays` er feltene som sier
+payloaden bærer resultatet. `provenance.base` og `provenance.overlays` er feltene som sier
 hvem den kom fra. Det er den samme erklæringa i begge tilfeller, med to bindingstidspunkter.
 
 ## Slik starter brukerne klienten fra en Tier 2-pakke

--- a/docs/README.agentpakke.md
+++ b/docs/README.agentpakke.md
@@ -430,6 +430,45 @@ Flagg som strekker seg forbi erklæringa, motsier `--frozen` og avvises som bruk
 
 Utvelgelse er et Tier 1-begrep. Tier 1 er en layout av filer som kan adresseres hver for seg, og det er det som gjør «disse fire» uttrykkbart. En Tier 2-pakke leverer digest-bundne payload-trær der installasjonsenheten er revisjonen, ikke fila: agentene i en payload stages sammen og verifiseres mot digesten som én ting. Derfor **nektes** `items` mot en Tier 2-pakke framfor å bli ignorert — meldingen ber om at blokka fjernes, eller at pakka publiserer en payload-kontekst som bærer akkurat det teamet trenger.
 
+## En pakke som gjenbruker en annen
+
+Et team som vil distribuere sitt eget oppsett, men ikke vil vedlikeholde en kopi av
+plattformpakka, gjenbruker den i stedet.
+
+Det er ikke et eget felt. En pakke som gjenbruker en annen er et repo som *både* sender et
+manifest og committer den samme erklæringa en konsument committer:
+
+```
+navikt/eget-team/
+├── .nav-pilot/
+│   ├── agentpakke.json        ← hva dette repoet sender
+│   └── agentpakke.lock.json   ← hva det gjenbruker, og fra hvilken revisjon
+└── agents/
+    └── grillmester.agent.md
+```
+
+Den som installerer `navikt/eget-team` får begge pakkenes innhold. `install` skriver hvilken
+pakke som ble gjenbrukt, ved siden av kilden:
+
+```
+Source: navikt/eget-team@c3f7ca3
+Reuses: navikt/copilot@4946a27
+```
+
+**Kollisjonsregelen er at nærmeste vinner.** Sender begge pakkene en agent som heter
+`grillmester`, er det den gjenbrukende pakkas egen som installeres. Den vinner ved å bli
+spurt først, og det er samme regel som `overrides` i `.github/copilot-sync.json` ett nivå
+opp: det teamet eier selv, eier de. Å skygge et artefakt er den normale måten å endre én
+ting fra en pakke du ellers tar rått — det er ikke en feil, og varsles ikke.
+
+**En gjenbrukssyklus nektes.** Gjenbruker to pakker hverandre, finnes det ingen rekkefølge å
+løse dem i, og feilen ber om at syklusen brytes i én av dem.
+
+**Bindingstidspunktet følger formen på manifestet**, ikke en egen mekanisme. En layout-pakke
+løser erklæringa si ved hver `install` og `sync`. En payload-pakke løste den ved byggetid, og
+payloaden bærer resultatet — `provenance.base` og `provenance.overlays` er feltene som sier
+hvem den kom fra. Det er den samme erklæringa i begge tilfeller, med to bindingstidspunkter.
+
 ## Slik starter brukerne klienten fra en Tier 2-pakke
 
 Peker kilden på en agentpakke som deklarerer `payloads` for klienten, kjører nav-pilot klienten fra en verifisert revisjon av pakka som ligger på maskinen:

--- a/docs/README.nav-pilot.md
+++ b/docs/README.nav-pilot.md
@@ -477,6 +477,8 @@ Et team kan distribuere sitt eget innhold som en **agentpakke**, et repo med man
 `.nav-pilot/agentpakke.json`. Installer det med `--source`. Kilden huskes per scope til du
 tømmer den.
 
+Skal du lage en selv, står oppskrifta i [lag-en-agentpakke.md](lag-en-agentpakke.md).
+
 ```bash
 nav-pilot install --source navikt/<repo> <pakkenavn>
 nav-pilot config set source ""     # tilbake til navikt/copilot

--- a/docs/lag-en-agentpakke.md
+++ b/docs/lag-en-agentpakke.md
@@ -1,0 +1,118 @@
+# 📦 Lag en agentpakke
+
+Denne siden er oppskrifta: veien fra et tomt repo til at et annet team kjører
+`nav-pilot install` og får innholdet ditt. [README.agentpakke.md](README.agentpakke.md) er
+referansen som sier hva hvert felt betyr. Begynn her, slå opp der.
+
+En agentpakke er et git-repo som sender AI-artefakter og en fil som beskriver dem. Det er
+alt. Det er ingen registrering, ingen godkjenning og ingen sentral liste å komme inn på.
+
+## 1. Legg innholdet der manifestet sier
+
+```
+ditt-repo/
+├── .nav-pilot/
+│   └── agentpakke.json
+├── agents/
+│   └── grillmester.agent.md
+└── skills/
+```
+
+Katalognavnene er dine egne. `layout` i manifestet peker på dem, så heter de `innhold/agenter`
+hos deg, sier du det der. `agents` og `skills` må begge finnes i `layout`, også når den ene
+er tom.
+
+## 2. Skriv manifestet
+
+`.nav-pilot/agentpakke.json`, minste form som validerer:
+
+```json
+{
+  "contractVersion": "1",
+  "name": "ditt-team",
+  "description": "Hva pakka er til for",
+  "layout": {
+    "agents": "agents",
+    "skills": "skills"
+  },
+  "clients": {
+    "copilot": {
+      "primaryAgents": ["grillmester"]
+    }
+  }
+}
+```
+
+`primaryAgents` er de agentene brukeren kan starte klienten som. Resten er underagenter som
+bare kan kalles av andre.
+
+## 3. Valider før du pusher
+
+```bash
+nav-pilot validate --source .
+```
+
+```
+Validating: ditt-team@c3f7ca3
+
+  ℹ manifest: .nav-pilot/agentpakke.json
+  ℹ agentpakke: ditt-team (contract version 1)
+  ℹ clients: copilot (tier 1)
+
+✓ . conforms to the agentpakke contract.
+```
+
+Kjør den i CI også. Skjemaet er publisert, så du kan linte mot det uten nav-pilot:
+`cli/nav-pilot/schemas/agentpakke-v1.json`.
+
+## 4. La noen installere den
+
+```bash
+nav-pilot install ditt-team --source navikt/ditt-repo --repo
+```
+
+Det er hele distribusjonen. Den som installerer får en `.nav-pilot/agentpakke.lock.json` i
+sitt eget repo, med kilden og revisjonen, og committer den. Da installerer hele teamet fra
+samme revisjon, og `nav-pilot sync` flytter pinnen som en linje i en pull request.
+
+## 5. Gjenbruk framfor å kopiere
+
+Vil du bygge på plattformpakka uten å vedlikeholde en kopi av den, committer du den samme
+erklæringa i ditt eget pakkerepo:
+
+`.nav-pilot/agentpakke.lock.json`
+
+```json
+{
+  "contractVersion": "1",
+  "source": "navikt/copilot",
+  "sha": "b73a69e0000000000000000000000000000000aa"
+}
+```
+
+Repoet ditt sender nå både et manifest og en erklæring. Den som installerer pakka di får
+begge pakkenes innhold. Sender begge en agent med samme navn, vinner din.
+
+`sha` er påkrevd for en kilde på formen `owner/repo`. Uten den ville gjenbruken hentet det
+main tilfeldigvis holdt, og to installasjoner en uke fra hverandre fikk ulikt innhold.
+
+## Hva du kan sende
+
+Seks typer: `agents`, `skills`, `instructions`, `prompts`, `hooks` og `extensions`.
+
+Hooks og extensions er kjørbar kode, ikke tekst en modell leser. En hook kjører ved
+verktøykall, en extension lastes av klienten. Den som installerer pakka di kjører koden din
+på maskinen sin, så si i `description` hva den gjør.
+
+## Når du fjerner noe
+
+Slett aldri et artefakt uten å føre det opp i `.nav-pilot/retired-artifacts.json`. En kilde
+hentes med `--depth 1`, så brukeren har ingen historikk å slå opp i, og en fil som bare
+forsvinner blir liggende hos alle som installerte den. Generer lista og commit den. I
+navikt/copilot gjør `mise run retired:generate` det, og `mise run retired:check` verifiserer
+i CI at lista stemmer med historikken. Skriptet er rundt hundre linjer og kan kopieres.
+
+## Se også
+
+- [README.agentpakke.md](README.agentpakke.md), feltreferansen og kontrakten
+- [README.nav-pilot.md](README.nav-pilot.md), hvordan brukerne installerer


### PR DESCRIPTION
Siste posten i #572 som er arbeid: komposisjon. Kristofer har bekreftet at watson vil distribuere, så forutsetningen speccen ble skrevet under er nå et svar.

## Hva

En pakke som vil distribuere sitt eget oppsett uten å vedlikeholde en kopi av plattformpakka gjenbruker den i stedet. Det er ikke et nytt felt: en pakke som gjenbruker en annen er et repo som både sender et manifest og committer den samme erklæringa en konsument committer. `Declaration` sa det allerede selv — «a repo can hold both — an agentpakke that consumes another agentpakke is a normal thing to be».

Det som manglet var oppslaget. `SourceResolver` får en valgfri base som konsulteres først når kilden selv bommer, og `composeResolver` henter den basen erklæringa navngir på pinnet revisjon. `pakkeContents` lister gjennom resolveren, så det arvede innholdet blir en del av manifestet uten et eget flettesteg.

## Kollisjonsregelen

Nærmeste vinner, og den vinner ved å bli spurt først. Sender begge pakkene en `grillmester`, installeres den gjenbrukende pakkas egen. Samme regel som `overrides` i `.github/copilot-sync.json` ett nivå opp.

En gjenbrukssyklus nektes framfor å bli kuttet i stillhet.

## Bindingstidspunkt

Følger formen på manifestet, ikke en egen mekanisme. Layout løses ved hver install og sync; payload ble løst ved byggetid og bærer resultatet i `provenance.base`/`overlays`. Det følger at en byggetidskomponist ikke er en Tier 2-funksjon — den er det som løser den samme erklæringa inn i en payload.

## Verifisert

- Ende-til-ende med to ekte pakker: `felles` arvet fra basen, `eget` fra egen, `grillmester` kollidert og løst til egen. `Reuses:`-linja skrevet.
- Syklusvakta: slått av, testen timer ut på 90 s. Uendelig rekursjon uten den.
- Skyggeregelen: snudd rekkefølgen i `Get`, testen feiler.
- `mise run nav-pilot:check` grønn.

## Sidefunn, rettet her

`applyDeclaredItems` hadde sin egen liste over artefakttyper — den fjerde. #739 la til `extension` i de tre andre, så en erklæring som valgte en extension feilet med at pakka ikke sender den. Tre håndsummerte tellinger av manifestinnhold talte den heller ikke, så en pakke som bare sender extensions telte som tom. Begge utledes nå fra `AllKinds`. Testen henter typene derfra, ikke fra en ny liste.

De to tellingene som summerer agenter, skills og instruksjoner hver for seg er urørt: feilmeldinga deres navngir de tre eksplisitt, og å endre dem er en annen avgjørelse enn denne.
