### PR TITLE
fix(agentpakke): pensjoneringer i en gjenbrukt pakke nådde aldri konsumenten

### DIFF
--- a/cli/nav-pilot/e2e/golden_path_test.go
+++ b/cli/nav-pilot/e2e/golden_path_test.go
@@ -283,3 +283,81 @@ func TestSyncReadsTheDeclaredSource(t *testing.T) {
 		t.Errorf("sync mente filene var slettet, altså leste den feil kilde:\n%s", out)
 	}
 }
+
+// En gjenbrukt pakke pensjonerer artefakter den også, og recorden er dens egen
+// fil. Leste sync bare toppkildens, ble et artefakt basen trakk tilbake
+// liggende for alltid hos hver konsument av en pakke som gjenbruker den.
+func TestRetirementsInTheBaseReachTheConsumer(t *testing.T) {
+	e := newEnv(t)
+	base := e.pakke("basepakke", "felles", "utgaar")
+	own := e.pakke("egenpakke", "eget")
+	e.declareReuse(own, base)
+	cons := e.consumer("forbruker")
+
+	if out, code := e.run(cons, "install", "egenpakke", "--source", own, "--repo"); code != 0 {
+		t.Fatalf("install feilet: %d\n%s", code, out)
+	}
+	installed := filepath.Join(cons, ".github", "agents", "utgaar.agent.md")
+	if !e.exists(installed) {
+		t.Fatal("artefaktet fra basen ble ikke installert")
+	}
+
+	// Fjern artefaktet fra staten, men la fila ligge. Det er tilstanden
+	// recorden finnes for: en fil nav-pilot skrev, som ingen state sporer, og
+	// som den ordinære slettestien derfor aldri ser. Uten dette ville testen
+	// målt slettestien i stedet, og passert også uten fiksen.
+	untrackFromState(t, cons, "agents/utgaar.agent.md")
+
+	// Basen trekker artefaktet tilbake og fører det opp i recorden sin.
+	body, err := os.ReadFile(filepath.Join(base, "agents", "utgaar.agent.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(base, "agents", "utgaar.agent.md")); err != nil {
+		t.Fatal(err)
+	}
+	e.write(filepath.Join(base, ".nav-pilot", "retired-artifacts.json"),
+		`{"paths":{"agents/utgaar.agent.md":["`+gitBlobHash(body)+`"]}}`)
+	e.commit(base, "pensjonert")
+
+	out, _ := e.run(cons, "sync", "--repo", "--apply", "--source", own)
+	if e.exists(installed) {
+		t.Errorf("artefaktet basen pensjonerte ble liggende:\n%s", out)
+	}
+}
+
+// untrackFromState fjerner én sti fra scopets tilstandsfil og lar fila ligge.
+func untrackFromState(t *testing.T, repo, suffix string) {
+	t.Helper()
+	path := filepath.Join(repo, ".github", ".nav-pilot-state.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatal(err)
+	}
+	files, _ := doc["files"].([]any)
+	kept := make([]any, 0, len(files))
+	dropped := false
+	for _, f := range files {
+		m, _ := f.(map[string]any)
+		if p, _ := m["path"].(string); strings.HasSuffix(p, suffix) {
+			dropped = true
+			continue
+		}
+		kept = append(kept, f)
+	}
+	if !dropped {
+		t.Fatalf("fant ikke %s i staten, da tester dette noe annet", suffix)
+	}
+	doc["files"] = kept
+	out, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cli/nav-pilot/e2e/harness_test.go
+++ b/cli/nav-pilot/e2e/harness_test.go
@@ -15,6 +15,9 @@
 package e2e
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -213,5 +216,29 @@ func TestHarnessRunsTheRealBinary(t *testing.T) {
 	}
 	if e.exists(filepath.Join(e.home, ".copilot")) {
 		t.Error("~/.copilot fantes før noe var installert")
+	}
+}
+
+// gitBlobHash is the id git would give this content: sha1 over the blob
+// header and the bytes. The retired record is keyed by it.
+func gitBlobHash(data []byte) string {
+	h := sha1.New()
+	fmt.Fprintf(h, "blob %d\x00", len(data))
+	h.Write(data)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// commit records whatever is in dir right now.
+func (e *env) commit(dir, msg string) {
+	e.t.Helper()
+	for _, args := range [][]string{
+		{"add", "-A"},
+		{"-c", "user.email=e2e@example.test", "-c", "user.name=e2e", "commit", "-qm", msg},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			e.t.Fatalf("git %v i %s: %v\n%s", args, dir, err, out)
+		}
 	}
 }

--- a/cli/nav-pilot/internal/cli/retired.go
+++ b/cli/nav-pilot/internal/cli/retired.go
@@ -346,3 +346,27 @@ func withinScope(scope *InstallScope, path string) bool {
 	}
 	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
+
+// mergeRetired joins two orphan lists, keeping one entry per local path.
+//
+// A pakke and the pakke it reuses may both retire the same path, and the sweep
+// ends in a delete: listing it twice reported one removal as two and tried the
+// same unlink again.
+func mergeRetired(a, b []retiredOrphan) []retiredOrphan {
+	if len(b) == 0 {
+		return a
+	}
+	seen := make(map[string]bool, len(a))
+	for _, o := range a {
+		seen[o.Local] = true
+	}
+	for _, o := range b {
+		if seen[o.Local] {
+			continue
+		}
+		seen[o.Local] = true
+		a = append(a, o)
+	}
+	sort.Slice(a, func(i, j int) bool { return a[i].Path < a[j].Path })
+	return a
+}

--- a/cli/nav-pilot/internal/cli/sync.go
+++ b/cli/nav-pilot/internal/cli/sync.go
@@ -206,6 +206,13 @@ func syncScope(scope *InstallScope, ref, sourceRepo string, apply, jsonOutput bo
 	if err != nil {
 		return err
 	}
+	// A reused pakke retires artifacts too, and its record is its own file.
+	// Reading only the top source's meant an artifact the base withdrew stayed
+	// installed forever in every consumer of a pakke that reuses it, which is
+	// the whole thing the retired record exists to prevent (#716).
+	if reusedInSync != nil {
+		retired = mergeRetired(retired, findRetiredOrphans(scope, reusedInSync.Dir, reusedInSync.Pakke))
+	}
 	if reusedInSync != nil && !jsonOutput {
 		fmt.Printf("%s %s\n", dim("Reuses:"), dim(fmt.Sprintf("%s@%s", sourceLabelFor(reusedInSync), shortSHA(reusedInSync.SHA))))
 	}


### PR DESCRIPTION
Komposisjonen fra #742 gjeninnførte tilstanden #716 fantes for å hindre.

## Feilen

`sync` leste bare toppkildens `retired-artifacts.json`. En pakke som gjenbruker en annen arver basens artefakter, men ikke basens pensjoneringer, så et artefakt basen trakk tilbake ble liggende for alltid hos hver eneste konsument.

Sync slår nå opp i begge recordene, og slår listene sammen på lokal sti: en pensjonering begge fører opp gir én fjerning, ikke to.

## Testen måtte skrives om for å måle noe

Første versjon installerte, lot basen trekke artefaktet tilbake, og passerte også med fiksen fjernet. Årsaken var at fila var sporet i state, så den ordinære slettestien tok den og recorden ble aldri spurt.

Den fjerner nå fila fra staten først. Det er tilstanden recorden er til for: en fil nav-pilot skrev, som ingen state sporer, og som slettestien derfor aldri ser. Med fiksen fjernet:

```
--- FAIL: TestRetirementsInTheBaseReachTheConsumer
    artefaktet basen pensjonerte ble liggende
```

Verdt å merke: den første, tomme varianten så helt riktig ut. Det var bare mutasjonskontrollen som avslørte at den ikke målte noe.