### PR TITLE
feat(my-copilot): søkeinngang på forsiden (#300)

### DIFF
--- a/apps/my-copilot/src/app/(nb)/(home)/page.tsx
+++ b/apps/my-copilot/src/app/(nb)/(home)/page.tsx
@@ -2,6 +2,7 @@ import { getNewsItems } from "@/lib/news";
 import { Box, VStack, Heading, HGrid, BodyShort } from "@navikt/ds-react";
 import { ExternalLinkIcon, PlayIcon, BookIcon } from "@navikt/aksel-icons";
 import { NewsFeed } from "@/components/news-feed";
+import { HomeSearch } from "@/components/home-search";
 import { HighlightCards } from "@/components/pulse-strip";
 import { HomeShortsFeed } from "@/components/video/home-shorts-feed";
 import { Sidebar, SidebarCompact } from "@/components/sidebar";
@@ -40,6 +41,7 @@ export default async function Home() {
                 Nyheter, beste praksis og verktøy for AI-drevet utvikling i Nav.
               </BodyShort>
             </VStack>
+            <HomeSearch />
             <div className="flex flex-wrap gap-2 hero-animate-d2">
               {NAV_ITEMS.map(({ href, icon: Icon, label, requiresAuth }) => (
                 <NavPill

--- a/apps/my-copilot/src/components/home-search.tsx
+++ b/apps/my-copilot/src/components/home-search.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Search } from "@navikt/ds-react";
+import { useRouter } from "next/navigation";
+
+/**
+ * Search entry point on the front page.
+ *
+ * The catalogue at /verktoy has had search since it was built, and reads the
+ * term from `?q=` (customization-catalog.tsx). What was missing was a way in:
+ * a user had to know the tool catalogue existed, navigate to it, and only then
+ * could they look for anything (#300). This submits into that same page, so
+ * there is one search implementation, not two.
+ */
+export function HomeSearch() {
+  const router = useRouter();
+
+  return (
+    <form
+      role="search"
+      className="max-w-md hero-animate-d2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        const q = new FormData(e.currentTarget).get("q");
+        const term = typeof q === "string" ? q.trim() : "";
+        router.push(term ? `/verktoy?q=${encodeURIComponent(term)}` : "/verktoy");
+      }}
+    >
+      <Search
+        name="q"
+        label="Søk etter agenter, skills og instruksjoner"
+        hideLabel
+        placeholder="Søk etter agenter, skills og instruksjoner"
+        variant="secondary"
+        size="medium"
+      />
+    </form>
+  );
+}


### PR DESCRIPTION
Katalogen på /verktoy har hatt søk hele tiden og leser termen fra ?q=
(customization-catalog.tsx:39). Det som manglet var veien inn: en bruker
måtte vite at verktøykatalogen fantes, navigere dit, og først da kunne han
lete. Feltet i heroen sender til den samme sida, så det finnes fortsatt én
søkeimplementasjon, ikke to.

Tomt søk går til /verktoy uten parameter framfor å gjøre ingenting.

Verifisert i appen: forsiden svarer 200 med role="search" i markupen, og
lenka den bygger treffer katalogen. Merk at /verktoy gir 500 i dev-modus,
også på main uten denne endringa: getMcpServers bruker "use cache", som
dev-serveren ikke har påslått. Produksjon svarer 200 på både /verktoy og
/verktoy?q=aksel, så det er en dev-only-sak og hører hjemme for seg.
