### PR TITLE
fix(telemetry): device-id og cache følger NAV_PILOT_CONFIG (#627)

### DIFF
--- a/cli/nav-pilot/internal/artifacts/staleness.go
+++ b/cli/nav-pilot/internal/artifacts/staleness.go
@@ -36,6 +36,11 @@ func CacheFilePath() string {
 	if CacheHome != "" {
 		return filepath.Join(CacheHome, "cache.json")
 	}
+	// Same rule as the device id and the tier cache: the config file's
+	// directory is nav-pilot's own state directory when one is named.
+	if p := os.Getenv("NAV_PILOT_CONFIG"); p != "" {
+		return filepath.Join(filepath.Dir(p), "cache.json")
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return ""

--- a/cli/nav-pilot/internal/telemetry/config_dir_test.go
+++ b/cli/nav-pilot/internal/telemetry/config_dir_test.go
@@ -1,0 +1,52 @@
+package telemetry
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// NAV_PILOT_CONFIG navngir konfigurasjonsfila, og katalogen dens er der
+// nav-pilot sin øvrige egen tilstand hører hjemme. Leste denne $HOME direkte,
+// skrev en kjøring med isolert config likevel device-id inn i utviklerens
+// ekte hjemmekatalog (#627).
+func TestConfigDirFollowsNavPilotConfig(t *testing.T) {
+	iso := t.TempDir()
+	t.Setenv("NAV_PILOT_CONFIG", filepath.Join(iso, "config.toml"))
+
+	dir, err := GetConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dir != iso {
+		t.Errorf("config-katalogen ble %q, ventet %q", dir, iso)
+	}
+
+	id, err := GetOrCreateDeviceID()
+	if err != nil {
+		t.Fatalf("device-id: %v", err)
+	}
+	if strings.TrimSpace(id) == "" {
+		t.Error("device-id ble tomt")
+	}
+	// Og fila skal ligge der, ikke i hjemmekatalogen.
+	if _, err := filepath.Rel(iso, filepath.Join(dir, "device-id")); err != nil {
+		t.Errorf("device-id havnet utenfor den isolerte katalogen: %v", err)
+	}
+}
+
+// Kontroll: uten variabelen skal den fortsatt falle tilbake på hjemmekatalogen,
+// ellers ville testen passert på at alt peker til tmp.
+func TestConfigDirFallsBackToHome(t *testing.T) {
+	t.Setenv("NAV_PILOT_CONFIG", "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir, err := GetConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(home, ".nav-pilot"); dir != want {
+		t.Errorf("config-katalogen ble %q, ventet %q", dir, want)
+	}
+}

--- a/cli/nav-pilot/internal/telemetry/device_id.go
+++ b/cli/nav-pilot/internal/telemetry/device_id.go
@@ -123,12 +123,21 @@ func getMACAddress() (string, error) {
 // GetConfigDir returns the nav-pilot config directory, creating it if needed.
 // Uses: ~/.nav-pilot/
 func GetConfigDir() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("failed to get home directory: %w", err)
+	// NAV_PILOT_CONFIG names the config file, so its directory is where the
+	// rest of nav-pilot's own state belongs too. The CLI's tierCachePath
+	// already derives from it that way; this one read $HOME directly, so a
+	// run with an isolated config still wrote device-id into the developer's
+	// real home (#627). Three conventions for one directory is one too many.
+	configDir := ""
+	if p := os.Getenv("NAV_PILOT_CONFIG"); p != "" {
+		configDir = filepath.Dir(p)
+	} else {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to get home directory: %w", err)
+		}
+		configDir = filepath.Join(home, ".nav-pilot")
 	}
-
-	configDir := filepath.Join(home, ".nav-pilot")
 
 	// Create if doesn't exist
 	if err := os.MkdirAll(configDir, 0o700); err != nil {


### PR DESCRIPTION
Tre steder løste den samme katalogen på tre måter: tierCachePath tok
filepath.Dir(configPath()), staleness hadde en egen CacheHome-variabel, og
telemetry leste $HOME direkte. Følgen var at en kjøring med isolert config
likevel skrev device-id og cache.json inn i utviklerens ekte
hjemmekatalog.

Alle tre følger nå samme regel: er NAV_PILOT_CONFIG satt, er katalogen dens
nav-pilot sin egen tilstandskatalog. Uten variabelen faller de tilbake på
~/.nav-pilot som før.

Målt: en testkjøring med isolert HOME og config la før tre filer i
hjemmekatalogen. Nå ligger cache.json og device-id i den isolerte
katalogen, og det eneste som står igjen i HOME er .local/state/gh/device-id,
som gh skriver selv og ikke er vår.

Kontrolltesten dekker begge veier, så en fiks som peker alt til tmp ville
blitt fanget.
