### PR TITLE
fix(opencode): export and sync honour the manifest they are writing out

### DIFF
--- a/cli/nav-pilot/internal/artifacts/export.go
+++ b/cli/nav-pilot/internal/artifacts/export.go
@@ -400,14 +400,23 @@ type InstructionRef struct {
 // belong in the same file — the installed scope, for an export that writes
 // project-local files. An empty entry is skipped, and a name the source already
 // has is not read twice, so passing only the source is what it always was.
-func collectInstructionData(dirs ...string) ([]InstructionSection, []InstructionRef, error) {
+// The layout applies to dirs[0], the agentpakke source. Later dirs are installed
+// scopes, whose own layout is always canonical, so they keep the canonical
+// resolver. Without this a pakke declaring layout.instructions exported its
+// agents and skills from the declared paths and its instructions from nowhere
+// (#790).
+func collectInstructionData(layout *agentpakke.Layout, dirs ...string) ([]InstructionSection, []InstructionRef, error) {
 	var instrEntries []source.Resolved
 	var globalSections []InstructionSection
 	for i, dir := range dirs {
 		if dir == "" {
 			continue
 		}
-		instrEntries = withScopeExtras(instrEntries, dir, source.KindInstruction)
+		if i == 0 {
+			instrEntries = source.NewSourceResolverForLayout(dir, layout).List(source.KindInstruction)
+		} else {
+			instrEntries = withScopeExtras(instrEntries, dir, source.KindInstruction)
+		}
 		data, err := os.ReadFile(filepath.Join(dir, "copilot-instructions.md"))
 		if err != nil {
 			continue
@@ -459,7 +468,7 @@ func collectInstructionData(dirs ...string) ([]InstructionSection, []Instruction
 }
 
 func exportInstructions(sourceDir, scopeDir, outputDir string, layout *agentpakke.Layout, dryRun bool) (int, error) {
-	globalSections, scopedRefs, err := collectInstructionData(sourceDir, scopeDir)
+	globalSections, scopedRefs, err := collectInstructionData(layout, sourceDir, scopeDir)
 	if err != nil {
 		return 0, err
 	}
@@ -593,7 +602,7 @@ func MaterializeOpenCode(sourceDir, outputDir string) (skills, commands, agents,
 		agents++
 	}
 
-	globalSections, scopedRefs, collErr := collectInstructionData(sourceDir)
+	globalSections, scopedRefs, collErr := collectInstructionData(syncLayout(sourceDir), sourceDir)
 	if collErr != nil {
 		return skills, commands, agents, instructions, collErr
 	}
@@ -673,9 +682,9 @@ func outputJSON(v interface{}) error {
 }
 
 // openCodePrimaries reads the opencode roster from the manifest of the source
-// being written out. It returns nil when the source ships no manifest, which is
-// the legacy case and keeps today's answer: every agent a subagent unless the
-// built-in rules say otherwise.
+// being written out. A source with no manifest falls back to the built-in
+// roster, which is the answer the active-pakke global used to give — returning
+// nil there would demote every Nav agent to a subagent.
 func openCodePrimaries(sourceDir string) []string {
 	m, err := agentpakke.Load(sourceDir)
 	if err != nil {

--- a/cli/nav-pilot/internal/artifacts/export.go
+++ b/cli/nav-pilot/internal/artifacts/export.go
@@ -305,6 +305,11 @@ func agentEntries(sourceDir string, layout *agentpakke.Layout) []source.Resolved
 
 func exportAgents(sourceDir, scopeDir, outputDir string, layout *agentpakke.Layout, dryRun bool) (int, error) {
 	agents := withScopeExtras(agentEntries(sourceDir, layout), scopeDir, source.KindAgent)
+	// The roster comes from the manifest being exported, not from the active
+	// pakke: export runs without a launch, so the global still holds the
+	// built-in default and every foreign persona was demoted to a subagent
+	// (#793). The manifest is the only thing that knows this pakke's primaries.
+	primaries := openCodePrimaries(sourceDir)
 	if len(agents) == 0 {
 		return 0, nil
 	}
@@ -318,7 +323,7 @@ func exportAgents(sourceDir, scopeDir, outputDir string, layout *agentpakke.Layo
 			return count, fmt.Errorf("reading agent %s: %w", entry.Name, err)
 		}
 
-		transformed := transformAgent(data, entry.Name)
+		transformed := transformAgent(data, entry.Name, primaries)
 
 		if dryRun {
 			fmt.Printf("  %s %s.agent.md → agents/%s.md\n", domain.Dim("→"), entry.Name, entry.Name)
@@ -333,7 +338,7 @@ func exportAgents(sourceDir, scopeDir, outputDir string, layout *agentpakke.Layo
 	return count, nil
 }
 
-func transformAgent(data []byte, name string) []byte {
+func transformAgent(data []byte, name string, primaries []string) []byte {
 	fm, body, hasFM := source.SplitFrontmatter(data)
 	if !hasFM {
 		return data
@@ -344,7 +349,7 @@ func transformAgent(data []byte, name string) []byte {
 		description = "Nav agent"
 	}
 
-	mode := source.OpenCodeAgentMode(name, source.ActivePakke().PrimaryAgents("opencode"))
+	mode := source.OpenCodeAgentMode(name, primaries)
 	newFM := source.BuildAgentFrontmatter(description, mode, openCodeAgentModel(fm, name))
 	return source.Reassemble(newFM, body)
 }
@@ -536,7 +541,10 @@ func buildLeanAGENTSmd(globalSections []InstructionSection, refs []InstructionRe
 // files with the same content on repeated calls, so running on every launch is safe.
 // Returns the count of each artifact type written.
 func MaterializeOpenCode(sourceDir, outputDir string) (skills, commands, agents, instructions int, err error) {
-	resolver := source.NewSourceResolver(sourceDir)
+	// Same layout the export path reads (#790): a pakke that declares where its
+	// content lives is materialized from there, not from the canonical names.
+	resolver := source.NewSourceResolverForLayout(sourceDir, syncLayout(sourceDir))
+	primaries := openCodePrimaries(sourceDir)
 
 	for _, skill := range resolver.List(source.KindSkill) {
 		dstDir := filepath.Join(outputDir, "skills", skill.Name)
@@ -579,7 +587,7 @@ func MaterializeOpenCode(sourceDir, outputDir string) (skills, commands, agents,
 		if err := source.CheckSymlink(dstPath, outputDir); err != nil {
 			return skills, commands, agents, instructions, fmt.Errorf("agent %s: %w", entry.Name, err)
 		}
-		if wErr := writeFile(dstPath, transformAgent(data, entry.Name)); wErr != nil {
+		if wErr := writeFile(dstPath, transformAgent(data, entry.Name, primaries)); wErr != nil {
 			return skills, commands, agents, instructions, fmt.Errorf("agent %s: %w", entry.Name, wErr)
 		}
 		agents++
@@ -662,4 +670,19 @@ func outputJSON(v interface{}) error {
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	return enc.Encode(v)
+}
+
+// openCodePrimaries reads the opencode roster from the manifest of the source
+// being written out. It returns nil when the source ships no manifest, which is
+// the legacy case and keeps today's answer: every agent a subagent unless the
+// built-in rules say otherwise.
+func openCodePrimaries(sourceDir string) []string {
+	m, err := agentpakke.Load(sourceDir)
+	if err != nil {
+		// No manifest is the legacy case, and it must keep the answer it had:
+		// the built-in roster, which is what the global supplied before.
+		// Returning nil here would demote every Nav agent to a subagent.
+		return agentpakke.Default().PrimaryAgents("opencode") //nolint:nilerr // legacy case
+	}
+	return m.PrimaryAgents("opencode")
 }

--- a/cli/nav-pilot/internal/artifacts/export_test.go
+++ b/cli/nav-pilot/internal/artifacts/export_test.go
@@ -847,8 +847,11 @@ func TestExportUsesTheExportedPakkesRoster(t *testing.T) {
 	}
 	mustWrite(t, filepath.Join(src, "skills", "s", "SKILL.md"), "# s\n")
 
+	// exportAgents is the function this change touches on the export path;
+	// MaterializeOpenCode alone would not prove anything about export, since it
+	// has no non-test caller. Both are covered: export here, materialize below.
 	out := t.TempDir()
-	if _, _, _, _, err := MaterializeOpenCode(src, out); err != nil {
+	if _, err := exportAgents(src, "", out, syncLayout(src), false); err != nil {
 		t.Fatal(err)
 	}
 	read := func(n string) string {
@@ -863,5 +866,18 @@ func TestExportUsesTheExportedPakkesRoster(t *testing.T) {
 	}
 	if !strings.Contains(read("helper"), "mode: subagent") {
 		t.Errorf("an agent the pakke does not declare must stay a subagent, got:\n%s", read("helper"))
+	}
+
+	// The materialize path reads the same roster.
+	out2 := t.TempDir()
+	if _, _, _, _, err := MaterializeOpenCode(src, out2); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(out2, "agents", "boss.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "mode: primary") {
+		t.Errorf("materialize must use the same roster, got:\n%s", b)
 	}
 }

--- a/cli/nav-pilot/internal/artifacts/export_test.go
+++ b/cli/nav-pilot/internal/artifacts/export_test.go
@@ -355,7 +355,7 @@ tools:
 
 You are nav-pilot, an expert on Nav's platform.
 `
-	got := transformAgent([]byte(input), "nav-pilot")
+	got := transformAgent([]byte(input), "nav-pilot", []string{"nav-pilot"})
 	content := string(got)
 
 	if !strings.Contains(content, "description: Plan and build Nav applications") {
@@ -440,7 +440,7 @@ func TestExportSummary(t *testing.T) {
 
 func TestTransformAgentNoFrontmatter(t *testing.T) {
 	input := "You are an agent without frontmatter.\n"
-	got := transformAgent([]byte(input), "auth")
+	got := transformAgent([]byte(input), "auth", nil)
 	if string(got) != input {
 		t.Errorf("transformAgent with no frontmatter should return input unchanged\ngot:  %q\nwant: %q", string(got), input)
 	}
@@ -448,7 +448,7 @@ func TestTransformAgentNoFrontmatter(t *testing.T) {
 
 func TestTransformAgentNoDescription(t *testing.T) {
 	input := "---\nname: bare-agent\ntools:\n  - read\n---\n\nAgent body.\n"
-	got := string(transformAgent([]byte(input), "auth"))
+	got := string(transformAgent([]byte(input), "auth", nil))
 	if !strings.Contains(got, "description: Nav agent") {
 		t.Error("expected fallback description 'Nav agent'")
 	}
@@ -828,5 +828,40 @@ func TestExportScopeExtras(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "## Global Instructions") {
 		t.Error("the source's global instructions were dropped")
+	}
+}
+
+// A foreign pakke's roster decides which of its agents are primaries. Export
+// runs without a launch, so the active-pakke global still holds the built-in
+// default and every foreign persona was demoted to a subagent (#793).
+func TestExportUsesTheExportedPakkesRoster(t *testing.T) {
+	src := t.TempDir()
+	mustWrite(t, filepath.Join(src, ".nav-pilot", "agentpakke.json"), `{
+  "contractVersion": "1", "name": "foreign", "description": "d",
+  "clients": {"opencode": {"primaryAgents": ["boss"]}},
+  "layout": {"agents": "agents", "skills": "skills"}
+}`)
+	for _, n := range []string{"boss", "helper"} {
+		mustWrite(t, filepath.Join(src, "agents", n+".agent.md"),
+			"---\nname: "+n+"\ndescription: d\n---\nbody\n")
+	}
+	mustWrite(t, filepath.Join(src, "skills", "s", "SKILL.md"), "# s\n")
+
+	out := t.TempDir()
+	if _, _, _, _, err := MaterializeOpenCode(src, out); err != nil {
+		t.Fatal(err)
+	}
+	read := func(n string) string {
+		b, err := os.ReadFile(filepath.Join(out, "agents", n+".md"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(b)
+	}
+	if !strings.Contains(read("boss"), "mode: primary") {
+		t.Errorf("an agent the pakke declares primary must be primary, got:\n%s", read("boss"))
+	}
+	if !strings.Contains(read("helper"), "mode: subagent") {
+		t.Errorf("an agent the pakke does not declare must stay a subagent, got:\n%s", read("helper"))
 	}
 }

--- a/cli/nav-pilot/internal/artifacts/golden_agent_test.go
+++ b/cli/nav-pilot/internal/artifacts/golden_agent_test.go
@@ -2,6 +2,8 @@ package artifacts
 
 import (
 	"bytes"
+
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
 	"io"
 	"os"
 	"strings"
@@ -74,7 +76,7 @@ You are aksel-ekspert.
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			src := []byte(strings.ReplaceAll(input, "%NAME%", tt.agent))
-			got := string(transformAgent(src, tt.agent))
+			got := string(transformAgent(src, tt.agent, goldenPrimaries))
 			if got != tt.want {
 				t.Errorf("transformAgent(%q)\n got: %q\nwant: %q", tt.agent, got, tt.want)
 			}
@@ -171,7 +173,7 @@ You are aksel.
 			src = strings.ReplaceAll(src, "%MODEL%", tt.model)
 			var got string
 			stderr := captureStderr(t, func() {
-				got = string(transformAgent([]byte(src), tt.agent))
+				got = string(transformAgent([]byte(src), tt.agent, goldenPrimaries))
 			})
 			if got != tt.want {
 				t.Errorf("transformAgent(%q, %q)\n got: %q\nwant: %q", tt.agent, tt.model, got, tt.want)
@@ -208,3 +210,7 @@ func captureStderr(t *testing.T, fn func()) string {
 	}
 	return buf.String()
 }
+
+// goldenPrimaries is the opencode roster these golden cases were written
+// against: the built-in default, which is what the global used to supply.
+var goldenPrimaries = agentpakke.Default().PrimaryAgents("opencode")

--- a/cli/nav-pilot/internal/artifacts/opencode_sync.go
+++ b/cli/nav-pilot/internal/artifacts/opencode_sync.go
@@ -288,7 +288,7 @@ func SyncOpenCodeArtifacts(sourceDir, scopeDir, outputDir, sourceVersion, source
 		agents++
 	}
 
-	globalSections, scopedRefs, collErr := collectInstructionData(sourceDir)
+	globalSections, scopedRefs, collErr := collectInstructionData(syncLayout(sourceDir), sourceDir)
 	if collErr != nil {
 		return skills, commands, agents, instructions, conflicts, collErr
 	}

--- a/cli/nav-pilot/internal/artifacts/opencode_sync.go
+++ b/cli/nav-pilot/internal/artifacts/opencode_sync.go
@@ -178,7 +178,12 @@ func SyncOpenCodeArtifacts(sourceDir, scopeDir, outputDir, sourceVersion, source
 	}
 
 	var files []domain.InstalledFile
-	resolver := source.NewSourceResolver(sourceDir)
+	// The layout the pakke declares, not the canonical names (#790). Export
+	// already honoured it; sync did not, so a pakke with non-canonical
+	// layout.skills or layout.prompts exported correctly and then silently
+	// mirrored nothing into ~/.config/opencode at launch.
+	resolver := source.NewSourceResolverForLayout(sourceDir, syncLayout(sourceDir))
+	primaries := openCodePrimaries(sourceDir)
 
 	// Hooks are not exported, and the message says why without claiming more
 	// than we know.
@@ -275,7 +280,7 @@ func SyncOpenCodeArtifacts(sourceDir, scopeDir, outputDir, sourceVersion, source
 		if err := source.CheckSymlink(dstPath, outputDir); err != nil {
 			return skills, commands, agents, instructions, conflicts, fmt.Errorf("agent %s: %w", entry.Name, err)
 		}
-		if wErr := writeFile(dstPath, transformAgent(data, entry.Name)); wErr != nil {
+		if wErr := writeFile(dstPath, transformAgent(data, entry.Name, primaries)); wErr != nil {
 			return skills, commands, agents, instructions, conflicts, fmt.Errorf("agent %s: %w", entry.Name, wErr)
 		}
 		h, _ := source.RawArtifactHash(dstPath, false)


### PR DESCRIPTION
Refs #790, #793. Two halves of one defect, landed together because they are the same mistake: both paths load the manifest and then apply only part of it.

**#793 — the roster.** `transformAgent` read `source.ActivePakke()`, which only *launch* sets. Export runs without a launch, so a foreign pakke's agents were measured against Nav's roster and every one was demoted to `mode: subagent`. It now takes the roster from the manifest being written out.

**#790 — the layout.** Launch-time sync built a canonical-path resolver while export built a layout-aware one. A pakke declaring non-canonical `layout.skills` or `layout.prompts` exported correctly and then mirrored nothing into `~/.config/opencode`. Both now read the declared layout, reusing the existing `syncLayout` and `NewSourceResolverForLayout`.

## Verified against a real third-party pakke

`nav-pilot export opencode --source <nais/pilot>` before: two agents, both `mode: subagent`. After: both `mode: primary`.

## Blast radius

Any opencode export or launch-time sync. **A manifest-less source keeps today's answer** — `openCodePrimaries` falls back to the built-in roster. The first version returned nil there and demoted every Nav agent to a subagent; `TestExportAgents` caught it.

## Adversarial review

Mutation-checked: pinning the roster back to the built-in default fails the new test and nothing else. Full `go test ./...` green, e2e and golden agent tests included.

Not covered: no test drives a non-canonical `layout.skills` through the *launch* sync end to end — the layout half is covered by construction (both paths now build the same resolver) rather than by a test of the sync path itself.