### PR TITLE
fix(opencode): en konflikt står til brukeren rydder opp (#580)

### DIFF
--- a/cli/nav-pilot/internal/artifacts/opencode_sync.go
+++ b/cli/nav-pilot/internal/artifacts/opencode_sync.go
@@ -136,15 +136,33 @@ func withScopeExtras(entries []source.Resolved, scopeDir string, kind *source.Ar
 func SyncOpenCodeArtifacts(sourceDir, scopeDir, outputDir, sourceVersion, sourceSHA, sourceRepo string) (skills, commands, agents, instructions int, conflicts []string, err error) {
 	existingState, _ := ReadOpenCodeState(outputDir)
 	stateHashes := map[string]string{}
+	stillConflicted := map[string]bool{}
 	if existingState != nil {
+		conflicted := map[string]bool{}
 		for _, f := range existingState.Files {
-			if f.Status != domain.FileStatusConflict {
-				stateHashes[f.Path] = f.Hash
+			stateHashes[f.Path] = f.Hash
+			if f.Status == domain.FileStatusConflict {
+				// A conflict stands until the user resolves it (#580).
+				//
+				// Dropping the entry here meant the next sync found no stored
+				// hash, isConflict returned false, and the write went through:
+				// the first sync after an edit reported the conflict and left
+				// the file alone, the second overwrote it in silence. That made
+				// a conflicted file safer if its author left the repo than if
+				// they stayed in it, and it disagreed with navPilotOwns, which
+				// has treated a conflict entry as the user's for good since
+				// #579.
+				conflicted[f.Path] = true
 			}
 		}
+		stillConflicted = conflicted
 	}
 
 	isConflict := func(relPath, dstPath string, isDir bool) bool {
+		// Already conflicted and not yet resolved: still the user's.
+		if stillConflicted[relPath] {
+			return true
+		}
 		storedHash, inState := stateHashes[relPath]
 		if !inState {
 			return false

--- a/cli/nav-pilot/internal/artifacts/opencode_sync_test.go
+++ b/cli/nav-pilot/internal/artifacts/opencode_sync_test.go
@@ -489,3 +489,53 @@ func TestSyncOpenCodeArtifacts_KeepsEditedFileOnScopeSwitch(t *testing.T) {
 		t.Errorf("conflicts = %v, want the edited skill reported", conflicts)
 	}
 }
+
+// En konflikt står til brukeren rydder opp (#580).
+//
+// Konfliktoppføringer ble utelatt fra stateHashes, så neste synk fant ingen
+// lagret hash, isConflict returnerte false, og skrivingen gikk gjennom. Første
+// synk etter en endring rapporterte konflikten og lot fila stå; den andre
+// overskrev den i stillhet. Sekvensen fra saken er nøyaktig den under.
+func TestSyncOpenCodeArtifacts_ConflictSurvivesASecondSync(t *testing.T) {
+	sourceDir := setupTestSource(t)
+	outputDir := t.TempDir()
+
+	// Synk 1: alt skrives, ingen konflikt.
+	if _, _, _, _, conflicts, err := SyncOpenCodeArtifacts(sourceDir, "", outputDir, "v1", "sha1", ""); err != nil {
+		t.Fatalf("første synk: %v", err)
+	} else if len(conflicts) != 0 {
+		t.Fatalf("konflikter på første synk: %v", conflicts)
+	}
+
+	// Brukeren endrer en fil nav-pilot skrev.
+	agents := filepath.Join(outputDir, "AGENTS.md")
+	mine := "# min egen versjon\n"
+	if err := os.WriteFile(agents, []byte(mine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Synk 2: konflikt rapporteres, fila står.
+	_, _, _, _, conflicts, err := SyncOpenCodeArtifacts(sourceDir, "", outputDir, "v1", "sha1", "")
+	if err != nil {
+		t.Fatalf("andre synk: %v", err)
+	}
+	if len(conflicts) == 0 {
+		t.Fatal("andre synk meldte ingen konflikt")
+	}
+	if body, _ := os.ReadFile(agents); string(body) != mine {
+		t.Fatalf("andre synk overskrev brukerens fil:\n%s", body)
+	}
+
+	// Synk 3: den som pleide å overskrive i stillhet.
+	_, _, _, _, conflicts, err = SyncOpenCodeArtifacts(sourceDir, "", outputDir, "v1", "sha1", "")
+	if err != nil {
+		t.Fatalf("tredje synk: %v", err)
+	}
+	body, _ := os.ReadFile(agents)
+	if string(body) != mine {
+		t.Errorf("tredje synk overskrev brukerens fil:\n%s", body)
+	}
+	if len(conflicts) == 0 {
+		t.Error("tredje synk meldte ingen konflikt, så brukeren får ingen beskjed om at fila fortsatt avviker")
+	}
+}


### PR DESCRIPTION
Konfliktoppføringer ble utelatt fra stateHashes, så neste synk fant ingen
lagret hash for stien, isConflict returnerte false, og skrivingen gikk
gjennom. Første synk etter at brukeren endret fila rapporterte konflikten
og lot den stå; den andre overskrev den i stillhet.

Det gjorde en konfliktmarkert fil tryggere hvis brukeren forlot repoet enn
hvis han ble i det, og det var uenig med navPilotOwns, som har behandlet en
konfliktoppføring som brukerens for godt siden #579.

Oppføringa blir nå i stateHashes, og en sti som alt er i konflikt leses som
konflikt til hashen stemmer igjen. Saken kalte dette en produktbeslutning,
ikke en ren feilretting, og valget er tatt: konflikten står.

Testen kjører sekvensen fra saken, tre synk. Med vakta slått av overskriver
den tredje brukerens fil, som er nøyaktig det som ble rapportert.
