### PR TITLE
docs(article): pin the survey year and its denominator

### DIFF
--- a/docs/news/articles/sandbox-confines-the-process-not-the-token.md
+++ b/docs/news/articles/sandbox-confines-the-process-not-the-token.md
@@ -12,8 +12,9 @@ tags:
 
 Nav is Norway's labour and welfare administration. We pay out roughly a third
 of the national budget, and around 700 developers with GitHub Copilot licences
-keep that running. In March we asked them how they work with AI coding tools.
-163 answered. Twelve said they use none. Three quarters use two or more.
+keep that running. In March 2026 we asked about 500 of them how they work with
+AI coding tools. 163 answered. Twelve said they use none. Three quarters use
+two or more.
 
 That is the context for what follows. The agents are here, they run on
 developer laptops with real credentials, and the question is no longer whether


### PR DESCRIPTION
Follow-up to #747, before the article goes to Hacker News.

Adding "around 700 developers" put that figure directly before "163 answered", which invites the reader to compute a **23% response rate** against the wrong denominator. The survey went to about 500 invited technologists, so the real rate is a third (`docs/utviklerundersokelsen-2026-oppsummering.md:3,7`). That arithmetic gets done in public on HN, and a bad-looking response rate would pull the thread away from the argument.

"In March" also goes ambiguous the moment the piece is read next year.

One clause fixes both:

> ...around 700 developers with GitHub Copilot licences keep that running. In March 2026 we asked about 500 of them how they work with AI coding tools. 163 answered. Twelve said they use none. Three quarters use two or more.

The six-month age of the survey is deliberately left unhedged. Adoption rose across those months (600 licences in May against 700 now), so the figures understate the current position, and a caveat would concede something that is not a weakness.

Other figures re-verified against the same source: 12 of 163 use no AI tools, and 74% use two or more, so "three quarters" holds.

523 tests pass.