### PR TITLE
fix(frozen): sti-kilder får ikke lenger et råd de ikke kan følge (#614)

### DIFF
--- a/cli/nav-pilot/internal/cli/frozen.go
+++ b/cli/nav-pilot/internal/cli/frozen.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
@@ -73,6 +74,16 @@ func frozenPrecheck(scope *InstallScope) error {
 	}
 	sha := strings.TrimSpace(d.SHA)
 	if sha == "" {
+		// A path source can never satisfy this, so it must not be told to try.
+		// install deliberately writes no pin for a working tree, and since #612
+		// neither does sync: there is no revision to fetch back. Sending the
+		// reader to `install` there is advice that cannot be followed, which is
+		// worse than the refusal it explains (#614).
+		if filepath.IsAbs(d.Source) {
+			return frozenf("%s names the local checkout %s, which has no revision to pin, so --frozen has nothing to hold the install to.\n"+
+				"Point %s at an %s source and commit the pin, or drop --frozen for installs from a working tree",
+				agentpakke.DeclarationPath, bold(d.Source), bold("source"), bold("owner/repo"))
+		}
 		return frozenf("%s names %s but pins no revision, so a frozen install would take whatever the default branch is today.\n"+
 			"Run %s and commit the pin it writes",
 			agentpakke.DeclarationPath, bold(d.Source), bold("nav-pilot install <name>"))

--- a/cli/nav-pilot/internal/cli/frozen_test.go
+++ b/cli/nav-pilot/internal/cli/frozen_test.go
@@ -535,3 +535,46 @@ func TestFrozenRefusesMixedPakke(t *testing.T) {
 		t.Errorf("the refusal does not say the pakke is mixed:\n%v", err)
 	}
 }
+
+// --frozen mot en sti-kilde uten pinne skal ikke be om noe som ikke lar seg
+// gjøre. install skriver bevisst ingen pinne for en arbeidskopi, og etter #612
+// gjør ikke sync det heller, så «kjør install og commit pinnen» er et råd
+// leseren aldri kan følge (#614).
+func TestFrozenDoesNotTellAPathSourceToPinItself(t *testing.T) {
+	isolatedConfig(t)
+	installFrozen = true
+	t.Cleanup(func() { installFrozen = false })
+	scope := ScopeRepo(repoTarget(t))
+	local := t.TempDir()
+	writeDeclaration(t, scope, `{"contractVersion":"1","source":"`+local+`"}`)
+
+	err := frozenPrecheck(scope)
+	if err == nil {
+		t.Fatal("--frozen godtok en sti-kilde uten pinne")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "commit the pin it writes") {
+		t.Errorf("meldinga ber om en pinne install aldri skriver:\n%s", msg)
+	}
+	if !strings.Contains(msg, "no revision to pin") {
+		t.Errorf("meldinga sier ikke hvorfor sti-kilden ikke kan fryses:\n%s", msg)
+	}
+}
+
+// Kontroll: en repoform uten pinne skal fortsatt få det rådet, som der er
+// mulig å følge.
+func TestFrozenStillAsksARepoSourceToPin(t *testing.T) {
+	isolatedConfig(t)
+	installFrozen = true
+	t.Cleanup(func() { installFrozen = false })
+	scope := ScopeRepo(repoTarget(t))
+	writeDeclaration(t, scope, `{"contractVersion":"1","source":"navikt/grillmester"}`)
+
+	err := frozenPrecheck(scope)
+	if err == nil {
+		t.Fatal("--frozen godtok en repo-kilde uten pinne")
+	}
+	if !strings.Contains(err.Error(), "commit the pin it writes") {
+		t.Errorf("repoformen mistet rådet sitt:\n%s", err)
+	}
+}


### PR DESCRIPTION
--frozen mot en erklæring uten pinne ba om «kjør nav-pilot install og
commit pinnen den skriver». For en sti-kilde kan det aldri innfris:
install skriver bevisst ingen pinne for en arbeidskopi, og etter #612 gjør
ikke sync det heller, fordi det ikke finnes en revisjon å hente tilbake. Et
råd som ikke lar seg følge er verre enn nektingen det forklarer.

Meldinga sier nå at den lokale utsjekken ikke har noen revisjon å pinne, og
peker på de to veiene som finnes: bytt til en owner/repo-kilde, eller la
være å bruke --frozen for installasjoner fra en arbeidskopi.

Repoformen beholder rådet sitt, som der er mulig å følge. Kontrolltesten
dekker begge veier, og en invertert betingelse feiler begge.
