### PR TITLE
fix(agentpakke): fem funn fra den adversarielle gjennomgangen

### DIFF
--- a/cli/nav-pilot/internal/cli/artifact_cleanup.go
+++ b/cli/nav-pilot/internal/cli/artifact_cleanup.go
@@ -19,8 +19,10 @@ import (
 // that is no longer a skill and that nothing will ever clean up.
 //
 // Called from both removal paths, because there are two and they had drifted:
-// sync's deletion branch and the retired-artifact sweep.
-func afterArtifactRemoved(scope *InstallScope, absLocal string) {
+// sync's deletion branch and the retired-artifact sweep. It prints nothing when
+// quiet, because --json encodes to the same stdout and a stray status line
+// would corrupt the document.
+func afterArtifactRemoved(scope *InstallScope, absLocal string, quiet bool) {
 	if scope == nil {
 		return
 	}
@@ -39,7 +41,7 @@ func afterArtifactRemoved(scope *InstallScope, absLocal string) {
 			fmt.Fprintf(os.Stderr, "%s Could not update %s: %v\n", yellow("⚠"), source.RepoHooksConfig, err)
 			return
 		}
-		if removed > 0 {
+		if removed > 0 && !quiet {
 			fmt.Printf("  %s %s (hook entry in %s)\n", red("×"), name, source.RepoHooksConfig)
 		}
 		return

--- a/cli/nav-pilot/internal/cli/artifact_cleanup.go
+++ b/cli/nav-pilot/internal/cli/artifact_cleanup.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/source"
+)
+
+// afterArtifactRemoved cleans up what deleting an artifact's own file leaves
+// behind. Two kinds are more than the file the tracker names.
+//
+// A hook is a script plus an entry in a config the CLI reads. Removing only the
+// script left the entry pointing at a file that is gone, and Copilot CLI then
+// ran a missing path on every matching tool call. A skill is a directory whose
+// SKILL.md is what makes it a skill; removing only the marker left a directory
+// that is no longer a skill and that nothing will ever clean up.
+//
+// Called from both removal paths, because there are two and they had drifted:
+// sync's deletion branch and the retired-artifact sweep.
+func afterArtifactRemoved(scope *InstallScope, absLocal string) {
+	if scope == nil {
+		return
+	}
+
+	hooksDir := scope.DstPath(KindHook.Dir)
+	if filepath.Dir(absLocal) == hooksDir && strings.HasSuffix(absLocal, KindHook.Suffix) {
+		name := strings.TrimSuffix(filepath.Base(absLocal), KindHook.Suffix)
+		if scope.IsUser() {
+			// User scope gives each hook its own config file, so the file loop
+			// removes it only if it happens to be tracked. Take it here too.
+			_ = os.Remove(filepath.Join(hooksDir, source.UserHookConfigName(name)))
+			return
+		}
+		removed, err := source.RemoveRepoHooks(hooksDir, name)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s Could not update %s: %v\n", yellow("⚠"), source.RepoHooksConfig, err)
+			return
+		}
+		if removed > 0 {
+			fmt.Printf("  %s %s (hook entry in %s)\n", red("×"), name, source.RepoHooksConfig)
+		}
+		return
+	}
+
+	skillsDir := scope.DstPath(KindSkill.Dir)
+	if filepath.Base(absLocal) == KindSkill.Marker {
+		dir := filepath.Dir(absLocal)
+		if filepath.Dir(dir) == skillsDir {
+			_ = os.RemoveAll(dir)
+		}
+	}
+}

--- a/cli/nav-pilot/internal/cli/artifact_cleanup_test.go
+++ b/cli/nav-pilot/internal/cli/artifact_cleanup_test.go
@@ -30,7 +30,7 @@ func TestRemovingAHookScriptAlsoDeactivatesIt(t *testing.T) {
 	}
 
 	os.Remove(script)
-	afterArtifactRemoved(scope, script)
+	afterArtifactRemoved(scope, script, false)
 
 	names := source.HookNamesIn(filepath.Join(hooksDir, source.RepoHooksConfig))
 	if len(names) != 1 || names[0] != "annen" {
@@ -44,13 +44,17 @@ func TestRemovingOneHookLeavesTheOthers(t *testing.T) {
 	root := t.TempDir()
 	scope := ScopeRepo(root)
 	hooksDir := scope.DstPath(KindHook.Dir)
-	os.MkdirAll(hooksDir, 0o755)
-	source.MergeRepoHooks(hooksDir, []source.HookEntry{
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := source.MergeRepoHooks(hooksDir, []source.HookEntry{
 		{Name: "en", Matcher: "Bash", Command: "x"},
 		{Name: "to", Matcher: "Bash", Command: "x"},
 		{Name: "tre", Matcher: "Bash", Command: "x"},
-	})
-	afterArtifactRemoved(scope, filepath.Join(hooksDir, "to"+KindHook.Suffix))
+	}); err != nil {
+		t.Fatal(err)
+	}
+	afterArtifactRemoved(scope, filepath.Join(hooksDir, "to"+KindHook.Suffix), false)
 
 	names := source.HookNamesIn(filepath.Join(hooksDir, source.RepoHooksConfig))
 	if strings.Join(names, ",") != "en,tre" {
@@ -68,11 +72,15 @@ func TestRemovingASkillMarkerTakesTheDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 	marker := filepath.Join(skillDir, KindSkill.Marker)
-	os.WriteFile(marker, []byte("# skill"), 0o644)
-	os.WriteFile(filepath.Join(skillDir, "helper.md"), []byte("x"), 0o644)
+	if err := os.WriteFile(marker, []byte("# skill"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "helper.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	os.Remove(marker)
-	afterArtifactRemoved(scope, marker)
+	afterArtifactRemoved(scope, marker, false)
 
 	if _, err := os.Stat(skillDir); !os.IsNotExist(err) {
 		rest, _ := os.ReadDir(skillDir)
@@ -89,11 +97,15 @@ func TestRemovingAnAgentLeavesItsDirectory(t *testing.T) {
 	root := t.TempDir()
 	scope := ScopeRepo(root)
 	agentsDir := scope.DstPath(KindAgent.Dir)
-	os.MkdirAll(agentsDir, 0o755)
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	other := filepath.Join(agentsDir, "annen.agent.md")
-	os.WriteFile(other, []byte("x"), 0o644)
+	if err := os.WriteFile(other, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
-	afterArtifactRemoved(scope, filepath.Join(agentsDir, "borte.agent.md"))
+	afterArtifactRemoved(scope, filepath.Join(agentsDir, "borte.agent.md"), false)
 
 	if _, err := os.Stat(other); err != nil {
 		t.Errorf("naboartefaktet forsvant: %v", err)

--- a/cli/nav-pilot/internal/cli/artifact_cleanup_test.go
+++ b/cli/nav-pilot/internal/cli/artifact_cleanup_test.go
@@ -1,0 +1,101 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/source"
+)
+
+// Å slette hook-skriptet uten å fjerne aktiveringsoppføringa lot Copilot CLI
+// kjøre en fil som ikke finnes, ved hvert verktøykall som traff matcheren.
+func TestRemovingAHookScriptAlsoDeactivatesIt(t *testing.T) {
+	root := t.TempDir()
+	scope := ScopeRepo(root)
+	hooksDir := scope.DstPath(KindHook.Dir)
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := source.MergeRepoHooks(hooksDir, []source.HookEntry{
+		{Name: "vakt", Matcher: "Bash", Command: "python3 vakt.py"},
+		{Name: "annen", Matcher: "Bash", Command: "python3 annen.py"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(hooksDir, "vakt"+KindHook.Suffix)
+	if err := os.WriteFile(script, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	os.Remove(script)
+	afterArtifactRemoved(scope, script)
+
+	names := source.HookNamesIn(filepath.Join(hooksDir, source.RepoHooksConfig))
+	if len(names) != 1 || names[0] != "annen" {
+		t.Errorf("oppføringer igjen = %v, ventet bare [annen]", names)
+	}
+}
+
+// Kontroll: bare den navngitte hooken skal ut. Fjernet vi alle, ville en
+// pensjonering av én hook slått av hele teamets øvrige hooks.
+func TestRemovingOneHookLeavesTheOthers(t *testing.T) {
+	root := t.TempDir()
+	scope := ScopeRepo(root)
+	hooksDir := scope.DstPath(KindHook.Dir)
+	os.MkdirAll(hooksDir, 0o755)
+	source.MergeRepoHooks(hooksDir, []source.HookEntry{
+		{Name: "en", Matcher: "Bash", Command: "x"},
+		{Name: "to", Matcher: "Bash", Command: "x"},
+		{Name: "tre", Matcher: "Bash", Command: "x"},
+	})
+	afterArtifactRemoved(scope, filepath.Join(hooksDir, "to"+KindHook.Suffix))
+
+	names := source.HookNamesIn(filepath.Join(hooksDir, source.RepoHooksConfig))
+	if strings.Join(names, ",") != "en,tre" {
+		t.Errorf("oppføringer igjen = %v, ventet [en tre]", names)
+	}
+}
+
+// SKILL.md er det som gjør katalogen til en skill. Fjernet vi bare markøren,
+// ble en katalog liggende som ikke lenger er en skill og som ingenting rydder.
+func TestRemovingASkillMarkerTakesTheDirectory(t *testing.T) {
+	root := t.TempDir()
+	scope := ScopeRepo(root)
+	skillDir := filepath.Join(scope.DstPath(KindSkill.Dir), "gammel")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(skillDir, KindSkill.Marker)
+	os.WriteFile(marker, []byte("# skill"), 0o644)
+	os.WriteFile(filepath.Join(skillDir, "helper.md"), []byte("x"), 0o644)
+
+	os.Remove(marker)
+	afterArtifactRemoved(scope, marker)
+
+	if _, err := os.Stat(skillDir); !os.IsNotExist(err) {
+		rest, _ := os.ReadDir(skillDir)
+		names := make([]string, 0, len(rest))
+		for _, e := range rest {
+			names = append(names, e.Name())
+		}
+		t.Errorf("skill-katalogen ble liggende igjen med %v", names)
+	}
+}
+
+// Kontroll: en vanlig fil skal ikke dra med seg katalogen sin.
+func TestRemovingAnAgentLeavesItsDirectory(t *testing.T) {
+	root := t.TempDir()
+	scope := ScopeRepo(root)
+	agentsDir := scope.DstPath(KindAgent.Dir)
+	os.MkdirAll(agentsDir, 0o755)
+	other := filepath.Join(agentsDir, "annen.agent.md")
+	os.WriteFile(other, []byte("x"), 0o644)
+
+	afterArtifactRemoved(scope, filepath.Join(agentsDir, "borte.agent.md"))
+
+	if _, err := os.Stat(other); err != nil {
+		t.Errorf("naboartefaktet forsvant: %v", err)
+	}
+}

--- a/cli/nav-pilot/internal/cli/declaration.go
+++ b/cli/nav-pilot/internal/cli/declaration.go
@@ -195,6 +195,14 @@ func recordDeclaration(scope *InstallScope, src *Source) {
 	if existing != nil {
 		d = existing
 	}
+	// Installing a pakke into its own repo is dogfooding, not consuming. The
+	// declaration there says what *this pakke* reuses, and overwriting its
+	// source with this repo's own path points the pakke at itself: every
+	// consumer then silently loses the base, because composeResolver reads a
+	// self-reference and composes nothing (#572).
+	if selfInstall(scope, src) {
+		return
+	}
 	d.Source = sourceLabelFor(src)
 	// A path source is a working tree, not a revision: it has nothing
 	// fetchable to pin, and the "unknown" that used to be written here is a
@@ -346,4 +354,22 @@ func resolveDeclaredSource(scope *InstallScope, ref, sourceRepo string) (*Source
 		sourceRepo = declRepo
 	}
 	return resolveSource(ref, sourceRepo)
+}
+
+// selfInstall reports whether the scope being written to is the source repo
+// itself, compared by resolved path so a symlinked or relative route to the
+// same directory is still recognised.
+func selfInstall(scope *InstallScope, src *Source) bool {
+	if scope == nil || src == nil || src.Dir == "" {
+		return false
+	}
+	a, err := filepath.EvalSymlinks(scope.RootDir)
+	if err != nil {
+		a = scope.RootDir
+	}
+	b, err := filepath.EvalSymlinks(src.Dir)
+	if err != nil {
+		b = src.Dir
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
 }

--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -333,7 +333,7 @@ func cmdInstallAuto(name, itemType string, scope *InstallScope, ref, sourceRepo 
 				bold("--frozen"), agentpakke.DeclarationPath, bold("--type "+itemType))
 		}
 		if _, ok := kindByName[itemType]; !ok {
-			return fmt.Errorf("unknown type %q. Valid types: agent, skill, instruction, prompt, hook", itemType)
+			return fmt.Errorf("unknown type %q. Valid types: %s", itemType, strings.Join(kindNames(), ", "))
 		}
 		return cmdAdd(itemType, name, scope, ref, sourceRepo, dryRun, force, jsonOutput)
 	}
@@ -654,7 +654,7 @@ func cmdInstallFromSource(collection string, src *Source, scope *InstallScope, d
 // It preserves the à-la-carte state semantics from cmdAdd.
 func cmdAddFromSource(itemType, name string, src *Source, scope *InstallScope, explicitSource string, dryRun, force bool, jsonOutput bool) error {
 	if !scope.SupportsType(itemType) {
-		return fmt.Errorf("type %q is not supported in user scope. Only agents, skills, and instructions can be installed to ~/.copilot", itemType)
+		return fmt.Errorf("type %q is not supported in user scope. Only %s can be installed to ~/.copilot", itemType, strings.Join(scope.SupportedTypes, ", "))
 	}
 
 	sourceLabel := sourceLabelFor(src)

--- a/cli/nav-pilot/internal/cli/retired.go
+++ b/cli/nav-pilot/internal/cli/retired.go
@@ -140,17 +140,21 @@ func kindForPath(srcPath string, layout *agentpakke.Layout) (*source.ArtifactKin
 		kind *source.ArtifactKind
 	}
 	var candidates []candidate
+	// Derived from the layout's own field list, not written out again: this
+	// was the list that did not get extensions (#739), so a retired extension
+	// under a declared layout was never found. Layout.Dirs names each field
+	// as "layout.<dir>", which is the kind's canonical directory.
 	if layout != nil {
-		for _, m := range []candidate{
-			{layout.Agents, source.KindAgent},
-			{layout.Skills, source.KindSkill},
-			{layout.Instructions, source.KindInstruction},
-			{layout.Prompts, source.KindPrompt},
-			{layout.Hooks, source.KindHook},
-		} {
-			if m.dir != "" {
-				candidates = append(candidates, candidate{strings.Trim(m.dir, "/"), m.kind})
+		byDir := make(map[string]*source.ArtifactKind, len(AllKinds))
+		for _, k := range AllKinds {
+			byDir[k.Dir] = k
+		}
+		for _, d := range layout.Dirs() {
+			kind, ok := byDir[strings.TrimPrefix(d.Field, "layout.")]
+			if !ok || d.Value == "" {
+				continue
 			}
+			candidates = append(candidates, candidate{strings.Trim(d.Value, "/"), kind})
 		}
 	}
 	for _, k := range AllKinds {
@@ -170,7 +174,7 @@ func kindForPath(srcPath string, layout *agentpakke.Layout) (*source.ArtifactKin
 // removeRetiredOrphans deletes the given files, returning how many went away.
 // Best effort per file: one unremovable leftover must not fail a sync that has
 // already done its real work.
-func removeRetiredOrphans(orphans []retiredOrphan, quiet bool) int {
+func removeRetiredOrphans(scope *InstallScope, orphans []retiredOrphan, quiet bool) int {
 	removed := 0
 	for _, o := range orphans {
 		if err := os.Remove(o.Local); err != nil && !os.IsNotExist(err) {
@@ -179,6 +183,7 @@ func removeRetiredOrphans(orphans []retiredOrphan, quiet bool) int {
 			}
 			continue
 		}
+		afterArtifactRemoved(scope, o.Local)
 		if !quiet {
 			fmt.Printf("  %s %s\n", red("×"), o.Path)
 		}

--- a/cli/nav-pilot/internal/cli/retired.go
+++ b/cli/nav-pilot/internal/cli/retired.go
@@ -183,7 +183,7 @@ func removeRetiredOrphans(scope *InstallScope, orphans []retiredOrphan, quiet bo
 			}
 			continue
 		}
-		afterArtifactRemoved(scope, o.Local)
+		afterArtifactRemoved(scope, o.Local, quiet)
 		if !quiet {
 			fmt.Printf("  %s %s\n", red("×"), o.Path)
 		}

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -42,6 +42,7 @@ type syncPinBump struct {
 type syncUpdate struct {
 	Path        string `json:"path"`
 	SourcePath  string `json:"-"` // resolved source path, not serialized
+	SourceRoot  string `json:"-"` // the checkout SourcePath is relative to
 	CurrentHash string `json:"current_hash"`
 	SourceHash  string `json:"source_hash"`
 }
@@ -489,7 +490,14 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 	var appliedUpdates []syncUpdate
 	var applyErrors int
 	for _, u := range updates {
-		if err := applySyncUpdate(scope, src.Dir, u); err != nil {
+		// The root the comparison used, not the top source: an inherited file
+		// lives in the reused pakke, and copying it from src.Dir would read a
+		// path that is not there.
+		root := u.SourceRoot
+		if root == "" {
+			root = src.Dir
+		}
+		if err := applySyncUpdate(scope, root, u); err != nil {
 			fmt.Fprintf(os.Stderr, "%s Could not update %s: %v\n", yellow("⚠"), u.Path, err)
 			applyErrors++
 			continue
@@ -1039,7 +1047,7 @@ func checkSyncFile(targetDir, sourceDir string, sf syncFile) (*syncUpdate, error
 	if localHash == sourceHash {
 		return nil, nil
 	}
-	return &syncUpdate{Path: sf.localPath, SourcePath: sf.sourcePath, CurrentHash: localHash, SourceHash: sourceHash}, nil
+	return &syncUpdate{Path: sf.localPath, SourcePath: sf.sourcePath, SourceRoot: sourceDir, CurrentHash: localHash, SourceHash: sourceHash}, nil
 }
 
 // applySyncUpdate copies a single file/dir from source to target.

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -523,7 +523,7 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 			applyErrors++
 			continue
 		}
-		afterArtifactRemoved(scope, localFull)
+		afterArtifactRemoved(scope, localFull, jsonOutput)
 		fmt.Printf("  %s %s (deleted)\n", red("×"), p)
 		deleted++
 		deletedSuccessPaths = append(deletedSuccessPaths, p)

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -23,8 +23,8 @@ type syncResult struct {
 	Conflicts []string     `json:"conflicts,omitempty"`
 	// Retired names artifacts the source has withdrawn that are still
 	// installed, and whose bytes nav-pilot published (#716).
-	Retired []string `json:"retired,omitempty"`
-	PinBump   *syncPinBump `json:"pin_bump,omitempty"`
+	Retired []string     `json:"retired,omitempty"`
+	PinBump *syncPinBump `json:"pin_bump,omitempty"`
 }
 
 // syncPinBump is the committed pin moving, reported as its own unit of work.
@@ -259,7 +259,7 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 				reportRetired(retired, apply)
 			}
 			if apply {
-				removeRetiredOrphans(retired, jsonOutput)
+				removeRetiredOrphans(scope, retired, jsonOutput)
 				return nil
 			}
 			return errUpdatesAvailable
@@ -523,6 +523,7 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 			applyErrors++
 			continue
 		}
+		afterArtifactRemoved(scope, localFull)
 		fmt.Printf("  %s %s (deleted)\n", red("×"), p)
 		deleted++
 		deletedSuccessPaths = append(deletedSuccessPaths, p)
@@ -553,7 +554,7 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 	// the one --apply exists to move.
 	if len(retired) > 0 {
 		fmt.Printf("%s Removing %d retired artifact(s)\n", dim("→"), len(retired))
-		removeRetiredOrphans(retired, jsonOutput)
+		removeRetiredOrphans(scope, retired, jsonOutput)
 	}
 	if applyErrors == 0 {
 		bumpDeclarationSHA(scope, src)
@@ -943,10 +944,13 @@ func detectNewItems(scope *InstallScope, resolver *SourceResolver, src *Source) 
 	}
 
 	var newItems []string
-	// KindHook is in this list and KindPrompt is not: a hook that shipped after
-	// the last install is enforcement the user has not got yet, which is the
-	// thing #569 exists to surface.
-	for _, kind := range []*ArtifactKind{KindAgent, KindSkill, KindInstruction, KindHook} {
+	// Every kind except prompts. A hook or an extension that shipped after the
+	// last install is executable code the user has not got yet, which is the
+	// thing #569 exists to surface; a prompt is offered, never enforced.
+	for _, kind := range AllKinds {
+		if kind == KindPrompt {
+			continue
+		}
 		for _, art := range resolver.List(kind) {
 			relPath := kind.RelPathForName(scope, art.Name)
 			if !installed[relPath] {

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -322,14 +322,17 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 			continue
 		}
 
-		// Check if it exists in the source
-		sourceFull := filepath.Join(src.Dir, sf.sourcePath)
-		if _, statErr := os.Stat(sourceFull); os.IsNotExist(statErr) {
+		// Check if it exists in the source, or in a pakke this one reuses. A
+		// file inherited from a reused pakke is not under src.Dir, and reading
+		// that absence as "deleted upstream" deleted everything the base
+		// supplied on the first sync after install.
+		sourceRoot, found := resolver.SourceRootFor(sf.sourcePath)
+		if !found {
 			deletedPaths = append(deletedPaths, sf.localPath)
 			continue
 		}
 
-		u, err := checkSyncFile(scope.RootDir, src.Dir, sf)
+		u, err := checkSyncFile(scope.RootDir, sourceRoot, sf)
 		if err != nil {
 			if !jsonOutput {
 				fmt.Fprintf(os.Stderr, "%s %s: %v\n", yellow("⚠"), sf.localPath, err)

--- a/cli/nav-pilot/internal/source/compose_getfile_test.go
+++ b/cli/nav-pilot/internal/source/compose_getfile_test.go
@@ -19,10 +19,10 @@ func TestGetFileFindsInheritedArtifact(t *testing.T) {
 	if !ok {
 		t.Fatal("GetFile fant ikke det arvede artefaktet")
 	}
-	if rel != filepath.Join("agents", "felles.agent.md") {
-		t.Errorf("rel = %q, ventet agents/felles.agent.md", rel)
+	if rel != filepath.Join(KindAgent.Dir, "felles.agent.md") {
+		t.Errorf("rel = %q, ventet <agents>/felles.agent.md", rel)
 	}
-	if want := filepath.Join(baseDir, "agents", "felles.agent.md"); abs != want {
+	if want := filepath.Join(baseDir, KindAgent.Dir, "felles.agent.md"); abs != want {
 		t.Errorf("abs = %q, ventet %q", abs, want)
 	}
 }

--- a/cli/nav-pilot/internal/source/compose_getfile_test.go
+++ b/cli/nav-pilot/internal/source/compose_getfile_test.go
@@ -1,0 +1,54 @@
+package source
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// MapLocalPath må kunne navngi kildestien til et arvet artefakt. Klarte den
+// ikke det, falt den tilbake på den lokale stien, og sync lette etter den i
+// feil repo og meldte at fila var slettet oppstrøms. Første sync --apply etter
+// install av en gjenbrukende pakke slettet da alt basen bidro med (#572).
+func TestGetFileFindsInheritedArtifact(t *testing.T) {
+	baseDir, ownDir := t.TempDir(), t.TempDir()
+	writeAgent(t, baseDir, "felles", "fra basen")
+	writeAgent(t, ownDir, "eget", "eget")
+	r := NewSourceResolver(ownDir).WithBase(NewSourceResolver(baseDir))
+
+	abs, rel, ok := r.GetFile(KindAgent.Dir, "felles.agent.md")
+	if !ok {
+		t.Fatal("GetFile fant ikke det arvede artefaktet")
+	}
+	if rel != filepath.Join("agents", "felles.agent.md") {
+		t.Errorf("rel = %q, ventet agents/felles.agent.md", rel)
+	}
+	if want := filepath.Join(baseDir, "agents", "felles.agent.md"); abs != want {
+		t.Errorf("abs = %q, ventet %q", abs, want)
+	}
+}
+
+// Sync spør hvilken kilde som faktisk har fila. Uten kjeding svarte den nei
+// for alt basen bidro med.
+func TestSourceRootForWalksTheChain(t *testing.T) {
+	baseDir, ownDir := t.TempDir(), t.TempDir()
+	writeAgent(t, baseDir, "felles", "fra basen")
+	writeAgent(t, ownDir, "eget", "eget")
+	r := NewSourceResolver(ownDir).WithBase(NewSourceResolver(baseDir))
+
+	for _, tc := range []struct{ rel, want string }{
+		{filepath.Join("agents", "eget.agent.md"), ownDir},
+		{filepath.Join("agents", "felles.agent.md"), baseDir},
+	} {
+		got, ok := r.SourceRootFor(tc.rel)
+		if !ok {
+			t.Errorf("%s ble ikke funnet i noen kilde", tc.rel)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("%s løste til %s, ventet %s", tc.rel, got, tc.want)
+		}
+	}
+	if _, ok := r.SourceRootFor(filepath.Join("agents", "finnes-ikke.agent.md")); ok {
+		t.Error("en fil ingen av kildene har ble funnet")
+	}
+}

--- a/cli/nav-pilot/internal/source/hooks.go
+++ b/cli/nav-pilot/internal/source/hooks.go
@@ -273,11 +273,23 @@ func MergeRepoHooks(hooksDir string, entries []HookEntry) error {
 	return f.write(path)
 }
 
-// RemoveRepoHooks drops every entry nav-pilot marked as its own from the shared
+// RemoveRepoHooks drops entries nav-pilot marked as its own from the shared
 // repo config, and removes the file only once nothing at all is left in it.
 // Entries the user wrote are never touched, and a config that still holds one
 // stays a valid config.
-func RemoveRepoHooks(hooksDir string) (removed int, err error) {
+//
+// With no names it drops all of nav-pilot's, which is what uninstall wants.
+// With names it drops exactly those, which is what sync wants when one hook's
+// script goes away upstream: deleting the script while leaving the entry made
+// the CLI run a file that is no longer there on every matching tool call.
+func RemoveRepoHooks(hooksDir string, only ...string) (removed int, err error) {
+	var wanted map[string]bool
+	if len(only) > 0 {
+		wanted = make(map[string]bool, len(only))
+		for _, n := range only {
+			wanted[n] = true
+		}
+	}
 	path := filepath.Join(hooksDir, RepoHooksConfig)
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return 0, nil
@@ -289,7 +301,7 @@ func RemoveRepoHooks(hooksDir string) (removed int, err error) {
 	for event, list := range f.Hooks {
 		kept := list[:0]
 		for _, raw := range list {
-			if markerOf(raw) != "" {
+			if marker := markerOf(raw); marker != "" && (wanted == nil || wanted[marker]) {
 				removed++
 				continue
 			}

--- a/cli/nav-pilot/internal/source/resolver.go
+++ b/cli/nav-pilot/internal/source/resolver.go
@@ -127,6 +127,27 @@ func (r *SourceResolver) WithBase(base *SourceResolver) *SourceResolver {
 	return &chained
 }
 
+// SourceRootFor returns the source directory that actually holds a
+// source-relative path, looking through the reuse chain, and whether any of
+// them does.
+//
+// Sync needs this because a tracked file may have come from a reused pakke: it
+// is not under this source's directory, and reading that absence as "deleted
+// upstream" deletes what install just wrote. The same reason `add --source`
+// files are left alone (#571), one level up.
+func (r *SourceResolver) SourceRootFor(rel string) (string, bool) {
+	abs := filepath.Join(r.sourceDir, rel)
+	if _, err := r.checkSafePath(abs); err == nil {
+		if _, err := os.Stat(abs); err == nil {
+			return r.sourceDir, true
+		}
+	}
+	if r.base != nil {
+		return r.base.SourceRootFor(rel)
+	}
+	return "", false
+}
+
 // Base returns the reused resolver, or nil.
 func (r *SourceResolver) Base() *SourceResolver { return r.base }
 
@@ -281,6 +302,13 @@ func (r *SourceResolver) GetFile(typeDir, fileName string) (absPath, relPath str
 	abs := filepath.Join(r.sourceDir, rel)
 	if _, err := r.checkSafePath(abs); err == nil {
 		return abs, rel, true
+	}
+	// Then the reused pakke, for the same reason Get consults it. Without
+	// this, MapLocalPath could not name an inherited file's source path and
+	// fell back to the local path, which sync then looked for in the wrong
+	// repo and reported as deleted upstream.
+	if r.base != nil {
+		return r.base.GetFile(typeDir, fileName)
 	}
 	return "", "", false
 }

--- a/cli/nav-pilot/internal/source/resolver.go
+++ b/cli/nav-pilot/internal/source/resolver.go
@@ -136,11 +136,12 @@ func (r *SourceResolver) WithBase(base *SourceResolver) *SourceResolver {
 // upstream" deletes what install just wrote. The same reason `add --source`
 // files are left alone (#571), one level up.
 func (r *SourceResolver) SourceRootFor(rel string) (string, bool) {
+	// checkSafePath already Lstats the path, so its success is both "inside
+	// this checkout" and "exists". A second Stat would only add a window for
+	// the file to change between the two calls.
 	abs := filepath.Join(r.sourceDir, rel)
 	if _, err := r.checkSafePath(abs); err == nil {
-		if _, err := os.Stat(abs); err == nil {
-			return r.sourceDir, true
-		}
+		return r.sourceDir, true
 	}
 	if r.base != nil {
 		return r.base.SourceRootFor(rel)

--- a/scripts/generate-retired/main.go
+++ b/scripts/generate-retired/main.go
@@ -38,7 +38,7 @@ import (
 
 // artifactDirs are the trees whose deletions matter. A file outside them is not
 // something nav-pilot installs.
-var artifactDirs = []string{"agents", "skills", "instructions", "prompts", "hooks"}
+var artifactDirs = []string{"agents", "skills", "instructions", "prompts", "hooks", "extensions"}
 
 const outputPath = ".nav-pilot/retired-artifacts.json"
 


### PR DESCRIPTION
Bygger på #749. Fem funn fra Fables mutasjonsgjennomgang, hvert verifisert med den ekte binæren før fiks.

| Funn | Konsekvens | Verifisert |
|---|---|---|
| Install i eget repo skrev om locken til seg selv | Gjenbruk døde stille for alle konsumenter | Lock gikk base → own; ny consumer fikk 1 av 3 artefakter |
| Pensjonert hook beholdt aktiveringsoppføringa | Copilot CLI kjørte en fil som ikke fantes | `navPilot: vakt` sto igjen etter `--apply` |
| Pensjonert skill beholdt katalogen | Katalog som ikke lenger er en skill | `helper.md` ble liggende |
| `kindForPath` manglet extensions | Pensjonert extension under deklarert layout ble aldri funnet | Kodelesing, fjerde liste av samme slag |
| Fem lister/meldinger uten extension | Feil hjelpetekst, ny extension aldri rapportert | `detectNewItems`, `artifactDirs`, to feilmeldinger |

## Ikke et funn likevel

Gjennomgangen meldte også at `layout.extensions` mot en manglende katalog validerer grønt. Det stemte da den kjørte, men #746 landet i mellomtiden og fikset det. Verifisert på nytt: `✗ layout.extensions references "does/not/exist", which does not exist`. Tatt med fordi et funn som ikke lenger finnes er verdt å si fra om.

## Mutasjonskontroller

Hook-deaktiveringa og katalogslettinga er begge slått av igjen, og testene feiler da. Kontrolltester dekker at bare den navngitte hooken fjernes, og at en vanlig fil ikke drar med seg katalogen sin.