### PR TITLE
feat(my-copilot): egne metadata for videoruta (#287)

### DIFF
--- a/apps/my-copilot/src/app/(nb)/videos/[id]/page.tsx
+++ b/apps/my-copilot/src/app/(nb)/videos/[id]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { Box } from "@navikt/ds-react";
@@ -11,6 +12,41 @@ import { RelatedVideos } from "@/components/video/related-videos";
 type Props = {
   params: Promise<{ id: string }>;
 };
+
+/**
+ * Per-video metadata, so a shared link previews as the video it points at.
+ *
+ * Without this the route inherited the site-wide title and description, and a
+ * link pasted into Slack or Teams said "Copilot i Nav" whatever it led to
+ * (#287). The poster is the video's own frame, which is the part that makes a
+ * preview worth pasting.
+ */
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params;
+  const video = await fetchVideoById(id);
+
+  if (!video) {
+    return { title: "Videoen finnes ikke" };
+  }
+
+  return {
+    title: video.title,
+    description: video.description,
+    openGraph: {
+      title: video.title,
+      description: video.description,
+      type: "video.other",
+      locale: video.language === "en" ? "en_GB" : "nb_NO",
+      images: video.posterUrl ? [{ url: video.posterUrl }] : undefined,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: video.title,
+      description: video.description,
+      images: video.posterUrl ? [video.posterUrl] : undefined,
+    },
+  };
+}
 
 export default async function VideoPage({ params }: Props) {
   const { id } = await params;


### PR DESCRIPTION
En delt videolenke forhåndsvistes med sidas generelle metadata. Målt i
produksjon før endringa:

  og:title       Oh-My-Nav
  og:description Nyheter, beste praksis og verktøy for AI-drevet utvikling i Nav.
  og:type        website

Beskrivelsen er den nettstedet bruker overalt, og typen sier «website» om
en video. Ruta har nå generateMetadata med videoens egen tittel,
beskrivelse, plakat og type video.other, etter samme mønster som de tre
andre rutene som alt har det.

Verifisert: tsc og mise run check er grønne, og produksjon bekrefter
defekten over. Ikke verifisert: hvordan taggene faktisk rendres, fordi
dev-serveren ikke når video-API-et (fetch failed) og /videos/<id> derfor
gir 500 lokalt uavhengig av denne endringa. Det bør ses etter deploy.
