### PR TITLE
feat(doctor): sier fra om filer som er ignorert og installert samtidig (#724)

### DIFF
--- a/cli/nav-pilot/internal/cli/conflict_message_test.go
+++ b/cli/nav-pilot/internal/cli/conflict_message_test.go
@@ -70,3 +70,16 @@ func codeWithoutComments(src string) string {
 	}
 	return strings.Join(kept, "\n")
 }
+
+// #724-tilstanden skal også nevnes av doctor, ikke bare av sync. Det var
+// doctor som fanget symptomet i saken, en persona pinnet til en modell GitHub
+// hadde trukket, uten å si hvorfor fila aldri ble oppdatert.
+func TestDoctorReportsIgnoredButInstalled(t *testing.T) {
+	src := readSourceFile(t, "doctor.go")
+	if !strings.Contains(src, "reportScopeIgnoredButInstalled") {
+		t.Fatal("doctor.go nevner ikke installert-og-ignorert")
+	}
+	if got := strings.Count(src, "reportScopeIgnoredButInstalled("); got != 3 {
+		t.Errorf("nevnt %d ganger (definisjon pluss to scope), ventet 3", got)
+	}
+}

--- a/cli/nav-pilot/internal/cli/doctor.go
+++ b/cli/nav-pilot/internal/cli/doctor.go
@@ -31,6 +31,31 @@ func reportScopeConflicts(scope *InstallScope) {
 	fmt.Printf("          %s %s takes the source's version of these too.\n", yellow("Solution:"), bold("nav-pilot sync --apply"))
 }
 
+// reportScopeIgnoredButInstalled names files marked ignored in state that are
+// nonetheless on disk (#724).
+//
+// doctor is where this belongs: it was doctor that noticed the symptom in the
+// first place, a persona pinned to a model GitHub had withdrawn, and said
+// nothing about why sync kept skipping the file. Sync reports it too, but a
+// user chasing a stale artifact reaches for doctor.
+//
+// Like the conflict report it does not set hasErrors. The combination is
+// usually an older install's residue rather than something broken now, and the
+// file may be exactly what someone wants; what is wrong is that nothing said it
+// had stopped being maintained.
+func reportScopeIgnoredButInstalled(scope *InstallScope) {
+	stale := ignoredButInstalled(scope)
+	if len(stale) == 0 {
+		return
+	}
+	fmt.Printf("      %s %d file(s) are recorded as ignored but are installed, so sync skips them\n",
+		yellow("⚠"), len(stale))
+	for _, p := range stale {
+		fmt.Printf("          %s %s\n", dim("⊘"), p)
+	}
+	fmt.Printf("          %s %s brings one back under sync.\n", yellow("Solution:"), bold("nav-pilot add <type> <name> --force"))
+}
+
 // cmdDoctor runs system health checks and outputs actionable diagnostics.
 func cmdDoctor() error {
 	fmt.Printf("%s\n\n", bold("nav-pilot doctor"))
@@ -81,6 +106,7 @@ func cmdDoctor() error {
 				fmt.Printf("      %s %d files OK\n", green("✓"), ok)
 			}
 			reportScopeConflicts(userScope)
+			reportScopeIgnoredButInstalled(userScope)
 		} else {
 			fmt.Printf("    • User scope (~/.copilot): Not installed\n")
 		}
@@ -106,6 +132,7 @@ func cmdDoctor() error {
 				fmt.Printf("      %s %d files OK\n", green("✓"), ok)
 			}
 			reportScopeConflicts(repoScope)
+			reportScopeIgnoredButInstalled(repoScope)
 		} else {
 			fmt.Printf("    • Repo scope (.github): Not installed\n")
 		}


### PR DESCRIPTION
Tredje retning i saken. De to andre er alt på plass: sync rapporterer
tilstanden, og fold-inn markerer ikke lenger et artefakt som ignorert når
det ligger på disk.

doctor er der dette hører hjemme. Det var doctor som fanget symptomet i
saken, en persona pinnet til en modell GitHub hadde trukket, uten å si
hvorfor fila aldri ble oppdatert. En bruker som jakter på et gammelt
artefakt går til doctor, ikke til sync.

Setter ikke hasErrors, av samme grunn som konfliktrapporten ikke gjør det:
kombinasjonen er som regel rester etter en eldre installasjon, og fila kan
være akkurat det noen vil ha. Det som er galt er at ingenting sa at den
sluttet å bli vedlikeholdt.
