### PR TITLE
fix(agentpakke): sync slettet alt en gjenbrukt pakke bidro med (#572)

### DIFF
--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -42,6 +42,7 @@ type syncPinBump struct {
 type syncUpdate struct {
 	Path        string `json:"path"`
 	SourcePath  string `json:"-"` // resolved source path, not serialized
+	SourceRoot  string `json:"-"` // the checkout SourcePath is relative to
 	CurrentHash string `json:"current_hash"`
 	SourceHash  string `json:"source_hash"`
 }
@@ -489,7 +490,14 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 	var appliedUpdates []syncUpdate
 	var applyErrors int
 	for _, u := range updates {
-		if err := applySyncUpdate(scope, src.Dir, u); err != nil {
+		// The root the comparison used, not the top source: an inherited file
+		// lives in the reused pakke, and copying it from src.Dir would read a
+		// path that is not there.
+		root := u.SourceRoot
+		if root == "" {
+			root = src.Dir
+		}
+		if err := applySyncUpdate(scope, root, u); err != nil {
 			fmt.Fprintf(os.Stderr, "%s Could not update %s: %v\n", yellow("⚠"), u.Path, err)
 			applyErrors++
 			continue
@@ -1039,7 +1047,7 @@ func checkSyncFile(targetDir, sourceDir string, sf syncFile) (*syncUpdate, error
 	if localHash == sourceHash {
 		return nil, nil
 	}
-	return &syncUpdate{Path: sf.localPath, SourcePath: sf.sourcePath, CurrentHash: localHash, SourceHash: sourceHash}, nil
+	return &syncUpdate{Path: sf.localPath, SourcePath: sf.sourcePath, SourceRoot: sourceDir, CurrentHash: localHash, SourceHash: sourceHash}, nil
 }
 
 // applySyncUpdate copies a single file/dir from source to target.

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -322,14 +322,17 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 			continue
 		}
 
-		// Check if it exists in the source
-		sourceFull := filepath.Join(src.Dir, sf.sourcePath)
-		if _, statErr := os.Stat(sourceFull); os.IsNotExist(statErr) {
+		// Check if it exists in the source, or in a pakke this one reuses. A
+		// file inherited from a reused pakke is not under src.Dir, and reading
+		// that absence as "deleted upstream" deleted everything the base
+		// supplied on the first sync after install.
+		sourceRoot, found := resolver.SourceRootFor(sf.sourcePath)
+		if !found {
 			deletedPaths = append(deletedPaths, sf.localPath)
 			continue
 		}
 
-		u, err := checkSyncFile(scope.RootDir, src.Dir, sf)
+		u, err := checkSyncFile(scope.RootDir, sourceRoot, sf)
 		if err != nil {
 			if !jsonOutput {
 				fmt.Fprintf(os.Stderr, "%s %s: %v\n", yellow("⚠"), sf.localPath, err)

--- a/cli/nav-pilot/internal/source/compose_getfile_test.go
+++ b/cli/nav-pilot/internal/source/compose_getfile_test.go
@@ -19,10 +19,10 @@ func TestGetFileFindsInheritedArtifact(t *testing.T) {
 	if !ok {
 		t.Fatal("GetFile fant ikke det arvede artefaktet")
 	}
-	if rel != filepath.Join("agents", "felles.agent.md") {
-		t.Errorf("rel = %q, ventet agents/felles.agent.md", rel)
+	if rel != filepath.Join(KindAgent.Dir, "felles.agent.md") {
+		t.Errorf("rel = %q, ventet <agents>/felles.agent.md", rel)
 	}
-	if want := filepath.Join(baseDir, "agents", "felles.agent.md"); abs != want {
+	if want := filepath.Join(baseDir, KindAgent.Dir, "felles.agent.md"); abs != want {
 		t.Errorf("abs = %q, ventet %q", abs, want)
 	}
 }

--- a/cli/nav-pilot/internal/source/compose_getfile_test.go
+++ b/cli/nav-pilot/internal/source/compose_getfile_test.go
@@ -1,0 +1,54 @@
+package source
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// MapLocalPath må kunne navngi kildestien til et arvet artefakt. Klarte den
+// ikke det, falt den tilbake på den lokale stien, og sync lette etter den i
+// feil repo og meldte at fila var slettet oppstrøms. Første sync --apply etter
+// install av en gjenbrukende pakke slettet da alt basen bidro med (#572).
+func TestGetFileFindsInheritedArtifact(t *testing.T) {
+	baseDir, ownDir := t.TempDir(), t.TempDir()
+	writeAgent(t, baseDir, "felles", "fra basen")
+	writeAgent(t, ownDir, "eget", "eget")
+	r := NewSourceResolver(ownDir).WithBase(NewSourceResolver(baseDir))
+
+	abs, rel, ok := r.GetFile(KindAgent.Dir, "felles.agent.md")
+	if !ok {
+		t.Fatal("GetFile fant ikke det arvede artefaktet")
+	}
+	if rel != filepath.Join("agents", "felles.agent.md") {
+		t.Errorf("rel = %q, ventet agents/felles.agent.md", rel)
+	}
+	if want := filepath.Join(baseDir, "agents", "felles.agent.md"); abs != want {
+		t.Errorf("abs = %q, ventet %q", abs, want)
+	}
+}
+
+// Sync spør hvilken kilde som faktisk har fila. Uten kjeding svarte den nei
+// for alt basen bidro med.
+func TestSourceRootForWalksTheChain(t *testing.T) {
+	baseDir, ownDir := t.TempDir(), t.TempDir()
+	writeAgent(t, baseDir, "felles", "fra basen")
+	writeAgent(t, ownDir, "eget", "eget")
+	r := NewSourceResolver(ownDir).WithBase(NewSourceResolver(baseDir))
+
+	for _, tc := range []struct{ rel, want string }{
+		{filepath.Join("agents", "eget.agent.md"), ownDir},
+		{filepath.Join("agents", "felles.agent.md"), baseDir},
+	} {
+		got, ok := r.SourceRootFor(tc.rel)
+		if !ok {
+			t.Errorf("%s ble ikke funnet i noen kilde", tc.rel)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("%s løste til %s, ventet %s", tc.rel, got, tc.want)
+		}
+	}
+	if _, ok := r.SourceRootFor(filepath.Join("agents", "finnes-ikke.agent.md")); ok {
+		t.Error("en fil ingen av kildene har ble funnet")
+	}
+}

--- a/cli/nav-pilot/internal/source/resolver.go
+++ b/cli/nav-pilot/internal/source/resolver.go
@@ -127,6 +127,27 @@ func (r *SourceResolver) WithBase(base *SourceResolver) *SourceResolver {
 	return &chained
 }
 
+// SourceRootFor returns the source directory that actually holds a
+// source-relative path, looking through the reuse chain, and whether any of
+// them does.
+//
+// Sync needs this because a tracked file may have come from a reused pakke: it
+// is not under this source's directory, and reading that absence as "deleted
+// upstream" deletes what install just wrote. The same reason `add --source`
+// files are left alone (#571), one level up.
+func (r *SourceResolver) SourceRootFor(rel string) (string, bool) {
+	abs := filepath.Join(r.sourceDir, rel)
+	if _, err := r.checkSafePath(abs); err == nil {
+		if _, err := os.Stat(abs); err == nil {
+			return r.sourceDir, true
+		}
+	}
+	if r.base != nil {
+		return r.base.SourceRootFor(rel)
+	}
+	return "", false
+}
+
 // Base returns the reused resolver, or nil.
 func (r *SourceResolver) Base() *SourceResolver { return r.base }
 
@@ -281,6 +302,13 @@ func (r *SourceResolver) GetFile(typeDir, fileName string) (absPath, relPath str
 	abs := filepath.Join(r.sourceDir, rel)
 	if _, err := r.checkSafePath(abs); err == nil {
 		return abs, rel, true
+	}
+	// Then the reused pakke, for the same reason Get consults it. Without
+	// this, MapLocalPath could not name an inherited file's source path and
+	// fell back to the local path, which sync then looked for in the wrong
+	// repo and reported as deleted upstream.
+	if r.base != nil {
+		return r.base.GetFile(typeDir, fileName)
 	}
 	return "", "", false
 }

--- a/cli/nav-pilot/internal/source/resolver.go
+++ b/cli/nav-pilot/internal/source/resolver.go
@@ -136,11 +136,12 @@ func (r *SourceResolver) WithBase(base *SourceResolver) *SourceResolver {
 // upstream" deletes what install just wrote. The same reason `add --source`
 // files are left alone (#571), one level up.
 func (r *SourceResolver) SourceRootFor(rel string) (string, bool) {
+	// checkSafePath already Lstats the path, so its success is both "inside
+	// this checkout" and "exists". A second Stat would only add a window for
+	// the file to change between the two calls.
 	abs := filepath.Join(r.sourceDir, rel)
 	if _, err := r.checkSafePath(abs); err == nil {
-		if _, err := os.Stat(abs); err == nil {
-			return r.sourceDir, true
-		}
+		return r.sourceDir, true
 	}
 	if r.base != nil {
 		return r.base.SourceRootFor(rel)


### PR DESCRIPTION
Komposisjonen fra #742 virket ved install og var ødelagt ved sync.

## Målt på main, før fiksen

Tre ekte repoer: `base` (agent `felles`), `own` (agent `eget`, lock mot base), consumer.

```
$ nav-pilot install egenpakke --source own --repo
Reuses: .../base@6d11d18
  3 agents: eget, felles, grillmester

$ nav-pilot sync --repo
⚠ 1 file(s) deleted in source and will be removed
  - .github/agents/felles.agent.md
```

`--apply` fjernet den. Neste install la den tilbake. Slik vekslet det.

## Årsaken

`GetFile` hadde ingen base-fallback, i motsetning til `Get`. `MapLocalPath` klarte derfor ikke navngi kildestien til et arvet artefakt, og falt tilbake på den lokale stien. Sync lette så etter `.github/agents/felles.agent.md` inne i pakkerepoet og fant den ikke.

Feilsøkingen viste det direkte:

```
sourcePath="agents/eget.agent.md"           found=true
sourcePath=".github/agents/felles.agent.md" found=false
```

## Etter

```
✓ All 3 files up to date (source: ee501bb)
```

`--apply` lar fila stå.

## Funnet av

En adversariell gjennomgang med mutasjonstesting. Den fant også at min egen `TestSyncResolverComposesToo` er tom: den kaller `composeResolver` selv i stedet for å kjøre sync, så den passerer med kallet fjernet fra `sync.go`. Den og åtte andre tomme tester tas i egen PR.

Testene her feiler uten base-fallbacken, verifisert ved å fjerne den.