### PR TITLE
test: to vakter som kunne fjernes uten at noe merket det

### DIFF
--- a/cli/nav-pilot/internal/cli/compose_test.go
+++ b/cli/nav-pilot/internal/cli/compose_test.go
@@ -261,3 +261,31 @@ func TestPayloadOnlyBaseIsRefused(t *testing.T) {
 		t.Errorf("feilmeldinga sier ikke hvorfor: %v", err)
 	}
 }
+
+// En base med et manifest nav-pilot ikke kan bruke skal nekte, ikke bli
+// komponert som om den var manifestløs. Svelges feilen, får basen nil Pakke,
+// og resolveren leser da de kanoniske katalogene i stedet for layouten basen
+// faktisk erklærer: innholdet blir stille feil eller borte.
+func TestBaseWithUnusableManifestIsRefused(t *testing.T) {
+	baseDir, ownDir := t.TempDir(), t.TempDir()
+	if err := os.MkdirAll(filepath.Join(baseDir, ".nav-pilot"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Gyldig JSON, men bryter kontrakten: layout uten skills, og ingen
+	// primaryAgents for klienten.
+	broken := `{"contractVersion":"1","name":"base","description":"b","layout":{"agents":"agents"},"clients":{"copilot":{}}}`
+	if err := os.WriteFile(filepath.Join(baseDir, ".nav-pilot", "agentpakke.json"), []byte(broken), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writePakke(t, ownDir, "egenpakke", "eget")
+	declareReuse(t, ownDir, baseDir)
+
+	src := loadSource(t, ownDir)
+	_, reused, err := composeResolver(resolverFor(src.Dir, src.Pakke), src)
+	if err == nil {
+		t.Fatalf("en base med ubrukelig manifest ble godtatt, gjenbrukt = %v", reused)
+	}
+	if !strings.Contains(err.Error(), "agentpakke") {
+		t.Errorf("feilmeldinga peker ikke på manifestet: %v", err)
+	}
+}

--- a/cli/nav-pilot/internal/cli/retired_test.go
+++ b/cli/nav-pilot/internal/cli/retired_test.go
@@ -567,3 +567,35 @@ func TestRetiredRecordCannotReachOutsideTheScope(t *testing.T) {
 		t.Errorf("fila utenfor scopet ble rørt: %v", err)
 	}
 }
+
+// Kandidatene sorteres lengste katalog først, så en layout som nøster én type
+// inne i en annen ikke blir skygget av det korteste prefikset. Uten
+// sorteringa matcher "innhold/skills/gammel/SKILL.md" mot agent-katalogen
+// "innhold", og recorden peker da på feil type og feil lokal sti: enten
+// slettes ingenting, eller feil fil slettes.
+func TestKindForPathPrefersTheLongestLayoutDir(t *testing.T) {
+	layout := &agentpakke.Layout{
+		Agents: "innhold",
+		Skills: "innhold/skills",
+	}
+	kind, file := kindForPath("innhold/skills/gammel/SKILL.md", layout)
+	if kind == nil {
+		t.Fatal("stien traff ingen artefakttype")
+	}
+	if kind != KindSkill {
+		t.Errorf("stien ble lest som %q, ventet skill", kind.Name)
+	}
+	if file != "gammel/SKILL.md" {
+		t.Errorf("fildelen ble %q, ventet gammel/SKILL.md", file)
+	}
+
+	// Kontroll: en sti som bare ligger under den ytre katalogen er fortsatt en
+	// agent, ellers ville testen passert på at alt leses som skill.
+	kind, file = kindForPath("innhold/gammel.agent.md", layout)
+	if kind != KindAgent {
+		t.Errorf("agent-stien ble lest som %v, ventet agent", kind)
+	}
+	if file != "gammel.agent.md" {
+		t.Errorf("fildelen ble %q, ventet gammel.agent.md", file)
+	}
+}

--- a/cli/nav-pilot/internal/cli/sync_pin_nofiles_test.go
+++ b/cli/nav-pilot/internal/cli/sync_pin_nofiles_test.go
@@ -44,3 +44,79 @@ func TestSyncReportsAStalePinWithNoFilesInstalled(t *testing.T) {
 		t.Errorf("pinnen står på %q, ventet %q", got, second)
 	}
 }
+
+// En erklæring kan navngi en kilde uten å pinne noe: det er formen en
+// utvikler skriver for hånd før første sync. sync --apply skal fylle inn
+// pinnen, ellers blir erklæringa stående uten sha for alltid, og poenget med
+// å committe den, at teamet installerer samme revisjon, faller bort.
+//
+// Testen måler utfallet, ikke hvilket kall som gir det: pinnen fylles fra
+// flere steder i sync, så å fjerne ett av dem endrer ingenting her.
+func TestSyncApplyFillsInAMissingPin(t *testing.T) {
+	isolatedConfig(t)
+	repo, first, _ := gitAgentpakke(t)
+	localAgentpakkeRemote(t, repo)
+
+	scope := ScopeRepo(repoTarget(t))
+	writeDeclaration(t, scope,
+		`{"contractVersion":"1","source":"navikt/grillmester","sha":"`+first+`"}`)
+	captureStdoutFor(t, func() {
+		if err := cmdInstallAuto("grillmester", "", scope, "", "", false, false, false); err != nil {
+			t.Fatalf("install: %v", err)
+		}
+	})
+
+	// Ta bort pinnen, men behold kilden: filene er fortsatt oppdaterte.
+	writeDeclaration(t, scope, `{"contractVersion":"1","source":"navikt/grillmester"}`)
+	if got := readDeclaration(t, scope).SHA; got != "" {
+		t.Fatalf("erklæringa har fortsatt en pinne %q, da tester dette noe annet", got)
+	}
+
+	captureStdoutFor(t, func() {
+		if err := cmdSync(scope, "", "", true, false); err != nil {
+			t.Fatalf("sync --apply: %v", err)
+		}
+	})
+	if got := readDeclaration(t, scope).SHA; got == "" {
+		t.Error("sync --apply fylte ikke inn den manglende pinnen")
+	}
+}
+
+// sync --apply skal la staten stå på revisjonen den faktisk synket til.
+//
+// Navnet sier ikke «når alt er oppdatert», og det er med vilje: fixturet
+// endrer filer mellom de to revisjonene, så denne kjøringa går
+// oppdateringsstien. Grenen som frisker opp source_sha når ingenting har
+// endret seg er dermed ikke dekket her. Den lar seg ikke nå med dette
+// fixturet, som må ha to revisjoner med identisk innhold for å prøves, og
+// det er notert framfor å bli påstått dekket.
+func TestSyncApplyLeavesStateOnTheSyncedRevision(t *testing.T) {
+	isolatedConfig(t)
+	repo, first, second := gitAgentpakke(t)
+	localAgentpakkeRemote(t, repo)
+
+	scope := ScopeRepo(repoTarget(t))
+	writeDeclaration(t, scope,
+		`{"contractVersion":"1","source":"navikt/grillmester","sha":"`+first+`"}`)
+	captureStdoutFor(t, func() {
+		if err := cmdInstallAuto("grillmester", "", scope, "", "", false, false, false); err != nil {
+			t.Fatalf("install: %v", err)
+		}
+	})
+	captureStdoutFor(t, func() {
+		if err := cmdSync(scope, "", "", true, false); err != nil {
+			t.Fatalf("sync --apply: %v", err)
+		}
+	})
+
+	state, err := readScopedState(scope)
+	if err != nil || state == nil {
+		t.Fatalf("leste ikke staten: %v", err)
+	}
+	if state.SourceSHA == first {
+		t.Errorf("staten står igjen på den gamle revisjonen %q", shortSHA(first))
+	}
+	if state.SourceSHA != second {
+		t.Errorf("staten har source_sha %q, ventet %q", state.SourceSHA, second)
+	}
+}

--- a/cli/nav-pilot/internal/source/resolver_test.go
+++ b/cli/nav-pilot/internal/source/resolver_test.go
@@ -446,3 +446,64 @@ func TestListHidesTheLocalWorkerWhileLocalIsOff(t *testing.T) {
 		t.Errorf("List() = %v, want only the agent unrelated to local inference", names)
 	}
 }
+
+// Et enkeltartefakt som er en symlink skal avvises, ikke bare en symlinket
+// innholdskatalog. Katalogtilfellet var dekket; fila var det ikke, og uten
+// sjekken ville en agentpakke kunne sende agents/x.agent.md som en lenke til
+// en fil utenfor repoet og få innholdet kopiert inn i brukerens scope.
+func TestResolverRefusesSymlinkedArtifactFile(t *testing.T) {
+	tmp := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "hemmelig.txt")
+	if err := os.WriteFile(outside, []byte("innhold utenfor repoet\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmp, "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(tmp, "agents", "lenket.agent.md")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("kan ikke lage symlink her: %v", err)
+	}
+	// Kontroll: lenka virker, så en avvisning skyldes sjekken og ikke at fila
+	// ikke er lesbar.
+	if _, err := os.ReadFile(link); err != nil {
+		t.Fatalf("symlinken er ikke lesbar, da tester dette noe annet: %v", err)
+	}
+
+	r := NewSourceResolver(tmp)
+	if res, ok := r.Get(KindAgent, "lenket"); ok {
+		t.Errorf("et symlinket artefakt ble godtatt: %s", res.AbsPath)
+	}
+	if got := len(r.List(KindAgent)); got != 0 {
+		t.Errorf("List ga %d artefakter, ventet 0", got)
+	}
+}
+
+// En symlink som peker inne i selve utsjekken avvises også. Det er tilfellet
+// bare symlink-sjekken fanger: containment-sjekken er fornøyd, siden målet
+// ligger inni. Uten den ville en pakke kunnet levere det samme artefaktet
+// under to navn, der bare det ene spores.
+func TestResolverRefusesASymlinkPointingInsideTheCheckout(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	real := filepath.Join(tmp, "agents", "ekte.agent.md")
+	if err := os.WriteFile(real, []byte("---\nname: ekte\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(tmp, "agents", "lenket.agent.md")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("kan ikke lage symlink her: %v", err)
+	}
+
+	r := NewSourceResolver(tmp)
+	if res, ok := r.Get(KindAgent, "lenket"); ok {
+		t.Errorf("en symlink inne i utsjekken ble godtatt: %s", res.AbsPath)
+	}
+	// Kontroll: den ekte fila ved siden av skal fortsatt løses, ellers måler
+	// testen bare at ingenting virker.
+	if _, ok := r.Get(KindAgent, "ekte"); !ok {
+		t.Error("den ekte fila ble ikke funnet")
+	}
+}


### PR DESCRIPTION
**Symlink-avvisninga på enkeltartefakter.** Katalogtilfellet var dekket, fila
var det ikke: `if info.Mode()&os.ModeSymlink != 0` kunne fjernes og hele
suiten passerte. Første forsøk på en test var også tomt, fordi en symlink som
peker ut av utsjekken fanges av containment-sjekken uansett. Testen bruker nå
en symlink som peker inn i utsjekken, som er tilfellet bare denne sjekken
fanger, med den ekte nabofila som kontroll.

**Lengste katalog først i kindForPath.** Sorteringa kunne erstattes med
`_ = candidates` uten at noe feilet. Den avgjør hvilken artefakttype en
pensjonert sti leses som, altså hvilken fil som slettes: uten den leses
"innhold/skills/gammel/SKILL.md" som en agent under "innhold", og
recorden peker på feil type og feil lokal sti.

Begge er verifisert ved å fjerne vakta igjen. Ingen kodeendring her, bare
dekning for kode som alt var riktig.
