### PR TITLE
fix(prompts): nais-manifestet skal ikke overskrive et annet teams (#619)

### DIFF
--- a/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
+++ b/apps/mcp-onboarding/internal/discovery/copilot-manifest.json
@@ -495,7 +495,7 @@
         "infrastructure"
       ],
       "filePath": "prompts/golang-service.prompt.md",
-      "contentHash": "6b0b8487f8cc481e1632f2888e331e2cda331a0bbd0c6a3c3f2682967741aab7",
+      "contentHash": "dc21d1c2ee4c168502d3aef869e7e7908e6b96eefab0512f0f1f0e0243d0966d",
       "installUrl": "vscode:chat-prompt/install?url=https://raw.githubusercontent.com/navikt/copilot/main/prompts/golang-service.prompt.md",
       "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/prompts/golang-service.prompt.md"
     },
@@ -537,7 +537,7 @@
         "infrastructure"
       ],
       "filePath": "prompts/nais-manifest.prompt.md",
-      "contentHash": "8576571223ffef8a3a02b2e6ae8b5ac3ca1c2f2c2aa09740222fc7fbcac0f0e0",
+      "contentHash": "f90a562ca7f8233c7ee7a32a26cc5c9140097379266cfe66b58fe9461e2972ed",
       "installUrl": "vscode:chat-prompt/install?url=https://raw.githubusercontent.com/navikt/copilot/main/prompts/nais-manifest.prompt.md",
       "rawUrl": "https://raw.githubusercontent.com/navikt/copilot/main/prompts/nais-manifest.prompt.md"
     },

--- a/apps/my-copilot/src/lib/copilot-manifest.json
+++ b/apps/my-copilot/src/lib/copilot-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-09-08T17:39:57.009Z",
+  "generatedAt": "2026-09-08T17:49:50.837Z",
   "items": [
     {
       "id": "accessibility-agent",
@@ -818,7 +818,7 @@
       "filePath": ".github/prompts/golang-service.prompt.md",
       "repoPath": "prompts/golang-service.prompt.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/prompts/golang-service.prompt.md",
-      "contentHash": "6b0b8487f8cc481e1632f2888e331e2cda331a0bbd0c6a3c3f2682967741aab7",
+      "contentHash": "dc21d1c2ee4c168502d3aef869e7e7908e6b96eefab0512f0f1f0e0243d0966d",
       "installUrl": "/install/prompt?url=vscode%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fprompts%2Fgolang-service.prompt.md",
       "insidersInstallUrl": "/install/prompt?url=vscode-insiders%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fprompts%2Fgolang-service.prompt.md",
       "invocation": "#golang-service",
@@ -865,7 +865,7 @@
       "filePath": ".github/prompts/nais-manifest.prompt.md",
       "repoPath": "prompts/nais-manifest.prompt.md",
       "rawGitHubUrl": "https://raw.githubusercontent.com/navikt/copilot/main/prompts/nais-manifest.prompt.md",
-      "contentHash": "8576571223ffef8a3a02b2e6ae8b5ac3ca1c2f2c2aa09740222fc7fbcac0f0e0",
+      "contentHash": "f90a562ca7f8233c7ee7a32a26cc5c9140097379266cfe66b58fe9461e2972ed",
       "installUrl": "/install/prompt?url=vscode%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fprompts%2Fnais-manifest.prompt.md",
       "insidersInstallUrl": "/install/prompt?url=vscode-insiders%3Achat-prompt%2Finstall%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fnavikt%2Fcopilot%2Fmain%2Fprompts%2Fnais-manifest.prompt.md",
       "invocation": "#nais-manifest",

--- a/prompts/golang-service.prompt.md
+++ b/prompts/golang-service.prompt.md
@@ -22,7 +22,8 @@ Generate a Go service with:
 4. **`sql/queries/*.sql`** — sqlc query definitions
 5. **`sql/migrations/001_initial.sql`** — goose migration
 6. **`sqlc.yaml`** — sqlc configuration
-7. **`.nais/app.yaml`** — NAIS manifest with PostgreSQL
+7. **`.nais/app.yaml`** — NAIS manifest with PostgreSQL. If that file already exists for a
+   different application, write `.nais/<app-name>.yaml` rather than editing it.
 8. **`Dockerfile`** — Multi-stage with Chainguard base images
 
 ## Patterns

--- a/prompts/nais-manifest.prompt.md
+++ b/prompts/nais-manifest.prompt.md
@@ -4,7 +4,12 @@ description: Generer et produksjonsklart Nais-applikasjonsmanifest for Kubernete
 model: GPT-5.3-Codex
 ---
 
-You are creating a Nais application manifest in `.nais/app.yaml` for deploying to Nav's Kubernetes platform.
+You are creating a Nais application manifest for deploying to Nav's Kubernetes platform.
+
+The default path is `.nais/app.yaml`. If that file already exists and declares a different
+application, do not edit it: it belongs to another deployment, and overwriting it takes that
+team's manifest with it. Write `.nais/<app-name>.yaml` instead, and say which path you chose
+and why.
 
 ## Required Configuration
 


### PR DESCRIPTION
Prompten sa «You are creating a Nais application manifest in
`.nais/app.yaml`» uten en regel for hva som skjer når fila alt finnes og
gjelder en annen applikasjon. Bedt om et manifest for dp-vedtak i et repo
som hadde .nais/app.yaml for dp-soknad, redigerte begge armene den
eksisterende fila. Det er den eneste faktiske skaden de 62 levende kallene
i #618 produserte.

Standardstien er fortsatt .nais/app.yaml. Finnes den for en annen app,
skriver prompten nå .nais/<app-navn>.yaml og sier hvilken sti den valgte.
golang-service-prompten hadde samme hull i fillista si og har fått samme
regel.

Uavhengig av #604 og hva vi lander på der: defekten ligger i prompten som
er i bruk i dag.
