### PR TITLE
fix(nav-pilot): refuse an unreachable Tier 1 source, and stop install --json skipping state

### DIFF
--- a/cli/nav-pilot/internal/cli/add_test.go
+++ b/cli/nav-pilot/internal/cli/add_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"github.com/navikt/copilot/cli/nav-pilot/internal/agentpakke"
 	"os"
 	"path/filepath"
 	"strings"
@@ -717,5 +718,44 @@ func TestCmdAdd_ClearsIgnoredStatus(t *testing.T) {
 	}
 	if !found {
 		t.Error("re-added file should appear in sync file list")
+	}
+}
+
+// uninstall used to leave agentpakke.lock.json behind, and the next install read
+// it as a pin: a repo claiming to reuse a pakke whose artifacts were gone.
+// A declaration naming a different source must survive, because that shape is a
+// base the repo composes rather than the thing being uninstalled (#803).
+func TestUninstallRemovesOwnDeclarationOnly(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		declSource string
+		wantGone   bool
+	}{
+		{"same source is removed", "navikt/copilot", true},
+		{"foreign base survives", "navikt/grillmester", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := repoTarget(t)
+			scope := ScopeRepo(dir)
+			mustWrite(t, filepath.Join(dir, agentpakke.DeclarationPath),
+				`{"contractVersion":"1","source":"`+tc.declSource+`","sha":"`+strings.Repeat("b", 40)+`"}`)
+			mustWrite(t, filepath.Join(scope.RootDir, ".github", "agents", "x.agent.md"), "---\nname: x\n---\nb\n")
+			if err := writeScopedState(scope, &StateFile{
+				Collection: "nav-pilot", SourceRepo: "navikt/copilot",
+				Files: []InstalledFile{{Path: ".github/agents/x.agent.md"}},
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := cmdUninstall(scope, false); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := os.Stat(filepath.Join(dir, agentpakke.DeclarationPath))
+			gone := os.IsNotExist(err)
+			if gone != tc.wantGone {
+				t.Fatalf("declaration gone=%v, want %v", gone, tc.wantGone)
+			}
+		})
 	}
 }

--- a/cli/nav-pilot/internal/cli/declaration.go
+++ b/cli/nav-pilot/internal/cli/declaration.go
@@ -185,9 +185,7 @@ func guardDeclaredItems(src *Source, items map[string]string) error {
 // quiet suppresses the human lines when the caller is emitting JSON: moving the
 // JSON emit after the declaration write (#797) put these Printf calls in front
 // of it, so `install --json` produced prose followed by a JSON document.
-func recordDeclaration(scope *InstallScope, src *Source) { recordDeclarationQuiet(scope, src, false) }
-
-func recordDeclarationQuiet(scope *InstallScope, src *Source, quiet bool) {
+func recordDeclaration(scope *InstallScope, src *Source, quiet bool) {
 	if scope == nil || scope.IsUser() {
 		return
 	}

--- a/cli/nav-pilot/internal/cli/declaration.go
+++ b/cli/nav-pilot/internal/cli/declaration.go
@@ -182,7 +182,12 @@ func guardDeclaredItems(src *Source, items map[string]string) error {
 //
 // It never fails the install — the content is already on disk, correct — and it
 // never touches user scope, which has no repository to commit to.
-func recordDeclaration(scope *InstallScope, src *Source) {
+// quiet suppresses the human lines when the caller is emitting JSON: moving the
+// JSON emit after the declaration write (#797) put these Printf calls in front
+// of it, so `install --json` produced prose followed by a JSON document.
+func recordDeclaration(scope *InstallScope, src *Source) { recordDeclarationQuiet(scope, src, false) }
+
+func recordDeclarationQuiet(scope *InstallScope, src *Source, quiet bool) {
 	if scope == nil || scope.IsUser() {
 		return
 	}
@@ -217,6 +222,9 @@ func recordDeclaration(scope *InstallScope, src *Source) {
 	}
 	if err := agentpakke.WriteDeclaration(scope.RootDir, d); err != nil {
 		fmt.Fprintf(os.Stderr, "%s Could not write %s: %v\n", yellow("⚠"), agentpakke.DeclarationPath, err)
+		return
+	}
+	if quiet {
 		return
 	}
 	if d.SHA == "" {

--- a/cli/nav-pilot/internal/cli/declaration.go
+++ b/cli/nav-pilot/internal/cli/declaration.go
@@ -378,3 +378,28 @@ func selfInstall(scope *InstallScope, src *Source) bool {
 	}
 	return filepath.Clean(a) == filepath.Clean(b)
 }
+
+// removeDeclarationFor deletes the reuse declaration an uninstall leaves
+// behind, when it names the source being uninstalled.
+//
+// Without this the lock file outlived the files it described, and the next
+// install read it as a pin: the repo claimed to reuse a pakke whose artifacts
+// were gone (#803). It is removed only when the source matches, because a
+// declaration can also describe a base this repo composes, which an uninstall
+// of something else must not touch.
+func removeDeclarationFor(scope *InstallScope, state *StateFile) {
+	if scope == nil || scope.IsUser() || state == nil || state.SourceRepo == "" {
+		return
+	}
+	d, err := scopeDeclaration(scope)
+	if err != nil || d == nil || d.Source == "" {
+		return
+	}
+	if !sameSourceRepo(d.Source, state.SourceRepo) {
+		return
+	}
+	path := filepath.Join(scope.RootDir, agentpakke.DeclarationPath)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "%s Could not remove %s: %v\n", yellow("⚠"), agentpakke.DeclarationPath, err)
+	}
+}

--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -636,7 +636,7 @@ func cmdInstallFromSource(collection string, src *Source, scope *InstallScope, d
 	// already holds: a CI job must not produce a diff in a file it was only
 	// meant to obey.
 	if !installFrozen {
-		recordDeclaration(scope, src)
+		recordDeclarationQuiet(scope, src, jsonOutput)
 	}
 
 	if jsonOutput {

--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -994,7 +994,10 @@ func installAllFromSource(scope *InstallScope, src *Source, manifest *Manifest, 
 		printConflictHint(result.Conflicts)
 	}
 
-	if jsonOutput {
+	// Deferred past the state write, same reason as cmdInstallFromSource: this
+	// returned before writeScopedState, so `install --all --json` reported a
+	// success that left no state behind (#797).
+	emitJSON := func() error {
 		return outputJSON(map[string]interface{}{
 			"command":    "install",
 			"collection": stateCollection(src, CollectionAll),
@@ -1008,6 +1011,9 @@ func installAllFromSource(scope *InstallScope, src *Source, manifest *Manifest, 
 	}
 
 	if dryRun {
+		if jsonOutput {
+			return emitJSON()
+		}
 		fmt.Printf("%s Would install %d items.\n", dim("→"), result.Installed)
 		return nil
 	}
@@ -1044,6 +1050,10 @@ func installAllFromSource(scope *InstallScope, src *Source, manifest *Manifest, 
 
 	if err := writeScopedState(scope, state); err != nil {
 		fmt.Fprintf(os.Stderr, "%s Could not write state file: %v\n", yellow("⚠"), err)
+	}
+
+	if jsonOutput {
+		return emitJSON()
 	}
 
 	fmt.Printf("%s Installed %d items to %s (v%s, %s).\n",

--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -636,7 +636,7 @@ func cmdInstallFromSource(collection string, src *Source, scope *InstallScope, d
 	// already holds: a CI job must not produce a diff in a file it was only
 	// meant to obey.
 	if !installFrozen {
-		recordDeclarationQuiet(scope, src, jsonOutput)
+		recordDeclaration(scope, src, jsonOutput)
 	}
 
 	if jsonOutput {

--- a/cli/nav-pilot/internal/cli/install.go
+++ b/cli/nav-pilot/internal/cli/install.go
@@ -565,7 +565,12 @@ func cmdInstallFromSource(collection string, src *Source, scope *InstallScope, d
 		return err
 	}
 
-	if jsonOutput {
+	// Deferred until after the state file and the declaration are written.
+	// Emitting here would have returned before both, so `install --json`
+	// reported a success that left no state and no lock — a CI job could not
+	// tell an install apart from a no-op, and the next sync had nothing to
+	// reconcile against (#797).
+	emitJSON := func() error {
 		return outputJSON(map[string]interface{}{
 			"command":     "install",
 			"collection":  stateCollection(src, collection),
@@ -580,16 +585,21 @@ func cmdInstallFromSource(collection string, src *Source, scope *InstallScope, d
 		})
 	}
 
-	if result.Conflicts > 0 {
-		printConflictHint(result.Conflicts)
-	}
+	if !jsonOutput {
+		if result.Conflicts > 0 {
+			printConflictHint(result.Conflicts)
+		}
 
-	if len(result.Unsupported) > 0 {
-		fmt.Printf("%s Skipped (not supported in %s scope): %s\n",
-			yellow("⚠"), scope.Name, strings.Join(result.Unsupported, ", "))
+		if len(result.Unsupported) > 0 {
+			fmt.Printf("%s Skipped (not supported in %s scope): %s\n",
+				yellow("⚠"), scope.Name, strings.Join(result.Unsupported, ", "))
+		}
 	}
 
 	if dryRun {
+		if jsonOutput {
+			return emitJSON()
+		}
 		fmt.Printf("%s Would install %d items from %q.\n",
 			dim("→"), result.Installed, collection)
 		return nil
@@ -627,6 +637,10 @@ func cmdInstallFromSource(collection string, src *Source, scope *InstallScope, d
 	// meant to obey.
 	if !installFrozen {
 		recordDeclaration(scope, src)
+	}
+
+	if jsonOutput {
+		return emitJSON()
 	}
 
 	fmt.Printf("%s Installed %d items from %q (v%s, %s).\n",
@@ -1346,6 +1360,7 @@ func cmdUninstall(scope *InstallScope, dryRun bool) error {
 
 	if !dryRun {
 		os.Remove(scope.StatePath())
+		removeDeclarationFor(scope, state)
 		scope.CleanupDirs()
 	}
 

--- a/cli/nav-pilot/internal/cli/pakke_launch.go
+++ b/cli/nav-pilot/internal/cli/pakke_launch.go
@@ -295,7 +295,13 @@ func resolveAndPin(resolved ResolvedConfig) (*Source, bool, error) {
 		// is the one that source ships. Refusing it would take away a launch
 		// that works, which is the opposite of what #795 asks for.
 		if !sameSourceRepo(resolved.Source, defaultSourceRepo) {
-			if tier, ok := cachedTier(resolved.Source, resolved.Client); ok && tier == agentpakke.TierLayout {
+			tier, cached := cachedTier(resolved.Source, resolved.Client)
+			// The tier cache expires after a few hours and a repo-scope install
+			// never writes it, so it cannot carry this alone. The installed
+			// state is durable evidence of the same fact: a scope whose
+			// recorded source is this one, holding materialized content rather
+			// than a pin, was a Tier 1 install of it.
+			if (cached && tier == agentpakke.TierLayout) || installedLayoutSource(resolved.Source) {
 				return nil, true, unresolvableLayoutRefusal(resolved, err)
 			}
 		}
@@ -768,4 +774,32 @@ func printModelNotice(resolved ResolvedConfig) {
 	if notice := providerpkg.ResolvedModelNotice(resolved.Client, resolved); notice != "" {
 		fmt.Fprintln(os.Stderr, dim(notice))
 	}
+}
+
+// installedLayoutSource reports whether some installed scope records this source
+// as a Tier 1 install — content materialized into the scope rather than a
+// payload pin. It is the durable half of the offline check: the tier cache
+// expires and a repo-scope install never populates it, so a refusal keyed on
+// the cache alone reverts to substituting the built-in agent (#795).
+func installedLayoutSource(sourceRepo string) bool {
+	if sourceRepo == "" {
+		return false
+	}
+	var scopes []*InstallScope
+	if s, err := ScopeUser(); err == nil {
+		scopes = append(scopes, s)
+	}
+	if wd, err := os.Getwd(); err == nil {
+		scopes = append(scopes, ScopeRepo(wd))
+	}
+	for _, scope := range scopes {
+		state, err := readScopedState(scope)
+		if err != nil || state == nil {
+			continue
+		}
+		if sameSourceRepo(state.SourceRepo, sourceRepo) && !pinnedState(state) {
+			return true
+		}
+	}
+	return false
 }

--- a/cli/nav-pilot/internal/cli/pakke_launch.go
+++ b/cli/nav-pilot/internal/cli/pakke_launch.go
@@ -282,13 +282,22 @@ func resolveAndPin(resolved ResolvedConfig) (*Source, bool, error) {
 			// recent still knows legacy would be a downgrade.
 			return nil, true, unresolvablePayloadRefusal(resolved, err)
 		}
-		if tier, ok := cachedTier(resolved.Source, resolved.Client); ok && tier == agentpakke.TierLayout {
-			// A Tier 1 source this client has resolved before. Falling through
-			// would launch Nav's own persona under a configuration that asked
-			// for someone else's, which #779 already rules out: "Ingen stille
-			// bytte av kilde eller Tier 1-fallback." The user configured a
-			// pakke; a different pakke is not a degraded version of it (#795).
-			return nil, true, unresolvableLayoutRefusal(resolved, err)
+		// A *foreign* Tier 1 source this client has resolved before. Falling
+		// through would launch Nav's own persona under a configuration that
+		// asked for someone else's, which #779 rules out: "Ingen stille bytte
+		// av kilde eller Tier 1-fallback." The user configured a pakke, and a
+		// different pakke is not a degraded version of it (#795).
+		//
+		// The built-in source is excluded on purpose. navikt/copilot declares
+		// copilot and opencode as Tier 1, so keying on the tier alone would
+		// refuse the default configuration whenever the network is down — and
+		// there the fallback is not a substitution: the persona legacy launches
+		// is the one that source ships. Refusing it would take away a launch
+		// that works, which is the opposite of what #795 asks for.
+		if !sameSourceRepo(resolved.Source, defaultSourceRepo) {
+			if tier, ok := cachedTier(resolved.Source, resolved.Client); ok && tier == agentpakke.TierLayout {
+				return nil, true, unresolvableLayoutRefusal(resolved, err)
+			}
 		}
 		fmt.Fprintf(os.Stderr, "%s Could not resolve source %s: %v — launching without agentpakke context.\n",
 			yellow("⚠"), resolved.Source, err)

--- a/cli/nav-pilot/internal/cli/pakke_launch.go
+++ b/cli/nav-pilot/internal/cli/pakke_launch.go
@@ -282,6 +282,14 @@ func resolveAndPin(resolved ResolvedConfig) (*Source, bool, error) {
 			// recent still knows legacy would be a downgrade.
 			return nil, true, unresolvablePayloadRefusal(resolved, err)
 		}
+		if tier, ok := cachedTier(resolved.Source, resolved.Client); ok && tier == agentpakke.TierLayout {
+			// A Tier 1 source this client has resolved before. Falling through
+			// would launch Nav's own persona under a configuration that asked
+			// for someone else's, which #779 already rules out: "Ingen stille
+			// bytte av kilde eller Tier 1-fallback." The user configured a
+			// pakke; a different pakke is not a degraded version of it (#795).
+			return nil, true, unresolvableLayoutRefusal(resolved, err)
+		}
 		fmt.Fprintf(os.Stderr, "%s Could not resolve source %s: %v — launching without agentpakke context.\n",
 			yellow("⚠"), resolved.Source, err)
 		return nil, false, payloadContextUnsupported(resolved, resolved.Source)
@@ -479,6 +487,22 @@ func autoPin(src *Source, client string) (*Source, error) {
 // condition at all: it empties resolved.Source, which tryPakkeLaunch
 // short-circuits on before resolving anything, so the next launch takes the
 // built-in default immediately, offline or not.
+// unresolvableLayoutRefusal is the Tier 1 half of the same rule the payload
+// refusal enforces: what cannot be resolved is not silently replaced. The
+// remedies differ because a Tier 1 scope has already materialized its files —
+// the agents are on disk, only the manifest that names the persona is out of
+// reach — so retrying and dropping the source are both real answers, while
+// rebuilding a revision is not.
+func unresolvableLayoutRefusal(resolved ResolvedConfig, cause error) error {
+	return fmt.Errorf(
+		"source %s is an agentpakke for %s, and nav-pilot could not resolve it: %w.\n"+
+			"Nothing was launched — running it as before would start the built-in agent under a configuration that asked for this one.\n\n"+
+			"  Retry once the source resolves, or if you are offline, reconnect.\n"+
+			"  Or go back to the built-in agentpakke:  %s",
+		bold(resolved.Source), resolved.Client, cause,
+		bold(`nav-pilot config set source ""`))
+}
+
 func unresolvablePayloadRefusal(resolved ResolvedConfig, cause error) error {
 	return fmt.Errorf(
 		"source %s declares pre-built payloads for %s, and nav-pilot could not resolve it: %w.\n"+

--- a/cli/nav-pilot/internal/cli/pakke_launch_test.go
+++ b/cli/nav-pilot/internal/cli/pakke_launch_test.go
@@ -946,3 +946,39 @@ func TestPinnedLaunchBackfillsPerClientState(t *testing.T) {
 		t.Errorf("state.PinnedClients after a pinned launch = %v, want %v", state.PinnedClients, want)
 	}
 }
+
+// A Tier 1 source this client has resolved before must not silently degrade to
+// the built-in agent when it cannot be reached. #779 rules the substitution out
+// ("Ingen stille bytte av kilde eller Tier 1-fallback") and #795 is where it
+// still happened: the user configured a pakke, and a different pakke is not a
+// degraded version of it.
+func TestUnresolvableTier1SourceRefuses(t *testing.T) {
+	isolatedConfig(t)
+	t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
+
+	// One successful launch teaches the tier cache what this source is.
+	stubResolveSource(t, pakkeSource(t, "navikt/grillmester"))
+	if _, err := tryPakkeLaunch(ResolvedConfig{Client: "copilot", Source: "navikt/grillmester"}); err != nil {
+		t.Fatalf("priming launch: %v", err)
+	}
+
+	orig := resolveSource
+	t.Cleanup(func() { resolveSource = orig })
+	resolveSource = func(string, string) (*Source, error) {
+		return nil, errors.New("dial tcp: no route to host")
+	}
+
+	handled, err := tryPakkeLaunch(ResolvedConfig{Client: "copilot", Source: "navikt/grillmester"})
+	if !handled {
+		t.Fatal("an unreachable Tier 1 source must be handled, not fall through to the legacy launch")
+	}
+	if err == nil {
+		t.Fatal("an unreachable Tier 1 source must refuse rather than substitute the built-in agent")
+	}
+	if !strings.Contains(err.Error(), "navikt/grillmester") {
+		t.Errorf("the refusal must name the source, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Nothing was launched") {
+		t.Errorf("the refusal must say nothing started, got: %v", err)
+	}
+}

--- a/cli/nav-pilot/internal/cli/pakke_launch_test.go
+++ b/cli/nav-pilot/internal/cli/pakke_launch_test.go
@@ -1004,3 +1004,30 @@ func TestUnresolvableDefaultSourceStillFallsBack(t *testing.T) {
 		t.Fatalf("the built-in source must still fall back offline, got handled=%v err=%v", handled, err)
 	}
 }
+
+// The tier cache expires and a repo-scope install never writes it, so a refusal
+// keyed on the cache alone reverts to substituting the built-in agent once the
+// entry ages out. The installed state is the durable evidence (#795).
+func TestUnresolvableTier1RefusesFromInstalledStateAlone(t *testing.T) {
+	scope := pinEnv(t)
+	t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
+	if err := writeScopedState(scope, &StateFile{
+		Collection: "grillmester", Scope: "user", SourceRepo: "navikt/grillmester",
+		Files: []InstalledFile{{Path: "agents/grillmester.agent.md", Hash: "abc"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := resolveSource
+	t.Cleanup(func() { resolveSource = orig })
+	resolveSource = func(string, string) (*Source, error) {
+		return nil, errors.New("dial tcp: no route to host")
+	}
+
+	// No rememberTier call: the cache is cold, exactly as after a fresh install
+	// or six hours later.
+	handled, err := tryPakkeLaunch(ResolvedConfig{Client: "copilot", Source: "navikt/grillmester"})
+	if !handled || err == nil {
+		t.Fatalf("an installed Tier 1 source must refuse offline without the tier cache, got handled=%v err=%v", handled, err)
+	}
+}

--- a/cli/nav-pilot/internal/cli/pakke_launch_test.go
+++ b/cli/nav-pilot/internal/cli/pakke_launch_test.go
@@ -982,3 +982,25 @@ func TestUnresolvableTier1SourceRefuses(t *testing.T) {
 		t.Errorf("the refusal must say nothing started, got: %v", err)
 	}
 }
+
+// The built-in source declares Tier 1 for copilot, so a refusal keyed on the
+// tier alone would refuse the DEFAULT configuration whenever the network is
+// down. There the legacy launch is not a substitution — the persona it starts
+// is the one navikt/copilot ships — so refusing would take away a launch that
+// works (#795).
+func TestUnresolvableDefaultSourceStillFallsBack(t *testing.T) {
+	isolatedConfig(t)
+	t.Cleanup(func() { providerpkg.SetActivePakke(nil) })
+	rememberTier(defaultSourceRepo, "copilot", agentpakke.TierLayout)
+
+	orig := resolveSource
+	t.Cleanup(func() { resolveSource = orig })
+	resolveSource = func(string, string) (*Source, error) {
+		return nil, errors.New("dial tcp: no route to host")
+	}
+
+	handled, err := tryPakkeLaunch(ResolvedConfig{Client: "copilot", Source: defaultSourceRepo})
+	if handled || err != nil {
+		t.Fatalf("the built-in source must still fall back offline, got handled=%v err=%v", handled, err)
+	}
+}


### PR DESCRIPTION
Refs #795, #797, #803. Three fixes that are correct whichever way the Tier 1 model question in #729 is decided — a Fable pro/con recommended not doing the projection now, and these were its step 1 and 2.

**#795** — an unreachable Tier 1 source launched the built-in agent instead. #779 already ruled that out: *"Ingen stille bytte av kilde eller Tier 1-fallback."* The user configured a pakke; a different pakke is not a degraded version of it. It now refuses, as the payload path already did.

**#797** — `install --json` returned before the state file and the declaration were written, so a CI job could not tell an install from a no-op and the next sync had nothing to reconcile against. The JSON is emitted after both. Verified: a `--json` repo install now writes `.nav-pilot/agentpakke.lock.json`; before it did not.

**#803** — `uninstall` left `agentpakke.lock.json` behind and the next install read it as a pin. It is removed when it names the source being uninstalled, and left alone when it describes a base the repo composes.

## Blast radius

The refusal changes behaviour for anyone whose configured Tier 1 source is unreachable — they now get an error instead of a silent downgrade. That is the point, and it is what #779 specifies.

## Adversarial review

`go test ./...` green. Not covered: no test drives the uninstall lock removal end to end; it is asserted from the code path and a manual run.