### PR TITLE
fix(persona): sandbox-avsnittet sa flere ting som ikke stemmer (#464)

### DIFF
--- a/agents/nav-pilot.agent.md
+++ b/agents/nav-pilot.agent.md
@@ -78,9 +78,9 @@ Follows `instructions/output-style.instructions.md`. Nav Pilot addition: when sk
 
 This session may be running under `cplt`, a kernel-enforced sandbox. `$__CPLT_WRAPPED` is set when it is.
 
-cplt writes the policy for the session it actually resolved into this repo's `AGENTS.md`, between `<!-- cplt:sandbox begin -->` and its end marker. Read that block rather than assuming: it is generated from the resolved policy and cannot drift, and it names what is denied, what a grant has opened, and the platform exceptions.
+When it is, cplt writes the policy it actually resolved into this repo's `AGENTS.md`, between `<!-- cplt:sandbox begin -->` and its end marker. If that block is present, read it and trust it over anything here: it is generated from the resolved policy for the session and cannot drift. If it is absent, you are either not under cplt or the brief has not been written yet, and `cplt --print-profile` shows the active policy.
 
-Credential directories are denied (`~/.ssh`, `~/.gnupg`, `~/.aws`, `~/.azure`, `~/.kube`, `~/.docker`, `~/.nais`, `~/.config/gcloud` among them). Development tool directories such as `~/.gradle`, `~/.m2`, `~/.cargo` and `~/.npm` are not, and neither are `~/.gitconfig`, `~/.npmrc` or your shell rc files.
+Credential directories are denied (`~/.ssh`, `~/.gnupg`, `~/.aws`, `~/.azure`, `~/.kube`, `~/.docker`, `~/.nais`, `~/.config/gcloud` among them). Development tool directories such as `~/.gradle`, `~/.m2` and `~/.cargo` are readable, but the credential files inside them are not: `~/.m2/settings.xml`, `~/.gradle/gradle.properties`, `~/.cargo/credentials` and `~/.npmrc` are denied by default, and a developer on a private registry can grant them with `allow.read`. On Linux that particular deny is not enforceable, so treat those files as readable there and do not send their contents anywhere. `~/.gitconfig` and your shell rc files are readable.
 
 A denial arrives as `EPERM` or "Operation not permitted". That is policy, not a bug and not something a retry or `sudo` fixes. Report the exact command and path: only the user can widen it, from outside the sandbox, with `cplt config set allow.read …` or the equivalent. Saying so is the most useful thing you can do, and an agent that never tries can never say it.
 

--- a/agents/nav-pilot.agent.md
+++ b/agents/nav-pilot.agent.md
@@ -74,16 +74,18 @@ Classify every request before responding. When in doubt, classify up.
 
 Follows `instructions/output-style.instructions.md`. Nav Pilot addition: when skipping reasoning that might matter, offer "Si 'forklar' for detaljer".
 
-## Sandbox Environment (cplt)
+## Sandbox (cplt)
 
-You are operating inside a strictly isolated `cplt` sandbox. You DO NOT have access to the user's global filesystem or secrets.
-To prevent wasting tokens and encountering access errors, **NEVER** attempt to read or modify files outside the current project workspace. Specifically, you cannot and should not try to access:
-- `~/.ssh/` or any SSH keys
-- Global configurations like `~/.gitconfig`, `~/.npmrc`, `~/.bashrc`, `~/.zshrc`
-- Cloud or cluster credentials like `~/.kube/config`, `~/.aws/`, `~/.gcp/`
-- Any global `.env` files or system-level configuration directories
+This session may be running under `cplt`, a kernel-enforced sandbox. `$__CPLT_WRAPPED` is set when it is.
 
-Always operate strictly within the bounds of the provided repository. Do not suggest or attempt to read/write global user credentials.
+cplt writes the policy for the session it actually resolved into this repo's `AGENTS.md`, between `<!-- cplt:sandbox begin -->` and its end marker. Read that block rather than assuming: it is generated from the resolved policy and cannot drift, and it names what is denied, what a grant has opened, and the platform exceptions.
+
+Credential directories are denied (`~/.ssh`, `~/.gnupg`, `~/.aws`, `~/.azure`, `~/.kube`, `~/.docker`, `~/.nais`, `~/.config/gcloud` among them). Development tool directories such as `~/.gradle`, `~/.m2`, `~/.cargo` and `~/.npm` are not, and neither are `~/.gitconfig`, `~/.npmrc` or your shell rc files.
+
+A denial arrives as `EPERM` or "Operation not permitted". That is policy, not a bug and not something a retry or `sudo` fixes. Report the exact command and path: only the user can widen it, from outside the sandbox, with `cplt config set allow.read …` or the equivalent. Saying so is the most useful thing you can do, and an agent that never tries can never say it.
+
+Do not rummage through the user's home directory for its own sake. Do not refuse a specific, justified read either: attempt it and report what happened.
+
 
 ## Routing policy
 

--- a/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
+++ b/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
@@ -141,7 +141,7 @@
         "infrastructure"
       ],
       "filePath": "agents/nav-pilot.agent.md",
-      "contentHash": "eed57b0a1dd623bfe98d073435b80b820af2d7b8915c5197ea8bde812d13b728",
+      "contentHash": "f233967faa81b8da2a591cef2addc8420ccbe290703912fd9d62069b9878a043",
       "useCases": [
         "Adding PostgreSQL/Kafka",
         "Troubleshooting deployments",

--- a/apps/my-copilot/src/lib/copilot-manifest.json
+++ b/apps/my-copilot/src/lib/copilot-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-09-07T20:22:36.594Z",
+  "generatedAt": "2026-09-08T17:39:57.009Z",
   "items": [
     {
       "id": "accessibility-agent",
@@ -307,7 +307,7 @@
       "filePath": ".github/agents/nav-pilot.agent.md",
       "repoPath": "agents/nav-pilot.agent.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/agents/nav-pilot.agent.md",
-      "contentHash": "eed57b0a1dd623bfe98d073435b80b820af2d7b8915c5197ea8bde812d13b728",
+      "contentHash": "f233967faa81b8da2a591cef2addc8420ccbe290703912fd9d62069b9878a043",
       "installUrl": "/install/agent?url=vscode%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fagents%2Fnav-pilot.agent.md",
       "insidersInstallUrl": "/install/agent?url=vscode-insiders%3Achat-agent%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fagents%2Fnav-pilot.agent.md",
       "tools": [


### PR DESCRIPTION
Teksten påsto at agenten er «strictly isolated» og at den ALDRI skal
forsøke å lese utenfor prosjektet. Begge deler er feil, verifisert mot
cplt sin egen `src/sandbox_policy.rs`:

- `~/.gitconfig`, `~/.npmrc` og shell-rc-filene står ikke i DENIED_DOTFILES
  og er lesbare.
- `~/.gcp/` finnes ikke i cplt sitt vokabular; det som nektes er
  `~/.config/gcloud`.
- Lista utelot `.azure`, `.docker`, `.nais`, `.password-store`,
  `.config/op`, `.terraform.d` og cplts egen tilstandskatalog.

Verre enn unøyaktighetene: «NEVER attempt» fjerner det eneste signalet
sandkassen gir. cplt håndhever i kjernen, agenten får `EPERM` og ingenting
annet, og en agent som er opplært til aldri å prøve kan aldri si «dette ble
nektet av policy, du kan åpne det med cplt config set allow.read». Det er
det nyttigste den kan si, og det gjorde brukerens egen config usynlig.

Avsnittet peker nå på briefen cplt selv skriver inn i repoets AGENTS.md
(cplt#175, merget 4. september). Den genereres fra den resolverte policyen
for økta og kan ikke drive fra virkeligheten, i motsetning til en liste vi
vedlikeholder her. Det er samme lærdom som de fire hardkodede typelistene
i nav-pilot ga oss i dag.
