### PR TITLE
docs(news): cplt config-lagene forklart, og flere repoer i samme sesjon

### DIFF
--- a/docs/news/articles/cplt-lokal-config-og-flere-repoer.md
+++ b/docs/news/articles/cplt-lokal-config-og-flere-repoer.md
@@ -11,7 +11,13 @@ tags:
   - nav-pilot
 ---
 
-Kortversjonen: **Det prosjektet trenger (porter, docker, hemmeligheter som skal holdes ute), setter du med `cplt config set --repo …`. Det havner i `.cplt.toml`, som du committer. Det som bare er sant på din maskin (stier i hjemmekatalogen, et nested repo), setter du med `--local`. Global skal være liten. Start med `cplt init --write` i repoet, og sjekk resultatet med `cplt config show`.**
+Kortversjonen: **Det prosjektet trenger (porter, docker, hemmeligheter som skal holdes ute), setter du med `cplt config set --repo …`. Det havner i `.cplt.toml`, som du committer. Det som bare er sant på din maskin, setter du med `--local` — stier i hjemmekatalogen, og repoer du har sjekket ut inni prosjektet:**
+
+```sh
+cplt config set --local sandbox.repo_dirs ~/src/spleis/libs/sykepenger-model
+```
+
+**Global skal være liten. Start med `cplt init --write` i repoet, og sjekk resultatet med `cplt config show`.**
 
 Du starter agenten med [nav-pilot](/nav-pilot), og nav-pilot kjører den trygt i en sandbox. Første gang du merker [cplt](/cplt), er som regel når noe blir stoppet: Gradle får ikke lese `~/.gradle/gradle.properties`, Testcontainers finner ikke docker, `npm install` nekter å kjøre postinstall. Da må du justere sandboxen, og spørsmålet blir: skal innstillingen settes globalt, lokalt eller i repoet?
 

--- a/docs/news/articles/cplt-lokal-config-og-flere-repoer.md
+++ b/docs/news/articles/cplt-lokal-config-og-flere-repoer.md
@@ -11,17 +11,17 @@ tags:
   - nav-pilot
 ---
 
-Du starter agenter gjennom [nav-pilot](/nav-pilot), og nav-pilot kjører dem i [cplt](/cplt). Første gang du merker cplt er som regel når noe blir stoppet: Gradle får ikke lese `~/.gradle/gradle.properties`, Testcontainers finner ikke docker, `npm install` nekter å kjøre postinstall. Da må du justere sandboxen, og da dukker spørsmålet opp: skal innstillingen settes globalt, lokalt eller i repoet?
+Du starter agenten med [nav-pilot](/nav-pilot), og nav-pilot kjører den trygt i en sandbox. Første gang du merker [cplt](/cplt), er som regel når noe blir stoppet: Gradle får ikke lese `~/.gradle/gradle.properties`, Testcontainers finner ikke docker, `npm install` nekter å kjøre postinstall. Da må du justere sandboxen, og spørsmålet blir: skal innstillingen settes globalt, lokalt eller i repoet?
 
-Dette innlegget svarer på det, og viser hvordan du lar agenten jobbe mot to repoer i samme sesjon. Alt gjøres med `cplt config`. Du trenger ikke åpne en fil.
+Dette innlegget svarer på det, og viser hvordan du lar agenten jobbe mot to repoer i samme sesjon. Alt gjøres med `cplt config` uten at du trenger å redigere config-filer for hånd.
 
-Én ting er verdt å ta med seg med én gang: nav-pilot starter cplt for deg, så du har ingen kommandolinje å henge flagg på. Derfor er det lagret config som gjelder. Setter du det med `cplt config set --local`, plukker nav-pilot det opp neste gang du starter en agent, uten at du gjør noe mer.
+Setter du noe med `cplt config set --local`, plukker nav-pilot det opp neste gang du starter en agent.
 
 ---
 
 ## Fire lag
 
-cplt slår opp en innstilling i denne rekkefølgen. Første treff vinner for enkeltverdier; lister (`allow.read`, `allow.write`, `allow.ports`, `allow.localhost`, `deny.paths`) slås sammen på tvers av lagene.
+cplt slår opp en innstilling i denne rekkefølgen. Første treff vinner for enkeltverdier. Lister (`allow.read`, `allow.write`, `allow.ports`, `allow.localhost`, `deny.paths`) slås sammen på tvers av lagene.
 
 | Lag | Gjelder for | Settes med | Ligger i |
 | --- | --- | --- | --- |
@@ -30,10 +30,10 @@ cplt slår opp en innstilling i denne rekkefølgen. Første treff vinner for enk
 | **Global** | hele maskinen din | `cplt config set …` | `~/.config/cplt/config.toml` |
 | Defaults | alle | preset `standard` | innebygd |
 
-`.cplt.toml` i repoet er et femte sted, men det står utenfor rekkefølgen over og har sin egen tillitsmodell. Det er teamets fil, ikke din:
+`.cplt.toml` i repoet er et femte sted, men det står utenfor rekkefølgen over og har sin egen tillitsmodell. Det er teamets innstillinger for den aktuelle applikasjonen:
 
-- `[deny]` slår inn med en gang. Repoet kan alltid stramme inn.
-- `[propose]` er forslag om å utvide, og krever at hver utvikler godkjenner med `cplt trust`. Godkjenningen er bundet til innholdet i fila; endres fila, må du godkjenne på nytt.
+- `[deny]` gjelder med en gang. Repoet kan alltid stramme inn.
+- `[propose]` er forslag om å utvide, og hver utvikler må godkjenne dem med `cplt trust`. Godkjenningen er bundet til innholdet i fila. Endres fila, må du godkjenne på nytt.
 - cplt leser fila fra git HEAD, ikke fra working tree. Agenten kan altså ikke redigere sin egen sandbox-config og få det til å gjelde.
 
 Regelen for å velge lag er ett spørsmål: **hvem gjelder dette for?**
@@ -43,21 +43,21 @@ Regelen for å velge lag er ett spørsmål: **hvem gjelder dette for?**
 - Meg, uansett hvilket repo jeg står i → global
 - Ingen spesielle → la default stå
 
-Nesten alt du trenger å justere havner i **local**.
+Nesten alt du trenger å justere, havner i **local**.
 
 ---
 
 ## Hvorfor local, og ikke global
 
-Det fristende er å sette alt globalt, så slipper du å gjøre det igjen. Ikke gjør det. En grant i global følger deg inn i hver eneste sesjon, også i repoer der stien betyr noe helt annet. Gir du `~/.gradle/gradle.properties` globalt, kan en agent i et Node-prosjekt lese GitHub Packages-tokenet ditt, uten å ha noen grunn til det. Setter du det lokalt, gjelder det bare den Kotlin-tjenesten som faktisk bygger med Gradle.
+Det er fristende å sette alt globalt, så slipper du å gjøre det igjen. Ikke gjør det. En grant i global følger deg inn i hver eneste sesjon, også i repoer der stien betyr noe helt annet. Gir du `~/.gradle/gradle.properties` globalt, kan en agent i et Node-prosjekt lese GitHub Packages-tokenet ditt uten å ha noen grunn til det. Setter du det lokalt, gjelder det bare den Kotlin-tjenesten som faktisk bygger med Gradle.
 
-Global skal være liten: ting som er sanne for maskinen din uansett prosjekt. Signerer du commits med GPG, er det et godt eksempel — det følger deg, ikke prosjektet:
+Global skal være liten: ting som er sanne for maskinen din uansett prosjekt. Signerer du commits med GPG, er det et godt eksempel. Det følger deg, ikke prosjektet:
 
 ```sh
 cplt config set sandbox.allow_gpg_signing true --force
 ```
 
-Det leder til et rimelig spørsmål: hvorfor får local lov til å utvide sandboxen i det hele tatt, når repo-config må be om godkjenning for det samme? Fordi local-fila ligger utenfor repoet, i `~/.config/cplt/`, og sandboxen nekter skriving dit. Agenten kan ikke skrive sine egne grants. En fil i working tree kunne ikke lovet det, og derfor må alt som utvider i `.cplt.toml` gjennom `cplt trust`.
+Da kan du lure på hvorfor local får utvide sandboxen i det hele tatt, når repo-config må be om godkjenning for det samme. Svaret er at local-fila ligger utenfor repoet, i `~/.config/cplt/`, og sandboxen nekter skriving dit. Agenten kan ikke skrive sine egne grants. En fil i working tree kan ikke love det samme, og derfor må alt som utvider i `.cplt.toml` gjennom `cplt trust`.
 
 ---
 
@@ -71,25 +71,25 @@ cplt config set --local allow.read ~/.gradle/gradle.properties
 
 Finnes ikke fila ennå, får du en advarsel, men verdien lagres likevel.
 
-**Testcontainers trenger docker.** Docker-tilgang svekker sandboxen, så cplt nekter uten `--force` og forteller deg nøyaktig hvilken kommando som trengs:
+**Testcontainers trenger docker.** Docker-tilgang svekker sandboxen, så cplt nekter uten `--force` og forteller deg nøyaktig hvilken kommando du trenger:
 
 ```sh
 cplt config set --local sandbox.allow_docker true --force
 ```
 
-**Node-appen kjører på en localhost-port.** Localhost er blokkert som standard. Trenger bare du det, er det local:
+**Node-appen kjører på en localhost-port.** Localhost er blokkert som standard. Er det bare du som trenger porten, er det local:
 
 ```sh
 cplt config set --local allow.localhost 3000
 ```
 
-Trenger hele teamet det, hører det hjemme i `.cplt.toml`. Den skriver du også med en kommando:
+Trenger hele teamet den, hører den hjemme i `.cplt.toml`. Den setter du også med en kommando:
 
 ```sh
 cplt config set --repo allow.localhost 3000
 ```
 
-Verdien havner under `[propose]`, og cplt minner deg på begge stegene som gjenstår: `cplt trust accept --all` for å godkjenne på din egen maskin, og en commit av `.cplt.toml` så resten av teamet får den.
+Verdien havner under `[propose]`, og cplt minner deg på de to stegene som gjenstår: `cplt trust accept --all` for å godkjenne på din egen maskin, og en commit av `.cplt.toml` så resten av teamet får den.
 
 Skal du sette opp et repo fra bunnen, skanner `cplt init` prosjektet og skriver fila for deg:
 
@@ -104,9 +104,9 @@ cplt init --write    # skriv .cplt.toml, commit den
 cplt config set --local sandbox.allow_lifecycle_scripts true --force
 ```
 
-**Agenten skal pushe en feature branch.** Ingenting. Preset `standard` har git guard på i block-modus og beskytter bare default branch. Push til feature branch går, push til main stoppes.
+**Agenten skal pushe en feature branch.** Ingenting å gjøre. Preset `standard` har git guard på i block-modus og beskytter bare default branch. Push til feature branch går, push til main stoppes.
 
-**git-oppsettet ditt** i `~/.gitconfig` er sant for maskinen din, ikke ett prosjekt. Global, altså uten `--local`:
+**git-oppsettet ditt** i `~/.gitconfig` gjelder maskinen din, ikke ett prosjekt. Global, altså uten `--local`:
 
 ```sh
 cplt config set allow.read ~/.gitconfig
@@ -123,7 +123,7 @@ cplt config path --local            # hvor local-fila for denne checkouten ligge
 cplt config local list              # alle prosjekter du har local-config for
 ```
 
-Merk at listeverdier vises sammenslått uten lag-merking, så en `allow.read` du satte lokalt får ikke `(local)` etter seg i `config show`.
+Listeverdier vises sammenslått uten lag-merking. En `allow.read` du satte lokalt, får derfor ikke `(local)` etter seg i `config show`.
 
 Ved oppstart viser cplt hvilken local-fil som er i bruk. `Local:`-raden vises bare når en slik fil faktisk gjelder:
 
@@ -136,7 +136,7 @@ Ved oppstart viser cplt hvilken local-fil som er i bruk. `Local:`-raden vises ba
 
 ## Flere repoer i samme sesjon
 
-Et typisk oppsett: `navikt/spleis` har `navikt/sykepenger-model` sjekket ut under `libs/` i samme tre. Agenten kan allerede lese og skrive filene i `libs/sykepenger-model`, fordi prosjektkatalogen er gitt som ett subtre. Det den ikke kan, er å behandle det nested repoet som *et repo*: gh guard slipper bare gjennom skriveoperasjoner mot repoet du startet i, så `gh pr create -R navikt/sykepenger-model` stoppes.
+Et typisk oppsett: `navikt/spleis` har `navikt/sykepenger-model` sjekket ut under `libs/` i samme tre. Agenten kan allerede lese og skrive filene i `libs/sykepenger-model`, fordi prosjektkatalogen er gitt som ett subtre. Det den ikke kan, er å behandle det nested repoet som *et repo*. gh guard slipper bare gjennom skriveoperasjoner mot repoet du startet i, så `gh pr create -R navikt/sykepenger-model` stoppes.
 
 `sandbox.repo_dirs` fikser det. Du navngir repoet, og det får identitet i sesjonen:
 
@@ -152,15 +152,15 @@ Stien må være absolutt eller starte med `~/`. Ved neste oppstart viser cplt be
    navikt/sykepenger-model  ~/src/spleis/libs/sykepenger-model   local config
 ```
 
-Nå kan agenten opprette PR-er mot `navikt/sykepenger-model`. Merk hva som *ikke* skjedde: det ble ikke gitt noen ny filtilgang. Å navngi et repo handler om identitet, ikke om tilgang.
+Nå kan agenten opprette PR-er mot `navikt/sykepenger-model`. Legg merke til at agenten ikke fikk noen ny filtilgang. Å navngi et repo gir identitet, ikke tilgang.
 
-Kjører du cplt direkte og bare vil prøve, finnes flagget. Det gjelder for den ene kjøringen og skriver ingenting til fila, og det kommer i tillegg til det som allerede er lagret, ikke i stedet for:
+Kjører du cplt direkte og bare vil prøve, finnes det et flagg. Det gjelder for den ene kjøringen og skriver ingenting til fila. Flagget kommer i tillegg til det som allerede er lagret, ikke i stedet for:
 
 ```sh
 cplt --repo-dir ~/src/spleis/libs/sykepenger-model exec -- ./gradlew build
 ```
 
-Går du via nav-pilot, er `--local` den eneste veien; det er ingen kommandolinje å sette flagget på.
+Går du via nav-pilot, er `--local` den eneste veien. Der er det ingen kommandolinje å sette flagget på.
 
 ### Bare nested, ikke sibling
 
@@ -172,28 +172,28 @@ Repoet må ligge inni prosjektkatalogen. Ligger `sykepenger-model` som `~/src/sy
   sibling repositories are not yet supported; use `--allow-write` for edit-only.
 ```
 
-Dagens svar for sibling-repoer er `--allow-write`: agenten får redigere filene, men ikke gh-identitet mot repoet.
+For sibling-repoer er svaret i dag `--allow-write`. Agenten får redigere filene, men ikke gh-identitet mot repoet:
 
 ```sh
 cplt --allow-write ~/src/sykepenger-model
 ```
 
-Å starte fra `~/src` med `--project-dir` er ikke en omvei rundt dette. `--repo-dir` krever at du starter fra toppen av et git-repo, og en katalog som bare inneholder repoer er ikke det. Ordentlig sibling-støtte er [navikt/cplt#344](https://github.com/navikt/cplt/issues/344).
+Du kommer ikke rundt dette ved å starte fra `~/src` med `--project-dir`. `--repo-dir` krever at du starter fra toppen av et git-repo, og en katalog som bare inneholder repoer er ikke det. Ordentlig sibling-støtte er [navikt/cplt#344](https://github.com/navikt/cplt/issues/344).
 
-Å navngi repoet du startet i, nektes også; det er alltid i scope.
+Du får heller ikke navngi repoet du startet i. Det er alltid i scope.
 
 ### Local, og bare local
 
 `sandbox.repo_dirs` kan bare settes med `--local`. De to andre lagene nekter, med hver sin begrunnelse:
 
-- Global: en repo-liste i global config ville hengt seg på hver eneste sesjon. Det er per prosjekt, ikke per maskin.
-- Repo-config: å utnevne andre trær til prosjektnivå er en path grant, og repo-config kan ikke gi stier. Det er en per-checkout brukerinnstilling.
+- Global: en repo-liste i global config ville hengt seg på hver eneste sesjon. Dette er per prosjekt, ikke per maskin.
+- Repo-config: å løfte andre trær til prosjektnivå er en path grant, og repo-config kan ikke gi stier. Det er en per-checkout brukerinnstilling.
 
 Det passer regelen fra toppen: dette gjelder deg, i denne checkouten.
 
 ### Sjekkes på nytt hver gang
 
-Local-fila kan være uker gammel, og treet den peker på kan agenten skrive til. Derfor sjekker cplt hver lagrede oppføring ved *hver* oppstart, ikke bare når du skriver den. Oppstarten stopper, i stedet for å stille droppe oppføringen, hvis den
+Local-fila kan være uker gammel, og treet den peker på kan agenten skrive til. Derfor sjekker cplt hver lagrede oppføring ved *hver* oppstart, ikke bare når du skriver den. Er noe galt, stopper oppstarten i stedet for å droppe oppføringen i stillhet. Det skjer hvis oppføringen
 
 - ikke er toppen av et git-repo
 - ikke ligger inni prosjektkatalogen
@@ -201,7 +201,7 @@ Local-fila kan være uker gammel, og treet den peker på kan agenten skrive til.
 - inneholder `..`
 - er hjemmekatalogen eller en annen utrygg rot
 
-Feilmeldingen sier hvilken fil oppføringen kom fra, så du vet hva du skal rydde. Det finnes ingen `cplt config unset`; fjerning er `config set … --unset`:
+Feilmeldingen sier hvilken fil oppføringen kom fra, så du vet hva du skal rydde. Det finnes ingen `cplt config unset`. Du fjerner med `config set … --unset`:
 
 ```sh
 cplt config set --local sandbox.repo_dirs ~/src/spleis/libs/sykepenger-model --unset   # fjern ett element
@@ -212,7 +212,7 @@ cplt config set --local sandbox.repo_dirs --unset                               
 
 ## Flyttet eller byttet checkout
 
-Local-fila husker hvilken `origin` den ble skrevet for. Står det et annet repo på samme sti nå, advarer cplt (også med `--quiet`) og bruker ingenting fra fila. Vil du ta den i bruk igjen, setter du en hvilken som helst nøkkel med `--local` på nytt. En checkout du har flyttet etterlater en foreldreløs fil; `cplt config local list` viser den som «path no longer exists».
+Local-fila husker hvilken `origin` den ble skrevet for. Står det et annet repo på samme sti nå, advarer cplt (også med `--quiet`) og bruker ingenting fra fila. Vil du ta den i bruk igjen, setter du en hvilken som helst nøkkel med `--local` på nytt. En checkout du har flyttet, etterlater en foreldreløs fil. `cplt config local list` viser den som «path no longer exists».
 
 ---
 

--- a/docs/news/articles/cplt-lokal-config-og-flere-repoer.md
+++ b/docs/news/articles/cplt-lokal-config-og-flere-repoer.md
@@ -66,9 +66,10 @@ cplt config set sandbox.allow_gpg_signing true --force
 
 ## Repoet må be om én ting om gangen
 
-Grensen mellom repo og local er ikke bare en konvensjon. Noen nøkler nekter `.cplt.toml` å ta imot, og sier hvorfor. Prøver du å sette `sandbox.preset` med `--repo`, får du:
+Grensen mellom repo og local er ikke bare en konvensjon. Noen nøkler nekter `.cplt.toml` å ta imot, og sier hvorfor:
 
 ```
+$ cplt config set --repo sandbox.preset permissive
 [cplt] sandbox.preset is not valid in repo config.
   Reason: composes multiple dangerous permissions (docker, tmp exec, ...). A repo must request individual keys so each can be reviewed and trusted.
 ```
@@ -181,10 +182,10 @@ Repoet må ligge inni prosjektkatalogen. Ligger `sykepenger-model` som `~/src/sy
   sibling repositories are not yet supported; use `--allow-write` for edit-only.
 ```
 
-For sibling-repoer er svaret i dag `--allow-write`. Agenten får redigere filene, men ikke gh-identitet mot repoet:
+For sibling-repoer er svaret i dag `allow.write`. Agenten får redigere filene, men ikke gh-identitet mot repoet:
 
 ```sh
-cplt --allow-write ~/src/sykepenger-model
+cplt config set --local allow.write ~/src/sykepenger-model
 ```
 
 Å starte fra `~/src` med `--project-dir` hjelper ikke; `--repo-dir` krever at du starter fra toppen av et git-repo. Ordentlig sibling-støtte er [navikt/cplt#344](https://github.com/navikt/cplt/issues/344). Repoet du startet i, kan du heller ikke navngi. Det er alltid i scope.

--- a/docs/news/articles/cplt-lokal-config-og-flere-repoer.md
+++ b/docs/news/articles/cplt-lokal-config-og-flere-repoer.md
@@ -178,23 +178,40 @@ Nøkkelen kan bare settes med `--local`. Global nekter, fordi en repo-liste der 
 
 Kjører du cplt direkte, gjør flagget `--repo-dir <sti>` det samme for én kjøring, i tillegg til det som er lagret. Går du via nav-pilot, er `--local` den eneste veien.
 
-### Bare nested, ikke sibling
+### Repoet må ligge inni prosjektkatalogen
 
-Repoet må ligge inni prosjektkatalogen. Ligger `sykepenger-model` som `~/src/sykepenger-model`, ved siden av `spleis`, får du nei:
+Dette er begrensningen som svir, og vi skal være ærlige om den: et repo du vil navngi må være sjekket ut *inni* katalogen du starter fra. Ligger `sykepenger-model` på `~/src/sykepenger-model`, ved siden av `spleis`, får du nei.
 
-```
-[cplt] --repo-dir /path/to/sibling is outside the project directory
-  /path/to/launch-repo
-  sibling repositories are not yet supported; use `--allow-write` for edit-only.
-```
+De fleste av oss har repoene liggende side om side. Det betyr at funksjonen slik den står i dag treffer færre enn den burde.
 
-For sibling-repoer er svaret i dag `allow.write`. Agenten får redigere filene, men ikke gh-identitet mot repoet:
+Du kan få tilgang til filene, men ikke gh-identitet mot repoet:
 
 ```sh
 cplt config set --local allow.write ~/src/sykepenger-model
 ```
 
-Å starte fra `~/src` med `--project-dir` hjelper ikke; `--repo-dir` krever at du starter fra toppen av et git-repo. Ordentlig sibling-støtte er [navikt/cplt#344](https://github.com/navikt/cplt/issues/344). Repoet du startet i, kan du heller ikke navngi. Det er alltid i scope.
+Agenten kan da bygge og redigere der, men ikke opprette PR-er mot repoet.
+
+**Det som faktisk virker i dag** er å legge repoene inni et felles repo og starte derfra. Lag en katalog, `git init` i den, og sjekk ut repoene du jobber med under den:
+
+```sh
+mkdir ~/src/min-arbeidsflate && cd ~/src/min-arbeidsflate
+git init
+git clone git@github.com:navikt/spleis.git
+git clone git@github.com:navikt/sykepenger-model.git
+cplt config set --local sandbox.repo_dirs ~/src/min-arbeidsflate/spleis
+cplt config set --local sandbox.repo_dirs ~/src/min-arbeidsflate/sykepenger-model
+```
+
+Da får begge repoene identitet, og agenten kan opprette PR-er mot begge. Én ting må være på plass: den ytre katalogen må selv ha en GitHub-remote. Uten den klarer ikke cplt å fastslå hvilket repo sesjonen starter i, og da blokkeres alle gh-kommandoer som sjekkes mot scope — også mot de navngitte repoene.
+
+Det er en omvei, ikke en løsning. Den krever at du legger om hvordan du har sjekket ut kode, og det er ikke noe vi mener du bør måtte gjøre.
+
+**Vi er ikke i mål her.** Å la et repo utenfor prosjektkatalogen bli førsteklasses er ikke vanskelig i seg selv — sandkassa håndterer allerede den slags tilgang, og cplt kan allerede lese identiteten til en hvilken som helst katalog. Det som tar tid, er å få grensesnittet og sikkerhetsmodellen riktig samtidig: hvem som får peke ut hvilke repoer, hva som skjer når en katalog byttes ut under føttene på deg, og hvordan du ser hva agenten faktisk har lov til før du starter den. Vi har brukt uka på å tette hull der nettopp den slags var uklart, så vi tar den tiden.
+
+Målet er en ordentlig workspace-modell, der repoer som ligger side om side kan kobles sammen uten omveier. Følg [navikt/cplt#344](https://github.com/navikt/cplt/issues/344).
+
+Repoet du startet i, kan du forresten ikke navngi. Det er alltid i scope.
 
 ### Sjekkes på nytt hver gang
 

--- a/docs/news/articles/cplt-lokal-config-og-flere-repoer.md
+++ b/docs/news/articles/cplt-lokal-config-og-flere-repoer.md
@@ -1,0 +1,225 @@
+---
+title: "cplt: global, local eller repo, og flere repoer i samme sesjon"
+date: 2026-09-08
+author: starefossen
+category: praksis
+excerpt: "Fire config-lag i cplt, én regel for å velge riktig. Pluss sandbox.repo_dirs, som lar agenten jobbe mot et nested repo i samme sesjon."
+tags:
+  - cplt
+  - config
+  - sandbox
+  - nav-pilot
+---
+
+Du starter agenter gjennom nav-pilot, og nav-pilot kjører dem i [cplt](/cplt). Første gang du merker cplt er som regel når noe blir stoppet: Gradle får ikke lese `~/.gradle/gradle.properties`, Testcontainers finner ikke docker, `npm install` nekter å kjøre postinstall. Da må du justere sandboxen, og da dukker spørsmålet opp: skal innstillingen settes globalt, lokalt eller i repoet?
+
+Dette innlegget svarer på det, og viser hvordan du lar agenten jobbe mot to repoer i samme sesjon. Alt gjøres med `cplt config`. Du trenger ikke åpne en fil.
+
+---
+
+## Fire lag
+
+cplt slår opp en innstilling i denne rekkefølgen. Første treff vinner for enkeltverdier; lister (`allow.read`, `allow.write`, `allow.ports`, `allow.localhost`, `deny.paths`) slås sammen på tvers av lagene.
+
+| Lag | Gjelder for | Settes med | Ligger i |
+| --- | --- | --- | --- |
+| Flagg | denne ene kjøringen | `cplt --allow-write …` | ingenting lagres |
+| **Local** | én checkout | `cplt config set --local …` | `~/.config/cplt/local/<hash>.toml` |
+| **Global** | hele maskinen din | `cplt config set …` | `~/.config/cplt/config.toml` |
+| Defaults | alle | preset `standard` | innebygd |
+
+`.cplt.toml` i repoet er et femte sted, men det står utenfor rekkefølgen over og har sin egen tillitsmodell. Det er teamets fil, ikke din:
+
+- `[deny]` slår inn med en gang. Repoet kan alltid stramme inn.
+- `[propose]` er forslag om å utvide, og krever at hver utvikler godkjenner med `cplt trust`. Godkjenningen er bundet til innholdet i fila; endres fila, må du godkjenne på nytt.
+- cplt leser fila fra git HEAD, ikke fra working tree. Agenten kan altså ikke redigere sin egen sandbox-config og få det til å gjelde.
+
+Regelen for å velge lag er ett spørsmål: **hvem gjelder dette for?**
+
+- Hele teamet, i dette repoet → repo-config (`.cplt.toml`)
+- Meg, i denne checkouten → local
+- Meg, uansett hvilket repo jeg står i → global
+- Ingen spesielle → la default stå
+
+Nesten alt du trenger å justere havner i **local**.
+
+---
+
+## Hvorfor local, og ikke global
+
+Det fristende er å sette alt globalt, så slipper du å gjøre det igjen. Ikke gjør det. En grant i global følger deg inn i hver eneste sesjon, også i repoer der stien betyr noe helt annet. Gir du `~/.gradle/gradle.properties` globalt, kan en agent i et Node-prosjekt lese GitHub Packages-tokenet ditt, uten å ha noen grunn til det. Setter du det lokalt, gjelder det bare den Kotlin-tjenesten som faktisk bygger med Gradle.
+
+Global skal være liten: ting som er sanne for maskinen din uansett prosjekt. `~/.gitconfig`, GPG-signering, hvilken agent du foretrekker.
+
+Det leder til et rimelig spørsmål: hvorfor får local lov til å utvide sandboxen i det hele tatt, når repo-config må be om godkjenning for det samme? Fordi local-fila ligger utenfor repoet, i `~/.config/cplt/`, og sandboxen nekter skriving dit. Agenten kan ikke skrive sine egne grants. En fil i working tree kunne ikke lovet det, og derfor må alt som utvider i `.cplt.toml` gjennom `cplt trust`.
+
+---
+
+## Hvor hører dette hjemme?
+
+**Gradle trenger GitHub Packages-credentials** fra `~/.gradle/gradle.properties`. Det er ett prosjekt som trenger det, altså local:
+
+```sh
+cplt config set --local allow.read ~/.gradle/gradle.properties
+```
+
+Finnes ikke fila ennå, får du en advarsel, men verdien lagres likevel.
+
+**Testcontainers trenger docker.** Docker-tilgang svekker sandboxen, så cplt nekter uten `--force` og forteller deg nøyaktig hvilken kommando som trengs:
+
+```sh
+cplt config set --local sandbox.allow_docker true --force
+```
+
+**Node-appen kjører på en localhost-port.** Localhost er blokkert som standard. Trenger bare du det, er det local:
+
+```sh
+cplt config set --local allow.localhost 3000
+```
+
+Trenger hele teamet det, hører det hjemme i `.cplt.toml`. `cplt init` skanner prosjektet og skriver den for deg, så la den gjøre jobben i stedet for å skrive fila selv:
+
+```sh
+cplt init            # se hva som detekteres
+cplt init --write    # skriv .cplt.toml, commit den
+```
+
+**npm lifecycle scripts** (`postinstall` og venner) er blokkert som standard, fordi de er vilkårlig kodekjøring. Trenger prosjektet det, er det local, med `--force`, og ikke noe du committer for teamet:
+
+```sh
+cplt config set --local sandbox.allow_lifecycle_scripts true --force
+```
+
+**Agenten skal pushe en feature branch.** Ingenting. Preset `standard` har git guard på i block-modus og beskytter bare default branch. Push til feature branch går, push til main stoppes.
+
+**git-oppsettet ditt** i `~/.gitconfig` er sant for maskinen din, ikke ett prosjekt. Global, altså uten `--local`:
+
+```sh
+cplt config set allow.read ~/.gitconfig
+```
+
+---
+
+## Se hva som gjelder
+
+```sh
+cplt config show                    # alt som gjelder her; enkeltverdier fra local er merket (local)
+cplt config get sandbox.repo_dirs   # én verdi, med lag
+cplt config path --local            # hvor local-fila for denne checkouten ligger
+cplt config local list              # alle prosjekter du har local-config for
+```
+
+Merk at listeverdier vises sammenslått uten lag-merking, så en `allow.read` du satte lokalt får ikke `(local)` etter seg i `config show`.
+
+Ved oppstart viser cplt hvilken local-fil som er i bruk. `Local:`-raden vises bare når en slik fil faktisk gjelder:
+
+```
+[cplt] Project:  ~/src/spleis
+[cplt] Local:    /Users/x/.config/cplt/local/3291….toml
+```
+
+---
+
+## Flere repoer i samme sesjon
+
+Et typisk oppsett: `navikt/spleis` har `navikt/sykepenger-model` sjekket ut under `libs/` i samme tre. Agenten kan allerede lese og skrive filene i `libs/sykepenger-model`, fordi prosjektkatalogen er gitt som ett subtre. Det den ikke kan, er å behandle det nested repoet som *et repo*: gh guard slipper bare gjennom skriveoperasjoner mot repoet du startet i, så `gh pr create -R navikt/sykepenger-model` stoppes.
+
+`sandbox.repo_dirs` fikser det. Du navngir repoet, og det får identitet i sesjonen:
+
+```sh
+cplt config set --local sandbox.repo_dirs ~/src/spleis/libs/sykepenger-model
+```
+
+Stien må være absolutt eller starte med `~/`. Ved neste oppstart viser cplt begge:
+
+```
+ Repositories:
+   navikt/spleis            ~/src/spleis                        launch repository
+   navikt/sykepenger-model  ~/src/spleis/libs/sykepenger-model   local config
+```
+
+Nå kan agenten opprette PR-er mot `navikt/sykepenger-model`. Merk hva som *ikke* skjedde: det ble ikke gitt noen ny filtilgang. Å navngi et repo handler om identitet, ikke om tilgang.
+
+Vil du prøve én gang uten å lagre, bruker du flagget. Det legger til i settet som er lagret, det erstatter det ikke:
+
+```sh
+cplt --repo-dir ~/src/spleis/libs/sykepenger-model
+```
+
+### Bare nested, ikke sibling
+
+Repoet må ligge inni prosjektkatalogen. Ligger `sykepenger-model` som `~/src/sykepenger-model`, ved siden av `spleis`, får du nei:
+
+```
+[cplt] --repo-dir /path/to/sibling is outside the project directory
+  /path/to/launch-repo
+  sibling repositories are not yet supported; use `--allow-write` for edit-only.
+```
+
+Dagens svar for sibling-repoer er `--allow-write`: agenten får redigere filene, men ikke gh-identitet mot repoet.
+
+```sh
+cplt --allow-write ~/src/sykepenger-model
+```
+
+Å starte fra `~/src` med `--project-dir` er ikke en omvei rundt dette. `--repo-dir` krever at du starter fra toppen av et git-repo, og en katalog som bare inneholder repoer er ikke det. Ordentlig sibling-støtte er [navikt/cplt#344](https://github.com/navikt/cplt/issues/344).
+
+Å navngi repoet du startet i, nektes også; det er alltid i scope.
+
+### Local, og bare local
+
+`sandbox.repo_dirs` kan bare settes med `--local`. De to andre lagene nekter, med hver sin begrunnelse:
+
+- Global: en repo-liste i global config ville hengt seg på hver eneste sesjon. Det er per prosjekt, ikke per maskin.
+- Repo-config: å utnevne andre trær til prosjektnivå er en path grant, og repo-config kan ikke gi stier. Det er en per-checkout brukerinnstilling.
+
+Det passer regelen fra toppen: dette gjelder deg, i denne checkouten.
+
+### Sjekkes på nytt hver gang
+
+Local-fila kan være uker gammel, og treet den peker på kan agenten skrive til. Derfor sjekker cplt hver lagrede oppføring ved *hver* oppstart, ikke bare når du skriver den. Oppstarten stopper, i stedet for å stille droppe oppføringen, hvis den
+
+- ikke er toppen av et git-repo
+- ikke ligger inni prosjektkatalogen
+- har en symlink som siste ledd (en symlinket forelder er greit)
+- inneholder `..`
+- er hjemmekatalogen eller en annen utrygg rot
+
+Feilmeldingen sier hvilken fil oppføringen kom fra, så du vet hva du skal rydde. Det finnes ingen `cplt config unset`; fjerning er `config set … --unset`:
+
+```sh
+cplt config set --local sandbox.repo_dirs ~/src/spleis/libs/sykepenger-model --unset   # fjern ett element
+cplt config set --local sandbox.repo_dirs --unset                                      # fjern hele nøkkelen
+```
+
+---
+
+## Flyttet eller byttet checkout
+
+Local-fila husker hvilken `origin` den ble skrevet for. Står det et annet repo på samme sti nå, advarer cplt (også med `--quiet`) og bruker ingenting fra fila. Vil du ta den i bruk igjen, setter du en hvilken som helst nøkkel med `--local` på nytt. En checkout du har flyttet etterlater en foreldreløs fil; `cplt config local list` viser den som «path no longer exists».
+
+---
+
+## Kom i gang
+
+Kotlin-tjeneste med nested bibliotek, Gradle mot GitHub Packages og Testcontainers:
+
+```sh
+cd ~/src/spleis
+
+# Det som er ditt, i denne checkouten
+cplt config set --local allow.read ~/.gradle/gradle.properties
+cplt config set --local sandbox.allow_docker true --force
+cplt config set --local sandbox.repo_dirs ~/src/spleis/libs/sykepenger-model
+
+# Det teamet trenger, committet
+cplt init --write
+
+# Sjekk resultatet
+cplt config show
+cplt config get sandbox.repo_dirs
+```
+
+Start så agenten gjennom nav-pilot som før. Oppstartssammendraget viser `Local:`-raden og begge repoene.
+
+Full referanse i [docs/configuration.md](https://github.com/navikt/cplt/blob/main/docs/configuration.md).

--- a/docs/news/articles/cplt-lokal-config-og-flere-repoer.md
+++ b/docs/news/articles/cplt-lokal-config-og-flere-repoer.md
@@ -3,7 +3,7 @@ title: "cplt: global, local eller repo, og flere repoer i samme sesjon"
 date: 2026-09-08
 author: starefossen
 category: praksis
-excerpt: "Én regel for å velge mellom repo, local og global i cplt, og hvorfor det meste hører hjemme i .cplt.toml. Pluss sandbox.repo_dirs, som lar agenten jobbe mot et nested repo i samme sesjon."
+excerpt: "Det prosjektet trenger, hører hjemme i .cplt.toml. Det som bare gjelder din maskin, settes med --local. Global skal være liten. Pluss sandbox.repo_dirs, som lar agenten jobbe mot et nested repo i samme sesjon."
 tags:
   - cplt
   - config
@@ -11,11 +11,11 @@ tags:
   - nav-pilot
 ---
 
+Kortversjonen: **Det prosjektet trenger (porter, docker, hemmeligheter som skal holdes ute), setter du med `cplt config set --repo …`. Det havner i `.cplt.toml`, som du committer. Det som bare er sant på din maskin (stier i hjemmekatalogen, et nested repo), setter du med `--local`. Global skal være liten. Start med `cplt init --write` i repoet, og sjekk resultatet med `cplt config show`.**
+
 Du starter agenten med [nav-pilot](/nav-pilot), og nav-pilot kjører den trygt i en sandbox. Første gang du merker [cplt](/cplt), er som regel når noe blir stoppet: Gradle får ikke lese `~/.gradle/gradle.properties`, Testcontainers finner ikke docker, `npm install` nekter å kjøre postinstall. Da må du justere sandboxen, og spørsmålet blir: skal innstillingen settes globalt, lokalt eller i repoet?
 
-Dette innlegget svarer på det, og viser hvordan du lar agenten jobbe mot to repoer i samme sesjon. Alt gjøres med `cplt config` uten at du trenger å redigere config-filer for hånd.
-
-Det du setter med `cplt config`, plukker nav-pilot opp neste gang du starter en agent.
+Dette innlegget svarer på det, og viser hvordan du lar agenten jobbe mot to repoer i samme sesjon. Alt gjøres med `cplt config`, og nav-pilot plukker det opp neste gang du starter en agent.
 
 ---
 
@@ -30,55 +30,56 @@ cplt slår opp en innstilling i denne rekkefølgen. Første treff vinner for enk
 | **Global** | hele maskinen din | `cplt config set …` | `~/.config/cplt/config.toml` |
 | Defaults | alle | preset `standard` | innebygd |
 
-`.cplt.toml` i repoet er et femte sted, og det er stedet du bør begynne. Fila står utenfor rekkefølgen over og har sin egen tillitsmodell, fordi den er prosjektets innstillinger og ikke dine: den er sporet i git, går gjennom review i en PR, og en ny på teamet får riktig sandbox ved å klone.
+`.cplt.toml` i repoet er et femte sted, og det er stedet du bør begynne. Fila står utenfor rekkefølgen over fordi den er prosjektets innstillinger og ikke dine: den er sporet i git, går gjennom review i en PR, og en ny på teamet får riktig sandbox ved å klone. Den har derfor sin egen tillitsmodell:
 
 - `[deny]` gjelder med en gang. Repoet kan alltid stramme inn.
-- `[propose]` er forslag om å utvide, og hver utvikler må godkjenne dem på sin maskin med `cplt trust`. Godkjenningen er bundet til innholdet i fila. Endres fila, må du godkjenne på nytt.
+- `[propose]` er forslag om å utvide, og hver utvikler må godkjenne dem på sin maskin med `cplt trust`. Godkjenningen er bundet til innholdet i fila. Endres fila, må du godkjenne på nytt. Local slipper dette steget fordi fila ligger utenfor repoet, der agenten ikke kan skrive.
 - cplt leser fila fra git HEAD, ikke fra working tree. Agenten kan altså ikke redigere sin egen sandbox-config og få det til å gjelde.
 
 Regelen for å velge lag er ett spørsmål: **hvem gjelder dette for?**
 
 - Prosjektet, altså alle som sjekker det ut → repo-config (`.cplt.toml`)
-- Meg, i denne checkouten, og ikke nødvendigvis resten av teamet → local
+- Meg, i denne checkouten → local
 - Meg, uansett hvilket repo jeg står i → global
 - Ingen spesielle → la default stå
 
-Det meste prosjektet trenger, hører hjemme i repoet. Det gjelder også om du er alene på prosjektet: behovet er fortsatt prosjektets, og det følger med til neste maskin du kloner på. Local er for det som er annerledes på *din* maskin: en sti som bare finnes hos deg, et verktøy ikke alle på teamet bruker.
+Det meste prosjektet trenger, hører hjemme i repoet, også om du er alene på det. Behovet følger med til neste maskin du kloner på. Skal du sette opp et repo fra bunnen, skanner `cplt init` prosjektet og skriver fila for deg:
+
+```sh
+cplt init            # se hva som detekteres
+cplt init --write    # skriv .cplt.toml, commit den
+```
 
 ---
 
 ## Hvorfor ikke bare global
 
-Det er fristende å sette alt globalt, så slipper du å gjøre det igjen. Ikke gjør det. En grant i global følger deg inn i hver eneste sesjon, også i repoer der stien betyr noe helt annet. Gir du `~/.gradle/gradle.properties` globalt, kan en agent i et Node-prosjekt lese GitHub Packages-tokenet ditt uten å ha noen grunn til det. Setter du det lokalt, gjelder det bare den Kotlin-tjenesten som faktisk bygger med Gradle.
+Det er fristende å sette alt globalt, så slipper du å gjøre det igjen. Ikke gjør det. En grant i global følger deg inn i hver eneste sesjon, også i repoer der stien betyr noe helt annet. Gir du `~/.gradle/gradle.properties` globalt, kan en agent i et Node-prosjekt lese GitHub Packages-tokenet ditt uten å ha noen grunn til det.
 
-Global skal være liten: ting som er sanne for maskinen din uansett prosjekt. Signerer du commits med GPG, er det et godt eksempel. Det følger deg, ikke prosjektet:
+Global skal være liten: ting som er sanne for maskinen din uansett prosjekt. Signerer du commits med GPG, er det et godt eksempel:
 
 ```sh
 cplt config set sandbox.allow_gpg_signing true --force
 ```
 
-Da kan du lure på hvorfor local får utvide sandboxen i det hele tatt, når repo-config må be om godkjenning for det samme. Svaret er at local-fila ligger utenfor repoet, i `~/.config/cplt/`, og sandboxen nekter skriving dit. Agenten kan ikke skrive sine egne grants. En fil i working tree kan ikke love det samme, og derfor må alt som utvider i `.cplt.toml` gjennom `cplt trust`.
-
 ---
 
-## Skillet er håndhevet
+## Repoet må be om én ting om gangen
 
-Grensen mellom repo og local er ikke en konvensjon du må huske. `.cplt.toml` nekter nøkler som handler om maskinen din, og sier hvorfor:
+Grensen mellom repo og local er ikke bare en konvensjon. Noen nøkler nekter `.cplt.toml` å ta imot, og sier hvorfor. Prøver du å sette `sandbox.preset` med `--repo`, får du:
 
 ```
-$ cplt config set --repo sandbox.pass_env FOO
-[cplt] sandbox.pass_env is not valid in repo config.
-  Reason: environment variables are machine-specific, not project policy.
-  Use: cplt config set sandbox.pass_env FOO
+[cplt] sandbox.preset is not valid in repo config.
+  Reason: composes multiple dangerous permissions (docker, tmp exec, ...). A repo must request individual keys so each can be reviewed and trusted.
 ```
 
-`sandbox.use_bubblewrap` får samme svar («depends on bwrap being installed locally, not project policy»), og det samme gjør `sandbox.repo_dirs`, som vi kommer til. Mønsteret er at repo-config tar imot det som er sant for prosjektet, og avviser det som er sant for en maskin. Er du i tvil om hvor noe hører hjemme, prøv `--repo` og les svaret.
+Det er tillitsmodellen i én setning: repoet ber om én og én tillatelse, så hver kan reviewes og godkjennes for seg. Skillet er ikke like skarpt for alle nøkler, men er du i tvil om hvor noe hører hjemme, prøv `--repo` og les svaret.
 
 ---
 
 ## Hvor hører dette hjemme?
 
-**Appen lytter på en localhost-port.** Localhost er blokkert som standard. Lytter appen på 8080, gjør den det for alle på teamet, så porten hører hjemme i repoet:
+**Appen lytter på en localhost-port.** Localhost er blokkert som standard. Lytter appen på 8080, gjør den det for alle på teamet:
 
 ```sh
 cplt config set --repo allow.localhost 8080
@@ -97,17 +98,17 @@ cplt config set --repo sandbox.allow_docker true --force
 cplt config set --repo allow.ports 5432
 ```
 
-Begge havner under `[propose]`. Den som reviewer PR-en ser at prosjektet ber om docker, og hver utvikler godkjenner på sin maskin. Det er poenget med å legge det i repoet, ikke en omvei.
+Den som reviewer PR-en ser at prosjektet ber om docker, og hver utvikler godkjenner på sin maskin. Det er poenget med å legge det i repoet, ikke en omvei.
 
-**npm lifecycle scripts** (`postinstall` og venner) er blokkert som standard, fordi de er vilkårlig kodekjøring. Feiler `npm install` uten dem, feiler det for alle, så også dette er prosjektets. Det er samtidig det tyngste du kan be teamet godkjenne, og nettopp derfor hører det hjemme i en PR og ikke i hver utviklers local-fil:
+**npm lifecycle scripts** (`postinstall` og venner) er blokkert som standard, fordi de er vilkårlig kodekjøring. Feiler `npm install` uten dem, feiler det for alle. Det er samtidig det tyngste du kan be teamet godkjenne, og nettopp derfor hører det hjemme i en PR og ikke i hver utviklers local-fil:
 
 ```sh
 cplt config set --repo sandbox.allow_lifecycle_scripts true --force
 ```
 
-Merk at `cplt init` aldri foreslår denne selv, nettopp fordi den åpner for vilkårlig kodekjøring. Står den i `.cplt.toml`, er det fordi et menneske har satt den inn, og da er det verdt et spørsmål i reviewen: trenger `npm install` den virkelig, eller holder det å kjøre installasjonen med `--ignore-scripts`?
+`cplt init` foreslår aldri denne selv. Står den i `.cplt.toml`, har et menneske satt den inn, og da er det verdt et spørsmål i reviewen: trenger `npm install` den virkelig, eller holder det med `--ignore-scripts`?
 
-**Hemmeligheter som aldri skal inn i en agent-sesjon.** `[deny]` er den billige halvdelen av repo-config. Den krever ingen godkjenning og gjelder for alle som sjekker ut repoet, i det øyeblikket fila er committet:
+**Hemmeligheter som aldri skal inn i en agent-sesjon.** `[deny]` er den billige halvdelen av repo-config. Den gjelder for alle som sjekker ut repoet, i det øyeblikket fila er committet:
 
 ```sh
 cplt config set --repo deny.env VAULT_TOKEN
@@ -115,14 +116,7 @@ cplt config set --repo deny.env VAULT_TOKEN
 
 Ingen `cplt trust`, ingenting å vente på. Det er den ene linja i dette innlegget som ikke koster noen noe.
 
-Skal du sette opp et repo fra bunnen, skanner `cplt init` prosjektet og skriver fila for deg:
-
-```sh
-cplt init            # se hva som detekteres
-cplt init --write    # skriv .cplt.toml, commit den
-```
-
-**Gradle trenger GitHub Packages-credentials** fra `~/.gradle/gradle.properties`. Prosjektet trenger tokenet, men fila ligger i hjemmekatalogen din, og det er din maskin som avgjør hvor credentials bor. Det er en sti som finnes hos deg, altså local:
+**Gradle trenger GitHub Packages-credentials** fra `~/.gradle/gradle.properties`. Prosjektet trenger tokenet, men fila ligger i hjemmekatalogen din, og det er din maskin som avgjør hvor credentials bor. Local:
 
 ```sh
 cplt config set --local allow.read ~/.gradle/gradle.properties
@@ -149,14 +143,7 @@ cplt config path --local            # hvor local-fila for denne checkouten ligge
 cplt config local list              # alle prosjekter du har local-config for
 ```
 
-Listeverdier vises sammenslått uten lag-merking. En `allow.read` du satte lokalt, får derfor ikke `(local)` etter seg i `config show`.
-
-Ved oppstart viser cplt hvilken local-fil som er i bruk. `Local:`-raden vises bare når en slik fil faktisk gjelder:
-
-```
-[cplt] Project:  ~/src/spleis
-[cplt] Local:    /Users/x/.config/cplt/local/3291….toml
-```
+Listeverdier vises sammenslått uten lag-merking. En `allow.read` du satte lokalt, får derfor ikke `(local)` etter seg i `config show`. Ved oppstart viser cplt en `Local:`-rad med fila som er i bruk, når en slik fil faktisk gjelder.
 
 ---
 
@@ -180,13 +167,9 @@ Stien må være absolutt eller starte med `~/`. Ved neste oppstart viser cplt be
 
 Nå kan agenten opprette PR-er mot `navikt/sykepenger-model`. Legg merke til at agenten ikke fikk noen ny filtilgang. Å navngi et repo gir identitet, ikke tilgang.
 
-Kjører du cplt direkte og bare vil prøve, finnes det et flagg. Det gjelder for den ene kjøringen og skriver ingenting til fila. Flagget kommer i tillegg til det som allerede er lagret, ikke i stedet for:
+Nøkkelen kan bare settes med `--local`. Global nekter, fordi en repo-liste der ville hengt seg på hver eneste sesjon. Repo-config nekter, fordi «naming other trees as project-grade roots is a path grant, and repo config cannot grant paths». Hvor du har sjekket ut hva, er sant for din maskin, ikke for prosjektet.
 
-```sh
-cplt --repo-dir ~/src/spleis/libs/sykepenger-model exec -- ./gradlew build
-```
-
-Går du via nav-pilot, er `--local` den eneste veien. Der er det ingen kommandolinje å sette flagget på.
+Kjører du cplt direkte, gjør flagget `--repo-dir <sti>` det samme for én kjøring, i tillegg til det som er lagret. Går du via nav-pilot, er `--local` den eneste veien.
 
 ### Bare nested, ikke sibling
 
@@ -204,30 +187,11 @@ For sibling-repoer er svaret i dag `--allow-write`. Agenten får redigere filene
 cplt --allow-write ~/src/sykepenger-model
 ```
 
-Du kommer ikke rundt dette ved å starte fra `~/src` med `--project-dir`. `--repo-dir` krever at du starter fra toppen av et git-repo, og en katalog som bare inneholder repoer er ikke det. Ordentlig sibling-støtte er [navikt/cplt#344](https://github.com/navikt/cplt/issues/344).
-
-Du får heller ikke navngi repoet du startet i. Det er alltid i scope.
-
-### Local, og bare local
-
-`sandbox.repo_dirs` kan bare settes med `--local`. De to andre lagene nekter, med hver sin begrunnelse:
-
-- Global: en repo-liste i global config ville hengt seg på hver eneste sesjon. Dette er per prosjekt, ikke per maskin.
-- Repo-config: å løfte andre trær til prosjektnivå er en path grant, og repo-config kan ikke gi stier. Det er en per-checkout brukerinnstilling.
-
-Det er det samme skillet som over. Hvor du har sjekket ut hva, er sant for din maskin, ikke for prosjektet.
+Å starte fra `~/src` med `--project-dir` hjelper ikke; `--repo-dir` krever at du starter fra toppen av et git-repo. Ordentlig sibling-støtte er [navikt/cplt#344](https://github.com/navikt/cplt/issues/344). Repoet du startet i, kan du heller ikke navngi. Det er alltid i scope.
 
 ### Sjekkes på nytt hver gang
 
-Local-fila kan være uker gammel, og treet den peker på kan agenten skrive til. Derfor sjekker cplt hver lagrede oppføring ved *hver* oppstart, ikke bare når du skriver den. Er noe galt, stopper oppstarten i stedet for å droppe oppføringen i stillhet. Det skjer hvis oppføringen
-
-- ikke er toppen av et git-repo
-- ikke ligger inni prosjektkatalogen
-- har en symlink som siste ledd (en symlinket forelder er greit)
-- inneholder `..`
-- er hjemmekatalogen eller en annen utrygg rot
-
-Feilmeldingen sier hvilken fil oppføringen kom fra, så du vet hva du skal rydde. Det finnes ingen `cplt config unset`. Du fjerner med `config set … --unset`:
+Local-fila kan være uker gammel, og treet den peker på kan agenten skrive til. Derfor sjekker cplt hver lagrede oppføring ved *hver* oppstart, og stopper hvis den ikke lenger er toppen av et git-repo inni prosjektkatalogen. Feilmeldingen sier hvilken fil oppføringen kom fra, så du vet hva du skal rydde. Du fjerner med `config set … --unset`:
 
 ```sh
 cplt config set --local sandbox.repo_dirs ~/src/spleis/libs/sykepenger-model --unset   # fjern ett element

--- a/docs/news/articles/cplt-lokal-config-og-flere-repoer.md
+++ b/docs/news/articles/cplt-lokal-config-og-flere-repoer.md
@@ -105,6 +105,8 @@ Begge havner under `[propose]`. Den som reviewer PR-en ser at prosjektet ber om 
 cplt config set --repo sandbox.allow_lifecycle_scripts true --force
 ```
 
+Merk at `cplt init` aldri foreslår denne selv, nettopp fordi den åpner for vilkårlig kodekjøring. Står den i `.cplt.toml`, er det fordi et menneske har satt den inn, og da er det verdt et spørsmål i reviewen: trenger `npm install` den virkelig, eller holder det å kjøre installasjonen med `--ignore-scripts`?
+
 **Hemmeligheter som aldri skal inn i en agent-sesjon.** `[deny]` er den billige halvdelen av repo-config. Den krever ingen godkjenning og gjelder for alle som sjekker ut repoet, i det øyeblikket fila er committet:
 
 ```sh

--- a/docs/news/articles/cplt-lokal-config-og-flere-repoer.md
+++ b/docs/news/articles/cplt-lokal-config-og-flere-repoer.md
@@ -3,7 +3,7 @@ title: "cplt: global, local eller repo, og flere repoer i samme sesjon"
 date: 2026-09-08
 author: starefossen
 category: praksis
-excerpt: "Fire config-lag i cplt, én regel for å velge riktig. Pluss sandbox.repo_dirs, som lar agenten jobbe mot et nested repo i samme sesjon."
+excerpt: "Én regel for å velge mellom repo, local og global i cplt, og hvorfor det meste hører hjemme i .cplt.toml. Pluss sandbox.repo_dirs, som lar agenten jobbe mot et nested repo i samme sesjon."
 tags:
   - cplt
   - config
@@ -15,11 +15,11 @@ Du starter agenten med [nav-pilot](/nav-pilot), og nav-pilot kjører den trygt i
 
 Dette innlegget svarer på det, og viser hvordan du lar agenten jobbe mot to repoer i samme sesjon. Alt gjøres med `cplt config` uten at du trenger å redigere config-filer for hånd.
 
-Setter du noe med `cplt config set --local`, plukker nav-pilot det opp neste gang du starter en agent.
+Det du setter med `cplt config`, plukker nav-pilot opp neste gang du starter en agent.
 
 ---
 
-## Fire lag
+## Fire lag, og repoet
 
 cplt slår opp en innstilling i denne rekkefølgen. Første treff vinner for enkeltverdier. Lister (`allow.read`, `allow.write`, `allow.ports`, `allow.localhost`, `deny.paths`) slås sammen på tvers av lagene.
 
@@ -30,24 +30,24 @@ cplt slår opp en innstilling i denne rekkefølgen. Første treff vinner for enk
 | **Global** | hele maskinen din | `cplt config set …` | `~/.config/cplt/config.toml` |
 | Defaults | alle | preset `standard` | innebygd |
 
-`.cplt.toml` i repoet er et femte sted, men det står utenfor rekkefølgen over og har sin egen tillitsmodell. Det er teamets innstillinger for den aktuelle applikasjonen:
+`.cplt.toml` i repoet er et femte sted, og det er stedet du bør begynne. Fila står utenfor rekkefølgen over og har sin egen tillitsmodell, fordi den er prosjektets innstillinger og ikke dine: den er sporet i git, går gjennom review i en PR, og en ny på teamet får riktig sandbox ved å klone.
 
 - `[deny]` gjelder med en gang. Repoet kan alltid stramme inn.
-- `[propose]` er forslag om å utvide, og hver utvikler må godkjenne dem med `cplt trust`. Godkjenningen er bundet til innholdet i fila. Endres fila, må du godkjenne på nytt.
+- `[propose]` er forslag om å utvide, og hver utvikler må godkjenne dem på sin maskin med `cplt trust`. Godkjenningen er bundet til innholdet i fila. Endres fila, må du godkjenne på nytt.
 - cplt leser fila fra git HEAD, ikke fra working tree. Agenten kan altså ikke redigere sin egen sandbox-config og få det til å gjelde.
 
 Regelen for å velge lag er ett spørsmål: **hvem gjelder dette for?**
 
-- Hele teamet, i dette repoet → repo-config (`.cplt.toml`)
-- Meg, i denne checkouten → local
+- Prosjektet, altså alle som sjekker det ut → repo-config (`.cplt.toml`)
+- Meg, i denne checkouten, og ikke nødvendigvis resten av teamet → local
 - Meg, uansett hvilket repo jeg står i → global
 - Ingen spesielle → la default stå
 
-Nesten alt du trenger å justere, havner i **local**.
+Det meste prosjektet trenger, hører hjemme i repoet. Det gjelder også om du er alene på prosjektet: behovet er fortsatt prosjektets, og det følger med til neste maskin du kloner på. Local er for det som er annerledes på *din* maskin: en sti som bare finnes hos deg, et verktøy ikke alle på teamet bruker.
 
 ---
 
-## Hvorfor local, og ikke global
+## Hvorfor ikke bare global
 
 Det er fristende å sette alt globalt, så slipper du å gjøre det igjen. Ikke gjør det. En grant i global følger deg inn i hver eneste sesjon, også i repoer der stien betyr noe helt annet. Gir du `~/.gradle/gradle.properties` globalt, kan en agent i et Node-prosjekt lese GitHub Packages-tokenet ditt uten å ha noen grunn til det. Setter du det lokalt, gjelder det bare den Kotlin-tjenesten som faktisk bygger med Gradle.
 
@@ -61,35 +61,57 @@ Da kan du lure på hvorfor local får utvide sandboxen i det hele tatt, når rep
 
 ---
 
+## Skillet er håndhevet
+
+Grensen mellom repo og local er ikke en konvensjon du må huske. `.cplt.toml` nekter nøkler som handler om maskinen din, og sier hvorfor:
+
+```
+$ cplt config set --repo sandbox.pass_env FOO
+[cplt] sandbox.pass_env is not valid in repo config.
+  Reason: environment variables are machine-specific, not project policy.
+  Use: cplt config set sandbox.pass_env FOO
+```
+
+`sandbox.use_bubblewrap` får samme svar («depends on bwrap being installed locally, not project policy»), og det samme gjør `sandbox.repo_dirs`, som vi kommer til. Mønsteret er at repo-config tar imot det som er sant for prosjektet, og avviser det som er sant for en maskin. Er du i tvil om hvor noe hører hjemme, prøv `--repo` og les svaret.
+
+---
+
 ## Hvor hører dette hjemme?
 
-**Gradle trenger GitHub Packages-credentials** fra `~/.gradle/gradle.properties`. Det er ett prosjekt som trenger det, altså local:
+**Appen lytter på en localhost-port.** Localhost er blokkert som standard. Lytter appen på 8080, gjør den det for alle på teamet, så porten hører hjemme i repoet:
 
 ```sh
-cplt config set --local allow.read ~/.gradle/gradle.properties
+cplt config set --repo allow.localhost 8080
 ```
 
-Finnes ikke fila ennå, får du en advarsel, men verdien lagres likevel.
-
-**Testcontainers trenger docker.** Docker-tilgang svekker sandboxen, så cplt nekter uten `--force` og forteller deg nøyaktig hvilken kommando du trenger:
-
-```sh
-cplt config set --local sandbox.allow_docker true --force
-```
-
-**Node-appen kjører på en localhost-port.** Localhost er blokkert som standard. Er det bare du som trenger porten, er det local:
+Verdien havner under `[propose]`, og cplt minner deg på de to stegene som gjenstår: `cplt trust accept --all` for å godkjenne på din egen maskin, og en commit av `.cplt.toml` så resten av teamet får den. Kjører du noe på en port bare du bruker, er det local:
 
 ```sh
 cplt config set --local allow.localhost 3000
 ```
 
-Trenger hele teamet den, hører den hjemme i `.cplt.toml`. Den setter du også med en kommando:
+**Testcontainers trenger docker.** Testene er prosjektets, og da er docker-tilgangen det også. Docker svekker sandboxen, så cplt nekter uten `--force` og forteller deg nøyaktig hvilken kommando du trenger. Bruker testene Postgres på 5432, er den porten prosjektets på samme måte:
 
 ```sh
-cplt config set --repo allow.localhost 3000
+cplt config set --repo sandbox.allow_docker true --force
+cplt config set --repo allow.ports 5432
 ```
 
-Verdien havner under `[propose]`, og cplt minner deg på de to stegene som gjenstår: `cplt trust accept --all` for å godkjenne på din egen maskin, og en commit av `.cplt.toml` så resten av teamet får den.
+Begge havner under `[propose]`. Den som reviewer PR-en ser at prosjektet ber om docker, og hver utvikler godkjenner på sin maskin. Det er poenget med å legge det i repoet, ikke en omvei.
+
+**npm lifecycle scripts** (`postinstall` og venner) er blokkert som standard, fordi de er vilkårlig kodekjøring. Feiler `npm install` uten dem, feiler det for alle, så også dette er prosjektets. Det er samtidig det tyngste du kan be teamet godkjenne, og nettopp derfor hører det hjemme i en PR og ikke i hver utviklers local-fil:
+
+```sh
+cplt config set --repo sandbox.allow_lifecycle_scripts true --force
+```
+
+**Hemmeligheter som aldri skal inn i en agent-sesjon.** `[deny]` er den billige halvdelen av repo-config. Den krever ingen godkjenning og gjelder for alle som sjekker ut repoet, i det øyeblikket fila er committet:
+
+```sh
+cplt config set --repo deny.env VAULT_TOKEN
+```
+
+Ingen `cplt trust`, ingenting å vente på. Det er den ene linja i dette innlegget som ikke koster noen noe.
 
 Skal du sette opp et repo fra bunnen, skanner `cplt init` prosjektet og skriver fila for deg:
 
@@ -98,11 +120,13 @@ cplt init            # se hva som detekteres
 cplt init --write    # skriv .cplt.toml, commit den
 ```
 
-**npm lifecycle scripts** (`postinstall` og venner) er blokkert som standard, fordi de er vilkårlig kodekjøring. Trenger prosjektet det, er det local, med `--force`, og ikke noe du committer for teamet:
+**Gradle trenger GitHub Packages-credentials** fra `~/.gradle/gradle.properties`. Prosjektet trenger tokenet, men fila ligger i hjemmekatalogen din, og det er din maskin som avgjør hvor credentials bor. Det er en sti som finnes hos deg, altså local:
 
 ```sh
-cplt config set --local sandbox.allow_lifecycle_scripts true --force
+cplt config set --local allow.read ~/.gradle/gradle.properties
 ```
+
+Finnes ikke fila ennå, får du en advarsel, men verdien lagres likevel.
 
 **Agenten skal pushe en feature branch.** Ingenting å gjøre. Preset `standard` har git guard på i block-modus og beskytter bare default branch. Push til feature branch går, push til main stoppes.
 
@@ -189,7 +213,7 @@ Du får heller ikke navngi repoet du startet i. Det er alltid i scope.
 - Global: en repo-liste i global config ville hengt seg på hver eneste sesjon. Dette er per prosjekt, ikke per maskin.
 - Repo-config: å løfte andre trær til prosjektnivå er en path grant, og repo-config kan ikke gi stier. Det er en per-checkout brukerinnstilling.
 
-Det passer regelen fra toppen: dette gjelder deg, i denne checkouten.
+Det er det samme skillet som over. Hvor du har sjekket ut hva, er sant for din maskin, ikke for prosjektet.
 
 ### Sjekkes på nytt hver gang
 
@@ -223,14 +247,16 @@ Kotlin-tjeneste med nested bibliotek, Gradle mot GitHub Packages og Testcontaine
 ```sh
 cd ~/src/spleis
 
+# Det prosjektet trenger, i .cplt.toml
+cplt config set --repo allow.localhost 8080
+cplt config set --repo sandbox.allow_docker true --force
+cplt config set --repo deny.env VAULT_TOKEN
+cplt trust accept --all
+# commit .cplt.toml og åpne en PR
+
 # Det som er ditt, i denne checkouten
 cplt config set --local allow.read ~/.gradle/gradle.properties
-cplt config set --local sandbox.allow_docker true --force
 cplt config set --local sandbox.repo_dirs ~/src/spleis/libs/sykepenger-model
-
-# Det teamet trenger, committet
-cplt config set --repo allow.localhost 8080
-cplt trust accept --all
 
 # Sjekk resultatet
 cplt config show

--- a/docs/news/articles/cplt-lokal-config-og-flere-repoer.md
+++ b/docs/news/articles/cplt-lokal-config-og-flere-repoer.md
@@ -11,9 +11,11 @@ tags:
   - nav-pilot
 ---
 
-Du starter agenter gjennom nav-pilot, og nav-pilot kjører dem i [cplt](/cplt). Første gang du merker cplt er som regel når noe blir stoppet: Gradle får ikke lese `~/.gradle/gradle.properties`, Testcontainers finner ikke docker, `npm install` nekter å kjøre postinstall. Da må du justere sandboxen, og da dukker spørsmålet opp: skal innstillingen settes globalt, lokalt eller i repoet?
+Du starter agenter gjennom [nav-pilot](/nav-pilot), og nav-pilot kjører dem i [cplt](/cplt). Første gang du merker cplt er som regel når noe blir stoppet: Gradle får ikke lese `~/.gradle/gradle.properties`, Testcontainers finner ikke docker, `npm install` nekter å kjøre postinstall. Da må du justere sandboxen, og da dukker spørsmålet opp: skal innstillingen settes globalt, lokalt eller i repoet?
 
 Dette innlegget svarer på det, og viser hvordan du lar agenten jobbe mot to repoer i samme sesjon. Alt gjøres med `cplt config`. Du trenger ikke åpne en fil.
+
+Én ting er verdt å ta med seg med én gang: nav-pilot starter cplt for deg, så du har ingen kommandolinje å henge flagg på. Derfor er det lagret config som gjelder. Setter du det med `cplt config set --local`, plukker nav-pilot det opp neste gang du starter en agent, uten at du gjør noe mer.
 
 ---
 
@@ -49,7 +51,11 @@ Nesten alt du trenger å justere havner i **local**.
 
 Det fristende er å sette alt globalt, så slipper du å gjøre det igjen. Ikke gjør det. En grant i global følger deg inn i hver eneste sesjon, også i repoer der stien betyr noe helt annet. Gir du `~/.gradle/gradle.properties` globalt, kan en agent i et Node-prosjekt lese GitHub Packages-tokenet ditt, uten å ha noen grunn til det. Setter du det lokalt, gjelder det bare den Kotlin-tjenesten som faktisk bygger med Gradle.
 
-Global skal være liten: ting som er sanne for maskinen din uansett prosjekt. `~/.gitconfig`, GPG-signering, hvilken agent du foretrekker.
+Global skal være liten: ting som er sanne for maskinen din uansett prosjekt. Signerer du commits med GPG, er det et godt eksempel — det følger deg, ikke prosjektet:
+
+```sh
+cplt config set sandbox.allow_gpg_signing true --force
+```
 
 Det leder til et rimelig spørsmål: hvorfor får local lov til å utvide sandboxen i det hele tatt, når repo-config må be om godkjenning for det samme? Fordi local-fila ligger utenfor repoet, i `~/.config/cplt/`, og sandboxen nekter skriving dit. Agenten kan ikke skrive sine egne grants. En fil i working tree kunne ikke lovet det, og derfor må alt som utvider i `.cplt.toml` gjennom `cplt trust`.
 
@@ -77,7 +83,15 @@ cplt config set --local sandbox.allow_docker true --force
 cplt config set --local allow.localhost 3000
 ```
 
-Trenger hele teamet det, hører det hjemme i `.cplt.toml`. `cplt init` skanner prosjektet og skriver den for deg, så la den gjøre jobben i stedet for å skrive fila selv:
+Trenger hele teamet det, hører det hjemme i `.cplt.toml`. Den skriver du også med en kommando:
+
+```sh
+cplt config set --repo allow.localhost 3000
+```
+
+Verdien havner under `[propose]`, og cplt minner deg på begge stegene som gjenstår: `cplt trust accept --all` for å godkjenne på din egen maskin, og en commit av `.cplt.toml` så resten av teamet får den.
+
+Skal du sette opp et repo fra bunnen, skanner `cplt init` prosjektet og skriver fila for deg:
 
 ```sh
 cplt init            # se hva som detekteres
@@ -140,11 +154,13 @@ Stien må være absolutt eller starte med `~/`. Ved neste oppstart viser cplt be
 
 Nå kan agenten opprette PR-er mot `navikt/sykepenger-model`. Merk hva som *ikke* skjedde: det ble ikke gitt noen ny filtilgang. Å navngi et repo handler om identitet, ikke om tilgang.
 
-Vil du prøve én gang uten å lagre, bruker du flagget. Det legger til i settet som er lagret, det erstatter det ikke:
+Kjører du cplt direkte og bare vil prøve, finnes flagget. Det gjelder for den ene kjøringen og skriver ingenting til fila, og det kommer i tillegg til det som allerede er lagret, ikke i stedet for:
 
 ```sh
-cplt --repo-dir ~/src/spleis/libs/sykepenger-model
+cplt --repo-dir ~/src/spleis/libs/sykepenger-model exec -- ./gradlew build
 ```
+
+Går du via nav-pilot, er `--local` den eneste veien; det er ingen kommandolinje å sette flagget på.
 
 ### Bare nested, ikke sibling
 
@@ -213,7 +229,8 @@ cplt config set --local sandbox.allow_docker true --force
 cplt config set --local sandbox.repo_dirs ~/src/spleis/libs/sykepenger-model
 
 # Det teamet trenger, committet
-cplt init --write
+cplt config set --repo allow.localhost 8080
+cplt trust accept --all
 
 # Sjekk resultatet
 cplt config show


### PR DESCRIPTION
Nytt innlegg til ki-utvikling.nav.no: `docs/news/articles/cplt-lokal-config-og-flere-repoer.md`.

**Ikke merge ennå** — denne ligger her til gjennomlesing.

## Hvorfor

Utviklere starter agenter via nav-pilot og møter cplt først når noe blir stoppet. Da er spørsmålet «global, local eller repo?», og de fire lagene er i praksis fire ord uten innhold. Innlegget forklarer lagene, gir én regel for å velge (*hvem gjelder dette for?*), og dekker `sandbox.repo_dirs` for sesjoner som spenner over to repoer.

Alt gjøres med `cplt config`-kommandoer. Ingen steder blir leseren bedt om å åpne en fil.

## Verifisert mot binæret

Hver kommando i innlegget er kjørt mot `cplt 2026.09.08-074746-4f5caf5`, altså den versjonen folk har installert. Tre påstander overlevde ikke og ble rettet:

- `cplt init --write` sto som svaret for team-config. Erstattet med `cplt config set --repo allow.localhost 3000`, som er verifisert, skriver under `[propose]`, og der cplt selv sier fra om begge stegene som gjenstår. `init` står igjen der den hører hjemme: et repo som settes opp fra bunnen.
- GPG-signering var nevnt som et globalt eksempel uten kommando. `sandbox.allow_gpg_signing` finnes, så eksempelet er nå noe man kan lime inn.
- `--repo-dir`-avsnittet sa «uten å lagre» og «legger til i settet som er lagret» i samme åndedrag. Flagget gjelder én kjøring og skriver ingenting — verifisert.

Det viktigste for målgruppa manglet i første utkast og er lagt til: nav-pilot starter cplt for deg, så det finnes ingen kommandolinje å henge flagg på. Derfor er det lagret config som gjelder, og derfor er `--local` svaret.

## Å se særlig etter

- Om språket treffer. Målet var «ingeniør som forklarer noe til en kollega», ikke produktregister.
- Om eksemplene stemmer med hvordan folk faktisk jobber (spleis + sykepenger-model som nested par, Gradle mot GitHub Packages, Testcontainers, Node-port).
- Om `category: praksis` er riktig, og om taggene stemmer.

Refs navikt/cplt#340, navikt/cplt#344, navikt/cplt#425, navikt/cplt#429.