### PR TITLE
docs(article): name the scale, the rollout, and the open door

### DIFF
--- a/docs/news/articles/sandbox-confines-the-process-not-the-token.md
+++ b/docs/news/articles/sandbox-confines-the-process-not-the-token.md
@@ -11,9 +11,9 @@ tags:
 ---
 
 Nav is Norway's labour and welfare administration. We pay out roughly a third
-of the national budget, and a few hundred developers keep that running. In
-March we asked them how they work with AI coding tools. 163 answered. Twelve
-said they use none. Three quarters use two or more.
+of the national budget, and around 700 developers with GitHub Copilot licences
+keep that running. In March we asked them how they work with AI coding tools.
+163 answered. Twelve said they use none. Three quarters use two or more.
 
 That is the context for what follows. The agents are here, they run on
 developer laptops with real credentials, and the question is no longer whether
@@ -65,12 +65,15 @@ What the agent sees when it tries:
 ⚠️ BLOCKED by sandbox: 'git push' is not allowed in this environment.
 Push prevention is enabled — commit your changes locally.
 This operation is restricted by the cplt sandbox to prevent unintended pushes.
+'main' is the protected branch here. Only the default branch is protected
+(protect_default_branch_only), so pushing a feature branch works as it is:
+`git push origin <branch>` with any other name.
 Please make a note of this for the human operator and continue with your remaining work.
 ```
 
-The last line is deliberate. An agent that hits a wall with no explanation
+The middle lines are deliberate. An agent that hits a wall with no explanation
 tends to try the wall again, or route around it. Telling it what happened, and
-what to do instead, ends the loop.
+which door is open, ends the loop.
 
 We should be precise about what the guard is. It is a shim on the PATH. The
 real `/usr/bin/git` is untouched, and an agent that calls it by absolute path,
@@ -153,6 +156,13 @@ repository. The reasoning is duller: the tools hold credentials that can do
 irreversible things, the cost of preventing that is a wrapper and a config
 file, and we would rather write the rule down than trust that the next model
 release stays polite.
+
+None of it depends on a developer choosing to run it, either. cplt is a
+standalone binary and anyone can install it, but that is not how it reaches
+most of Nav. It is bundled into the agent harness we ship internally, so the
+sandbox is the way an agent starts by default rather than something a developer
+remembers to install. That distribution fact does more work than any rule in
+the config.
 
 Until recently the two guards had opposite defaults. The `gh` guard blocked
 and the `git` guard warned, so the weaker default sat on the operation with


### PR DESCRIPTION
Three edits to the English sandbox article ahead of wider sharing (Hacker News, the cold emails, the awesome-list entries).

## 1. Scale in the opening

"a few hundred developers" undersold it, and was vague where a number does more work. Now "around 700 developers with GitHub Copilot licences". The hedge is deliberate: the figure moves month to month and the sentence should stay true as it drifts. Paired with the survey that follows, the licence count gives scale and the survey gives intensity.

## 2. How the sandbox actually reaches people

"The honest part" gains the admission most useful to another platform team: none of this depends on a developer choosing to run it. It is bundled into the agent harness Nav ships internally, so the sandbox is how an agent starts by default rather than something you remember to install.

The internal harness is deliberately **not named or linked**, because its repository is not public and a dead reference helps nobody. The standalone-binary sentence comes first so no reader concludes cplt needs Nav's tooling to work.

## 3. The quoted guard output was incomplete

The article quoted four lines of `git push` refusal, then claimed in the next paragraph that the message tells the agent "what to do instead". It did not. Under the shipped default (`protect_default_branch_only`, on since #387) the guard also prints which branch is protected and how to push a feature branch instead, and that hint is exactly the part the following paragraph is about.

The block now matches what `src/gh_proxy.rs:2882` composes, hint included, so the paragraph after it describes something the reader can actually see.

## Checks

523 tests pass. The three remaining em dashes are all inside fenced blocks quoting cplt's own output and the generated `.cplt.toml`, which house style exempts as verbatim tool output.

The 700 figure comes from the author. The most recent number written down in this repo is "over 600 Copilot Business-brukere" from 2026-05-13, which is why the wording hedges.