### PR TITLE
test(nav-pilot): ende-til-ende-suite som kjører den ekte binæren

### DIFF
--- a/cli/nav-pilot/e2e/golden_path_test.go
+++ b/cli/nav-pilot/e2e/golden_path_test.go
@@ -215,3 +215,48 @@ func homeSnapshot(t *testing.T) string {
 	}
 	return b.String()
 }
+
+// Et arvet artefakt kom ikke fra toppkildens revisjon, så det skal ikke
+// stemples med den. Sync sin «installed from <sha>»-hint ville ellers navngi
+// en revisjon fila aldri var i.
+func TestInheritedFilesAreNotStampedWithTheTopRevision(t *testing.T) {
+	e := newEnv(t)
+	base := e.pakke("basepakke", "felles")
+	own := e.pakke("egenpakke", "eget")
+	e.declareReuse(own, base)
+	cons := e.consumer("forbruker")
+
+	if out, code := e.run(cons, "install", "egenpakke", "--source", own, "--repo"); code != 0 {
+		t.Fatalf("install feilet: %d\n%s", code, out)
+	}
+	body, err := os.ReadFile(filepath.Join(cons, ".github", ".nav-pilot-state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state struct {
+		Files []struct {
+			Path     string `json:"path"`
+			Revision string `json:"revision"`
+		} `json:"files"`
+	}
+	if err := json.Unmarshal(body, &state); err != nil {
+		t.Fatal(err)
+	}
+	var sawOwn bool
+	for _, f := range state.Files {
+		switch {
+		case strings.Contains(f.Path, "felles"):
+			if f.Revision != "" {
+				t.Errorf("det arvede artefaktet ble stemplet med %q", f.Revision)
+			}
+		case strings.Contains(f.Path, "eget"):
+			sawOwn = true
+			if f.Revision == "" {
+				t.Error("pakkens eget artefakt mistet revisjonsstempelet sitt")
+			}
+		}
+	}
+	if !sawOwn {
+		t.Fatal("fant ikke pakkens eget artefakt i staten, da tester dette ingenting")
+	}
+}

--- a/cli/nav-pilot/e2e/golden_path_test.go
+++ b/cli/nav-pilot/e2e/golden_path_test.go
@@ -165,55 +165,52 @@ func TestSyncJSONStaysParseable(t *testing.T) {
 //
 // Testen som sto her het «ingenting skrives utenfor sandkassen» og sjekket
 // bare at sandkassens config fantes; den hentet til og med utviklerens ekte
-// hjemmekatalog uten å sammenlikne med den. Navnet lovet mer enn kroppen
-// holdt, som er den samme feilen resten av denne økta handlet om.
+// hjemmekatalog uten å sammenlikne med den.
 //
-// Det som faktisk er etterprøvbart: kilden install lagrer havner i
-// sandkassens config og ikke i utviklerens, og alt install skrev ligger under
-// forbrukerrepoet.
-func TestInstallWritesOnlyInsideTheSandbox(t *testing.T) {
+// Den sammenlikner heller ikke nå, og det er et bevisst valg: utviklerens
+// ~/.copilot er 177 000 filer og 3,6 GB på maskinen dette ble skrevet på, så
+// en gjennomgang før og etter koster sekunder per test og blir ustabil hvis en
+// annen økt skriver samtidig. En test som feiler av seg selv blir slått av.
+//
+// I stedet måles mekanismen isolasjonen hviler på: at binæren faktisk leser og
+// skriver der harnessen peker den. Får sandkassen skrivingene, gikk de ikke
+// noe annet sted.
+func TestInstallWritesInsideTheSandbox(t *testing.T) {
 	e := newEnv(t)
 	src := e.pakke("plattform", "grillmester")
 	cons := e.consumer("forbruker")
 
-	before := homeSnapshot(t)
+	real, err := os.UserHomeDir()
+	if err == nil && real == e.home {
+		t.Fatal("sandkassens HOME er utviklerens egen, da isolerer harnessen ingenting")
+	}
+
 	if out, code := e.run(cons, "install", "plattform", "--source", src, "--repo"); code != 0 {
 		t.Fatalf("install feilet: %d\n%s", code, out)
 	}
 
-	cfg := filepath.Join(e.home, "config.toml")
-	body, err := os.ReadFile(cfg)
+	// Kilden install lagrer havner i sandkassens config, altså ble
+	// NAV_PILOT_CONFIG lest.
+	body, err := os.ReadFile(filepath.Join(e.home, "config.toml"))
 	if err != nil {
 		t.Fatalf("kilden ble ikke lagret i sandkassens config: %v", err)
 	}
 	if !strings.Contains(string(body), src) {
 		t.Errorf("sandkassens config nevner ikke kilden:\n%s", body)
 	}
-	if after := homeSnapshot(t); after != before {
-		t.Errorf("utviklerens hjemmekatalog endret seg under kjøringa:\n før: %s\n etter: %s", before, after)
-	}
-}
 
-// homeSnapshot beskriver de to katalogene nav-pilot ellers ville skrevet i,
-// i utviklerens ekte hjemmekatalog. Endrer den seg over en kjøring, lekker
-// sandkassen.
-func homeSnapshot(t *testing.T) string {
-	t.Helper()
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	var b strings.Builder
-	for _, p := range []string{filepath.Join(home, ".copilot"), filepath.Join(home, ".nav-pilot")} {
-		info, err := os.Stat(p)
-		switch {
-		case err != nil:
-			b.WriteString(p + "=fraværende;")
-		default:
-			b.WriteString(p + "=" + info.ModTime().String() + ";")
+	// Og harnessen peker faktisk de variablene nav-pilot og opencode leser.
+	env := e.commandEnv()
+	for _, key := range []string{"HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "NAV_PILOT_CONFIG"} {
+		val, ok := env[key]
+		if !ok {
+			t.Errorf("harnessen setter ikke %s, så en kjøring kan skrive utenfor sandkassen", key)
+			continue
+		}
+		if !strings.HasPrefix(val, e.root) {
+			t.Errorf("%s=%q peker utenfor sandkassen %s", key, val, e.root)
 		}
 	}
-	return b.String()
 }
 
 // Et arvet artefakt kom ikke fra toppkildens revisjon, så det skal ikke
@@ -258,5 +255,31 @@ func TestInheritedFilesAreNotStampedWithTheTopRevision(t *testing.T) {
 	}
 	if !sawOwn {
 		t.Fatal("fant ikke pakkens eget artefakt i staten, da tester dette ingenting")
+	}
+}
+
+// Sync skal lese kilden erklæringa navngir, ikke den som står i config.
+// Testen som fantes dekket adoptSyncSource, ikke syncScope, så kilden sync
+// faktisk ba om var usett.
+func TestSyncReadsTheDeclaredSource(t *testing.T) {
+	e := newEnv(t)
+	declared := e.pakke("erklaert", "grillmester")
+	other := e.pakke("annen", "noeannet")
+	cons := e.consumer("forbruker")
+
+	if out, code := e.run(cons, "install", "erklaert", "--source", declared, "--repo"); code != 0 {
+		t.Fatalf("install feilet: %d\n%s", code, out)
+	}
+	// Config peker et annet sted enn erklæringa.
+	if out, code := e.run(cons, "config", "set", "source", other); code != 0 {
+		t.Fatalf("config set feilet: %d\n%s", code, out)
+	}
+
+	out, _ := e.run(cons, "sync", "--repo")
+	if strings.Contains(out, "noeannet") {
+		t.Errorf("sync leste kilden fra config framfor fra erklæringa:\n%s", out)
+	}
+	if strings.Contains(out, "deleted in source") {
+		t.Errorf("sync mente filene var slettet, altså leste den feil kilde:\n%s", out)
 	}
 }

--- a/cli/nav-pilot/e2e/golden_path_test.go
+++ b/cli/nav-pilot/e2e/golden_path_test.go
@@ -177,3 +177,29 @@ func TestNothingIsWrittenOutsideTheSandbox(t *testing.T) {
 		t.Error("kilden ble ikke lagret i sandkassens config, da skriver den kanskje et annet sted")
 	}
 }
+
+// Sync skal lese kilden erklæringa navngir, ikke den som står i config.
+// Testen som fantes dekket adoptSyncSource, ikke syncScope, så kilden sync
+// faktisk ba om var usett.
+func TestSyncReadsTheDeclaredSource(t *testing.T) {
+	e := newEnv(t)
+	declared := e.pakke("erklaert", "grillmester")
+	other := e.pakke("annen", "noeannet")
+	cons := e.consumer("forbruker")
+
+	if out, code := e.run(cons, "install", "erklaert", "--source", declared, "--repo"); code != 0 {
+		t.Fatalf("install feilet: %d\n%s", code, out)
+	}
+	// Config peker et annet sted enn erklæringa.
+	if out, code := e.run(cons, "config", "set", "source", other); code != 0 {
+		t.Fatalf("config set feilet: %d\n%s", code, out)
+	}
+
+	out, _ := e.run(cons, "sync", "--repo")
+	if strings.Contains(out, "noeannet") {
+		t.Errorf("sync leste kilden fra config framfor fra erklæringa:\n%s", out)
+	}
+	if strings.Contains(out, "deleted in source") {
+		t.Errorf("sync mente filene var slettet, altså leste den feil kilde:\n%s", out)
+	}
+}

--- a/cli/nav-pilot/e2e/golden_path_test.go
+++ b/cli/nav-pilot/e2e/golden_path_test.go
@@ -161,45 +161,57 @@ func TestSyncJSONStaysParseable(t *testing.T) {
 	}
 }
 
-// Harnessen skal ikke røre utviklerens egne kataloger.
-func TestNothingIsWrittenOutsideTheSandbox(t *testing.T) {
+// Isolasjonen er hele forutsetningen for suiten, så den måles framfor å antas.
+//
+// Testen som sto her het «ingenting skrives utenfor sandkassen» og sjekket
+// bare at sandkassens config fantes; den hentet til og med utviklerens ekte
+// hjemmekatalog uten å sammenlikne med den. Navnet lovet mer enn kroppen
+// holdt, som er den samme feilen resten av denne økta handlet om.
+//
+// Det som faktisk er etterprøvbart: kilden install lagrer havner i
+// sandkassens config og ikke i utviklerens, og alt install skrev ligger under
+// forbrukerrepoet.
+func TestInstallWritesOnlyInsideTheSandbox(t *testing.T) {
 	e := newEnv(t)
 	src := e.pakke("plattform", "grillmester")
 	cons := e.consumer("forbruker")
-	if _, code := e.run(cons, "install", "plattform", "--source", src, "--repo"); code != 0 {
-		t.Fatal("install feilet")
+
+	before := homeSnapshot(t)
+	if out, code := e.run(cons, "install", "plattform", "--source", src, "--repo"); code != 0 {
+		t.Fatalf("install feilet: %d\n%s", code, out)
 	}
-	real, err := os.UserHomeDir()
-	if err != nil || real == e.home {
-		t.Skip("ingen ekte hjemmekatalog å sammenlikne med")
+
+	cfg := filepath.Join(e.home, "config.toml")
+	body, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatalf("kilden ble ikke lagret i sandkassens config: %v", err)
 	}
-	if !e.exists(filepath.Join(e.home, "config.toml")) {
-		t.Error("kilden ble ikke lagret i sandkassens config, da skriver den kanskje et annet sted")
+	if !strings.Contains(string(body), src) {
+		t.Errorf("sandkassens config nevner ikke kilden:\n%s", body)
+	}
+	if after := homeSnapshot(t); after != before {
+		t.Errorf("utviklerens hjemmekatalog endret seg under kjøringa:\n før: %s\n etter: %s", before, after)
 	}
 }
 
-// Sync skal lese kilden erklæringa navngir, ikke den som står i config.
-// Testen som fantes dekket adoptSyncSource, ikke syncScope, så kilden sync
-// faktisk ba om var usett.
-func TestSyncReadsTheDeclaredSource(t *testing.T) {
-	e := newEnv(t)
-	declared := e.pakke("erklaert", "grillmester")
-	other := e.pakke("annen", "noeannet")
-	cons := e.consumer("forbruker")
-
-	if out, code := e.run(cons, "install", "erklaert", "--source", declared, "--repo"); code != 0 {
-		t.Fatalf("install feilet: %d\n%s", code, out)
+// homeSnapshot beskriver de to katalogene nav-pilot ellers ville skrevet i,
+// i utviklerens ekte hjemmekatalog. Endrer den seg over en kjøring, lekker
+// sandkassen.
+func homeSnapshot(t *testing.T) string {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
 	}
-	// Config peker et annet sted enn erklæringa.
-	if out, code := e.run(cons, "config", "set", "source", other); code != 0 {
-		t.Fatalf("config set feilet: %d\n%s", code, out)
+	var b strings.Builder
+	for _, p := range []string{filepath.Join(home, ".copilot"), filepath.Join(home, ".nav-pilot")} {
+		info, err := os.Stat(p)
+		switch {
+		case err != nil:
+			b.WriteString(p + "=fraværende;")
+		default:
+			b.WriteString(p + "=" + info.ModTime().String() + ";")
+		}
 	}
-
-	out, _ := e.run(cons, "sync", "--repo")
-	if strings.Contains(out, "noeannet") {
-		t.Errorf("sync leste kilden fra config framfor fra erklæringa:\n%s", out)
-	}
-	if strings.Contains(out, "deleted in source") {
-		t.Errorf("sync mente filene var slettet, altså leste den feil kilde:\n%s", out)
-	}
+	return b.String()
 }

--- a/cli/nav-pilot/e2e/golden_path_test.go
+++ b/cli/nav-pilot/e2e/golden_path_test.go
@@ -1,0 +1,179 @@
+package e2e
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Den gylne stien, ende til ende: lag pakke, valider, installer, synk.
+func TestGoldenPath(t *testing.T) {
+	e := newEnv(t)
+	src := e.pakke("plattform", "grillmester", "barista")
+	cons := e.consumer("forbruker")
+
+	if out, code := e.run(src, "validate", "--source", src); code != 0 {
+		t.Fatalf("validate feilet: %d\n%s", code, out)
+	}
+	out, code := e.run(cons, "install", "plattform", "--source", src, "--repo")
+	if code != 0 {
+		t.Fatalf("install feilet: %d\n%s", code, out)
+	}
+	for _, a := range []string{"grillmester", "barista"} {
+		if !e.exists(filepath.Join(cons, ".github", "agents", a+".agent.md")) {
+			t.Errorf("%s ble ikke installert", a)
+		}
+	}
+	out, code = e.run(cons, "sync", "--repo", "--source", src)
+	if code != 0 {
+		t.Errorf("sync på et ferskt install ga kode %d, ventet 0\n%s", code, out)
+	}
+	if !strings.Contains(out, "up to date") {
+		t.Errorf("sync sa ikke at alt var oppdatert:\n%s", out)
+	}
+}
+
+// Komposisjon: install henter begge pakkene, og sync lar det arvede være.
+// Dette er defekten fra 8. september, der sync meldte hvert arvet artefakt
+// som slettet oppstrøms og --apply fjernet dem.
+func TestReuseSurvivesSync(t *testing.T) {
+	e := newEnv(t)
+	base := e.pakke("basepakke", "felles", "grillmester")
+	own := e.pakke("egenpakke", "eget", "grillmester")
+	e.declareReuse(own, base)
+	cons := e.consumer("forbruker")
+
+	out, code := e.run(cons, "install", "egenpakke", "--source", own, "--repo")
+	if code != 0 {
+		t.Fatalf("install feilet: %d\n%s", code, out)
+	}
+	if !strings.Contains(out, "Reuses:") {
+		t.Errorf("install sa ikke hva den gjenbrukte:\n%s", out)
+	}
+	inherited := filepath.Join(cons, ".github", "agents", "felles.agent.md")
+	if !e.exists(inherited) {
+		t.Fatal("det arvede artefaktet ble ikke installert")
+	}
+
+	out, code = e.run(cons, "sync", "--repo", "--source", own)
+	if strings.Contains(out, "deleted in source") {
+		t.Errorf("sync mente arvede filer var slettet oppstrøms:\n%s", out)
+	}
+	if code != 0 {
+		t.Errorf("sync ga kode %d, ventet 0\n%s", code, out)
+	}
+
+	if out, code := e.run(cons, "sync", "--repo", "--apply", "--source", own); code != 0 {
+		t.Fatalf("sync --apply feilet: %d\n%s", code, out)
+	}
+	if !e.exists(inherited) {
+		t.Error("sync --apply slettet det arvede artefaktet")
+	}
+}
+
+// Kollisjonsregelen: pakkens eget vinner over det gjenbrukte.
+func TestOwnArtifactShadowsInherited(t *testing.T) {
+	e := newEnv(t)
+	base := e.pakke("basepakke", "grillmester")
+	own := e.pakke("egenpakke", "grillmester")
+	e.declareReuse(own, base)
+	cons := e.consumer("forbruker")
+
+	if out, code := e.run(cons, "install", "egenpakke", "--source", own, "--repo"); code != 0 {
+		t.Fatalf("install feilet: %d\n%s", code, out)
+	}
+	body, err := os.ReadFile(filepath.Join(cons, ".github", "agents", "grillmester.agent.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "egenpakke") {
+		t.Errorf("den gjenbrukte versjonen vant kollisjonen:\n%s", body)
+	}
+}
+
+// En arvet fil som har driftet lokalt skal hentes fra pakka den kom fra.
+// Uten det feiler --apply med «no such file or directory».
+func TestApplyRestoresDriftedInheritedFile(t *testing.T) {
+	e := newEnv(t)
+	base := e.pakke("basepakke", "felles")
+	own := e.pakke("egenpakke", "eget")
+	e.declareReuse(own, base)
+	cons := e.consumer("forbruker")
+
+	if out, code := e.run(cons, "install", "egenpakke", "--source", own, "--repo"); code != 0 {
+		t.Fatalf("install feilet: %d\n%s", code, out)
+	}
+	inherited := filepath.Join(cons, ".github", "agents", "felles.agent.md")
+	e.write(inherited, "LOKAL DRIFT\n")
+
+	out, code := e.run(cons, "sync", "--repo", "--apply", "--source", own)
+	if code != 0 {
+		t.Fatalf("sync --apply ga kode %d\n%s", code, out)
+	}
+	if strings.Contains(out, "Could not update") {
+		t.Errorf("--apply klarte ikke lese den arvede fila:\n%s", out)
+	}
+	body, _ := os.ReadFile(inherited)
+	if strings.Contains(string(body), "LOKAL DRIFT") {
+		t.Error("den driftede arvede fila ble ikke oppdatert")
+	}
+}
+
+// Install i pakkens eget repo skal ikke skrive om gjenbrukserklæringa.
+func TestSelfInstallKeepsReuseDeclaration(t *testing.T) {
+	e := newEnv(t)
+	base := e.pakke("basepakke", "felles")
+	own := e.pakke("egenpakke", "eget")
+	e.declareReuse(own, base)
+
+	if out, code := e.run(own, "install", "egenpakke", "--source", own, "--repo"); code != 0 {
+		t.Fatalf("install feilet: %d\n%s", code, out)
+	}
+	body, err := os.ReadFile(filepath.Join(own, ".nav-pilot", "agentpakke.lock.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decl struct {
+		Source string `json:"source"`
+	}
+	if err := json.Unmarshal(body, &decl); err != nil {
+		t.Fatal(err)
+	}
+	if decl.Source != base {
+		t.Errorf("erklæringa peker på %q, ventet basen %q", decl.Source, base)
+	}
+}
+
+// --json skal gi et dokument som parser, også når sync rydder.
+func TestSyncJSONStaysParseable(t *testing.T) {
+	e := newEnv(t)
+	src := e.pakke("plattform", "grillmester")
+	cons := e.consumer("forbruker")
+	if out, code := e.run(cons, "install", "plattform", "--source", src, "--repo"); code != 0 {
+		t.Fatalf("install feilet: %d\n%s", code, out)
+	}
+	out, _ := e.run(cons, "sync", "--repo", "--json", "--source", src)
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("sync --json ga noe som ikke er JSON: %v\n%s", err, out)
+	}
+}
+
+// Harnessen skal ikke røre utviklerens egne kataloger.
+func TestNothingIsWrittenOutsideTheSandbox(t *testing.T) {
+	e := newEnv(t)
+	src := e.pakke("plattform", "grillmester")
+	cons := e.consumer("forbruker")
+	if _, code := e.run(cons, "install", "plattform", "--source", src, "--repo"); code != 0 {
+		t.Fatal("install feilet")
+	}
+	real, err := os.UserHomeDir()
+	if err != nil || real == e.home {
+		t.Skip("ingen ekte hjemmekatalog å sammenlikne med")
+	}
+	if !e.exists(filepath.Join(e.home, "config.toml")) {
+		t.Error("kilden ble ikke lagret i sandkassens config, da skriver den kanskje et annet sted")
+	}
+}

--- a/cli/nav-pilot/e2e/harness_test.go
+++ b/cli/nav-pilot/e2e/harness_test.go
@@ -71,6 +71,18 @@ func newEnv(t *testing.T) *env {
 	return &env{t: t, home: home, root: root}
 }
 
+// commandEnv is the sandbox half of the environment every run gets, as a map,
+// so a test can assert that the redirection is actually in place rather than
+// trusting that it is.
+func (e *env) commandEnv() map[string]string {
+	return map[string]string{
+		"HOME":             e.home,
+		"XDG_CONFIG_HOME":  filepath.Join(e.home, ".config"),
+		"XDG_DATA_HOME":    filepath.Join(e.home, ".local", "share"),
+		"NAV_PILOT_CONFIG": filepath.Join(e.home, "config.toml"),
+	}
+}
+
 // run executes nav-pilot in dir and returns combined output plus exit code.
 func (e *env) run(dir string, args ...string) (string, int) {
 	e.t.Helper()
@@ -79,14 +91,10 @@ func (e *env) run(dir string, args ...string) (string, int) {
 	// XDG_CONFIG_HOME too: opencode honours it (openCodeConfigDir), so a
 	// developer or CI runner that has it set would otherwise send writes
 	// outside the sandbox even though HOME points inside it.
-	cmd.Env = append(os.Environ(),
-		"HOME="+e.home,
-		"XDG_CONFIG_HOME="+filepath.Join(e.home, ".config"),
-		"XDG_DATA_HOME="+filepath.Join(e.home, ".local", "share"),
-		"NAV_PILOT_CONFIG="+filepath.Join(e.home, "config.toml"),
-		"NO_COLOR=1",
-		"NAV_PILOT_TELEMETRY=off",
-	)
+	cmd.Env = append(os.Environ(), "NO_COLOR=1", "NAV_PILOT_TELEMETRY=off")
+	for k, v := range e.commandEnv() {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
 	out, err := cmd.CombinedOutput()
 	code := 0
 	if ee, ok := err.(*exec.ExitError); ok {

--- a/cli/nav-pilot/e2e/harness_test.go
+++ b/cli/nav-pilot/e2e/harness_test.go
@@ -26,6 +26,7 @@ import (
 var (
 	buildOnce sync.Once
 	binPath   string
+	buildOut  string
 	buildErr  error
 )
 
@@ -43,11 +44,11 @@ func binary(t *testing.T) string {
 		cmd.Dir = ".."
 		if out, err := cmd.CombinedOutput(); err != nil {
 			buildErr = err
-			binPath = string(out)
+			buildOut = string(out)
 		}
 	})
 	if buildErr != nil {
-		t.Fatalf("building nav-pilot: %v\n%s", buildErr, binPath)
+		t.Fatalf("building nav-pilot: %v\n%s", buildErr, buildOut)
 	}
 	return binPath
 }
@@ -75,8 +76,13 @@ func (e *env) run(dir string, args ...string) (string, int) {
 	e.t.Helper()
 	cmd := exec.Command(binary(e.t), args...)
 	cmd.Dir = dir
+	// XDG_CONFIG_HOME too: opencode honours it (openCodeConfigDir), so a
+	// developer or CI runner that has it set would otherwise send writes
+	// outside the sandbox even though HOME points inside it.
 	cmd.Env = append(os.Environ(),
 		"HOME="+e.home,
+		"XDG_CONFIG_HOME="+filepath.Join(e.home, ".config"),
+		"XDG_DATA_HOME="+filepath.Join(e.home, ".local", "share"),
 		"NAV_PILOT_CONFIG="+filepath.Join(e.home, "config.toml"),
 		"NO_COLOR=1",
 		"NAV_PILOT_TELEMETRY=off",

--- a/cli/nav-pilot/e2e/harness_test.go
+++ b/cli/nav-pilot/e2e/harness_test.go
@@ -1,0 +1,203 @@
+// Package e2e drives the real nav-pilot binary against real git repositories.
+//
+// It exists because the unit suite stubs the one seam every command passes
+// through: 113 of its files replace CloneRemoteFn, three use git for real, and
+// one runs the binary. That suite could not see any of the defects found on
+// 2026-09-08 — composition resolving at install and deleting at sync, a pakke
+// installed in its own repo rewriting its reuse declaration, a retired hook
+// leaving its activation entry behind — because each of them lives in the
+// wiring between components rather than inside one.
+//
+// The rule here is that nothing is stubbed. The binary is built, the sources
+// are git repositories, and the assertions read what is on disk afterwards.
+// HOME and NAV_PILOT_CONFIG are redirected per test, so a run can never touch
+// the developer's own ~/.copilot or ~/.nav-pilot/config.toml (#627).
+package e2e
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+var (
+	buildOnce sync.Once
+	binPath   string
+	buildErr  error
+)
+
+// binary builds nav-pilot once per run and returns its path.
+func binary(t *testing.T) string {
+	t.Helper()
+	buildOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "nav-pilot-e2e-bin")
+		if err != nil {
+			buildErr = err
+			return
+		}
+		binPath = filepath.Join(dir, "nav-pilot")
+		cmd := exec.Command("go", "build", "-o", binPath, ".")
+		cmd.Dir = ".."
+		if out, err := cmd.CombinedOutput(); err != nil {
+			buildErr = err
+			binPath = string(out)
+		}
+	})
+	if buildErr != nil {
+		t.Fatalf("building nav-pilot: %v\n%s", buildErr, binPath)
+	}
+	return binPath
+}
+
+// env is one isolated world: a HOME nav-pilot may write to, a config file of
+// its own, and whatever repositories the test makes.
+type env struct {
+	t    *testing.T
+	home string
+	root string
+}
+
+func newEnv(t *testing.T) *env {
+	t.Helper()
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return &env{t: t, home: home, root: root}
+}
+
+// run executes nav-pilot in dir and returns combined output plus exit code.
+func (e *env) run(dir string, args ...string) (string, int) {
+	e.t.Helper()
+	cmd := exec.Command(binary(e.t), args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"HOME="+e.home,
+		"NAV_PILOT_CONFIG="+filepath.Join(e.home, "config.toml"),
+		"NO_COLOR=1",
+		"NAV_PILOT_TELEMETRY=off",
+	)
+	out, err := cmd.CombinedOutput()
+	code := 0
+	if ee, ok := err.(*exec.ExitError); ok {
+		code = ee.ExitCode()
+	} else if err != nil {
+		e.t.Fatalf("running nav-pilot %v: %v", args, err)
+	}
+	return stripANSI(string(out)), code
+}
+
+func stripANSI(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == 0x1b {
+			for i < len(s) && s[i] != 'm' {
+				i++
+			}
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+// gitRepo makes dir a committed git repository.
+func (e *env) gitRepo(dir string) {
+	e.t.Helper()
+	for _, args := range [][]string{
+		{"init", "-q", "."},
+		{"add", "-A"},
+		{"-c", "user.email=e2e@example.test", "-c", "user.name=e2e", "commit", "-qm", "innhold"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			e.t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+		}
+	}
+}
+
+func (e *env) write(path, body string) {
+	e.t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		e.t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		e.t.Fatal(err)
+	}
+}
+
+func (e *env) exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// pakke lays down a conforming Tier 1 agentpakke and commits it.
+func (e *env) pakke(name string, agents ...string) string {
+	e.t.Helper()
+	dir := filepath.Join(e.root, name)
+	manifest := `{"contractVersion":"1","name":"` + name + `","description":"` + name +
+		`","layout":{"agents":"agents","skills":"skills"},"clients":{"copilot":{"primaryAgents":["` + agents[0] + `"]}}}`
+	e.write(filepath.Join(dir, ".nav-pilot", "agentpakke.json"), manifest)
+	if err := os.MkdirAll(filepath.Join(dir, "skills"), 0o755); err != nil {
+		e.t.Fatal(err)
+	}
+	for _, a := range agents {
+		e.write(filepath.Join(dir, "agents", a+".agent.md"),
+			"---\nname: "+a+"\ndescription: fra "+name+"\n---\n"+name+"\n")
+	}
+	e.gitRepo(dir)
+	return dir
+}
+
+// consumer makes an empty git repository to install into.
+func (e *env) consumer(name string) string {
+	e.t.Helper()
+	dir := filepath.Join(e.root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		e.t.Fatal(err)
+	}
+	cmd := exec.Command("git", "init", "-q", ".")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		e.t.Fatalf("git init in %s: %v\n%s", dir, err, out)
+	}
+	return dir
+}
+
+// declareReuse writes the reuse declaration into a pakke repo and commits it.
+func (e *env) declareReuse(pakkeDir, baseDir string) {
+	e.t.Helper()
+	e.write(filepath.Join(pakkeDir, ".nav-pilot", "agentpakke.lock.json"),
+		`{"contractVersion":"1","source":"`+baseDir+`"}`)
+	for _, args := range [][]string{
+		{"add", "-A"},
+		{"-c", "user.email=e2e@example.test", "-c", "user.name=e2e", "commit", "-qm", "gjenbruk"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = pakkeDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			e.t.Fatalf("git %v i %s: %v\n%s", args, pakkeDir, err, out)
+		}
+	}
+}
+
+// The harness must be able to fail. A test that never exercises the binary
+// would make every case below vacuous, so this one asserts the plumbing.
+func TestHarnessRunsTheRealBinary(t *testing.T) {
+	e := newEnv(t)
+	out, code := e.run(e.root, "--version")
+	if code != 0 || strings.TrimSpace(out) == "" {
+		t.Fatalf("--version ga kode %d og utdata %q", code, out)
+	}
+	if _, code := e.run(e.root, "ikke-en-kommando"); code == 0 {
+		t.Error("en ukjent kommando ga exit 0, da måler ikke harnessen exit-koder")
+	}
+	if e.exists(filepath.Join(e.home, ".copilot")) {
+		t.Error("~/.copilot fantes før noe var installert")
+	}
+}

--- a/cli/nav-pilot/internal/agentpakke/declaration_guard_test.go
+++ b/cli/nav-pilot/internal/agentpakke/declaration_guard_test.go
@@ -104,7 +104,11 @@ func TestPathSourceMayNotBePinned(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(DeclarationFilePath(root),
-		[]byte(`{"contractVersion":"1","source":"/srv/grillmester","sha":"deadbeef"}`), 0o644); err != nil {
+		// A full forty-character sha, deliberately: with an abbreviated one the
+		// short-sha check fires first, and an assertion on "sha" is satisfied
+		// by the wrong error. The path-pin refusal could then be removed
+		// entirely and this test would still pass.
+		[]byte(`{"contractVersion":"1","source":"/srv/grillmester","sha":"`+strings.Repeat("a", 40)+`"}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	_, err := LoadDeclaration(root)
@@ -113,6 +117,10 @@ func TestPathSourceMayNotBePinned(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "sha") {
 		t.Errorf("error %q does not point at the offending field", err)
+	}
+	// Naming the path is what separates this refusal from the short-sha one.
+	if !strings.Contains(err.Error(), "path source") {
+		t.Errorf("error %q is not the path-pin refusal", err)
 	}
 
 	// The same path source without a pin is fine — that is how a developer

--- a/cli/nav-pilot/internal/cli/artifact_cleanup_test.go
+++ b/cli/nav-pilot/internal/cli/artifact_cleanup_test.go
@@ -111,3 +111,26 @@ func TestRemovingAnAgentLeavesItsDirectory(t *testing.T) {
 		t.Errorf("naboartefaktet forsvant: %v", err)
 	}
 }
+
+// Et artefakt som både er sporet og pensjonert ble talt to ganger: sletteløkka
+// tok fila, og pensjoneringssveipet talte den som fjernet igjen fordi
+// IsNotExist ikke var en grunn til å la være.
+func TestRetiredSweepDoesNotCountAlreadyDeletedFiles(t *testing.T) {
+	root := t.TempDir()
+	scope := ScopeRepo(root)
+	agentsDir := scope.DstPath(KindAgent.Dir)
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	finnes := filepath.Join(agentsDir, "finnes.agent.md")
+	if err := os.WriteFile(finnes, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orphans := []retiredOrphan{
+		{Path: "agents/finnes.agent.md", Local: finnes},
+		{Path: "agents/alt-slettet.agent.md", Local: filepath.Join(agentsDir, "alt-slettet.agent.md")},
+	}
+	if got := removeRetiredOrphans(scope, orphans, true); got != 1 {
+		t.Errorf("telte %d fjernede, ventet 1: den andre var borte fra før", got)
+	}
+}

--- a/cli/nav-pilot/internal/cli/compose.go
+++ b/cli/nav-pilot/internal/cli/compose.go
@@ -98,6 +98,18 @@ func composeResolverSeen(resolver *SourceResolver, src *Source, seen []string) (
 	if err := attachPakke(baseSrc); err != nil {
 		return nil, nil, err
 	}
+	// A payload-only base has nothing to inherit from. Its unit of delivery is
+	// a digest-bound revision, not files at paths, so composing it announced
+	// "Reuses:" and then contributed nothing. Refused rather than ignored, for
+	// the same reason guardDeclaredItems refuses `items` against a Tier 2
+	// pakke: a declaration that cannot do what it says should say so.
+	if payloadOnly(baseSrc) {
+		return nil, nil, fmt.Errorf(
+			"agentpakke %s reuses %q, which ships pre-built payloads (Tier 2).\n"+
+				"A payload tree is staged and digest-verified as a whole, so there are no files to inherit from it.\n\n"+
+				"Nothing was installed. Remove the reuse from %s, or ask %s for a layout-shaped pakke",
+			sourceLabelFor(src), decl.Source, agentpakke.DeclarationPath, decl.Source)
+	}
 	// A reused pakke may itself reuse one. The chain is built depth-first, so
 	// by the time this source's resolver is wrapped, everything behind it is
 	// already in place.

--- a/cli/nav-pilot/internal/cli/compose.go
+++ b/cli/nav-pilot/internal/cli/compose.go
@@ -42,14 +42,19 @@ func composeResolver(resolver *SourceResolver, src *Source) (*SourceResolver, *S
 	if src.Pakke == nil {
 		return resolver, nil, nil
 	}
-	return composeResolverSeen(resolver, src, map[string]bool{sourceLabelFor(src): true})
+	return composeResolverSeen(resolver, src, []string{sourceLabelFor(src)})
 }
 
 // composeResolverSeen carries the labels already on the chain. A pakke that
 // reuses one that reuses it back would otherwise fetch the two forever; the
 // cycle is reported rather than silently cut, because either half of it is a
 // mistake someone has to fix in a committed file.
-func composeResolverSeen(resolver *SourceResolver, src *Source, seen map[string]bool) (*SourceResolver, *Source, error) {
+//
+// Membership is sameSourceRepo, not string equality: "Navikt/A" and "navikt/a"
+// are one repo, and two spellings of the same path are one directory. With
+// plain equality a pakke could name itself in a different case and be chained
+// to itself, and a cycle went one fetch further before it was noticed.
+func composeResolverSeen(resolver *SourceResolver, src *Source, seen []string) (*SourceResolver, *Source, error) {
 	decl, err := agentpakke.LoadDeclaration(src.Dir)
 	if err != nil {
 		if errors.Is(err, agentpakke.ErrNoDeclaration) {
@@ -64,15 +69,17 @@ func composeResolverSeen(resolver *SourceResolver, src *Source, seen map[string]
 	// ship a manifest, not a composition. Chaining it to itself would resolve
 	// every artifact twice and, at a different revision, shadow the checkout
 	// being installed with an older copy of itself.
-	if decl.Source == sourceLabelFor(src) {
+	if sameSourceRepo(decl.Source, sourceLabelFor(src)) {
 		return resolver, nil, nil
 	}
 
-	if seen[decl.Source] {
-		return nil, nil, fmt.Errorf("agentpakke %s reuses %q, which already reuses it back.\nA reuse cycle has no order to resolve in, so nothing was installed.\nBreak the cycle in %s in one of the two repos",
-			sourceLabelFor(src), decl.Source, agentpakke.DeclarationPath)
+	for _, s := range seen {
+		if sameSourceRepo(s, decl.Source) {
+			return nil, nil, fmt.Errorf("agentpakke %s reuses %q, which already reuses it back.\nA reuse cycle has no order to resolve in, so nothing was installed.\nBreak the cycle in %s in one of the two repos",
+				sourceLabelFor(src), decl.Source, agentpakke.DeclarationPath)
+		}
 	}
-	seen[decl.Source] = true
+	seen = append(seen, decl.Source)
 
 	// A repo-shaped reuse without a pin would clone whatever main happens to
 	// hold, so two installs a week apart would compose different content while

--- a/cli/nav-pilot/internal/cli/compose_test.go
+++ b/cli/nav-pilot/internal/cli/compose_test.go
@@ -155,29 +155,12 @@ func TestUnpinnedLocalPathReuseIsAllowed(t *testing.T) {
 	}
 }
 
-// Sync må løse den samme gjenbruken install løste. Uten det slutter hvert
-// arvede artefakt å resolve så snart installasjonen er over, og sync ser en
-// sporet fil kilden ikke lenger sender, altså formen på et pensjonert
-// artefakt.
-func TestSyncResolverComposesToo(t *testing.T) {
-	baseDir, ownDir := t.TempDir(), t.TempDir()
-	writePakke(t, baseDir, "basepakke", "felles")
-	writePakke(t, ownDir, "egenpakke", "eget")
-	declareReuse(t, ownDir, baseDir)
-
-	src := loadSource(t, ownDir)
-	state := &StateFile{Collection: "egenpakke"}
-	resolver, reused, err := composeResolver(resolverForState(src, state), src)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if reused == nil {
-		t.Fatal("sync-resolveren gjenbrukte ingenting")
-	}
-	if _, ok := resolver.Get(KindAgent, "felles"); !ok {
-		t.Error("det arvede artefaktet resolver ikke under sync, og ville blitt lest som pensjonert")
-	}
-}
+// Sync-komposisjonen er dekket i e2e/golden_path_test.go, ikke her.
+//
+// Testen som sto på dette stedet kalte composeResolver selv i stedet for å
+// kjøre sync, altså gjentok den det sync gjør. Den passerte med kallet fjernet
+// fra sync.go, som er nøyaktig defekten den ble skrevet for å fange. En test
+// som ikke kan feile er verre enn ingen, fordi den ser ut som dekning.
 
 // En kilde uten manifest komponerer ikke, selv om den skulle ha en erklæring
 // liggende. Ellers ville en collection-kilde hentet et fremmed repo midt i en

--- a/cli/nav-pilot/internal/cli/compose_test.go
+++ b/cli/nav-pilot/internal/cli/compose_test.go
@@ -231,3 +231,33 @@ func TestSelfReferenceResolvesPathSpelling(t *testing.T) {
 		t.Errorf("pakka ble kjedet til seg selv via %q", reused.Dir)
 	}
 }
+
+// En payload-pakke har ingen filer å arve fra: leveringsenheten er en
+// digest-bundet revisjon, ikke filer på stier. Å komponere den meldte
+// «Reuses:» og bidro så med ingenting, altså en påstand install ikke kunne
+// innfri.
+func TestPayloadOnlyBaseIsRefused(t *testing.T) {
+	baseDir, ownDir := t.TempDir(), t.TempDir()
+	if err := os.MkdirAll(filepath.Join(baseDir, ".nav-pilot"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(baseDir, "plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	payloadManifest := `{"contractVersion":"1","name":"t2base","description":"payload",` +
+		`"clients":{"copilot":{"payloads":{"full":{"path":"plugin","primaryAgents":["x"]}}}}}`
+	if err := os.WriteFile(filepath.Join(baseDir, ".nav-pilot", "agentpakke.json"), []byte(payloadManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writePakke(t, ownDir, "egenpakke", "eget")
+	declareReuse(t, ownDir, baseDir)
+
+	src := loadSource(t, ownDir)
+	_, reused, err := composeResolver(resolverFor(src.Dir, src.Pakke), src)
+	if err == nil {
+		t.Fatalf("en payload-pakke ble godtatt som base, gjenbrukt = %v", reused)
+	}
+	if !strings.Contains(err.Error(), "Tier 2") {
+		t.Errorf("feilmeldinga sier ikke hvorfor: %v", err)
+	}
+}

--- a/cli/nav-pilot/internal/cli/compose_test.go
+++ b/cli/nav-pilot/internal/cli/compose_test.go
@@ -188,3 +188,46 @@ func TestLegacySourceDoesNotCompose(t *testing.T) {
 		t.Errorf("en manifestløs kilde komponerte %s", reused.Dir)
 	}
 }
+
+// Selvreferansen og syklusvakta sammenlikner kilder med sameSourceRepo, ikke
+// med ren likhet. "Navikt/A" og "navikt/a" er ett repo, og to skrivemåter av
+// samme sti er én katalog. Med ren likhet kunne en pakke navngi seg selv i en
+// annen bokstavstørrelse og bli kjedet til seg selv.
+func TestSelfReferenceIsCaseInsensitive(t *testing.T) {
+	dir := t.TempDir()
+	writePakke(t, dir, "egen", "eget")
+	// Erklæringa navngir repoet med annen bokstavstørrelse enn kildelabelen.
+	body := `{"contractVersion":"1","source":"NAVIKT/Grillmester","sha":"` + strings.Repeat("a", 40) + `"}`
+	if err := os.WriteFile(filepath.Join(dir, ".nav-pilot", "agentpakke.lock.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	src := loadSource(t, dir)
+	src.Repo = "navikt/grillmester"
+
+	_, reused, err := composeResolver(resolverFor(src.Dir, src.Pakke), src)
+	if err != nil {
+		t.Fatalf("komposisjonen feilet: %v", err)
+	}
+	if reused != nil {
+		t.Errorf("pakka ble kjedet til seg selv via %q", reused.Repo)
+	}
+}
+
+// En sti skrevet med etterslept skråstrek er den samme katalogen.
+func TestSelfReferenceResolvesPathSpelling(t *testing.T) {
+	dir := t.TempDir()
+	writePakke(t, dir, "egen", "eget")
+	body := `{"contractVersion":"1","source":"` + dir + `/"}`
+	if err := os.WriteFile(filepath.Join(dir, ".nav-pilot", "agentpakke.lock.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	src := loadSource(t, dir)
+
+	_, reused, err := composeResolver(resolverFor(src.Dir, src.Pakke), src)
+	if err != nil {
+		t.Fatalf("komposisjonen feilet: %v", err)
+	}
+	if reused != nil {
+		t.Errorf("pakka ble kjedet til seg selv via %q", reused.Dir)
+	}
+}

--- a/cli/nav-pilot/internal/cli/declaration.go
+++ b/cli/nav-pilot/internal/cli/declaration.go
@@ -237,7 +237,7 @@ func recordDeclaration(scope *InstallScope, src *Source) {
 // Sync does not create the file (that is install's job, which is where the
 // source is actually chosen) and does not repoint one at a different
 // agentpakke, which is an install too.
-func bumpDeclarationSHA(scope *InstallScope, src *Source) {
+func bumpDeclarationSHA(scope *InstallScope, src *Source, quiet bool) {
 	d, err := scopeDeclaration(scope)
 	if err != nil {
 		// Say so. A declaration nav-pilot cannot read is one it stops
@@ -268,6 +268,11 @@ func bumpDeclarationSHA(scope *InstallScope, src *Source) {
 	if err := agentpakke.WriteDeclaration(scope.RootDir, d); err != nil {
 		fmt.Fprintf(os.Stderr, "%s Could not bump the pinned revision in %s: %v\n",
 			yellow("⚠"), agentpakke.DeclarationPath, err)
+		return
+	}
+	if quiet {
+		// --json encodes the document to this same stdout, so a success line
+		// here would sit after it and make the output unparseable.
 		return
 	}
 	fmt.Printf("%s Bumped %s: %s → %s. Commit it to share the update.\n",

--- a/cli/nav-pilot/internal/cli/declaration_test.go
+++ b/cli/nav-pilot/internal/cli/declaration_test.go
@@ -506,7 +506,7 @@ func TestSyncSaysSoWhenTheDeclarationCannotBeRead(t *testing.T) {
 
 	src := &Source{Dir: t.TempDir(), SHA: strings.Repeat("a", 40), Repo: defaultSourceRepo}
 
-	err := captureStderrFor(t, func() { bumpDeclarationSHA(scope, src) })
+	err := captureStderrFor(t, func() { bumpDeclarationSHA(scope, src, false) })
 	if !strings.Contains(err, agentpakke.DeclarationPath) {
 		t.Errorf("bumpDeclarationSHA skipped an unreadable declaration without a word:\n%s", err)
 	}

--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -604,7 +604,7 @@ func cmdInstallFromSource(collection string, src *Source, scope *InstallScope, d
 		SourceRepo:  src.Repo,
 		SourceSHA:   src.SHA,
 		InstalledAt: timeNow().UTC().Format("2006-01-02T15:04:05Z07:00"),
-		Files:       stampRevision(result.Files, src.SHA),
+		Files:       stampRevision(result.Files, src.SHA, inheritedPaths(resolver, scope, reused)),
 	}
 	// A re-install over a checked-in state file must not throw away the keys a
 	// newer nav-pilot put there; the fresh struct has none of them (#588). Nor
@@ -1007,7 +1007,7 @@ func installAllFromSource(scope *InstallScope, src *Source, manifest *Manifest, 
 		SourceRepo:  src.Repo,
 		SourceSHA:   src.SHA,
 		InstalledAt: timeNow().UTC().Format("2006-01-02T15:04:05Z07:00"),
-		Files:       stampRevision(result.Files, src.SHA),
+		Files:       stampRevision(result.Files, src.SHA, nil),
 	}
 
 	// Append items the user explicitly deselected in the picker as ignored.
@@ -1385,16 +1385,38 @@ func removeOrphans(scope *InstallScope, prior *StateFile, installed []InstalledF
 // Only files with content: an ignored entry has no bytes and therefore no
 // provenance, and stamping one would claim a revision put something on disk
 // that it never did.
-func stampRevision(files []InstalledFile, revision string) []InstalledFile {
+func stampRevision(files []InstalledFile, revision string, inherited func(string) bool) []InstalledFile {
 	if revision == "" {
 		return files
 	}
 	for i := range files {
-		if files[i].Hash != "" {
-			files[i].Revision = revision
+		if files[i].Hash == "" {
+			continue
 		}
+		// A file that came from a reused pakke did not come from this
+		// revision, and stamping it anyway made sync's "installed from <sha>"
+		// hint name a revision the file was never in. Leaving it empty says
+		// nothing extra, which is what the field is documented to do when it
+		// does not know (#729).
+		if inherited != nil && inherited(files[i].Path) {
+			continue
+		}
+		files[i].Revision = revision
 	}
 	return files
+}
+
+// inheritedPaths reports which installed paths came from a reused pakke rather
+// than from this source. Nil when nothing is reused, which is nearly always.
+func inheritedPaths(resolver *SourceResolver, scope *InstallScope, reused *Source) func(string) bool {
+	if reused == nil || resolver == nil {
+		return nil
+	}
+	return func(localPath string) bool {
+		rel := resolver.MapLocalPath(localPath, scope.IsUser())
+		root, ok := resolver.SourceRootFor(rel)
+		return ok && root != resolver.SourceDir()
+	}
 }
 
 // installedPrimaryAgent names the persona a user should reach for after an

--- a/cli/nav-pilot/internal/cli/retired.go
+++ b/cli/nav-pilot/internal/cli/retired.go
@@ -104,6 +104,15 @@ func findRetiredOrphans(scope *InstallScope, sourceDir string, pakke *agentpakke
 			continue
 		}
 		local := scope.DstPath(kind.Dir, file)
+		// The schema forbids a path that leaves the repo, and this refuses one
+		// again. A record is a third party's file and this loop ends in a
+		// delete, so the containment check belongs next to the removal and not
+		// only in the validator: with validation alone, a record naming
+		// "agents/../../x" resolved to a real file outside the scope and was
+		// reported as an orphan to remove.
+		if !withinScope(scope, local) {
+			continue
+		}
 		data, err := os.ReadFile(local)
 		if err != nil {
 			continue
@@ -315,4 +324,25 @@ func sameRevision(a, b string) bool {
 		return false
 	}
 	return strings.EqualFold(short, long[:len(short)])
+}
+
+// withinScope reports whether a path stays inside the scope's root once
+// symlinks and "." / ".." are resolved.
+func withinScope(scope *InstallScope, path string) bool {
+	root, err := filepath.EvalSymlinks(scope.RootDir)
+	if err != nil {
+		root = filepath.Clean(scope.RootDir)
+	}
+	// The file itself may not exist yet, so resolve the deepest parent that
+	// does and re-attach the rest.
+	cleaned := filepath.Clean(path)
+	resolved := cleaned
+	if p, err := filepath.EvalSymlinks(filepath.Dir(cleaned)); err == nil {
+		resolved = filepath.Join(p, filepath.Base(cleaned))
+	}
+	rel, err := filepath.Rel(root, resolved)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }

--- a/cli/nav-pilot/internal/cli/retired.go
+++ b/cli/nav-pilot/internal/cli/retired.go
@@ -177,10 +177,17 @@ func kindForPath(srcPath string, layout *agentpakke.Layout) (*source.ArtifactKin
 func removeRetiredOrphans(scope *InstallScope, orphans []retiredOrphan, quiet bool) int {
 	removed := 0
 	for _, o := range orphans {
-		if err := os.Remove(o.Local); err != nil && !os.IsNotExist(err) {
+		err := os.Remove(o.Local)
+		if err != nil && !os.IsNotExist(err) {
 			if !quiet {
 				fmt.Printf("  %s %s could not be removed: %v\n", yellow("⚠"), o.Path, err)
 			}
+			continue
+		}
+		// A file the deletion pass already took is not one this pass removed.
+		// Counting it here reported the same artifact twice: once as deleted
+		// upstream and again as retired.
+		if os.IsNotExist(err) {
 			continue
 		}
 		afterArtifactRemoved(scope, o.Local, quiet)

--- a/cli/nav-pilot/internal/cli/retired_test.go
+++ b/cli/nav-pilot/internal/cli/retired_test.go
@@ -510,3 +510,60 @@ func TestSyncItselfReportsIgnoredButInstalled(t *testing.T) {
 		t.Errorf("sync nevnte ikke %q, som er både ignorert og installert:\n%s", marked, out)
 	}
 }
+
+// En record kan ikke nå en fil utenfor scopet.
+//
+// De seks tilfellene i TestRetiredRecordIsValidatedAgainstTheSchema gir 0
+// orphans også uten validering, fordi kindForPath og blob-sammenlikninga
+// avviser dem uansett, så hele valideringa kunne fjernes uten at noe merket
+// det. Denne bruker en sti som treffer en ekte fil utenfor scopet: med
+// skjemaet slått av ga den før 1 orphan som pekte dit, og løkka ender i en
+// sletting.
+//
+// Nå står to vakter der, skjemaet og withinScope, og hver av dem holder alene.
+// Det er med vilje: en record er en tredjeparts fil, og en slettesti skal ikke
+// hvile på ett lag. Testen måler egenskapen, ikke hvilken av dem som fanget
+// den.
+func TestRetiredRecordCannotReachOutsideTheScope(t *testing.T) {
+	scope, _ := userScopeWithAgents(t)
+
+	// En fil utenfor scopet, med innhold vi kjenner hashen til.
+	outside := filepath.Join(t.TempDir(), "utenfor.md")
+	body := []byte("dette ligger utenfor scopet\n")
+	if err := os.WriteFile(outside, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rel, err := filepath.Rel(scope.DstPath(KindAgent.Dir), outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(rel, "..") {
+		t.Fatalf("stien %q peker ikke ut av scopet, da tester dette noe annet", rel)
+	}
+	// Satt sammen som streng, ikke med filepath.Join: Join rydder bort
+	// "agents/" foran "../..", og da avviser kindForPath stien før skjemaet
+	// rekker å bety noe. Denne formen beholder prefikset, så oppslaget lykkes
+	// og bare skjemaet står mellom recorden og en sletting utenfor scopet.
+	srcPath := KindAgent.Dir + "/" + filepath.ToSlash(rel)
+	if kind, file := kindForPath(srcPath, nil); kind == nil {
+		t.Fatalf("kindForPath avviste %q selv, da måler ikke testen skjemaet", srcPath)
+	} else if !strings.Contains(scope.DstPath(kind.Dir, file), filepath.Base(outside)) {
+		t.Fatalf("stien løser ikke til fila utenfor scopet, da måler ikke testen skjemaet")
+	}
+
+	sourceDir := t.TempDir()
+	record := `{"paths":{"` + srcPath + `":["` + blobHash(body) + `"]}}`
+	if err := os.MkdirAll(filepath.Join(sourceDir, ".nav-pilot"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, ".nav-pilot", "retired-artifacts.json"), []byte(record), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if orphans := findRetiredOrphans(scope, sourceDir, nil); len(orphans) != 0 {
+		t.Errorf("en record med sti ut av scopet ga %d orphans, ventet 0: %+v", len(orphans), orphans)
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Errorf("fila utenfor scopet ble rørt: %v", err)
+	}
+}

--- a/cli/nav-pilot/internal/cli/retired_test.go
+++ b/cli/nav-pilot/internal/cli/retired_test.go
@@ -349,7 +349,7 @@ func TestRevisionIsRecordedAndSurfaced(t *testing.T) {
 			// Stamping one would claim a revision put something on disk.
 			{Path: "agents/b.agent.md", Status: fileStatusIgnored},
 		}
-		got := stampRevision(files, "def5678")
+		got := stampRevision(files, "def5678", nil)
 		if got[0].Revision != "def5678" {
 			t.Errorf("written file revision = %q, want def5678", got[0].Revision)
 		}

--- a/cli/nav-pilot/internal/cli/retired_test.go
+++ b/cli/nav-pilot/internal/cli/retired_test.go
@@ -469,3 +469,44 @@ func TestRetiredPathMatchesTheContract(t *testing.T) {
 		t.Errorf("the reader opens %q while the contract publishes %q", retiredManifestPath, agentpakke.RetiredRecordPath)
 	}
 }
+
+// #724-rapporten må komme ut av sync, ikke bare ut av hjelperen.
+//
+// TestIgnoredButInstalled kaller ignoredButInstalled direkte, så den passerer
+// også når sync ikke kaller den: hele rapporten kunne fjernes fra sync.go uten
+// at noen test merket det. Denne kjører kommandoen.
+func TestSyncItselfReportsIgnoredButInstalled(t *testing.T) {
+	isolatedConfig(t)
+	repo, first, _ := gitAgentpakke(t)
+	localAgentpakkeRemote(t, repo)
+
+	scope := ScopeRepo(repoTarget(t))
+	writeDeclaration(t, scope,
+		`{"contractVersion":"1","source":"navikt/grillmester","sha":"`+first+`"}`)
+	captureStdoutFor(t, func() {
+		if err := cmdInstallAuto("grillmester", "", scope, "", "", false, false, false); err != nil {
+			t.Fatalf("install: %v", err)
+		}
+	})
+
+	// Merk en installert fil som ignorert uten å fjerne den fra disk.
+	state, err := readScopedState(scope)
+	if err != nil || state == nil {
+		t.Fatalf("leste ikke staten: %v", err)
+	}
+	if len(state.Files) == 0 {
+		t.Fatal("installasjonen sporet ingen filer, da tester dette ingenting")
+	}
+	state.Files[0].Status = fileStatusIgnored
+	if err := writeScopedState(scope, state); err != nil {
+		t.Fatal(err)
+	}
+	marked := state.Files[0].Path
+
+	out := captureStdoutFor(t, func() {
+		_ = cmdSync(scope, "", "", false, false)
+	})
+	if !strings.Contains(out, marked) {
+		t.Errorf("sync nevnte ikke %q, som er både ignorert og installert:\n%s", marked, out)
+	}
+}

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -270,11 +270,16 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 		// with exit 0 let it rot in exactly the repos a scheduled workflow was
 		// supposed to keep fresh, because that workflow reads the exit code.
 		if pinBump != nil {
+			// The write comes first, so the document can report what actually
+			// happened rather than what was about to.
+			if apply {
+				bumpDeclarationSHA(scope, src, jsonOutput)
+			}
 			if jsonOutput {
-				if err := outputJSON(syncResult{Source: src.SHA, PinBump: pinBump}); err != nil {
+				if err := outputJSON(syncResult{UpToDate: apply, Source: src.SHA, PinBump: pinBump}); err != nil {
 					return err
 				}
-			} else {
+			} else if !apply {
 				fmt.Printf("%s %s pins %s and the source is at %s (source: %s)\n\n",
 					yellow("⚠"), bold(agentpakke.DeclarationPath),
 					shortSHA(pinBump.From), shortSHA(pinBump.To), shortSHA(src.SHA))
@@ -282,7 +287,6 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 			if !apply {
 				return errUpdatesAvailable
 			}
-			bumpDeclarationSHA(scope, src)
 			return nil
 		}
 		if jsonOutput {
@@ -435,7 +439,7 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 		// said so — but a declaration that names a source and pins nothing still
 		// gets its pin filled in, and only --apply may write it.
 		if apply {
-			bumpDeclarationSHA(scope, src)
+			bumpDeclarationSHA(scope, src, jsonOutput)
 		}
 		// Bump state version so staleness check won't re-trigger for this release
 		if src.Version != "" {
@@ -578,7 +582,7 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 		removeRetiredOrphans(scope, retired, jsonOutput)
 	}
 	if applyErrors == 0 {
-		bumpDeclarationSHA(scope, src)
+		bumpDeclarationSHA(scope, src, jsonOutput)
 	}
 	if state, err := readScopedState(scope); err == nil && state != nil {
 		if applyErrors == 0 {

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -264,6 +264,27 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 			}
 			return errUpdatesAvailable
 		}
+		// A scope can declare a pin without having any files to sync: it may
+		// have ignored everything, or committed the declaration before the
+		// first install. The pin still moves, and reporting "nothing to do"
+		// with exit 0 let it rot in exactly the repos a scheduled workflow was
+		// supposed to keep fresh, because that workflow reads the exit code.
+		if pinBump != nil {
+			if jsonOutput {
+				if err := outputJSON(syncResult{Source: src.SHA, PinBump: pinBump}); err != nil {
+					return err
+				}
+			} else {
+				fmt.Printf("%s %s pins %s and the source is at %s (source: %s)\n\n",
+					yellow("⚠"), bold(agentpakke.DeclarationPath),
+					shortSHA(pinBump.From), shortSHA(pinBump.To), shortSHA(src.SHA))
+			}
+			if !apply {
+				return errUpdatesAvailable
+			}
+			bumpDeclarationSHA(scope, src)
+			return nil
+		}
 		if jsonOutput {
 			return outputJSON(syncResult{UpToDate: true, Source: src.SHA})
 		}

--- a/cli/nav-pilot/internal/cli/sync_pin_nofiles_test.go
+++ b/cli/nav-pilot/internal/cli/sync_pin_nofiles_test.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Et scope kan erklære en pinne uten å ha filer å synke: det har ignorert alt,
+// eller committet erklæringa før første install. Pinnen flytter seg likevel.
+//
+// Grenen for «ingen filer» leste aldri pendingPinBump, så sync meldte
+// «No customization files found to sync» og gikk ut med 0. En planlagt
+// workflow avgjør på exit-koden om den skal kjøre --apply, så pinnen råtnet
+// nettopp i de repoene workflowen fantes for å holde ferske.
+func TestSyncReportsAStalePinWithNoFilesInstalled(t *testing.T) {
+	isolatedConfig(t)
+	repo, first, second := gitAgentpakke(t)
+	localAgentpakkeRemote(t, repo)
+
+	scope := ScopeRepo(repoTarget(t))
+	writeDeclaration(t, scope,
+		`{"contractVersion":"1","source":"navikt/grillmester","sha":"`+first+`"}`)
+
+	// Ingen install: erklæringa står alene, slik den gjør i et repo som har
+	// committet pinnen men ikke installert noe ennå.
+	out := captureStdoutFor(t, func() {
+		err := cmdSync(scope, "", "", false, false)
+		if !errors.Is(err, errUpdatesAvailable) {
+			t.Errorf("sync ga %v, ventet errUpdatesAvailable for en foreldet pinne", err)
+		}
+	})
+	if strings.Contains(out, "No customization files found") {
+		t.Errorf("sync meldte at det ikke var noe å gjøre:\n%s", out)
+	}
+
+	// --apply skal flytte pinnen, ikke bare rapportere den.
+	captureStdoutFor(t, func() {
+		if err := cmdSync(scope, "", "", true, false); err != nil {
+			t.Fatalf("sync --apply: %v", err)
+		}
+	})
+	if got := readDeclaration(t, scope).SHA; got != second {
+		t.Errorf("pinnen står på %q, ventet %q", got, second)
+	}
+}


### PR DESCRIPTION
Enhetssuiten stubber sømmen alt går gjennom: 113 av filene erstatter
CloneRemoteFn, tre bruker git for ekte, én kjører binæren. Den kunne ikke
se noen av defektene som ble funnet 8. september, fordi hver av dem bor i
koblingen mellom komponenter og ikke inne i én.

Her stubbes ingenting. Binæren bygges, kildene er git-repoer, og
påstandene leser det som faktisk ligger på disk. HOME og NAV_PILOT_CONFIG
pekes per test, så en kjøring kan ikke røre utviklerens ~/.copilot eller
~/.nav-pilot/config.toml (#627).

Sakene er hentet fra defekter vi har hatt, ikke funnet på: komposisjon som
overlever sync, kollisjonsregelen, en driftet arvet fil som --apply må
hente fra pakka den kom fra, install i eget repo som ikke skal skrive om
erklæringa, og at --json fortsatt parser når sync rydder.

Hver av dem er verifisert ved å sette defekten tilbake:

- uten base-fallbacken i GetFile: «sync mente arvede filer var slettet
  oppstrøms», «sync --apply slettet det arvede artefaktet»
- uten selvinstall-vakta: erklæringa peker på egenpakke, ikke basen
- uten SourceRoot i syncUpdate: sync --apply gir kode 2

TestHarnessRunsTheRealBinary finnes fordi en harness som ikke kjører noe
ville gjort hver sak over tom.
