### PR TITLE
fix(agentpakke): refuse a primaryAgents name that has no agent file

### DIFF
--- a/cli/nav-pilot/internal/agentpakke/load.go
+++ b/cli/nav-pilot/internal/agentpakke/load.go
@@ -524,7 +524,13 @@ func checkAgentFiles(agentsDir, field string, declared map[string][]string, comp
 			continue
 		}
 		found++
-		present[strings.TrimSuffix(e.Name(), agentFileSuffix)] = true
+		// Same two rules source.ValidateName applies, inlined because importing
+		// internal/source here would cycle. Without them a stem install would
+		// never materialize counts as present, and the typo it hides surfaces
+		// at launch instead.
+		if stem := strings.TrimSuffix(e.Name(), agentFileSuffix); !strings.Contains(stem, "..") && !strings.ContainsAny(stem, `/\`) {
+			present[stem] = true
+		}
 		// A symlinked agent file reads whatever it points at — including files
 		// outside the checkout — so it is refused rather than parsed.
 		if e.Type()&os.ModeSymlink != 0 {

--- a/cli/nav-pilot/internal/agentpakke/load.go
+++ b/cli/nav-pilot/internal/agentpakke/load.go
@@ -372,12 +372,12 @@ func (m *Manifest) validateContent(sourceRoot string) []error {
 				continue
 			}
 			if d.Field == "layout.agents" {
-				errs = append(errs, checkAgentFiles(filepath.Join(sourceRoot, filepath.FromSlash(d.Value)), d.Field)...)
+				errs = append(errs, checkAgentFiles(
+					filepath.Join(sourceRoot, filepath.FromSlash(d.Value)),
+					d.Field, m.tier1PrimaryAgents(), reusesAnotherPakke(sourceRoot))...)
 			}
 		}
 	}
-
-	errs = append(errs, m.checkPrimaryAgents(sourceRoot)...)
 
 	for _, client := range m.ClientIDs() {
 		entry := m.Clients[client]
@@ -505,18 +505,26 @@ func requireContained(sourceRoot, field, rel string) error {
 // Tier 1 layout resolver — importing it here would close that cycle. Deep
 // frontmatter conformance therefore belongs in the sync layer, where the parser
 // already runs.
-func checkAgentFiles(agentsDir, field string) []error {
+// checkAgentFiles validates the agent files on disk and cross-checks the
+// primaryAgents each Tier 1 client declares against them. The cross-check lives
+// here because this function already reads the directory: a separate os.Stat
+// would accept names ReadDir does not — "../x", "sub/x", and a wrong-case name
+// on a case-insensitive filesystem — while install materializes only the flat,
+// ValidateName-clean entries this loop sees (#796).
+func checkAgentFiles(agentsDir, field string, declared map[string][]string, composed bool) []error {
 	entries, err := os.ReadDir(agentsDir)
 	if err != nil {
 		return []error{fmt.Errorf("%s: reading %q: %v", field, agentsDir, err)}
 	}
 	var errs []error
 	var found int
+	present := make(map[string]bool, len(entries))
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), agentFileSuffix) {
 			continue
 		}
 		found++
+		present[strings.TrimSuffix(e.Name(), agentFileSuffix)] = true
 		// A symlinked agent file reads whatever it points at — including files
 		// outside the checkout — so it is refused rather than parsed.
 		if e.Type()&os.ModeSymlink != 0 {
@@ -537,6 +545,43 @@ func checkAgentFiles(agentsDir, field string) []error {
 	}
 	if found == 0 {
 		errs = append(errs, fmt.Errorf("%s: %q contains no *%s files", field, agentsDir, agentFileSuffix))
+	}
+	errs = append(errs, checkPrimaryAgentsPresent(present, declared, composed)...)
+	return errs
+}
+
+// checkPrimaryAgentsPresent refuses a declared primary agent that no file
+// provides. The name reaches the client verbatim as --agent, so an unchecked
+// typo is caught nowhere: validate passed, install wrote the files, and the
+// failure landed at launch on every consumer's machine.
+//
+// A composed pakke is exempt. It may legitimately name an agent inherited from
+// the pakke it reuses, and neither validate nor the pre-install check composes,
+// so enforcing here would refuse a documented, working shape.
+func checkPrimaryAgentsPresent(present map[string]bool, declared map[string][]string, composed bool) []error {
+	if composed {
+		return nil
+	}
+	have := make([]string, 0, len(present))
+	for name := range present {
+		have = append(have, name)
+	}
+	sort.Strings(have)
+	clients := make([]string, 0, len(declared))
+	for c := range declared {
+		clients = append(clients, c)
+	}
+	sort.Strings(clients)
+	var errs []error
+	for _, client := range clients {
+		for _, name := range declared[client] {
+			if name == "" || present[name] {
+				continue
+			}
+			errs = append(errs, fmt.Errorf(
+				"clients.%s.primaryAgents: %q has no agent file; this directory provides: %s",
+				client, name, strings.Join(have, ", ")))
+		}
 	}
 	return errs
 }
@@ -566,36 +611,23 @@ func hasFrontmatter(data []byte) bool {
 	return false
 }
 
-// checkPrimaryAgents refuses a Tier 1 client whose primaryAgents names an agent
-// that does not exist. The name reaches the client verbatim as --agent, so a
-// typo is caught nowhere: validate passes, install writes the files, and the
-// failure surfaces at launch on every consumer's machine. That is why it
-// belongs in the pakke author's own CI (#796).
-//
-// Tier 2 is excluded on purpose: its roster lives in the payload manifest, not
-// in the client entry.
-func (m *Manifest) checkPrimaryAgents(sourceRoot string) []error {
-	if m.Layout == nil || m.Layout.Agents == "" {
-		return nil
-	}
-	agentsDir := filepath.Join(sourceRoot, filepath.FromSlash(m.Layout.Agents))
-	var errs []error
+// tier1PrimaryAgents is the per-client roster the layout must provide. Tier 2 is
+// excluded: its roster lives in the payload manifest, and a stale client-level
+// list is documented as tolerated there.
+func (m *Manifest) tier1PrimaryAgents() map[string][]string {
+	out := map[string][]string{}
 	for _, client := range m.ClientIDs() {
-		if m.Tier(client) != TierLayout {
-			continue
-		}
-		for _, name := range m.Clients[client].PrimaryAgents {
-			if name == "" {
-				continue
-			}
-			file := name + agentFileSuffix
-			if _, err := os.Stat(filepath.Join(agentsDir, file)); err != nil {
-				errs = append(errs, fmt.Errorf(
-					"clients.%s.primaryAgents: %q names no agent — %s is absent. "+
-						"The launcher passes this name to the client verbatim, so the pakke installs and then fails at launch for every consumer",
-					client, name, filepath.ToSlash(filepath.Join(m.Layout.Agents, file))))
-			}
+		if m.Tier(client) == TierLayout {
+			out[client] = m.Clients[client].PrimaryAgents
 		}
 	}
-	return errs
+	return out
+}
+
+// reusesAnotherPakke reports whether this checkout composes a base pakke, in
+// which case agents it names may come from that base rather than from its own
+// layout.
+func reusesAnotherPakke(sourceRoot string) bool {
+	d, err := LoadDeclaration(sourceRoot)
+	return err == nil && d != nil && d.Source != ""
 }

--- a/cli/nav-pilot/internal/agentpakke/load.go
+++ b/cli/nav-pilot/internal/agentpakke/load.go
@@ -377,6 +377,8 @@ func (m *Manifest) validateContent(sourceRoot string) []error {
 		}
 	}
 
+	errs = append(errs, m.checkPrimaryAgents(sourceRoot)...)
+
 	for _, client := range m.ClientIDs() {
 		entry := m.Clients[client]
 		contexts := make([]string, 0, len(entry.Payloads))
@@ -562,4 +564,38 @@ func hasFrontmatter(data []byte) bool {
 		}
 	}
 	return false
+}
+
+// checkPrimaryAgents refuses a Tier 1 client whose primaryAgents names an agent
+// that does not exist. The name reaches the client verbatim as --agent, so a
+// typo is caught nowhere: validate passes, install writes the files, and the
+// failure surfaces at launch on every consumer's machine. That is why it
+// belongs in the pakke author's own CI (#796).
+//
+// Tier 2 is excluded on purpose: its roster lives in the payload manifest, not
+// in the client entry.
+func (m *Manifest) checkPrimaryAgents(sourceRoot string) []error {
+	if m.Layout == nil || m.Layout.Agents == "" {
+		return nil
+	}
+	agentsDir := filepath.Join(sourceRoot, filepath.FromSlash(m.Layout.Agents))
+	var errs []error
+	for _, client := range m.ClientIDs() {
+		if m.Tier(client) != TierLayout {
+			continue
+		}
+		for _, name := range m.Clients[client].PrimaryAgents {
+			if name == "" {
+				continue
+			}
+			file := name + agentFileSuffix
+			if _, err := os.Stat(filepath.Join(agentsDir, file)); err != nil {
+				errs = append(errs, fmt.Errorf(
+					"clients.%s.primaryAgents: %q names no agent — %s is absent. "+
+						"The launcher passes this name to the client verbatim, so the pakke installs and then fails at launch for every consumer",
+					client, name, filepath.ToSlash(filepath.Join(m.Layout.Agents, file))))
+			}
+		}
+	}
+	return errs
 }

--- a/cli/nav-pilot/internal/agentpakke/load_test.go
+++ b/cli/nav-pilot/internal/agentpakke/load_test.go
@@ -875,7 +875,18 @@ func TestValidateSourceRejectsPrimaryAgentWithoutFile(t *testing.T) {
 	if len(errs) == 0 {
 		t.Fatal("a primaryAgent naming no agent file must be refused")
 	}
-	if !strings.Contains(errs[0].Error(), "agents/typo.agent.md") {
-		t.Fatalf("the finding must name the missing file, got %q", errs[0])
+	if !strings.Contains(errs[0].Error(), "this directory provides: real") {
+		t.Fatalf("the finding must name what does exist, got %q", errs[0])
+	}
+
+	// A composed pakke may name an agent its base ships, and neither validate
+	// nor the pre-install check composes — so enforcing here would refuse a
+	// documented, working shape.
+	lock := `{"contractVersion":"1","source":"navikt/copilot","sha":"` + strings.Repeat("a", 40) + `"}`
+	if err := os.WriteFile(filepath.Join(dir, ".nav-pilot", "agentpakke.lock.json"), []byte(lock), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if errs := ValidateSource(dir); len(errs) != 0 {
+		t.Fatalf("a composed pakke may inherit its persona, got %v", errs)
 	}
 }

--- a/cli/nav-pilot/internal/agentpakke/load_test.go
+++ b/cli/nav-pilot/internal/agentpakke/load_test.go
@@ -837,3 +837,45 @@ func TestRequireSeparatesUnreadableFromAbsent(t *testing.T) {
 		t.Errorf("requireFile reported a permission failure as absence: %v", fileErr)
 	}
 }
+
+// A primaryAgents entry that names no agent file is the one manifest typo that
+// validate used to pass: the name reaches the client as --agent, so every
+// consumer hits it at launch and nobody hits it before (#796).
+func TestValidateSourceRejectsPrimaryAgentWithoutFile(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest := func(primary string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Join(dir, ".nav-pilot"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		m := `{"contractVersion":"1","name":"p","description":"d",` +
+			`"clients":{"copilot":{"primaryAgents":["` + primary + `"]}},` +
+			`"layout":{"agents":"agents","skills":"skills"}}`
+		if err := os.WriteFile(filepath.Join(dir, ".nav-pilot", "agentpakke.json"), []byte(m), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, d := range []string{"agents", "skills"} {
+		if err := os.MkdirAll(filepath.Join(dir, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	agent := filepath.Join(dir, "agents", "real.agent.md")
+	if err := os.WriteFile(agent, []byte("---\nname: real\ndescription: d\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	writeManifest("real")
+	if errs := ValidateSource(dir); len(errs) != 0 {
+		t.Fatalf("a primaryAgent with a file must validate, got %v", errs)
+	}
+
+	writeManifest("typo")
+	errs := ValidateSource(dir)
+	if len(errs) == 0 {
+		t.Fatal("a primaryAgent naming no agent file must be refused")
+	}
+	if !strings.Contains(errs[0].Error(), "agents/typo.agent.md") {
+		t.Fatalf("the finding must name the missing file, got %q", errs[0])
+	}
+}


### PR DESCRIPTION
Refs #796 (the `defaultModel` half of that issue is not done here).

`primaryAgents` reaches the client verbatim as `--agent`. A typo was caught nowhere: `validate` passed, `install` wrote the files, and the failure landed at launch on every consumer's machine with a name they did not choose.

## What changed after review

The first version added a separate `os.Stat` walk. Review found it **refused composed pakker** — one that reuses another may legitimately name an inherited agent as its persona, and neither `validate` nor the pre-install check composes, so both refused a documented, working shape. Reproduced against built binaries.

The cross-check now lives inside `checkAgentFiles`, which already reads that directory. Three things fall out:

- The oracle is the same `ReadDir` install materializes from. The old `os.Stat` accepted `../x`, `sub/x` and a wrong-case name on a case-insensitive filesystem — none of which install would ever install.
- A missing `layout.agents` no longer reports every primary as absent on top of the real error.
- The message lists the agents that do exist.

Composed checkouts are exempt until `validate` composes too.

## Blast radius

Tier 1 only; Tier 2's roster lives in the payload manifest. `validate` and `install` share `ValidateSource`, so a pakke shipping this typo fails its own CI instead of its users.

## Adversarial review

Mutation-checked twice: forcing the composition exemption off fails the composed case and nothing else; a no-op on the cross-check fails the typo case. `go test ./...` and `go vet ./...` green, e2e included.

Not covered: an external composed pakke end to end — the exemption is asserted from a lock file in a unit test, not from a real base clone.