### PR TITLE
fix: signer sync-commits, og fjern et dødt egress-domene (#278, #242)

### DIFF
--- a/.github/workflows/copilot-customization-sync.yml
+++ b/.github/workflows/copilot-customization-sync.yml
@@ -161,6 +161,9 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # ratchet:peter-evans/create-pull-request@v7
         with:
           token: ${{ github.token }}
+          # Signed as github-actions[bot] via the API, so a reviewer can tell a
+          # sync commit from one that merely claims to be (#278).
+          sign-commits: true
           commit-message: "chore: sync Copilot customizations from ${{ inputs.source_repo }}"
           title: "chore: sync ${{ steps.check.outputs.update_count }} Copilot customization(s)"
           body: |

--- a/apps/copilot-metrics/.nais/naisjob.yaml
+++ b/apps/copilot-metrics/.nais/naisjob.yaml
@@ -33,7 +33,6 @@ spec:
     outbound:
       external:
         - host: api.github.com
-        - host: copilot-reports-acc0engfa5gra7ha.b01.azurefd.net
         - host: copilot-reports.github.com
         - host: bigquery.googleapis.com
         - host: storage.googleapis.com


### PR DESCRIPTION
**Signerte commits i copilot-customization-sync (#278).** Workflowen er den
eneste i repoet som åpner PR-er, så spørsmålet om «alle sync-workflows»
besvarer seg selv. `sign-commits: true` finnes i den pinnede versjonen av
peter-evans/create-pull-request, verifisert mot action.yml på selve SHA-en
`5f6978fa`, og signerer som github-actions[bot] når `GITHUB_TOKEN` brukes,
som er det denne gjør. Ingen ny hemmelighet, ingen GPG-nøkkel å rotere.

Verdien er for den som reviewer: en sync-PR kan skilles fra en som bare
utgir seg for å være det.

**Dødt egress-domene (#242).** `copilot-reports-acc0engfa5gra7ha.b01.azurefd.net`
sto i naisjob-en uten at noe i koden kaller det; `copilot-reports.github.com`
er det som faktisk brukes. En åpning ingen trenger er en åpning som ikke
skal stå.
